### PR TITLE
Reinstates Validations + Supports Calling Procs w/ Secondary Entry Point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ out/
 *.vsix
 **/*.DS_Store
 scripts/*.html
+coverage/

--- a/packages/language/src/language-server/connection-handler.ts
+++ b/packages/language/src/language-server/connection-handler.ts
@@ -10,13 +10,13 @@
  */
 
 import { Connection, TextDocumentSyncKind } from "vscode-languageserver";
-import { SourceFileHandler } from "../workspace/source-file";
-import { TextDocuments } from "./text-documents";
-import { definitionRequest } from "./definition-request";
 import { URI } from "../utils/uri";
-import { rangeToLSP } from "./types";
+import { SourceFileHandler } from "../workspace/source-file";
+import { definitionRequest } from "./definition-request";
 import { referencesRequest } from "./references-request";
 import { semanticTokenLegend, semanticTokens } from "./semantic-tokens";
+import { TextDocuments } from "./text-documents";
+import { rangeToLSP } from "./types";
 
 export function startLanguageServer(connection: Connection): void {
   const sourceFileHandler = new SourceFileHandler();

--- a/packages/language/src/language-server/types.ts
+++ b/packages/language/src/language-server/types.ts
@@ -12,6 +12,8 @@
 import { IToken } from "chevrotain";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import * as lsp from "vscode-languageserver-types";
+import { getNameToken } from "../linking/tokens";
+import { SyntaxNode } from "../syntax-tree/ast";
 
 export type Offset = number;
 
@@ -60,6 +62,17 @@ export function tokenToRange(token: IToken): Range {
   };
 }
 
+/**
+ * Retrieve the range of the given syntax node, when possible.
+ */
+export function getSyntaxNodeRange(node: SyntaxNode): Range | undefined {
+  const token = getNameToken(node);
+  if (token) {
+    return tokenToRange(token);
+  }
+  return undefined;
+}
+
 export enum Severity {
   /** Info */
   I,
@@ -97,6 +110,12 @@ export interface Diagnostic {
   data?: any;
   source?: string;
 }
+
+/**
+ * DiagnosticInfo is a Diagnostic without the severity and message fields.
+ * For convenience w/ prior-langium diagnostic reporting in our validations
+ */
+export type DiagnosticInfo = Omit<Diagnostic, "severity" | "message">;
 
 export function diagnosticToLSP(
   textDocument: TextDocument,

--- a/packages/language/src/parser/abstract-parser.ts
+++ b/packages/language/src/parser/abstract-parser.ts
@@ -82,7 +82,6 @@ export interface TokenPayload {
 }
 
 export class AbstractParser extends EmbeddedActionsParser {
-
   constructor(tokens: TokenType[], config?: IParserConfig) {
     super(tokens, {
       ...config,
@@ -343,8 +342,8 @@ export class AbstractParser extends EmbeddedActionsParser {
   ]);
 
   /**
-   * Constructs a binary expression from an intermediate representation, 
-   * used when popping infix exprs from the stack, 
+   * Constructs a binary expression from an intermediate representation,
+   * used when popping infix exprs from the stack,
    * so we get the whole thing together
    */
   private constructBinaryExpression(

--- a/packages/language/src/parser/abstract-parser.ts
+++ b/packages/language/src/parser/abstract-parser.ts
@@ -11,40 +11,78 @@
 
 import {
   EmbeddedActionsParser,
-  TokenType,
+  IOrAlt,
   IParserConfig,
+  IToken,
   ParserMethod,
   SubruleMethodOpts,
-  IToken,
-  IOrAlt,
+  TokenType,
 } from "chevrotain";
 import { LLStarLookaheadStrategy } from "chevrotain-allstar";
-import type { CstNodeKind } from "../syntax-tree/cst";
 import {
   SyntaxKind,
   type BinaryExpression,
   type SyntaxNode,
 } from "../syntax-tree/ast";
+import type { CstNodeKind } from "../syntax-tree/cst";
 import * as tokens from "./tokens";
 
+/**
+ * Options for assigning a result to a subrule.
+ * @template ARGS - The arguments type for the subrule.
+ * @template R - The return type of the subrule.
+ */
 export interface SubruleAssignMethodOpts<ARGS, R>
   extends SubruleMethodOpts<ARGS> {
+  /**
+   * A function to assign the result of the subrule.
+   * @param result - The result to assign.
+   */
   assign: (result: R) => void;
 }
 
+/**
+ * Represents an intermediate binary expression used during parsing.
+ */
 export interface IntermediateBinaryExpression {
+  /**
+   * The items (operands) in the binary expression.
+   */
   items: any[];
+
+  /**
+   * The operators in the binary expression.
+   */
   operators: string[];
+
+  /**
+   * Indicates that this is an infix expression.
+   */
   infix: true;
 }
 
+/**
+ * Payload for a token, containing metadata about its syntax and element.
+ */
 export interface TokenPayload {
+  /**
+   * The URI associated with the token, if any.
+   */
   uri?: string;
+
+  /**
+   * The kind of CST (Concrete Syntax Tree) node.
+   */
   kind: CstNodeKind;
+
+  /**
+   * The syntax node associated with the token.
+   */
   element: SyntaxNode;
 }
 
 export class AbstractParser extends EmbeddedActionsParser {
+
   constructor(tokens: TokenType[], config?: IParserConfig) {
     super(tokens, {
       ...config,
@@ -53,6 +91,12 @@ export class AbstractParser extends EmbeddedActionsParser {
     });
   }
 
+  /**
+   * Assigns a payload to a token
+   * @param token - The token to assign the payload to
+   * @param element - The syntax node associated with the token
+   * @param kind - The kind of CST node
+   */
   protected tokenPayload(
     token: IToken,
     element: SyntaxNode,
@@ -97,6 +141,9 @@ export class AbstractParser extends EmbeddedActionsParser {
     });
   }
 
+  /**
+   * Defines an OR rule with a name and a set of alternative rules.
+   */
   protected OR_RULE<T>(
     name: string,
     rules: () => ParserMethod<any, any>[],
@@ -252,6 +299,9 @@ export class AbstractParser extends EmbeddedActionsParser {
     this.subrule_assign(9, ruleToCall, options);
   }
 
+  /**
+   * Builds a precedence map from precedence groups
+   */
   private buildPrecendenceMap(
     precedenceGroups: TokenType[][],
   ): Map<string, number> {
@@ -292,6 +342,11 @@ export class AbstractParser extends EmbeddedActionsParser {
     [tokens.Pipe, tokens.Not],
   ]);
 
+  /**
+   * Constructs a binary expression from an intermediate representation, 
+   * used when popping infix exprs from the stack, 
+   * so we get the whole thing together
+   */
   private constructBinaryExpression(
     obj: IntermediateBinaryExpression,
   ): BinaryExpression {

--- a/packages/language/src/pli.langium
+++ b/packages/language/src/pli.langium
@@ -714,7 +714,10 @@ LocatorCall:
         (pointer?="->" | handle?="=>") element=MemberCall
     )*;
 
-ProcedureCall: procedure=[ProcedureStatement:ID]  ('(' (args+=(Expression | '*') (',' args+=(Expression | '*'))*)? ')')?;
+/**
+ * Call to a known procedure or external declaration (via a named element), does not necessarily require an arg list
+ */
+ProcedureCall: procedure=[NamedElement:ID] (hasArgs?='(' (args+=(Expression | '*') (',' args+=(Expression | '*'))*)? ')')?;
 
 LabelReference: label=[LabelPrefix:ID];
 

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -1412,7 +1412,10 @@ export interface PrintDirective extends AstNode {
 }
 export interface ProcedureCall extends AstNode {
   kind: SyntaxKind.ProcedureCall;
-  procedure: Reference<ProcedureStatement> | null;
+  /**
+   * Call to a known procedure or external declaration (via a named element), does not necessarily require an arg list
+   */
+  procedure: Reference<NamedElement> | null;
   /**
    * First argument list of the CALL statement.
    * In case of a procedure array, this is the index!

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -201,6 +201,7 @@ export enum SyntaxKind {
 
 export interface AstNode {
   container: SyntaxNode | null;
+  kind: SyntaxKind;
 }
 
 export interface Reference<T extends SyntaxNode = SyntaxNode> {

--- a/packages/language/src/validation/messages/IBM1295IE-sole-bound-specified.ts
+++ b/packages/language/src/validation/messages/IBM1295IE-sole-bound-specified.ts
@@ -25,10 +25,10 @@ export function IBM1295IE_sole_bound_specified(
   if (isBoundNegative(upper) || isBoundZero(upper)) {
     const code = Error.IBM1295I;
     accept(Severity.E, code.message, {
-    //   node: bound
+      //   node: bound
       range: getSyntaxNodeRange(bound)!,
       uri: "", // TODO: Add URI
-    //   property: "bound1",
+      //   property: "bound1",
       code: code.fullCode,
     });
   }
@@ -48,14 +48,12 @@ function isBoundNegative(bound: Bound | null) {
 }
 
 function isBoundZero(bound: Bound | null): boolean {
-  return (
-    bound &&
+  return (bound &&
     bound.expression &&
     bound.expression !== "*" &&
     bound.expression.kind === SyntaxKind.Literal &&
     bound.expression.value &&
     bound.expression.value.kind === SyntaxKind.NumberLiteral &&
     //TODO find other cases when it is zero
-    bound.expression.value.value === "0"
-  )!!;
+    bound.expression.value.value === "0")!!;
 }

--- a/packages/language/src/validation/messages/IBM1324IE-name-occurs-more-than-once-within-exports-clause.ts
+++ b/packages/language/src/validation/messages/IBM1324IE-name-occurs-more-than-once-within-exports-clause.ts
@@ -9,30 +9,31 @@
  *
  */
 
-// TODO: Reimplement once the validation infrastructure is in place
+import { getSyntaxNodeRange, Severity } from "../../language-server/types";
+import { Exports } from "../../syntax-tree/ast";
+import { PliValidationAcceptor } from "../validator";
 
-// import { ValidationAcceptor } from "langium";
-// import { Exports } from "../../generated/ast";
-
-// export function IBM1324IE_name_occurs_more_than_once_within_exports_clause(
-//   exports: Exports,
-//   accept: ValidationAcceptor,
-// ): void {
-//   const set = new Set<string>();
-//   exports.procedures.forEach((procedure, index) => {
-//     if (!set.has(procedure)) {
-//       set.add(procedure);
-//     } else {
-//       accept(
-//         "error",
-//         `The name '${procedure}' occurs more than once in the EXPORTS clause.`,
-//         {
-//           code: "IBM1324IE",
-//           node: exports,
-//           property: "procedures",
-//           index,
-//         },
-//       );
-//     }
-//   });
-// }
+export function IBM1324IE_name_occurs_more_than_once_within_exports_clause(
+  exports: Exports,
+  accept: PliValidationAcceptor,
+): void {
+  const set = new Set<string>();
+  exports.procedures.forEach((procedure, index) => {
+    if (!set.has(procedure)) {
+      set.add(procedure);
+    } else {
+      accept(
+        Severity.E,
+        `The name '${procedure}' occurs more than once in the EXPORTS clause.`,
+        {
+          code: "IBM1324IE",
+          range: getSyntaxNodeRange(exports)!,
+          uri: "" // TODO: Add URI
+        //   node: exports,
+        //   property: "procedures",
+        //   index,
+        },
+      );
+    }
+  });
+}

--- a/packages/language/src/validation/messages/IBM1324IE-name-occurs-more-than-once-within-exports-clause.ts
+++ b/packages/language/src/validation/messages/IBM1324IE-name-occurs-more-than-once-within-exports-clause.ts
@@ -28,10 +28,10 @@ export function IBM1324IE_name_occurs_more_than_once_within_exports_clause(
         {
           code: "IBM1324IE",
           range: getSyntaxNodeRange(exports)!,
-          uri: "" // TODO: Add URI
-        //   node: exports,
-        //   property: "procedures",
-        //   index,
+          uri: "", // TODO: Add URI
+          //   node: exports,
+          //   property: "procedures",
+          //   index,
         },
       );
     }

--- a/packages/language/src/validation/messages/IBM1388IE-NODESCRIPTOR-attribute-is-invalid-when-any-parameter-has-NONCONNECTED-attribute.ts
+++ b/packages/language/src/validation/messages/IBM1388IE-NODESCRIPTOR-attribute-is-invalid-when-any-parameter-has-NONCONNECTED-attribute.ts
@@ -9,59 +9,58 @@
  *
  */
 
-// TODO: Reimplement once the validation infrastructure is in place
+import { getSyntaxNodeRange, Severity } from "../../language-server/types";
+import { DeclareStatement, ProcedureStatement, SimpleOptionsItem, SyntaxKind } from "../../syntax-tree/ast";
+import { compareIdentifiers, normalizeIdentifier } from "../utils";
+import { PliValidationAcceptor } from "../validator";
 
-// import { ValidationAcceptor } from "langium";
-// import {
-//   isComputationDataAttribute,
-//   isDeclaredVariable,
-//   isDeclareStatement,
-//   isSimpleOptionsItem,
-//   isStatement,
-//   ProcedureStatement,
-//   SimpleOptionsItem,
-// } from "../../generated/ast";
-// import { compareIdentifiers, normalizeIdentifier } from "../utils";
+export function IBM1388IE_NODESCRIPTOR_attribute_is_invalid_when_any_parameter_has_NONCONNECTED_attribute(
+  procedureStatement: ProcedureStatement,
+  accept: PliValidationAcceptor,
+): void {
+  const items = procedureStatement.options.flatMap((o) => o.items);
+  const item = items.find(
+    (i) =>
+        i.kind === SyntaxKind.SimpleOptionsItem &&
+        i.value && i.value.toUpperCase() === "NODESCRIPTOR",
+  ) as SimpleOptionsItem | undefined;
+  if (item) {
+    const parameterNames = new Set(
+      procedureStatement.parameters.map((p) => p.id ? normalizeIdentifier(p.id) : p.id),
+    );
 
-// export function IBM1388IE_NODESCRIPTOR_attribute_is_invalid_when_any_parameter_has_NONCONNECTED_attribute(
-//   procedureStatement: ProcedureStatement,
-//   accept: ValidationAcceptor,
-// ): void {
-//   const items = procedureStatement.options.flatMap((o) => o.items);
-//   const item = items.find(
-//     (i) => isSimpleOptionsItem(i) && i.value.toUpperCase() === "NODESCRIPTOR",
-//   ) as SimpleOptionsItem | undefined;
-//   if (item) {
-//     const parameterNames = new Set(
-//       procedureStatement.parameters.map((p) => normalizeIdentifier(p.id)),
-//     );
-//     const nonConnectedParameters = procedureStatement.statements
-//       .filter(isStatement)
-//       .map((s) => s.value)
-//       .filter(isDeclareStatement)
-//       .flatMap((d) => d.items)
-//       .filter(
-//         (i) =>
-//           isDeclaredVariable(i.element) &&
-//           parameterNames.has(normalizeIdentifier(i.element.name)),
-//       )
-//       .filter((i) =>
-//         i.attributes.some(
-//           (a) =>
-//             isComputationDataAttribute(a) &&
-//             compareIdentifiers(a.type, "NONCONNECTED"),
-//         ),
-//       );
-//     if (nonConnectedParameters.length > 0) {
-//       accept(
-//         "error",
-//         "The NODESCRIPTOR attribute is invalid when any parameters have the NONCONNECTED attribute.",
-//         {
-//           code: "IBM1388IE",
-//           node: item,
-//           property: "value",
-//         },
-//       );
-//     }
-//   }
-// }
+    const declareStmts: DeclareStatement[] = procedureStatement.statements
+        .filter(s => s.kind === SyntaxKind.Statement)
+        .map(s => s.value)
+        .filter(s => s !== null && s.kind === SyntaxKind.DeclareStatement) as DeclareStatement[];
+
+
+    const nonConnectedParameters = declareStmts
+      .flatMap(d => d.items)
+      .filter(
+        (i) =>
+          i.element && i.element !== '*' && i.element.kind === SyntaxKind.DeclaredVariable &&
+          parameterNames.has(normalizeIdentifier(i.element.name!)),
+      )
+      .filter((i) =>
+        i.attributes.some(
+          (a) =>
+            a.kind === SyntaxKind.ComputationDataAttribute &&
+            compareIdentifiers(a.type!, "NONCONNECTED"),
+        ),
+      );
+    if (nonConnectedParameters.length > 0) {
+      accept(
+        Severity.E,
+        "The NODESCRIPTOR attribute is invalid when any parameters have the NONCONNECTED attribute.",
+        {
+          code: "IBM1388IE",
+          range: getSyntaxNodeRange(item)!,
+          uri: "", // TODO: Add URI
+        //   node: item,
+        //   property: "value",
+        },
+      );
+    }
+  }
+}

--- a/packages/language/src/validation/messages/IBM1388IE-NODESCRIPTOR-attribute-is-invalid-when-any-parameter-has-NONCONNECTED-attribute.ts
+++ b/packages/language/src/validation/messages/IBM1388IE-NODESCRIPTOR-attribute-is-invalid-when-any-parameter-has-NONCONNECTED-attribute.ts
@@ -10,7 +10,12 @@
  */
 
 import { getSyntaxNodeRange, Severity } from "../../language-server/types";
-import { DeclareStatement, ProcedureStatement, SimpleOptionsItem, SyntaxKind } from "../../syntax-tree/ast";
+import {
+  DeclareStatement,
+  ProcedureStatement,
+  SimpleOptionsItem,
+  SyntaxKind,
+} from "../../syntax-tree/ast";
 import { compareIdentifiers, normalizeIdentifier } from "../utils";
 import { PliValidationAcceptor } from "../validator";
 
@@ -21,25 +26,31 @@ export function IBM1388IE_NODESCRIPTOR_attribute_is_invalid_when_any_parameter_h
   const items = procedureStatement.options.flatMap((o) => o.items);
   const item = items.find(
     (i) =>
-        i.kind === SyntaxKind.SimpleOptionsItem &&
-        i.value && i.value.toUpperCase() === "NODESCRIPTOR",
+      i.kind === SyntaxKind.SimpleOptionsItem &&
+      i.value &&
+      i.value.toUpperCase() === "NODESCRIPTOR",
   ) as SimpleOptionsItem | undefined;
   if (item) {
     const parameterNames = new Set(
-      procedureStatement.parameters.map((p) => p.id ? normalizeIdentifier(p.id) : p.id),
+      procedureStatement.parameters.map((p) =>
+        p.id ? normalizeIdentifier(p.id) : p.id,
+      ),
     );
 
     const declareStmts: DeclareStatement[] = procedureStatement.statements
-        .filter(s => s.kind === SyntaxKind.Statement)
-        .map(s => s.value)
-        .filter(s => s !== null && s.kind === SyntaxKind.DeclareStatement) as DeclareStatement[];
-
+      .filter((s) => s.kind === SyntaxKind.Statement)
+      .map((s) => s.value)
+      .filter(
+        (s) => s !== null && s.kind === SyntaxKind.DeclareStatement,
+      ) as DeclareStatement[];
 
     const nonConnectedParameters = declareStmts
-      .flatMap(d => d.items)
+      .flatMap((d) => d.items)
       .filter(
         (i) =>
-          i.element && i.element !== '*' && i.element.kind === SyntaxKind.DeclaredVariable &&
+          i.element &&
+          i.element !== "*" &&
+          i.element.kind === SyntaxKind.DeclaredVariable &&
           parameterNames.has(normalizeIdentifier(i.element.name!)),
       )
       .filter((i) =>
@@ -57,8 +68,8 @@ export function IBM1388IE_NODESCRIPTOR_attribute_is_invalid_when_any_parameter_h
           code: "IBM1388IE",
           range: getSyntaxNodeRange(item)!,
           uri: "", // TODO: Add URI
-        //   node: item,
-        //   property: "value",
+          //   node: item,
+          //   property: "value",
         },
       );
     }

--- a/packages/language/src/validation/messages/IBM1747IS-Function-cannot-be-used-before-the-functions-descriptor-list-has-been-scanned.ts
+++ b/packages/language/src/validation/messages/IBM1747IS-Function-cannot-be-used-before-the-functions-descriptor-list-has-been-scanned.ts
@@ -9,6 +9,10 @@
  *
  */
 
+// import { getSyntaxNodeRange, Severity } from "../../language-server/types";
+// import { DeclaredItem, MemberCall, SyntaxKind } from "../../syntax-tree/ast";
+// import { PliValidationAcceptor } from "../validator";
+
 // TODO: Reimplement once the validation infrastructure is in place
 
 // import { AstUtils, ValidationAcceptor } from "langium";
@@ -18,44 +22,50 @@
 //   MemberCall,
 // } from "../../generated/ast";
 
-// /**
-//  * This validation addresses functions, not procedures.
-//  * TODO check if also procedures are affected
-//  * @see https://www.ibm.com/docs/en/epfz/6.1?topic=codes-compiler-severe-messages-1500-2399#ibm1747i__msgId__1
-//  */
+/**
+ * This validation addresses functions, not procedures.
+ * TODO check if also procedures are affected
+ * @see https://www.ibm.com/docs/en/epfz/6.1?topic=codes-compiler-severe-messages-1500-2399#ibm1747i__msgId__1
+ */
+// TODO @montymxb Mar. 27th, 2025: Needs to have a way to readily access the containing 'document' (SourceFile) to compare the offsets
 // export function IBM1747IS_Function_cannot_be_used_before_the_functions_descriptor_list_has_been_scanned(
-//   call: MemberCall,
-//   accept: ValidationAcceptor,
+//     call: MemberCall,
+//     accept: PliValidationAcceptor,
 // ): void {
-//   //member call points to variable declaration...
-//   if (!isDeclaredVariable(call.element.ref.ref)) {
-//     return;
-//   }
-//   //...which actually is a function declaration...
-//   const declaration = call.element.ref.ref.$container;
-//   if (!declaration.attributes.some((a) => isEntryAttribute(a) && a.returns)) {
-//     return;
-//   }
-//   //... where both function call and function declaration are in the same file...
-//   const callDocument = AstUtils.getDocument(call);
-//   const declarationDocument = AstUtils.getDocument(declaration);
-//   if (callDocument !== declarationDocument) {
-//     return;
-//   }
-//   //...and the declaration happens after the call
-//   const callOffset = call.$cstNode!.offset;
-//   const declarationOffset = declaration.$cstNode!.offset;
-//   if (callOffset > declarationOffset) {
-//     return;
-//   }
-//   //throw error
-//   accept(
-//     "error",
-//     "Function cannot be used before the function's descriptor list has been scanned.",
-//     {
-//       code: "IBM1747IS",
-//       node: call,
-//       property: "element",
-//     },
-//   );
+//     // member call points to variable declaration...
+//     // if (!isDeclaredVariable(call.element.ref.ref)) {
+//     if (call.element?.ref?.node?.kind !== SyntaxKind.DeclaredVariable) {
+//         return;
+//     }
+//     // ...which actually is a function declaration...
+//     // const declaration = call.element.ref.ref.$container;
+//     const declaration = call.element.ref.node.container as DeclaredItem;
+//     // if (!declaration || !declaration.attributes.some((a) => isEntryAttribute(a) && a.returns)) {
+//     if (!declaration || !declaration.attributes.some((a) => a.kind === SyntaxKind.EntryAttribute && a.returns)) {
+//         return;
+//     }
+//     //... where both function call and function declaration are in the same file...
+//     const callDocument = AstUtils.getDocument(call);
+//     const declarationDocument = AstUtils.getDocument(declaration);
+//     if (callDocument !== declarationDocument) {
+//         return;
+//     }
+//     //...and the declaration happens after the call
+//     const callOffset = call.$cstNode!.offset;
+//     const declarationOffset = declaration.$cstNode!.offset;
+//     if (callOffset > declarationOffset) {
+//         return;
+//     }
+//     //throw error
+//     accept(
+//         Severity.E,
+//         "Function cannot be used before the function's descriptor list has been scanned.",
+//         {
+//             code: "IBM1747IS",
+//             range: getSyntaxNodeRange(call)!,
+//             uri: "", // TODO: Add URI
+//             // node: call,
+//             // property: "element",
+//         },
+//     );
 // }

--- a/packages/language/src/validation/messages/pli-codes.ts
+++ b/packages/language/src/validation/messages/pli-codes.ts
@@ -5579,7 +5579,7 @@ export const Error = {
     code: "IBM1230I",
     severity: "E",
     message: (variablename: string) =>
-      `Arguments have been specified for the variable ${variablename} , but it is not an entry variable.`,
+      `Arguments have been specified for the variable ${variablename}, but it is not an entry variable.`,
     fullCode: "IBM1230IE",
   } as ParametricPLICode,
 
@@ -5771,10 +5771,10 @@ export const Error = {
   IBM1243I: {
     code: "IBM1243I",
     severity: "E",
-    message:
-      "REGIONAL( ${integerspecification(2or3)} ) ENVIRONMENT option is not supported.",
+    message: (integerSpec2or3: string) =>
+      `REGIONAL(${integerSpec2or3}) ENVIRONMENT option is not supported.`,
     fullCode: "IBM1243IE",
-  } as SimplePLICode,
+  } as ParametricPLICode,
 
   /**
    * This applies to the KEYLENGTH, KEYLOC and RECSIZE suboptions.
@@ -16196,10 +16196,10 @@ export const Severe = {
   IBM1818I: {
     code: "IBM1818I",
     severity: "S",
-    message:
-      "${I/Ooption} conflicts with previous options on the ${I/Ostmt} statement.",
+    message: (ioOption: string, ioStmt: string) =>
+      `${ioOption} conflicts with previous options on the ${ioStmt} statement.`,
     fullCode: "IBM1818IS",
-  } as SimplePLICode,
+  } as ParametricPLICode,
 
   /**
    * Each option may be specified only once.
@@ -16211,10 +16211,10 @@ export const Severe = {
   IBM1819I: {
     code: "IBM1819I",
     severity: "S",
-    message:
-      "The ${I/Ooption} option is multiply specified on the ${I/Ostmt} statement.",
+    message: (ioOption: string, ioStmt: string) =>
+      `The ${ioOption} option is multiply specified on the ${ioStmt} statement.`,
     fullCode: "IBM1819IS",
-  } as SimplePLICode,
+  } as ParametricPLICode,
 
   /**
    * A required statement element has not been specified.
@@ -16227,10 +16227,10 @@ export const Severe = {
   IBM1820I: {
     code: "IBM1820I",
     severity: "S",
-    message:
-      "Mandatory ${I/Ooption} option not specified on the ${I/Ostmt} statement.",
+    message: (ioOption: string, ioStmt: string) =>
+      `Mandatory ${ioOption} option not specified on the ${ioStmt} statement.`,
     fullCode: "IBM1820IS",
-  } as SimplePLICode,
+  } as ParametricPLICode,
 
   /**
    * An invalid scalar or aggregate reference has been specified for the FROM or INTO

--- a/packages/language/src/validation/pli-validator.ts
+++ b/packages/language/src/validation/pli-validator.ts
@@ -19,155 +19,174 @@ import { PliValidationAcceptor } from "./validator";
 /**
  * A function that accepts a diagnostic for PL/I validation
  */
-export type PliValidationFunction = (node: any, acceptor: PliValidationAcceptor) => void;
+export type PliValidationFunction = (
+  node: any,
+  acceptor: PliValidationAcceptor,
+) => void;
 
 export type SyntaxKindStrings = keyof typeof AST.SyntaxKind;
 
 export type PliValidationChecks = Partial<
-    Record<
-        SyntaxKindStrings,
-        PliValidationFunction | PliValidationFunction[]
-    >
+  Record<SyntaxKindStrings, PliValidationFunction | PliValidationFunction[]>
 >;
 
 /**
  * Register custom validation checks.
  */
 export function registerValidationChecks(): PliValidationChecks {
-    const validator = new Pl1Validator();
-    const checks: PliValidationChecks = {
-        // DimensionBound: [IBM1295IE_sole_bound_specified],
-        PliProgram: [validator.checkPliProgram],
-        Exports: [IBM1324IE_name_occurs_more_than_once_within_exports_clause],
-        ReturnsOption: [validator.checkReturnsOption],
-        // TODO @montymxb Mar. 27th, 2025: Needs to have a way to readily access the containing 'document' (SourceFile) to compare the offsets (see def)
-        // MemberCall: [IBM1747IS_Function_cannot_be_used_before_the_functions_descriptor_list_has_been_scanned],
-        ProcedureStatement: [
-            IBM1388IE_NODESCRIPTOR_attribute_is_invalid_when_any_parameter_has_NONCONNECTED_attribute,
-        ],
-        LabelReference: [validator.checkLabelReference],
-        CallStatement: [validator.checkCallStatement],
-    };
+  const validator = new Pl1Validator();
+  const checks: PliValidationChecks = {
+    // DimensionBound: [IBM1295IE_sole_bound_specified],
+    PliProgram: [validator.checkPliProgram],
+    Exports: [IBM1324IE_name_occurs_more_than_once_within_exports_clause],
+    ReturnsOption: [validator.checkReturnsOption],
+    // TODO @montymxb Mar. 27th, 2025: Needs to have a way to readily access the containing 'document' (SourceFile) to compare the offsets (see def)
+    // MemberCall: [IBM1747IS_Function_cannot_be_used_before_the_functions_descriptor_list_has_been_scanned],
+    ProcedureStatement: [
+      IBM1388IE_NODESCRIPTOR_attribute_is_invalid_when_any_parameter_has_NONCONNECTED_attribute,
+    ],
+    LabelReference: [validator.checkLabelReference],
+    CallStatement: [validator.checkCallStatement],
+  };
 
-    return checks;
+  return checks;
 }
 
 /**
  * Implementation of custom validations.
  */
 export class Pl1Validator {
-    /**
-     * Verify programs contain at least one parsed statement
-     */
-    checkPliProgram(node: AST.PliProgram, acceptor: PliValidationAcceptor): void {
-        if (node.statements.length === 0) {
-            acceptor(Severity.S, PLICodes.Severe.IBM1917I.message, {
-                code: PLICodes.Severe.IBM1917I.fullCode,
-                range: getSyntaxNodeRange(node)!,
-                uri: "" // TODO @montymxb Still need to supply URI for this document we're working in
-            });
-        }
+  /**
+   * Verify programs contain at least one parsed statement
+   */
+  checkPliProgram(node: AST.PliProgram, acceptor: PliValidationAcceptor): void {
+    if (node.statements.length === 0) {
+      acceptor(Severity.S, PLICodes.Severe.IBM1917I.message, {
+        code: PLICodes.Severe.IBM1917I.fullCode,
+        range: getSyntaxNodeRange(node)!,
+        uri: "", // TODO @montymxb Still need to supply URI for this document we're working in
+      });
     }
+  }
 
-    /**
-     * Checks return options for mutually exclusive attributes
-     */
-    checkReturnsOption(node: AST.ReturnsOption, acceptor: PliValidationAcceptor): void {
-        const attrSet = new Set<string>();
-        for (const attr of node.returnAttributes) {
-            if (attr.kind === AST.SyntaxKind.ComputationDataAttribute) {
-                const typ = attr.type!.toUpperCase();
-                attrSet.add(typ); // dupes are ok
+  /**
+   * Checks return options for mutually exclusive attributes
+   */
+  checkReturnsOption(
+    node: AST.ReturnsOption,
+    acceptor: PliValidationAcceptor,
+  ): void {
+    const attrSet = new Set<string>();
+    for (const attr of node.returnAttributes) {
+      if (attr.kind === AST.SyntaxKind.ComputationDataAttribute) {
+        const typ = attr.type!.toUpperCase();
+        attrSet.add(typ); // dupes are ok
 
-                // look for a generally negated version of this attribute (there are several)
-                if (attrSet.has(`UN${typ}`)) {
-                    acceptor(Severity.E, PLICodes.Error.IBM2462I.message(typ, `UN${typ}`), {
-                        code: PLICodes.Error.IBM2462I.fullCode,
-                        range: getSyntaxNodeRange(node)!,
-                        uri: "" // TODO @montymxb Still need to supply URI for this document we're working in
-                        // property: "returnAttributes",
-                        // node
-                    });
-                }
-
-                // look for a non-negated version of this type
-                if (typ.startsWith("UN") && attrSet.has(typ.slice(2))) {
-                    acceptor(Severity.E, PLICodes.Error.IBM2462I.message(typ, typ.slice(2)), {
-                        code: PLICodes.Error.IBM2462I.fullCode,
-                        range: getSyntaxNodeRange(node)!,
-                        uri: "" // TODO @montymxb Still need to supply URI for this document we're working in
-                        // property: "returnAttributes",
-                        // node
-                    });
-                }
-            }
+        // look for a generally negated version of this attribute (there are several)
+        if (attrSet.has(`UN${typ}`)) {
+          acceptor(
+            Severity.E,
+            PLICodes.Error.IBM2462I.message(typ, `UN${typ}`),
+            {
+              code: PLICodes.Error.IBM2462I.fullCode,
+              range: getSyntaxNodeRange(node)!,
+              uri: "", // TODO @montymxb Still need to supply URI for this document we're working in
+              // property: "returnAttributes",
+              // node
+            },
+          );
         }
-    }
 
-    /**
-     * Verify label references
-     */
-    checkLabelReference(
-        node: AST.LabelReference,
-        acceptor: PliValidationAcceptor,
-    ): void {
-        if (node.label && !node.label.node) {
-            acceptor(Severity.W, PLICodes.Warning.IBM3332I.message, {
-                code: PLICodes.Warning.IBM3332I.fullCode,
-                range: getSyntaxNodeRange(node)!,
-                uri: "", // TODO @montymxb Still need to supply URI for this document we're
-                // property: "label"
-                // node
-            });
-
-            // add Error.IBM1316I as well
-            acceptor(Severity.E, PLICodes.Error.IBM1316I.message, {
-                code: PLICodes.Error.IBM1316I.fullCode,
-                range: getSyntaxNodeRange(node)!,
-                uri: "" // TODO @montymxb Still need to supply URI for this document we're working in
-                // property: "label",
-                // node
-            });
+        // look for a non-negated version of this type
+        if (typ.startsWith("UN") && attrSet.has(typ.slice(2))) {
+          acceptor(
+            Severity.E,
+            PLICodes.Error.IBM2462I.message(typ, typ.slice(2)),
+            {
+              code: PLICodes.Error.IBM2462I.fullCode,
+              range: getSyntaxNodeRange(node)!,
+              uri: "", // TODO @montymxb Still need to supply URI for this document we're working in
+              // property: "returnAttributes",
+              // node
+            },
+          );
         }
+      }
     }
+  }
 
-    /**
+  /**
+   * Verify label references
+   */
+  checkLabelReference(
+    node: AST.LabelReference,
+    acceptor: PliValidationAcceptor,
+  ): void {
+    if (node.label && !node.label.node) {
+      acceptor(Severity.W, PLICodes.Warning.IBM3332I.message, {
+        code: PLICodes.Warning.IBM3332I.fullCode,
+        range: getSyntaxNodeRange(node)!,
+        uri: "", // TODO @montymxb Still need to supply URI for this document we're
+        // property: "label"
+        // node
+      });
+
+      // add Error.IBM1316I as well
+      acceptor(Severity.E, PLICodes.Error.IBM1316I.message, {
+        code: PLICodes.Error.IBM1316I.fullCode,
+        range: getSyntaxNodeRange(node)!,
+        uri: "", // TODO @montymxb Still need to supply URI for this document we're working in
+        // property: "label",
+        // node
+      });
+    }
+  }
+
+  /**
    * Validate call statements to external declarations (requires an entry check)
    */
-    checkCallStatement(node: AST.CallStatement, acceptor: PliValidationAcceptor): void {
-        // const ref = node.call.procedure.ref;
-        const ref = node.call?.procedure?.node;
-        // node.call.procedure
-        if (ref && ref.kind === AST.SyntaxKind.DeclaredVariable) {
-            // get the parent of the declared variable
-            const parent = ref.container as AST.DeclaredItem;
-            if (parent.kind === AST.SyntaxKind.DeclaredItem) {
-                // check if it has the 'entry' attribute
-                // if (!parent.attributes.some((attr) => isEntryAttribute(attr))) {
-                if (!parent.attributes.some((attr) => attr.kind === AST.SyntaxKind.EntryAttribute)) {
-                    acceptor(Severity.S, PLICodes.Severe.IBM1695I.message, {
-                        code: PLICodes.Severe.IBM1695I.fullCode,
-                        range: getSyntaxNodeRange(node)!,
-                        uri: "" // TODO @montymxb Still need to supply URI for this document we're working in
-                        // node,
-                        // property: "call",
-                    });
+  checkCallStatement(
+    node: AST.CallStatement,
+    acceptor: PliValidationAcceptor,
+  ): void {
+    // const ref = node.call.procedure.ref;
+    const ref = node.call?.procedure?.node;
+    // node.call.procedure
+    if (ref && ref.kind === AST.SyntaxKind.DeclaredVariable) {
+      // get the parent of the declared variable
+      const parent = ref.container as AST.DeclaredItem;
+      if (parent.kind === AST.SyntaxKind.DeclaredItem) {
+        // check if it has the 'entry' attribute
+        // if (!parent.attributes.some((attr) => isEntryAttribute(attr))) {
+        if (
+          !parent.attributes.some(
+            (attr) => attr.kind === AST.SyntaxKind.EntryAttribute,
+          )
+        ) {
+          acceptor(Severity.S, PLICodes.Severe.IBM1695I.message, {
+            code: PLICodes.Severe.IBM1695I.fullCode,
+            range: getSyntaxNodeRange(node)!,
+            uri: "", // TODO @montymxb Still need to supply URI for this document we're working in
+            // node,
+            // property: "call",
+          });
 
-                    // also flag when we have any sort of args list (even an empty one) present after the call
-                    if (node.call?.args1) {
-                        acceptor(Severity.E,
-                            PLICodes.Error.IBM1231I.message(node.call?.procedure?.text!),
-                            {
-                                code: PLICodes.Error.IBM1231I.fullCode,
-                                range: getSyntaxNodeRange(node)!,
-                                uri: "", // TODO @montymxb Still need to supply URI for this document we're working in
-                                // node: node.call,
-                                // property: "args"
-                            }
-                        );
-                    }
-                }
-            }
+          // also flag when we have any sort of args list (even an empty one) present after the call
+          if (node.call?.args1) {
+            acceptor(
+              Severity.E,
+              PLICodes.Error.IBM1231I.message(node.call?.procedure?.text!),
+              {
+                code: PLICodes.Error.IBM1231I.fullCode,
+                range: getSyntaxNodeRange(node)!,
+                uri: "", // TODO @montymxb Still need to supply URI for this document we're working in
+                // node: node.call,
+                // property: "args"
+              },
+            );
+          }
         }
+      }
     }
+  }
 }

--- a/packages/language/src/validation/pli-validator.ts
+++ b/packages/language/src/validation/pli-validator.ts
@@ -154,7 +154,7 @@ export class Pl1Validator {
                     });
 
                     // also flag when we have any sort of args list (even an empty one) present after the call
-                    if (node.call?.hasArgs) {
+                    if (node.call?.args1) {
                         acceptor(Severity.E,
                             PLICodes.Error.IBM1231I.message(node.call?.procedure?.text!),
                             {

--- a/packages/language/src/validation/pli-validator.ts
+++ b/packages/language/src/validation/pli-validator.ts
@@ -9,112 +9,124 @@
  *
  */
 
-// import type { ValidationAcceptor, ValidationChecks } from "langium";
-// import {
-//   isComputationDataAttribute,
-//   type LabelReference,
-//   type Pl1AstType,
-//   type PliProgram,
-//   type ReturnsOption,
-// } from "../generated/ast.js";
-// import type { Pl1Services } from "../pli-module.js";
-// Remove until grammar support for dimensions work as expected
-// import { IBM1295IE_sole_bound_specified } from './messages/IBM1295IE-sole-bound-specified.js';
-// import { IBM1324IE_name_occurs_more_than_once_within_exports_clause } from "./messages/IBM1324IE-name-occurs-more-than-once-within-exports-clause.js";
-// import { IBM1388IE_NODESCRIPTOR_attribute_is_invalid_when_any_parameter_has_NONCONNECTED_attribute } from "./messages/IBM1388IE-NODESCRIPTOR-attribute-is-invalid-when-any-parameter-has-NONCONNECTED-attribute.js";
-// import { IBM1747IS_Function_cannot_be_used_before_the_functions_descriptor_list_has_been_scanned } from "./messages/IBM1747IS-Function-cannot-be-used-before-the-functions-descriptor-list-has-been-scanned.js";
-// import { Error as PLIError, Severe, Warning } from "./messages/pli-codes.js";
+import { getSyntaxNodeRange, Severity } from "../language-server/types";
+import * as AST from "../syntax-tree/ast";
+import { IBM1324IE_name_occurs_more_than_once_within_exports_clause } from "./messages/IBM1324IE-name-occurs-more-than-once-within-exports-clause.js";
+import { IBM1388IE_NODESCRIPTOR_attribute_is_invalid_when_any_parameter_has_NONCONNECTED_attribute } from "./messages/IBM1388IE-NODESCRIPTOR-attribute-is-invalid-when-any-parameter-has-NONCONNECTED-attribute.js";
+import * as PLICodes from "./messages/pli-codes";
+import { PliValidationAcceptor } from "./validator";
 
-// /**
-//  * Register custom validation checks.
-//  */
-// export function registerValidationChecks(services: Pl1Services) {
-//   const registry = services.validation.ValidationRegistry;
-//   const validator = services.validation.Pl1Validator;
-//   const checks: ValidationChecks<Pl1AstType> = {
-//     // DimensionBound: [IBM1295IE_sole_bound_specified],
-//     PliProgram: [validator.checkPliProgram],
-//     Exports: [IBM1324IE_name_occurs_more_than_once_within_exports_clause],
-//     ReturnsOption: [validator.checkReturnsOption],
-//     MemberCall: [
-//       IBM1747IS_Function_cannot_be_used_before_the_functions_descriptor_list_has_been_scanned,
-//     ],
-//     ProcedureStatement: [
-//       IBM1388IE_NODESCRIPTOR_attribute_is_invalid_when_any_parameter_has_NONCONNECTED_attribute,
-//     ],
-//     LabelReference: [validator.checkLabelReference],
-//   };
-//   registry.register(checks, validator);
-// }
+/**
+ * A function that accepts a diagnostic for PL/I validation
+ */
+export type PliValidationFunction = (node: any, acceptor: PliValidationAcceptor) => void;
 
-// /**
-//  * Implementation of custom validations.
-//  */
-// export class Pl1Validator {
-//   /**
-//    * Verify programs contain at least one parsed statement
-//    */
-//   checkPliProgram(node: PliProgram, acceptor: ValidationAcceptor): void {
-//     if (node.statements.length === 0) {
-//       acceptor("error", Severe.IBM1917I.message, {
-//         code: Severe.IBM1917I.fullCode,
-//         node,
-//         property: "statements",
-//       });
-//     }
-//   }
+export type SyntaxKindStrings = keyof typeof AST.SyntaxKind;
 
-//   /**
-//    * Checks return options for mutually exclusive attributes
-//    */
-//   checkReturnsOption(node: ReturnsOption, acceptor: ValidationAcceptor): void {
-//     const attrSet = new Set<string>();
-//     for (const attr of node.returnAttributes) {
-//       if (isComputationDataAttribute(attr)) {
-//         const typ = attr.type.toUpperCase();
-//         attrSet.add(typ); // dupes are ok
+export type PliValidationChecks = Partial<
+    Record<
+        SyntaxKindStrings,
+        PliValidationFunction | PliValidationFunction[]
+    >
+>;
 
-//         // look for a generally negated version of this attribute (there are several)
-//         if (attrSet.has(`UN${typ}`)) {
-//           acceptor("error", PLIError.IBM2462I.message(typ, `UN${typ}`), {
-//             code: PLIError.IBM2462I.fullCode,
-//             node,
-//             property: "returnAttributes",
-//           });
-//         }
+/**
+ * Register custom validation checks.
+ */
+export function registerValidationChecks(): PliValidationChecks {
+    const validator = new Pl1Validator();
+    const checks: PliValidationChecks = {
+        // DimensionBound: [IBM1295IE_sole_bound_specified],
+        PliProgram: [validator.checkPliProgram],
+        Exports: [IBM1324IE_name_occurs_more_than_once_within_exports_clause],
+        ReturnsOption: [validator.checkReturnsOption],
+        // TODO @montymxb Mar. 27th, 2025: Needs to have a way to readily access the containing 'document' (SourceFile) to compare the offsets (see def)
+        // MemberCall: [IBM1747IS_Function_cannot_be_used_before_the_functions_descriptor_list_has_been_scanned],
+        ProcedureStatement: [
+            IBM1388IE_NODESCRIPTOR_attribute_is_invalid_when_any_parameter_has_NONCONNECTED_attribute,
+        ],
+        LabelReference: [validator.checkLabelReference],
+    };
 
-//         // look for a non-negated version of this type
-//         if (typ.startsWith("UN") && attrSet.has(typ.slice(2))) {
-//           acceptor("error", PLIError.IBM2462I.message(typ, typ.slice(2)), {
-//             code: PLIError.IBM2462I.fullCode,
-//             node,
-//             property: "returnAttributes",
-//           });
-//         }
-//       }
-//     }
-//   }
+    return checks;
+}
 
-//   /**
-//    * Verify label references
-//    */
-//   checkLabelReference(
-//     node: LabelReference,
-//     acceptor: ValidationAcceptor,
-//   ): void {
-//     if (node.label && !node.label.ref) {
-//       acceptor("warning", Warning.IBM3332I.message, {
-//         code: Warning.IBM3332I.fullCode,
-//         node,
-//         property: "label",
-//       });
+/**
+ * Implementation of custom validations.
+ */
+export class Pl1Validator {
+    /**
+     * Verify programs contain at least one parsed statement
+     */
+    checkPliProgram(node: AST.PliProgram, acceptor: PliValidationAcceptor): void {
+        if (node.statements.length === 0) {
+            acceptor(Severity.S, PLICodes.Severe.IBM1917I.message, {
+                code: PLICodes.Severe.IBM1917I.fullCode,
+                range: getSyntaxNodeRange(node)!,
+                uri: "" // TODO @montymxb Still need to supply URI for this document we're working in
+            });
+        }
+    }
 
-//       // add Error.IBM1316I as well
-//       acceptor("error", PLIError.IBM1316I.message, {
-//         code: PLIError.IBM1316I.fullCode,
-//         node,
-//         property: "label",
-//       });
-//     }
-//   }
-// }
+    /**
+     * Checks return options for mutually exclusive attributes
+     */
+    checkReturnsOption(node: AST.ReturnsOption, acceptor: PliValidationAcceptor): void {
+        const attrSet = new Set<string>();
+        for (const attr of node.returnAttributes) {
+            if (attr.kind === AST.SyntaxKind.ComputationDataAttribute) {
+                const typ = attr.type!.toUpperCase();
+                attrSet.add(typ); // dupes are ok
+
+                // look for a generally negated version of this attribute (there are several)
+                if (attrSet.has(`UN${typ}`)) {
+                    acceptor(Severity.E, PLICodes.Error.IBM2462I.message(typ, `UN${typ}`), {
+                        code: PLICodes.Error.IBM2462I.fullCode,
+                        range: getSyntaxNodeRange(node)!,
+                        uri: "" // TODO @montymxb Still need to supply URI for this document we're working in
+                        // property: "returnAttributes",
+                        // node
+                    });
+                }
+
+                // look for a non-negated version of this type
+                if (typ.startsWith("UN") && attrSet.has(typ.slice(2))) {
+                    acceptor(Severity.E, PLICodes.Error.IBM2462I.message(typ, typ.slice(2)), {
+                        code: PLICodes.Error.IBM2462I.fullCode,
+                        range: getSyntaxNodeRange(node)!,
+                        uri: "" // TODO @montymxb Still need to supply URI for this document we're working in
+                        // property: "returnAttributes",
+                        // node
+                    });
+                }
+            }
+        }
+    }
+
+    /**
+     * Verify label references
+     */
+    checkLabelReference(
+        node: AST.LabelReference,
+        acceptor: PliValidationAcceptor,
+    ): void {
+        if (node.label && !node.label.node) {
+            acceptor(Severity.W, PLICodes.Warning.IBM3332I.message, {
+                code: PLICodes.Warning.IBM3332I.fullCode,
+                range: getSyntaxNodeRange(node)!,
+                uri: "", // TODO @montymxb Still need to supply URI for this document we're
+                // property: "label"
+                // node
+            });
+
+            // add Error.IBM1316I as well
+            acceptor(Severity.E, PLICodes.Error.IBM1316I.message, {
+                code: PLICodes.Error.IBM1316I.fullCode,
+                range: getSyntaxNodeRange(node)!,
+                uri: "" // TODO @montymxb Still need to supply URI for this document we're working in
+                // property: "label",
+                // node
+            });
+        }
+    }
+}

--- a/packages/language/src/validation/validator.ts
+++ b/packages/language/src/validation/validator.ts
@@ -14,32 +14,48 @@ import {
   IRecognitionException,
   MismatchedTokenException,
 } from "chevrotain";
-import { Diagnostic, DiagnosticInfo, Range, Severity } from "../language-server/types";
+import {
+  Diagnostic,
+  DiagnosticInfo,
+  Range,
+  Severity,
+} from "../language-server/types";
 import { ReferencesCache } from "../linking/resolver";
 import { isValidToken } from "../linking/tokens";
 import { PliProgram, SyntaxKind, SyntaxNode } from "../syntax-tree/ast";
 import { forEachNode } from "../syntax-tree/ast-iterator";
-import { PliValidationChecks, PliValidationFunction, registerValidationChecks } from "./pli-validator";
+import {
+  PliValidationChecks,
+  PliValidationFunction,
+  registerValidationChecks,
+} from "./pli-validator";
 
 /**
  * A function that accepts a diagnostic for PL/I validation
  */
-export type PliValidationAcceptor = (severity: Severity, message: string, info: DiagnosticInfo) => void;
+export type PliValidationAcceptor = (
+  severity: Severity,
+  message: string,
+  info: DiagnosticInfo,
+) => void;
 
 /**
  * Generates validation diagnostics (semantic checks) from the given AST node.
  */
 export function generateValidationDiagnostics(root: PliProgram): Diagnostic[] {
-
   // TODO @montymxb Mar. 27th, 2025: Checks are generated on each invocation, not ideal, needs a rework still
   const handlers = registerValidationChecks();
 
   const diagnostics: Diagnostic[] = [];
-  const acceptor: PliValidationAcceptor = (severity: Severity, message: string, d: DiagnosticInfo) => {
+  const acceptor: PliValidationAcceptor = (
+    severity: Severity,
+    message: string,
+    d: DiagnosticInfo,
+  ) => {
     diagnostics.push({
       severity,
       message,
-      ...d
+      ...d,
     });
   };
 
@@ -56,11 +72,16 @@ export function generateValidationDiagnostics(root: PliProgram): Diagnostic[] {
  * @param handlers Registered handlers for validating specific node types
  */
 // function validateSyntaxNode(node: SyntaxNode, acceptor: PliValidationAcceptor, handlers: Map<SyntaxKind, AstNodeValidator>): void {
-function validateSyntaxNode(node: SyntaxNode, acceptor: PliValidationAcceptor, handlers: PliValidationChecks): void {
+function validateSyntaxNode(
+  node: SyntaxNode,
+  acceptor: PliValidationAcceptor,
+  handlers: PliValidationChecks,
+): void {
   // get the name of enum value for node.kind
   const name = SyntaxKind[node.kind] as keyof typeof SyntaxKind;
   if (handlers[name]) {
-    let fnOrArray: PliValidationFunction | PliValidationFunction[] = handlers[name] ?? [];
+    let fnOrArray: PliValidationFunction | PliValidationFunction[] =
+      handlers[name] ?? [];
     if (!(fnOrArray instanceof Array)) {
       fnOrArray = [fnOrArray];
     }

--- a/packages/language/src/validation/validator.ts
+++ b/packages/language/src/validation/validator.ts
@@ -22,13 +22,14 @@ import {
 } from "../language-server/types";
 import { ReferencesCache } from "../linking/resolver";
 import { isValidToken } from "../linking/tokens";
-import { PliProgram, SyntaxKind, SyntaxNode } from "../syntax-tree/ast";
+import { SyntaxKind, SyntaxNode } from "../syntax-tree/ast";
 import { forEachNode } from "../syntax-tree/ast-iterator";
 import {
   PliValidationChecks,
   PliValidationFunction,
   registerValidationChecks,
 } from "./pli-validator";
+import { SourceFile } from "../workspace/source-file";
 
 /**
  * A function that accepts a diagnostic for PL/I validation
@@ -42,7 +43,7 @@ export type PliValidationAcceptor = (
 /**
  * Generates validation diagnostics (semantic checks) from the given AST node.
  */
-export function generateValidationDiagnostics(root: PliProgram): Diagnostic[] {
+export function generateValidationDiagnostics(sourceFile: SourceFile): void {
   // TODO @montymxb Mar. 27th, 2025: Checks are generated on each invocation, not ideal, needs a rework still
   const handlers = registerValidationChecks();
 
@@ -60,9 +61,9 @@ export function generateValidationDiagnostics(root: PliProgram): Diagnostic[] {
   };
 
   // iterate over all nodes and validate them
-  validateSyntaxNode(root, acceptor, handlers);
+  validateSyntaxNode(sourceFile.ast, acceptor, handlers);
 
-  return diagnostics;
+  sourceFile.diagnostics.validation = diagnostics;
 }
 
 /**

--- a/packages/language/src/workspace/lifecycle.ts
+++ b/packages/language/src/workspace/lifecycle.ts
@@ -1,5 +1,4 @@
 import { ILexingResult } from "chevrotain";
-import { Diagnostic } from "../language-server/types";
 import { ReferencesCache, resolveReferences } from "../linking/resolver";
 import { iterateSymbols, SymbolTable } from "../linking/symbol-table";
 import { PliParserInstance } from "../parser/parser";
@@ -105,8 +104,6 @@ export function link(sourceFile: SourceFile): ReferencesCache {
 /**
  * Performs semantic validations on the AST of the source file
  */
-export function validate(sourceFile: SourceFile): Diagnostic[] {
-  const diagnostics = generateValidationDiagnostics(sourceFile.ast);
-  sourceFile.diagnostics.validation = diagnostics;
-  return diagnostics;
+export function validate(sourceFile: SourceFile): void {
+  generateValidationDiagnostics(sourceFile);
 }

--- a/packages/language/test/utils.ts
+++ b/packages/language/test/utils.ts
@@ -1,18 +1,58 @@
 import { expect } from "vitest";
-import { SourceFile, createSourceFile } from "../src/workspace/source-file";
-import * as lifecycle from "../src/workspace/lifecycle";
 import { URI } from "vscode-uri";
+import { Diagnostic } from "../src/language-server/types";
+import * as lifecycle from "../src/workspace/lifecycle";
+import { SourceFile, collectDiagnostics, createSourceFile } from "../src/workspace/source-file";
 
 export function assertNoParseErrors(sourceFile: SourceFile) {
   expect(sourceFile.diagnostics.lexer).toHaveLength(0);
   expect(sourceFile.diagnostics.parser).toHaveLength(0);
 }
 
-export function parse(text: string): SourceFile {
-  const sourceFile = createSourceFile(URI.file("test.pli"));
-  lifecycle.tokenize(sourceFile, text);
-  lifecycle.parse(sourceFile);
+/**
+ * Asserts the absence of linking errors in the given source file
+ */
+export function assertNoLinkingErrors(sourceFile: SourceFile) {
+  expect(sourceFile.diagnostics.linking).toHaveLength(0);
+}
+
+/**
+ * Asserts the absence of validation errors in the given source file
+ */
+export function assertNoValidationErrors(sourceFile: SourceFile) {
+  expect(sourceFile.diagnostics.validation).toHaveLength(0);
+}
+
+/**
+ * Asserts the absence of all diagnostics in the given source file
+ */
+export function assertNoDiagnostics(sourceFile: SourceFile) {
   assertNoParseErrors(sourceFile);
+  assertNoLinkingErrors(sourceFile);
+  assertNoValidationErrors(sourceFile);
+}
+
+export function assertDiagnostic(sourceFile: SourceFile, diagnostic: Partial<Diagnostic>) {
+  const diagnostics = collectDiagnostics(sourceFile);
+  // assert that there's at least one diagnostic that matches the given partial diagnostic
+  expect(diagnostics).toContainEqual(expect.objectContaining(diagnostic));
+
+}
+
+/**
+ * Parses the given text and returns a source file with attached diagnostics
+ * 
+ * @param text PL/I text to parse
+ * @param options Options for parsing, chiefly to enable additional validation
+ */
+export function parse(text: string, options?: { validate: boolean}): SourceFile {
+  const sourceFile = createSourceFile(URI.file("test.pli"));
+  if (!options?.validate) {
+    lifecycle.tokenize(sourceFile, text);
+    lifecycle.parse(sourceFile);
+  } else {
+    lifecycle.lifecycle(sourceFile, text);
+  }
   return sourceFile;
 }
 

--- a/packages/language/test/utils.ts
+++ b/packages/language/test/utils.ts
@@ -2,7 +2,11 @@ import { expect } from "vitest";
 import { URI } from "vscode-uri";
 import { Diagnostic } from "../src/language-server/types";
 import * as lifecycle from "../src/workspace/lifecycle";
-import { SourceFile, collectDiagnostics, createSourceFile } from "../src/workspace/source-file";
+import {
+  SourceFile,
+  collectDiagnostics,
+  createSourceFile,
+} from "../src/workspace/source-file";
 
 export function assertNoParseErrors(sourceFile: SourceFile) {
   expect(sourceFile.diagnostics.lexer).toHaveLength(0);
@@ -32,20 +36,25 @@ export function assertNoDiagnostics(sourceFile: SourceFile) {
   assertNoValidationErrors(sourceFile);
 }
 
-export function assertDiagnostic(sourceFile: SourceFile, diagnostic: Partial<Diagnostic>) {
+export function assertDiagnostic(
+  sourceFile: SourceFile,
+  diagnostic: Partial<Diagnostic>,
+) {
   const diagnostics = collectDiagnostics(sourceFile);
   // assert that there's at least one diagnostic that matches the given partial diagnostic
   expect(diagnostics).toContainEqual(expect.objectContaining(diagnostic));
-
 }
 
 /**
  * Parses the given text and returns a source file with attached diagnostics
- * 
+ *
  * @param text PL/I text to parse
  * @param options Options for parsing, chiefly to enable additional validation
  */
-export function parse(text: string, options?: { validate: boolean}): SourceFile {
+export function parse(
+  text: string,
+  options?: { validate: boolean },
+): SourceFile {
   const sourceFile = createSourceFile(URI.file("test.pli"));
   if (!options?.validate) {
     lifecycle.tokenize(sourceFile, text);

--- a/packages/language/test/validating.test.ts
+++ b/packages/language/test/validating.test.ts
@@ -9,20 +9,11 @@
  *
  */
 
-import { test } from "vitest";
-
-test("TODO", () => {});
-
-// import { beforeAll, describe, expect, test } from "vitest";
-// import { EmptyFileSystem, type LangiumDocument } from "langium";
-// import { parseHelper } from "langium/test";
-// import { DiagnosticSeverity } from "vscode-languageserver-types";
-// import { createPliServices, PliProgram } from "../src";
-// import { Error, Severe, Warning } from "../src/validation/messages/pli-codes";
-
-// let services: ReturnType<typeof createPliServices>;
-// let parse: ReturnType<typeof parseHelper<PliProgram>>;
-// let document: LangiumDocument<PliProgram> | undefined;
+import { describe, expect, test } from "vitest";
+import { Severity } from "../src/language-server/types";
+import * as PLICodes from "../src/validation/messages/pli-codes";
+import { collectDiagnostics } from "../src/workspace/source-file";
+import { assertDiagnostic, assertNoDiagnostics, parse } from "./utils";
 
 // beforeAll(async () => {
 //   services = createPliServices(EmptyFileSystem);
@@ -32,134 +23,159 @@ test("TODO", () => {});
 //   // activate the following if your linking test requires elements from a built-in library, for example
 //   await services.shared.workspace.WorkspaceManager.initializeWorkspace([]);
 // });
+// TODO @montymxb Mar. 28th, 2025: Topic of initializing workspace (for built-ins) is still needed
 
-// describe("Validating", () => {
-//   test("check empty program", async () => {
-//     document = await parse(`;`);
-//     expect(document.diagnostics?.length).toBe(1);
-//     expect(document.diagnostics?.[0].severity).toBe(DiagnosticSeverity.Error);
-//     expect(document.diagnostics?.[0].code).toBe(Severe.IBM1917I.fullCode);
-//   });
+/**
+ * Helper to parse w/ validations enabled
+ */
+function parseWithValidations(text: string) {
+    return parse(text, { validate: true });
+}
 
-//   test("check IBM2462I, unaligned & aligned conflict", async () => {
-//     document = await parse(`
-//   H: PROC OPTIONS (MAIN);
-//   xyz: proc returns ( optional aligned unaligned bit(4) ); // <-- conflicting attributes, second one should be ignored
-//   return(0);
-//   end xyz;
-//   call xyz();
-//   END H;
-//     `);
-//     expect(document.diagnostics?.length).toBe(1);
-//     expect(document.diagnostics?.[0].code).toBe(Error.IBM2462I.fullCode);
-//     expect(document.diagnostics?.[0].severity).toBe(DiagnosticSeverity.Error);
-//   });
+describe("Validating", () => {
 
-//   test("check mismatched end label", async () => {
-//     document = await parse(`
-//   MYPROC: PROCEDURE OPTIONS (MAIN);
-//   DCL TRUE BIT(1) INIT(1);
-//   DCL FALSE BIT(1) INIT(0);
-//   DCL OR_VALUE;
-//   OR_VALUE = TRUE | FALSE;
-//   DCL NOT_VALUE;
-//   END MYPROG;
-//     `);
+    test("check simple program", async () => {
+        const doc = parseWithValidations(`
+        H: PROC OPTIONS (MAIN);
+        DCL ABC BIT(1) INIT(1);
+        END H;
+        `);
+        assertNoDiagnostics(doc);
+    });
 
-//     // 2 diagnostics, 1 for a bad link, 2nd for the end statement that's mismatched, 3rd for an end label not associated w/ a group
-//     // the third comes up just by nature of the issue there being no match anyways
-//     expect(document.diagnostics?.length).toBe(3);
 
-//     // verify the first diagnostic is a warning
-//     expect(document.diagnostics?.[0].severity).toBe(DiagnosticSeverity.Warning);
+    test("check empty program", async () => {
+        const doc = parseWithValidations(`;`);
+        assertDiagnostic(doc, {
+            code: PLICodes.Severe.IBM1917I.fullCode,
+            severity: Severity.S
+        });
+    });
 
-//     // verify the 2nd diagnostic is an error w/ the IBM3332I as the code
-//     expect(document.diagnostics?.[1].code).toBe(Warning.IBM3332I.fullCode);
-//     expect(document.diagnostics?.[1].severity).toBe(DiagnosticSeverity.Warning);
+    test("check IBM2462I, unaligned & aligned conflict", async () => {
+        const doc = parseWithValidations(`
+        H: PROC OPTIONS (MAIN);
+        xyz: proc returns ( optional aligned unaligned bit(4) ); // <-- conflicting attributes, second one should be ignored
+        return(0);
+        end xyz;
+        call xyz();
+        END H;
+            `);
+        assertDiagnostic(doc, {
+            code: PLICodes.Error.IBM2462I.fullCode,
+            severity: Severity.E
+        });
+    });
 
-//     // verify the 3rd diagnostic is an error w/ the IBM1316IE as the code
-//     expect(document.diagnostics?.[2].code).toBe(Error.IBM1316I.fullCode);
-//     expect(document.diagnostics?.[2].severity).toBe(DiagnosticSeverity.Error);
-//   });
+    test("check mismatched end label", async () => {
+        const doc = parseWithValidations(`
+        MYPROC: PROCEDURE OPTIONS (MAIN);
+        DCL TRUE BIT(1) INIT(1);
+        DCL FALSE BIT(1) INIT(0);
+        DCL OR_VALUE;
+        OR_VALUE = TRUE | FALSE;
+        DCL NOT_VALUE;
+        END MYPROG;
+        `);
 
-//   test("package end label validates", async () => {
-//     document = await parse(`
-//       baseline: package;
-//       end baseline;
-//       `);
-//     expect(document.diagnostics?.length).toBe(0);
-//   });
+        const diagnostics = collectDiagnostics(doc);
 
-//   test("validates ordinal reference", async () => {
-//     document = await parse(`
-//     define ordinal day (
-//       Monday,
-//       Tuesday,
-//       Wednesday,
-//       Thursday,
-//       Friday,
-//       Saturday,
-//       Sunday
-//     ) prec(15);
+        // 2 diagnostics, 1 for a bad link, 2nd for the end statement that's mismatched, 3rd for an end label not associated w/ a group
+        // the third comes up just by nature of the issue there being no match anyways
+        expect(diagnostics.length).toBe(3);
 
-//     // should be able to parse return w/ ordinal correctly
-//     get_day: proc() returns(ordinal day byvalue);
-//       return( Friday );
-//     end get_day;`);
-//     expect(document.diagnostics?.length).toBe(0);
-//   });
+        // verify the first diagnostic is a warning
+        expect(diagnostics[0].severity).toBe(Severity.W);
 
-//   test("Reference to alias types __SIGNED_INT & __UNSIGNED_INT", async () => {
-//     document = await parse(`
-//     mypackage: package;
-//     DCL x type __SIGNED_INT;
-//     DCL y type __UNSIGNED_INT;
-//     end mypackage;
-//     `);
-//     expect(document.diagnostics?.length).toBe(0);
-//   });
+        // verify the 2nd diagnostic is an error w/ the IBM3332I as the code
+        expect(diagnostics[1].code).toBe(PLICodes.Warning.IBM3332I.fullCode);
+        expect(diagnostics[1].severity).toBe(Severity.W);
 
-//   //
-//   //     test('check no errors', async () => {
-//   //         document = await parse(`
-//   //             person Langium
-//   //         `);
-//   //
-//   //         expect(
-//   //             // here we first check for validity of the parsed document object by means of the reusable function
-//   //             //  'checkDocumentValid()' to sort out (critical) typos first,
-//   //             // and then evaluate the diagnostics by converting them into human readable strings;
-//   //             // note that 'toHaveLength()' works for arrays and strings alike ;-)
-//   //             checkDocumentValid(document) || document?.diagnostics?.map(diagnosticToString)?.join('\n')
-//   //         ).toHaveLength(0);
-//   //     });
-//   //
-//   //     test('check capital letter validation', async () => {
-//   //         document = await parse(`
-//   //             person langium
-//   //         `);
-//   //
-//   //         expect(
-//   //             checkDocumentValid(document) || document?.diagnostics?.map(diagnosticToString)?.join('\n')
-//   //         ).toEqual(
-//   //             // 'expect.stringContaining()' makes our test robust against future additions of further validation rules
-//   //             expect.stringContaining(s`
-//   //                 [1:19..1:26]: Person name should start with a capital.
-//   //             `)
-//   //         );
-//   //     });
-// });
+        // verify the 3rd diagnostic is an error w/ the IBM1316IE as the code
+        expect(diagnostics[2].code).toBe(PLICodes.Error.IBM1316I.fullCode);
+        expect(diagnostics[2].severity).toBe(Severity.E);
+    });
 
-// // function checkDocumentValid(document: LangiumDocument): string | undefined {
-// //     return document.parseResult.parserErrors.length && s`
-// //         Parser errors:
-// //           ${document.parseResult.parserErrors.map(e => e.message).join('\n  ')}
-// //     `
-// //         || document.parseResult.value === undefined && `ParseResult is 'undefined'.`
-// //         || !isPliProgram(document.parseResult.value) && `Root AST object is a ${document.parseResult.value.$type}, expected a 'Model'.`
-// //         || undefined;
-// // }
+    test("package end label validates", async () => {
+        const doc = parseWithValidations(`
+        baseline: package;
+        end baseline;
+        `);
+        assertNoDiagnostics(doc);
+    });
 
-// // function diagnosticToString(d: Diagnostic) {
-// //     return `[${d.range.start.line}:${d.range.start.character}..${d.range.end.line}:${d.range.end.character}]: ${d.message}`;
-// // }
+    // TODO @montymxb Mar. 28th, 2025: Pending a fix to linking + scoping
+    test.fails("validates ordinal reference", async () => {
+        const doc = parseWithValidations(`
+        define ordinal day (
+            Monday,
+            Tuesday,
+            Wednesday,
+            Thursday,
+            Friday,
+            Saturday,
+            Sunday
+        ) prec(15);
+
+        // should be able to parse return w/ ordinal correctly
+        get_day: proc() returns(ordinal day byvalue);
+        return( Friday );
+        end get_day;`);
+        assertNoDiagnostics(doc);
+    });
+
+    // TODO @montymxb Mar. 28th, 2025: Pending re-integration of the built-in library for testing
+    test.fails("Reference to alias types __SIGNED_INT & __UNSIGNED_INT", async () => {
+        const doc = parseWithValidations(`
+        mypackage: package;
+        DCL x type __SIGNED_INT;
+        DCL y type __UNSIGNED_INT;
+        end mypackage;
+        `);
+        assertNoDiagnostics(doc);
+    });
+
+    //
+    //     test('check no errors', async () => {
+    //         document = await parseWithValidations(`
+    //             person Langium
+    //         `);
+    //
+    //         expect(
+    //             // here we first check for validity of the parsed document object by means of the reusable function
+    //             //  'checkDocumentValid()' to sort out (critical) typos first,
+    //             // and then evaluate the diagnostics by converting them into human readable strings;
+    //             // note that 'toHaveLength()' works for arrays and strings alike ;-)
+    //             checkDocumentValid(document) || document?.diagnostics?.map(diagnosticToString)?.join('\n')
+    //         ).toHaveLength(0);
+    //     });
+    //
+    //     test('check capital letter validation', async () => {
+    //         document = await parseWithValidations(`
+    //             person langium
+    //         `);
+    //
+    //         expect(
+    //             checkDocumentValid(document) || document?.diagnostics?.map(diagnosticToString)?.join('\n')
+    //         ).toEqual(
+    //             // 'expect.stringContaining()' makes our test robust against future additions of further validation rules
+    //             expect.stringContaining(s`
+    //                 [1:19..1:26]: Person name should start with a capital.
+    //             `)
+    //         );
+    //     });
+});
+
+// function checkDocumentValid(document: LangiumDocument): string | undefined {
+//     return document.parseResult.parserErrors.length && s`
+//         Parser errors:
+//           ${document.parseResult.parserErrors.map(e => e.message).join('\n  ')}
+//     `
+//         || document.parseResult.value === undefined && `ParseResult is 'undefined'.`
+//         || !isPliProgram(document.parseResult.value) && `Root AST object is a ${document.parseResult.value.$type}, expected a 'Model'.`
+//         || undefined;
+// }
+
+// function diagnosticToString(d: Diagnostic) {
+//     return `[${d.range.start.line}:${d.range.start.character}..${d.range.end.line}:${d.range.end.character}]: ${d.message}`;
+// }

--- a/packages/language/test/validating.test.ts
+++ b/packages/language/test/validating.test.ts
@@ -29,30 +29,29 @@ import { assertDiagnostic, assertNoDiagnostics, parse } from "./utils";
  * Helper to parse w/ validations enabled
  */
 function parseWithValidations(text: string) {
-    return parse(text, { validate: true });
+  return parse(text, { validate: true });
 }
 
 describe("Validating", () => {
-
-    test("check simple program", async () => {
-        const doc = parseWithValidations(`
+  test("check simple program", async () => {
+    const doc = parseWithValidations(`
         H: PROC OPTIONS (MAIN);
         DCL ABC BIT(1) INIT(1);
         END H;
         `);
-        assertNoDiagnostics(doc);
-    });
+    assertNoDiagnostics(doc);
+  });
 
-    test("check empty program", async () => {
-        const doc = parseWithValidations(`;`);
-        assertDiagnostic(doc, {
-            code: PLICodes.Severe.IBM1917I.fullCode,
-            severity: Severity.S
-        });
+  test("check empty program", async () => {
+    const doc = parseWithValidations(`;`);
+    assertDiagnostic(doc, {
+      code: PLICodes.Severe.IBM1917I.fullCode,
+      severity: Severity.S,
     });
+  });
 
-    test("check IBM2462I, unaligned & aligned conflict", async () => {
-        const doc = parseWithValidations(`
+  test("check IBM2462I, unaligned & aligned conflict", async () => {
+    const doc = parseWithValidations(`
         H: PROC OPTIONS (MAIN);
         xyz: proc returns ( optional aligned unaligned bit(4) ); // <-- conflicting attributes, second one should be ignored
         return(0);
@@ -60,14 +59,14 @@ describe("Validating", () => {
         call xyz();
         END H;
             `);
-        assertDiagnostic(doc, {
-            code: PLICodes.Error.IBM2462I.fullCode,
-            severity: Severity.E
-        });
+    assertDiagnostic(doc, {
+      code: PLICodes.Error.IBM2462I.fullCode,
+      severity: Severity.E,
     });
+  });
 
-    test("check mismatched end label", async () => {
-        const doc = parseWithValidations(`
+  test("check mismatched end label", async () => {
+    const doc = parseWithValidations(`
         MYPROC: PROCEDURE OPTIONS (MAIN);
         DCL TRUE BIT(1) INIT(1);
         DCL FALSE BIT(1) INIT(0);
@@ -77,35 +76,35 @@ describe("Validating", () => {
         END MYPROG;
         `);
 
-        const diagnostics = collectDiagnostics(doc);
+    const diagnostics = collectDiagnostics(doc);
 
-        // 2 diagnostics, 1 for a bad link, 2nd for the end statement that's mismatched, 3rd for an end label not associated w/ a group
-        // the third comes up just by nature of the issue there being no match anyways
-        expect(diagnostics.length).toBe(3);
+    // 2 diagnostics, 1 for a bad link, 2nd for the end statement that's mismatched, 3rd for an end label not associated w/ a group
+    // the third comes up just by nature of the issue there being no match anyways
+    expect(diagnostics.length).toBe(3);
 
-        // verify the first diagnostic is a warning
-        expect(diagnostics[0].severity).toBe(Severity.W);
+    // verify the first diagnostic is a warning
+    expect(diagnostics[0].severity).toBe(Severity.W);
 
-        // verify the 2nd diagnostic is an error w/ the IBM3332I as the code
-        expect(diagnostics[1].code).toBe(PLICodes.Warning.IBM3332I.fullCode);
-        expect(diagnostics[1].severity).toBe(Severity.W);
+    // verify the 2nd diagnostic is an error w/ the IBM3332I as the code
+    expect(diagnostics[1].code).toBe(PLICodes.Warning.IBM3332I.fullCode);
+    expect(diagnostics[1].severity).toBe(Severity.W);
 
-        // verify the 3rd diagnostic is an error w/ the IBM1316IE as the code
-        expect(diagnostics[2].code).toBe(PLICodes.Error.IBM1316I.fullCode);
-        expect(diagnostics[2].severity).toBe(Severity.E);
-    });
+    // verify the 3rd diagnostic is an error w/ the IBM1316IE as the code
+    expect(diagnostics[2].code).toBe(PLICodes.Error.IBM1316I.fullCode);
+    expect(diagnostics[2].severity).toBe(Severity.E);
+  });
 
-    test("package end label validates", async () => {
-        const doc = parseWithValidations(`
+  test("package end label validates", async () => {
+    const doc = parseWithValidations(`
         baseline: package;
         end baseline;
         `);
-        assertNoDiagnostics(doc);
-    });
+    assertNoDiagnostics(doc);
+  });
 
-    // TODO @montymxb Mar. 28th, 2025: Pending a fix to linking + scoping
-    test.fails("validates ordinal reference", async () => {
-        const doc = parseWithValidations(`
+  // TODO @montymxb Mar. 28th, 2025: Pending a fix to linking + scoping
+  test.fails("validates ordinal reference", async () => {
+    const doc = parseWithValidations(`
         define ordinal day (
             Monday,
             Tuesday,
@@ -120,24 +119,27 @@ describe("Validating", () => {
         get_day: proc() returns(ordinal day byvalue);
         return( Friday );
         end get_day;`);
-        assertNoDiagnostics(doc);
-    });
+    assertNoDiagnostics(doc);
+  });
 
-    // TODO @montymxb Mar. 28th, 2025: Pending re-integration of the built-in library for testing
-    test.fails("Reference to alias types __SIGNED_INT & __UNSIGNED_INT", async () => {
-        const doc = parseWithValidations(`
+  // TODO @montymxb Mar. 28th, 2025: Pending re-integration of the built-in library for testing
+  test.fails(
+    "Reference to alias types __SIGNED_INT & __UNSIGNED_INT",
+    async () => {
+      const doc = parseWithValidations(`
         mypackage: package;
         DCL x type __SIGNED_INT;
         DCL y type __UNSIGNED_INT;
         end mypackage;
         `);
-        assertNoDiagnostics(doc);
-    });
+      assertNoDiagnostics(doc);
+    },
+  );
 
-    describe("Call validations", () => {
-        test("can call function declared by procedure", async () => {
-            const doc = parseWithValidations(
-                `
+  describe("Call validations", () => {
+    test("can call function declared by procedure", async () => {
+      const doc = parseWithValidations(
+        `
            MAINPR: procedure options( main );
            b: proc() returns( OPTIONAL byvalue fixed bin(31) );
              return(32);
@@ -145,93 +147,94 @@ describe("Validating", () => {
            call b();
            end MAINPR;
            `,
-            );
-            assertNoDiagnostics(doc);
-        });
+      );
+      assertNoDiagnostics(doc);
+    });
 
-        test("can call function declared by entry statement", async () => {
-            const doc = parseWithValidations(
-                `
+    test("can call function declared by entry statement", async () => {
+      const doc = parseWithValidations(
+        `
             MAINPR: procedure options( main );
             // calling 'a'
             dcl a ext('a') entry( fixed bin(31) byvalue )
               returns( optional bin(31) byvalue );
             call a(5);
             end MAINPR;
-             `
-            );
-            assertNoDiagnostics(doc);
-        });
+             `,
+      );
+      assertNoDiagnostics(doc);
+    });
 
-        test("cannot invoke function from declaration w/out entry (no args)", async () => {
-            const doc = parseWithValidations(
-                `
+    test("cannot invoke function from declaration w/out entry (no args)", async () => {
+      const doc = parseWithValidations(
+        `
             MAINPR: procedure options( main );
             dcl a fixed bin(31); // not callable
             call a;
             end MAINPR;
-             `
-            );
-            assertDiagnostic(doc, {
-                code: PLICodes.Severe.IBM1695I.fullCode,
-                severity: Severity.S
-            });
-            // expect(doc.diagnostics?.length).toBe(1);
-            // expect(document.diagnostics?.[0].code).toBe(Severe.IBM1695I.fullCode);
-        });
+             `,
+      );
+      assertDiagnostic(doc, {
+        code: PLICodes.Severe.IBM1695I.fullCode,
+        severity: Severity.S,
+      });
+      // expect(doc.diagnostics?.length).toBe(1);
+      // expect(document.diagnostics?.[0].code).toBe(Severe.IBM1695I.fullCode);
+    });
 
-        test("cannot invoke function from declaration w/out entry (w/ args)", async () => {
-            const doc = parseWithValidations(
-                `
+    test("cannot invoke function from declaration w/out entry (w/ args)", async () => {
+      const doc = parseWithValidations(
+        `
               MAINPR: procedure options( main );
               // calling 'a'
               dcl a fixed bin(31); // not callable
               call a();
               end MAINPR;
-                `
-            );
-            assertDiagnostic(doc, {
-                code: PLICodes.Severe.IBM1695I.fullCode,
-                severity: Severity.S
-            });
-            assertDiagnostic(doc, { // since we have parens
-                code: PLICodes.Error.IBM1231I.fullCode,
-                severity: Severity.E
-            });
-            const diagnostics = collectDiagnostics(doc);
-            expect(diagnostics.length).toBe(2);
-        });
+                `,
+      );
+      assertDiagnostic(doc, {
+        code: PLICodes.Severe.IBM1695I.fullCode,
+        severity: Severity.S,
+      });
+      assertDiagnostic(doc, {
+        // since we have parens
+        code: PLICodes.Error.IBM1231I.fullCode,
+        severity: Severity.E,
+      });
+      const diagnostics = collectDiagnostics(doc);
+      expect(diagnostics.length).toBe(2);
     });
+  });
 
-    //
-    //     test('check no errors', async () => {
-    //         document = await parseWithValidations(`
-    //             person Langium
-    //         `);
-    //
-    //         expect(
-    //             // here we first check for validity of the parsed document object by means of the reusable function
-    //             //  'checkDocumentValid()' to sort out (critical) typos first,
-    //             // and then evaluate the diagnostics by converting them into human readable strings;
-    //             // note that 'toHaveLength()' works for arrays and strings alike ;-)
-    //             checkDocumentValid(document) || document?.diagnostics?.map(diagnosticToString)?.join('\n')
-    //         ).toHaveLength(0);
-    //     });
-    //
-    //     test('check capital letter validation', async () => {
-    //         document = await parseWithValidations(`
-    //             person langium
-    //         `);
-    //
-    //         expect(
-    //             checkDocumentValid(document) || document?.diagnostics?.map(diagnosticToString)?.join('\n')
-    //         ).toEqual(
-    //             // 'expect.stringContaining()' makes our test robust against future additions of further validation rules
-    //             expect.stringContaining(s`
-    //                 [1:19..1:26]: Person name should start with a capital.
-    //             `)
-    //         );
-    //     });
+  //
+  //     test('check no errors', async () => {
+  //         document = await parseWithValidations(`
+  //             person Langium
+  //         `);
+  //
+  //         expect(
+  //             // here we first check for validity of the parsed document object by means of the reusable function
+  //             //  'checkDocumentValid()' to sort out (critical) typos first,
+  //             // and then evaluate the diagnostics by converting them into human readable strings;
+  //             // note that 'toHaveLength()' works for arrays and strings alike ;-)
+  //             checkDocumentValid(document) || document?.diagnostics?.map(diagnosticToString)?.join('\n')
+  //         ).toHaveLength(0);
+  //     });
+  //
+  //     test('check capital letter validation', async () => {
+  //         document = await parseWithValidations(`
+  //             person langium
+  //         `);
+  //
+  //         expect(
+  //             checkDocumentValid(document) || document?.diagnostics?.map(diagnosticToString)?.join('\n')
+  //         ).toEqual(
+  //             // 'expect.stringContaining()' makes our test robust against future additions of further validation rules
+  //             expect.stringContaining(s`
+  //                 [1:19..1:26]: Person name should start with a capital.
+  //             `)
+  //         );
+  //     });
 });
 
 // function checkDocumentValid(document: LangiumDocument): string | undefined {


### PR DESCRIPTION
Resolves #33 by expanding the grammar to accept `NamedElements` when considering callable things. The checking for declarations is setup in a new validation rule + associated validation tests.

Additionally, reinstates validations for the new parser architecture to support the PR as well.

Also took a moment to refactor a bunch of incorrectly generated compiler message fields in the pli-codes file. Many of these were supposed to be parametric, but the extraction & conversion scripts I wrote up didn't take into account some funky spacing. Those cases have been corrected to accept args accordingly for better message output.