### PR TITLE
Fix vite base path

### DIFF
--- a/.github/workflows/pr-previews.yml
+++ b/.github/workflows/pr-previews.yml
@@ -20,8 +20,7 @@ defaults:
     shell: bash
 
 jobs:
-  build-preview:
-    if: github.event_name == 'pull_request_target' && github.event.action != 'closed'
+  preview:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -29,39 +28,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install pnpm
+        if: github.event.action != 'closed'
         uses: pnpm/action-setup@v4
         with:
           version: 9
       - name: Use Node.js
+        if: github.event.action != 'closed'
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
       - name: Build Playground
+        if: github.event.action != 'closed'
         run: |
           pnpm install
           pnpm build:playground
       - uses: rossjrw/pr-preview-action@v1.6.0
         with:
-          action: deploy
           source-dir: ./packages/playground/out
           preview-branch: previews
           umbrella-dir: pr
-
-  # remove the preview page when the PR got closed
-  remove-preview:
-    if: github.event_name == 'pull_request_target' && github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      # checkout required for pr-preview-action to succeed,
-      # while the content will not be used
-      - name: Checkout
-        uses: actions/checkout@v4
-      - uses: rossjrw/pr-preview-action@v1.6.0
-        id: deployment
-        with:
-          action: remove
-          preview-branch: previews
-          umbrella-dir: pr
+          token: ${{ secrets.PREVIEW_PAT_TOKEN }}

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -1,7 +1,9 @@
 import path from "path";
 import importMetaUrlPlugin from "@codingame/esbuild-import-meta-url-plugin";
+import type { UserConfig } from "vite";
 
-export default {
+const config: UserConfig = {
+  base: '',
   build: {
     target: "ES2022",
     rollupOptions: {
@@ -21,8 +23,10 @@ export default {
   },
   optimizeDeps: {
     esbuildOptions: {
-      plugins: [importMetaUrlPlugin],
+      plugins: [importMetaUrlPlugin as any],
     },
     include: ["vscode-textmate", "vscode-oniguruma"],
   },
 };
+export default config;
+


### PR DESCRIPTION
Currently, the playground doesn't work due to absolute paths being required by the deployment. Using `base: ''` will make those paths relative, thereby preventing this issue.