### PR TITLE
Adds Development Previews

### DIFF
--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - development
 
 jobs:
   docs:
@@ -34,10 +35,24 @@ jobs:
           pnpm install --frozen-lockfile
           pnpm build
           pnpm playground
-      - name: Deploy 🚀
+      - name: Deploy Main 🚀
+        if: github.ref == 'refs/heads/main'
         uses: JamesIves/github-pages-deploy-action@v4.7.2
         with:
           folder: packages/playground/out
           branch: previews
-          clean-exclude: pr/ # Ensure that we don't delete the pr previews
+          clean-exclude: | # Ensure that we don't delete the pr & dev previews
+            dev/
+            pr/
           force: false # Ensure that we don't override the pr previews
+      - name: Deploy Dev 🚀
+        if: github.ref == 'refs/heads/development'
+        uses: JamesIves/github-pages-deploy-action@v4.7.2
+        with:
+          folder: packages/playground/out
+          branch: previews
+          clean-exclude: | # Ensure that we don't delete the pr & dev previews
+            dev/
+            pr/
+          force: false # Ensure that we don't override the pr previews
+          target-folder: dev

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -45,6 +45,7 @@ jobs:
             dev/
             pr/
           force: false # Ensure that we don't override the pr previews
+          target-folder: main
       - name: Deploy Dev 🚀
         if: github.ref == 'refs/heads/development'
         uses: JamesIves/github-pages-deploy-action@v4.7.2

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -51,8 +51,8 @@ jobs:
         with:
           folder: packages/playground/out
           branch: previews
-          clean-exclude: | # Ensure that we don't delete the pr & dev previews
-            dev/
+          clean-exclude: | # Ensure that we don't delete the pr & main previews
+            main/
             pr/
           force: false # Ensure that we don't override the pr previews
           target-folder: dev

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 PL/I Language Support by Zowe Community
 
-See it in an interactive [playground](https://zowe.github.io/zowe-pli-language-support/)!
+See it in an interactive [playground](https://zowe.github.io/zowe-pli-language-support/main/)!
 
 ### Contained Projects
 - [PL/I Language Support](./packages/language/README.md)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 PL/I Language Support by Zowe Community
 
-See it in an interactive [playground](https://zowe.github.io/zowe-pli-language-support/main/)!
+See it in an interactive playground:
+- [main playground](https://zowe.github.io/zowe-pli-language-support/main/)! (stable version of the project)
+- [development playground](https://zowe.github.io/zowe-pli-language-support/development/)! (active development state of the project)
 
 ### Contained Projects
 - [PL/I Language Support](./packages/language/README.md)

--- a/packages/playground/README.md
+++ b/packages/playground/README.md
@@ -1,6 +1,6 @@
 # PL/I Playground
 
-This project contains the source code for the PL/I playground. Which can be visited at https://zowe.github.io/zowe-pli-language-support/. The playground is a monaco-based editor that allows you to write and run PL/I code completely in your browser, without a backend.
+This project contains the source code for the PL/I playground. Which can be visited at https://zowe.github.io/zowe-pli-language-support/main/. The playground is a monaco-based editor that allows you to write and run PL/I code completely in your browser, without a backend.
 
 ### Getting Started
 


### PR DESCRIPTION
Modifies the existing playground workflow to also publish separately from the dev branch on push, while retaining the same behavior for main. Could also do `github.ref_name` for the branch checking as well, but opted for the full ref.