### PR TITLE
Fix `GET` statement parser ambiguity

### DIFF
--- a/packages/language/src/pli.langium
+++ b/packages/language/src/pli.langium
@@ -316,14 +316,16 @@ XFormatItem: 'X' '(' width=Expression ')';
 FreeStatement: 'FREE' references+=LocatorCall (',' references+=LocatorCall)* ';';
 
 GetStatement: 'GET' (
-    {infer GetFileStatement} ('LIST' '(' listExpr=Expression ')')? ('FILE' '(' file=Expression ')')?
-    (dataSpecification=DataSpecificationOptions)?
-    (copy?='COPY' ('(' /* TODO REFERENCE */ copyReference=FeatureID ')')?)?
-    (skip?='SKIP' ('(' skipExpression=Expression ')'))?
+    {infer GetFileStatement} specifications+=(GetFile|GetCopy|GetSkip|DataSpecificationOptions)+
     |
     {infer GetStringStatement} 'STRING' '(' expression=Expression ')' dataSpecification=DataSpecificationOptions
-    ) ';'
-;
+) ';';
+
+GetFile: 'FILE' '(' file=Expression ')';
+
+GetCopy: 'COPY' ('(' /* TODO REFERENCE */ copyReference=FeatureID ')')?;
+
+GetSkip: 'SKIP' ('(' skipExpression=Expression ')')?;
 
 GoToStatement: ('GO' 'TO' | 'GOTO') label=LabelReference ';';
 


### PR DESCRIPTION
Fixes a minor issue introduced in https://github.com/zowe/zowe-pli-language-support/pull/52. After adding the `LIST` option, we got into a parser conflict with the `LIST` option of the `DataSpecificationOptions` parser rule.

This fix resolves the issue by adhering to the additional information added to the `GET` statement in the documentation:

> **The keywords can appear in any order**. The data specification must appear unless the SKIP option is
specified.