### PR TITLE
Update READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,31 @@
 PL/I Language Support by Zowe Community
 
 See it in an interactive [playground](https://zowe.github.io/zowe-pli-language-support/)!
+
+### Contained Projects
+- [PL/I Language Support](./packages/language/README.md)
+- [PL/I VSCode Extension](./packages/vscode-extension/README.md)
+- [PL/I Playground](./packages/playground/README.md)
+
+### Getting Started
+
+To get started, make sure you have following installed:
+
+- [Node.js](https://nodejs.org/) (>=18.0.0 as specified in the package.json)
+- [pnpm](https://pnpm.io/) (version specified in `pnpm-lock.yaml`, which is 9.0 at the time of writing this)
+
+### Installing
+
+Via pnpm, you can quickly install all dependencies like so:
+```sh
+pnpm install
+```
+
+### Building
+
+Building at the top level will build all contained projects:
+```sh
+pnpm build
+```
+
+This will trigger generation, building the language & vscode-extension projects, and bundling of the extension. For more details on each of these projects, see their respective READMEs linked above.

--- a/packages/language/README.md
+++ b/packages/language/README.md
@@ -16,18 +16,18 @@ To get started, make sure you have following installed:
 pnpm install
 ```
 
-2. Build the project (will also regenerate the grammar too)
+2. Build the project (will also regenerate the grammar artifacts)
 ```sh
 pnpm build
 ```
 
 ## Development
 
-We have a pair of branches we're using for development currently:
+Two branches are of interest when developing:
 - `main`: The most recent stable state of the project, releases will be built off of this for public use.
 - `development`: The current state of the project, where new features are being developed and tested.
 
-When working on a new feature or issue, make sure to create a new branch off of `development`, and submit a PR against that when it's ready for review.
+When working on a new feature or issue, make sure to create a new branch off of `development`, and submit a PR against that.
 
 ### Running Tests
 

--- a/packages/language/README.md
+++ b/packages/language/README.md
@@ -1,1 +1,38 @@
 # PL1 Language Package
+
+This project contains the Langium-based implementation of PL/I and it's associated language server + tests. This includes features such as parsing & validation, along with standard LS features such as syntax highlighting, code completion, and cross-reference linking for PL/I code.
+
+## Getting Started
+
+To get started, make sure you have following installed:
+
+- [Node.js](https://nodejs.org/) (>=18.0.0 as specified in the package.json)
+- [pnpm](https://pnpm.io/) (version specified in `pnpm-lock.yaml`, which is 9.0 at the time of writing this)
+
+### Installation
+
+1. Install dependencies:
+```sh
+pnpm install
+```
+
+2. Build the project (will also regenerate the grammar too)
+```sh
+pnpm build
+```
+
+## Development
+
+We have a pair of branches we're using for development currently:
+- `main`: The most recent stable state of the project, releases will be built off of this for public use.
+- `development`: The current state of the project, where new features are being developed and tested.
+
+When working on a new feature or issue, make sure to create a new branch off of `development`, and submit a PR against that when it's ready for review.
+
+### Running Tests
+
+To run the tests across all packages, you can use:
+
+```sh
+pnpm test
+```

--- a/packages/playground/README.md
+++ b/packages/playground/README.md
@@ -1,0 +1,27 @@
+# PL/I Playground
+
+This project contains the source code for the PL/I playground. Which can be visited at https://zowe.github.io/zowe-pli-language-support/. The playground is a monaco-based editor that allows you to write and run PL/I code completely in your browser, without a backend.
+
+To get started, make sure you have following installed:
+
+- [Node.js](https://nodejs.org/) (>=18.0.0 as specified in the package.json)
+- [pnpm](https://pnpm.io/) (version specified in `pnpm-lock.yaml`, which is 9.0 at the time of writing this)
+
+### Installing
+
+Install dependencies:
+```sh
+pnpm install
+```
+
+### Building & Running
+
+You can build the playground by running the following command:
+```sh
+pnpm build
+```
+
+Then you can run the playground locally like so via the preview script:
+```sh
+pnpm preview
+```

--- a/packages/playground/README.md
+++ b/packages/playground/README.md
@@ -2,6 +2,8 @@
 
 This project contains the source code for the PL/I playground. Which can be visited at https://zowe.github.io/zowe-pli-language-support/. The playground is a monaco-based editor that allows you to write and run PL/I code completely in your browser, without a backend.
 
+### Getting Started
+
 To get started, make sure you have following installed:
 
 - [Node.js](https://nodejs.org/) (>=18.0.0 as specified in the package.json)
@@ -19,6 +21,9 @@ pnpm install
 You can build the playground by running the following command:
 ```sh
 pnpm build
+
+# you can also run a clean too to keep things fresh
+pnpm build:clean
 ```
 
 Then you can run the playground locally like so via the preview script:

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -11,9 +11,7 @@
     "build": "vite -c vite.config.ts build",
     "serve": "vite -c vite.config.ts serve",
     "preview": "vite -c vite.config.ts preview",
-    "build:clean": "npm run clean && npm run build",
-    "langium:generate": "langium generate",
-    "langium:watch": "langium generate --watch"
+    "build:clean": "npm run clean && npm run build"
   },
   "dependencies": {
     "@codingame/monaco-vscode-files-service-override": "~11.1.2",

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -1,1 +1,45 @@
-# PL1 Extension
+# PL/I VSCode Extension
+
+This project contains the VSCode extension for PL/I language support.
+
+## Getting Started
+
+To get started, make sure you have following installed:
+
+- [Node.js](https://nodejs.org/) (>=18.0.0 as specified in the package.json)
+- [pnpm](https://pnpm.io/) (version specified in `pnpm-lock.yaml`, which is 9.0 at the time of writing this)
+
+### Installing
+
+1. Install dependencies:
+```sh
+pnpm install
+```
+
+### Running the Extension
+
+You can run the regular VSCode extension via a launch configuration (for the web extension see the bottom of this section):
+
+1. Open the project in VS Code.
+2. From the Run and Debug view, select **Run Extension** & click the green play button.
+3. From the extension host window that pops up, navigate to the folder containing your PL/I code, and the LS should take care of the rest.
+
+The extension can also be debugged from the language server side by then launching the 'Attach to Language Server' configuration, also listed in the Run and Debug view. This can be started up after the extension host is running.
+
+To run the **Web Extension**, it's the same process, but select the **Run Web Extension** option instead.
+
+### Building the Extension
+
+You can also build a physical extension package to install locally:
+
+Build the project bundle w/ ESBuild
+```sh
+pnpm esbuild:bundle
+```
+
+Build a VSIX package
+```sh
+pnpm package
+```
+
+This will produce a **pli-vscode-x.x.x.vsix** file in the root of the project (x.x.x correlating with current extension version). This can be locally installed for testing.


### PR DESCRIPTION
This updates some of the existing READMEs w/ instructions to reflect the current state of the projects contained here. Also adds a couple of new READMEs for previously undocumented sections. Part of the focus is for other developers (or interested parties) to be able to build, run & test things going forward. Definitely open to feedback for wording & such.

Additionally drops a couple scripts from the playground package.json that appear to be non-functional.