### PR TITLE
Do not load workspace on language server start

### DIFF
--- a/packages/language/src/lsp/pli-document-update-handler.ts
+++ b/packages/language/src/lsp/pli-document-update-handler.ts
@@ -10,17 +10,21 @@
  */
 
 import { URI } from "langium";
-import { DefaultDocumentUpdateHandler, DocumentUpdateHandler } from "langium/lsp";
+import {
+  DefaultDocumentUpdateHandler,
+  DocumentUpdateHandler,
+} from "langium/lsp";
 import { TextDocument, TextDocumentChangeEvent } from "vscode-languageserver";
 
-export class PliDocumentUpdateHandler extends DefaultDocumentUpdateHandler implements DocumentUpdateHandler {
-
-    didCloseDocument(event: TextDocumentChangeEvent<TextDocument>): void {
-        const uri = URI.parse(event.document.uri);
-        if (uri.scheme !== 'pli-builtin') {
-            // Only remove the file from memory if it is not a built-in file
-            this.fireDocumentUpdate([], [uri]);
-        }
+export class PliDocumentUpdateHandler
+  extends DefaultDocumentUpdateHandler
+  implements DocumentUpdateHandler
+{
+  didCloseDocument(event: TextDocumentChangeEvent<TextDocument>): void {
+    const uri = URI.parse(event.document.uri);
+    if (uri.scheme !== "pli-builtin") {
+      // Only remove the file from memory if it is not a built-in file
+      this.fireDocumentUpdate([], [uri]);
     }
-
+  }
 }

--- a/packages/language/src/lsp/pli-document-update-handler.ts
+++ b/packages/language/src/lsp/pli-document-update-handler.ts
@@ -1,0 +1,26 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { URI } from "langium";
+import { DefaultDocumentUpdateHandler, DocumentUpdateHandler } from "langium/lsp";
+import { TextDocument, TextDocumentChangeEvent } from "vscode-languageserver";
+
+export class PliDocumentUpdateHandler extends DefaultDocumentUpdateHandler implements DocumentUpdateHandler {
+
+    didCloseDocument(event: TextDocumentChangeEvent<TextDocument>): void {
+        const uri = URI.parse(event.document.uri);
+        if (uri.scheme !== 'pli-builtin') {
+            // Only remove the file from memory if it is not a built-in file
+            this.fireDocumentUpdate([], [uri]);
+        }
+    }
+
+}

--- a/packages/language/src/pli-module.ts
+++ b/packages/language/src/pli-module.ts
@@ -40,6 +40,7 @@ import { PliDocumentationProvider } from "./documentation/pli-documentation-prov
 import { PliCompletionProvider } from "./lsp/pli-completion-provider.js";
 import { PliIndexManager } from "./workspace/pli-index-manager.js";
 import { PliWorkspaceManager } from "./workspace/pli-workspace-manager.js";
+import { PliDocumentUpdateHandler } from "./lsp/pli-document-update-handler.js";
 
 /**
  * Declaration of custom services - add your own service classes here.
@@ -94,6 +95,7 @@ export const PliSharedModule: Module<
 > = {
   lsp: {
     NodeKindProvider: () => new PliNodeKindProvider(),
+    DocumentUpdateHandler: services => new PliDocumentUpdateHandler(services)
   },
   workspace: {
     IndexManager: (services) => new PliIndexManager(services),

--- a/packages/language/src/pli-module.ts
+++ b/packages/language/src/pli-module.ts
@@ -95,7 +95,7 @@ export const PliSharedModule: Module<
 > = {
   lsp: {
     NodeKindProvider: () => new PliNodeKindProvider(),
-    DocumentUpdateHandler: services => new PliDocumentUpdateHandler(services)
+    DocumentUpdateHandler: (services) => new PliDocumentUpdateHandler(services),
   },
   workspace: {
     IndexManager: (services) => new PliIndexManager(services),

--- a/packages/language/src/workspace/pli-workspace-manager.ts
+++ b/packages/language/src/workspace/pli-workspace-manager.ts
@@ -37,4 +37,10 @@ export class PliWorkspaceManager extends DefaultWorkspaceManager {
     );
     _collector(document);
   }
+
+  protected override traverseFolder(): Promise<void> {
+    // Do not load the workspace on language server startup
+    // Files are mostly standalone, and any included files are loaded on demand.
+    return Promise.resolve();
+  }
 }


### PR DESCRIPTION
Closes https://github.com/zowe/zowe-pli-language-support/issues/31

Prevents Langium from loading the whole workspace during startup. Also deletes the file in memory if it has been closed (except if it is a builtin file).