### PR TITLE
Fix remaining grammar ambiguities

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@types/node": "^18.19.70",
     "deepmerge": "^1.5.2",
-    "langium": "~3.3.1",
+    "langium": "~3.4.0",
     "prettier": "^3.4.2",
     "shx": "~0.3.4",
     "typescript": "~5.4.5",

--- a/packages/language/package.json
+++ b/packages/language/package.json
@@ -31,11 +31,11 @@
   },
   "dependencies": {
     "chevrotain": "^11.0.3",
-    "langium": "~3.3.1",
+    "langium": "~3.4.0",
     "vscode-languageserver": "~9.0.1",
     "vscode-languageserver-types": "^3.17.5"
   },
   "devDependencies": {
-    "langium-cli": "~3.3.0"
+    "langium-cli": "~3.4.0"
   }
 }

--- a/packages/language/src/documentation/pli-documentation-provider.ts
+++ b/packages/language/src/documentation/pli-documentation-provider.ts
@@ -42,7 +42,7 @@ export class PliDocumentationProvider extends JSDocDocumentationProvider {
     node: ProcedureStatement,
   ): string | undefined {
     let text = "```\n";
-    for (const label of node.labels) {
+    for (const label of node.$container.labels) {
       text += `${label.name} `;
     }
     text += "PROCEDURE ";

--- a/packages/language/src/pli.langium
+++ b/packages/language/src/pli.langium
@@ -12,21 +12,15 @@
 grammar Pl1
 
 entry PliProgram:
-    (statements+=TopLevelStatement)*;
-
-TopLevelStatement: Package | PackageLevelStatements | Directives;
-
-Directives: SkipDirective | PopDirective | PushDirective | LineDirective | NoteDirective | PageDirective | PrintDirective | IncludeDirective | NoPrintDirective | ProcessDirective | ProcincDirective;
+    (statements+=Statement)*;
 
 // Defined on p. 90
 Package:
-    prefix=ConditionPrefix?
-    name=LabelPrefix
     'PACKAGE'
     exports=Exports? 
     reserves=Reserves? 
     options=Options? ';'
-    statements+=PackageLevelStatements*
+    statements+=Statement*
     end=EndStatement ';';
 
 ConditionPrefix: ('(' items+=ConditionPrefixItem ')' ':')+;
@@ -67,10 +61,7 @@ SimpleOptionsItem: value=(
     'INTER' | 'RECURSIVE'
     );
 
-PackageLevelStatements: DeclareStatement | DefineAliasStatement | DefineOrdinalStatement | DefineStructureStatement | DefaultStatement | ProcedureStatement;
-
 ProcedureStatement:
-    (labels+=LabelPrefix)*
     ('PROC' | 'PROCEDURE' | xProc?='XPROC' | xProc?='XPROCEDURE') 
     ('(' (parameters+=ProcedureParameter (',' parameters+=ProcedureParameter)*)? ')')?
     // These can appear in any order:
@@ -82,7 +73,7 @@ ProcedureStatement:
         (('EXTERNAL' | 'EXT') ('(' environmentName+=Expression ')')?) |
         scope+=ScopeAttribute
     )* ';'
-    statements+=ProcedureLevelStatement*
+    statements+=Statement*
     ('PROC' | 'PROCEDURE')? end=EndStatement ';';
 
 
@@ -98,8 +89,6 @@ EntryStatement:
     limited+='LIMITED' |
     returns+=ReturnsOption |
     options+=Options)* ';';
-
-ProcedureLevelStatement: Statement | ProcedureStatement;
 
 // #region Statements
 
@@ -122,7 +111,9 @@ Unit: DeclareStatement | AllocateStatement | AssertStatement | AssignmentStateme
     | ReadStatement | ReinitStatement | ReleaseStatement | ResignalStatement
     | ReturnStatement | RevertStatement | RewriteStatement
     | SelectStatement | SignalStatement | SkipDirective | StopStatement
-    | WaitStatement | WriteStatement;
+    | WaitStatement | WriteStatement
+    // Validate that these only appear at the expected locations
+    | ProcedureStatement | Package;
 
 AllocateStatement: ('ALLOCATE' | 'ALLOC') variables+=AllocatedVariable (',' variables+=AllocatedVariable)* ';';
 
@@ -169,7 +160,7 @@ CloseStatement: 'CLOSE' 'FILE' '(' (files+=MemberCall | files+='*') ')' (','? 'F
 
 DefaultStatement: ('DEFAULT' | 'DFT') expressions+=DefaultExpression (',' expressions+=DefaultExpression)* ';';
 
-DefaultExpression: expression=DefaultExpressionPart attributes+=DeclarationAttribute*;
+DefaultExpression: expression=DefaultExpressionPart attributes+=DefaultDeclarationAttribute*;
 
 DefaultExpressionPart: 'DESCRIPTORS' expression=DefaultAttributeExpression | ('RANGE' '(' identifiers=DefaultRangeIdentifiers ')' | '(' expression=DefaultAttributeExpression ')');
 
@@ -197,7 +188,7 @@ DefaultAttribute returns string:
     | 'NATIVE' | 'NONASSIGNABLE' | 'NONASGN' | 'NONCONNECTED' | 'NONNATIVE' | 'NONVARYING' | 'NORMAL'
     | 'OFFSET' | 'OPTIONAL' | 'OPTIONS' | 'OUTONLY' | 'OUTPUT'
     | 'PARAMETER' | 'POINTER' | 'PTR' | 'POSITION' | 'PRECISION' | 'PREC' | 'PRINT'
-    | 'RANGE' | 'REAL' | 'RECORD' | 'RESERVED' | 'RETURNS'
+    | 'RANGE' | 'REAL' | 'RECORD' | 'RESERVED'
     | 'SEQUENTIAL' | 'SIGNED' | 'STATIC' | 'STREAM' | 'STRUCTURE'
     | 'TASK' | 'TRANSIENT'
     | 'UNAL' | 'UCHAR' | 'UNALIGNED' | 'UNBUFFERED' | 'UNION' | 'UNSIGNED' | 'UPDATE'
@@ -406,10 +397,10 @@ PushDirective: {infer PushDirective} '%PUSH' ';';
 
 PutStatement: 'PUT' 
     (
-        {infer PutFileStatement} items+=(PutItem | DataSpecificationOptions)* 
+        {infer PutFileStatement} items+=(PutItem | DataSpecificationOptions)+
         | 
         {infer PutStringStatement} ('STRING' '(' stringExpression=Expression ')' dataSpecification=DataSpecificationOptions)
-    ) ';'
+    )? ';'
 ;
 
 PutItem: attribute=PutAttribute ('(' expression=Expression ')')?;
@@ -422,13 +413,9 @@ DataSpecificationOptions: (
     | edit?='EDIT' ('(' dataLists+=DataSpecificationDataList ')' '(' formatLists+=FormatList ')')+
 );
 
-DataSpecificationDataList: items+=DataSpecificationDataListEntry (',' items+=DataSpecificationDataListEntry)*;
-
-DataSpecificationDataListEntry: DataSpecificationDataListItem | DataSpecificationDataListItem3DO;
+DataSpecificationDataList: items+=DataSpecificationDataListItem (',' items+=DataSpecificationDataListItem)*;
 
 DataSpecificationDataListItem: value=Expression;
-
-DataSpecificationDataListItem3DO: '(' list=DataSpecificationDataList 'DO' do=DoType3<false> ')';
 
 QualifyStatement: 
     'QUALIFY' ';'
@@ -494,13 +481,12 @@ CharType returns string: 'CHAR' | 'UCHAR' | 'WCHAR';
 
 InitAcrossExpression: '(' expressions+=Expression (',' expressions+=Expression)* ')';
 
-InitialAttributeItem: InitialAttributeItemStar | InitialAttributeSpecification | InitialAttributeExpression;
+InitialAttributeItem: InitialAttributeItemStar | InitialAttributeSpecification;
 
 InitialAttributeItemStar: {infer InitialAttributeItemStar} '*';
-InitialAttributeExpression: expression=Expression;
-InitialAttributeSpecification: '(' (star?='*' | expression=Expression) ')' item=InitialAttributeSpecificationIteration;
+InitialAttributeSpecification: ('(' (star?='*') ')' | expression=Expression) item=InitialAttributeSpecificationIteration?;
 
-InitialAttributeSpecificationIteration: InitialAttributeItemStar | InitialAttributeExpression | InitialAttributeSpecificationIterationValue;
+InitialAttributeSpecificationIteration: InitialAttributeItemStar | InitialAttributeSpecificationIterationValue;
 
 InitialAttributeSpecificationIterationValue: '(' items+=InitialAttributeItem (',' items+=InitialAttributeItem)* ')';
 
@@ -513,7 +499,43 @@ type OrdinalType = DefineOrdinalStatement;
 
 DeclaredVariable: name=ID;
 
-DeclarationAttribute: InitialAttribute | DateAttribute | HandleAttribute | DefinedAttribute | PictureAttribute | EnvironmentAttribute | DimensionsDataAttribute | ValueAttribute | ValueListFromAttribute | ValueListAttribute | ValueRangeAttribute | ReturnsAttribute | ComputationDataAttribute | EntryAttribute | LikeAttribute | TypeAttribute | OrdinalTypeAttribute;
+DefaultDeclarationAttribute:
+    InitialAttribute
+    | DateAttribute
+    | HandleAttribute
+    | DefinedAttribute
+    | PictureAttribute
+    | EnvironmentAttribute
+    | DimensionsDataAttribute
+    | DefaultValueAttribute
+    | ValueListFromAttribute
+    | ValueListAttribute
+    | ValueRangeAttribute
+    | ReturnsAttribute
+    | ComputationDataAttribute
+    | EntryAttribute
+    | LikeAttribute
+    | TypeAttribute
+    | OrdinalTypeAttribute;
+
+DeclarationAttribute:
+    InitialAttribute
+    | DateAttribute
+    | HandleAttribute
+    | DefinedAttribute
+    | PictureAttribute
+    | EnvironmentAttribute
+    | DimensionsDataAttribute
+    | ValueAttribute
+    | ValueListFromAttribute
+    | ValueListAttribute
+    | ValueRangeAttribute
+    | ReturnsAttribute
+    | ComputationDataAttribute
+    | EntryAttribute
+    | LikeAttribute
+    | TypeAttribute
+    | OrdinalTypeAttribute;
 
 DateAttribute: 'DATE' ('(' pattern=STRING_TERM ')')?;
 
@@ -537,9 +559,11 @@ ReturnsAttribute: 'RETURNS' '(' (attrs+=(ComputationDataAttribute | DateAttribut
 
 ComputationDataAttribute: type=DataAttributeType dimensions=Dimensions?;
 
-ValueAttribute: 'VALUE' '(' (items+=ValueAttributeItem (',' items+=ValueAttributeItem)* | value=Expression) ')';
+DefaultValueAttribute: 'VALUE' '(' (items+=DefaultValueAttributeItem (',' items+=DefaultValueAttributeItem)*) ')';
 
-ValueAttributeItem: attributes+=DeclarationAttribute+;
+ValueAttribute: 'VALUE' '(' (value=Expression) ')';
+
+DefaultValueAttributeItem: attributes+=DeclarationAttribute+;
 
 ValueListAttribute: 'VALUELIST' '(' (values+=Expression (',' values+=Expression)*)? ')';
 
@@ -628,9 +652,14 @@ ExpExpression infers Expression: PrimaryExpression ({infer ExpExpression.left=cu
 
 PrimaryExpression infers Expression: 
     Literal
-    | '(' Expression ')'
+    | ParenthesizedExpression
     | UnaryExpression
     | LocatorCall;
+
+// Performs special handling as a recursive descent parser otherwise cannot handle the 
+// special data-list type-3-DO loop
+// See also language reference pp. 301
+ParenthesizedExpression infers Expression: {infer Parenthesis} '(' value=Expression ('DO' do=DoType3<false>)? ')' ({infer Literal.multiplier=current} value=LiteralValue)?;
 
 MemberCall:
     element=ReferenceItem
@@ -650,9 +679,8 @@ LabelReference: label=[LabelPrefix:ID];
 
 UnaryExpression: op=('+' | '-' | '¬' | '^') expr=Expression;
 
-ConstantExpression: Literal;
-
-Literal: ('(' multiplier=NUMBER ')')? value=(StringLiteral | NumberLiteral);
+Literal: value=LiteralValue;
+LiteralValue: StringLiteral | NumberLiteral;
 
 StringLiteral: value=STRING_TERM;
 NumberLiteral: value=NUMBER;

--- a/packages/language/src/references/pli-name-provider.ts
+++ b/packages/language/src/references/pli-name-provider.ts
@@ -15,7 +15,7 @@ import { isProcedureStatement } from "../generated/ast";
 export class PliNameProvider extends DefaultNameProvider {
   override getName(node: AstNode): string | undefined {
     if (isProcedureStatement(node)) {
-      const label = node.labels[0];
+      const label = node.$container.labels[0];
       return label?.name || undefined;
     } else {
       return super.getName(node);
@@ -23,7 +23,7 @@ export class PliNameProvider extends DefaultNameProvider {
   }
   override getNameNode(node: AstNode): CstNode | undefined {
     if (isProcedureStatement(node)) {
-      const label = node.labels[0];
+      const label = node.$container.labels[0];
       if (label) {
         return this.getNameNode(label);
       } else {

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -21,7 +21,7 @@
     "@codingame/monaco-vscode-theme-defaults-default-extension": "~11.1.2",
     "@codingame/monaco-vscode-theme-service-override": "~11.1.2",
     "@codingame/monaco-vscode-views-service-override": "~11.1.2",
-    "langium": "3.3.1",
+    "langium": "~3.4.0",
     "lz-string": "~1.5.0",
     "pli-language": "workspace:*",
     "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@~11.1.2",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -54,7 +54,7 @@
     "dependencies": false
   },
   "dependencies": {
-    "langium": "~3.3.1",
+    "langium": "~3.4.0",
     "pli-language": "workspace:*",
     "vscode-languageclient": "~9.0.1",
     "vscode-languageserver": "~9.0.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^1.5.2
         version: 1.5.2
       langium:
-        specifier: ~3.3.1
-        version: 3.3.1
+        specifier: ~3.4.0
+        version: 3.4.0
       prettier:
         specifier: ^3.4.2
         version: 3.4.2
@@ -39,8 +39,8 @@ importers:
         specifier: ^11.0.3
         version: 11.0.3
       langium:
-        specifier: ~3.3.1
-        version: 3.3.1
+        specifier: ~3.4.0
+        version: 3.4.0
       vscode-languageserver:
         specifier: ~9.0.1
         version: 9.0.1
@@ -49,8 +49,8 @@ importers:
         version: 3.17.5
     devDependencies:
       langium-cli:
-        specifier: ~3.3.0
-        version: 3.3.0
+        specifier: ~3.4.0
+        version: 3.4.0
 
   packages/playground:
     dependencies:
@@ -76,8 +76,8 @@ importers:
         specifier: ~11.1.2
         version: 11.1.2
       langium:
-        specifier: 3.3.1
-        version: 3.3.1
+        specifier: ~3.4.0
+        version: 3.4.0
       lz-string:
         specifier: ~1.5.0
         version: 1.5.0
@@ -86,10 +86,10 @@ importers:
         version: '@codingame/monaco-vscode-editor-api@11.1.2'
       monaco-editor-wrapper:
         specifier: ~6.1.0
-        version: 6.1.1(monaco-languageclient@9.1.1(@codingame/monaco-vscode-api@11.1.2)(@codingame/monaco-vscode-base-service-override@11.1.2)(@codingame/monaco-vscode-chat-extensions-notebook-common@11.1.2)(@codingame/monaco-vscode-chat-extensions-notebook-task-terminal-testing-common@11.1.2)(@codingame/monaco-vscode-comments-extensions-common@11.1.2)(@codingame/monaco-vscode-configuration-service-override@11.1.2)(@codingame/monaco-vscode-editor-api@11.1.2)(@codingame/monaco-vscode-editor-service-override@11.1.2)(@codingame/monaco-vscode-environment-service-override@11.1.2)(@codingame/monaco-vscode-extensions-service-override@11.1.2)(@codingame/monaco-vscode-files-service-override@11.1.2)(@codingame/monaco-vscode-host-service-override@11.1.2)(@codingame/monaco-vscode-keybindings-service-override@11.1.2)(@codingame/monaco-vscode-language-pack-cs@11.1.2)(@codingame/monaco-vscode-language-pack-de@11.1.2)(@codingame/monaco-vscode-language-pack-es@11.1.2)(@codingame/monaco-vscode-language-pack-fr@11.1.2)(@codingame/monaco-vscode-language-pack-it@11.1.2)(@codingame/monaco-vscode-language-pack-ja@11.1.2)(@codingame/monaco-vscode-language-pack-ko@11.1.2)(@codingame/monaco-vscode-language-pack-pl@11.1.2)(@codingame/monaco-vscode-language-pack-pt-br@11.1.2)(@codingame/monaco-vscode-language-pack-qps-ploc@11.1.2)(@codingame/monaco-vscode-language-pack-ru@11.1.2)(@codingame/monaco-vscode-language-pack-tr@11.1.2)(@codingame/monaco-vscode-language-pack-zh-hans@11.1.2)(@codingame/monaco-vscode-language-pack-zh-hant@11.1.2)(@codingame/monaco-vscode-languages-service-override@11.1.2)(@codingame/monaco-vscode-layout-service-override@11.1.2)(@codingame/monaco-vscode-localization-service-override@11.1.2)(@codingame/monaco-vscode-log-service-override@11.1.2)(@codingame/monaco-vscode-markers-service-override@11.1.2)(@codingame/monaco-vscode-model-service-override@11.1.2)(@codingame/monaco-vscode-monarch-service-override@11.1.2)(@codingame/monaco-vscode-quickaccess-service-override@11.1.2)(@codingame/monaco-vscode-textmate-service-override@11.1.2)(@codingame/monaco-vscode-theme-defaults-default-extension@11.1.2)(@codingame/monaco-vscode-theme-service-override@11.1.2)(@codingame/monaco-vscode-views-service-override@11.1.2)(@codingame/monaco-vscode-workbench-service-override@11.1.2))(vscode-ws-jsonrpc@3.4.0)
+        version: 6.1.1(monaco-languageclient@9.1.1(pr23a6xbqk4pjfo5zls3ianfqe))(vscode-ws-jsonrpc@3.4.0)
       monaco-languageclient:
         specifier: ~9.1.0
-        version: 9.1.1(@codingame/monaco-vscode-api@11.1.2)(@codingame/monaco-vscode-base-service-override@11.1.2)(@codingame/monaco-vscode-chat-extensions-notebook-common@11.1.2)(@codingame/monaco-vscode-chat-extensions-notebook-task-terminal-testing-common@11.1.2)(@codingame/monaco-vscode-comments-extensions-common@11.1.2)(@codingame/monaco-vscode-configuration-service-override@11.1.2)(@codingame/monaco-vscode-editor-api@11.1.2)(@codingame/monaco-vscode-editor-service-override@11.1.2)(@codingame/monaco-vscode-environment-service-override@11.1.2)(@codingame/monaco-vscode-extensions-service-override@11.1.2)(@codingame/monaco-vscode-files-service-override@11.1.2)(@codingame/monaco-vscode-host-service-override@11.1.2)(@codingame/monaco-vscode-keybindings-service-override@11.1.2)(@codingame/monaco-vscode-language-pack-cs@11.1.2)(@codingame/monaco-vscode-language-pack-de@11.1.2)(@codingame/monaco-vscode-language-pack-es@11.1.2)(@codingame/monaco-vscode-language-pack-fr@11.1.2)(@codingame/monaco-vscode-language-pack-it@11.1.2)(@codingame/monaco-vscode-language-pack-ja@11.1.2)(@codingame/monaco-vscode-language-pack-ko@11.1.2)(@codingame/monaco-vscode-language-pack-pl@11.1.2)(@codingame/monaco-vscode-language-pack-pt-br@11.1.2)(@codingame/monaco-vscode-language-pack-qps-ploc@11.1.2)(@codingame/monaco-vscode-language-pack-ru@11.1.2)(@codingame/monaco-vscode-language-pack-tr@11.1.2)(@codingame/monaco-vscode-language-pack-zh-hans@11.1.2)(@codingame/monaco-vscode-language-pack-zh-hant@11.1.2)(@codingame/monaco-vscode-languages-service-override@11.1.2)(@codingame/monaco-vscode-layout-service-override@11.1.2)(@codingame/monaco-vscode-localization-service-override@11.1.2)(@codingame/monaco-vscode-log-service-override@11.1.2)(@codingame/monaco-vscode-markers-service-override@11.1.2)(@codingame/monaco-vscode-model-service-override@11.1.2)(@codingame/monaco-vscode-monarch-service-override@11.1.2)(@codingame/monaco-vscode-quickaccess-service-override@11.1.2)(@codingame/monaco-vscode-textmate-service-override@11.1.2)(@codingame/monaco-vscode-theme-defaults-default-extension@11.1.2)(@codingame/monaco-vscode-theme-service-override@11.1.2)(@codingame/monaco-vscode-views-service-override@11.1.2)(@codingame/monaco-vscode-workbench-service-override@11.1.2)
+        version: 9.1.1(pr23a6xbqk4pjfo5zls3ianfqe)
       pli-language:
         specifier: workspace:*
         version: link:../language
@@ -122,8 +122,8 @@ importers:
   packages/vscode-extension:
     dependencies:
       langium:
-        specifier: ~3.3.1
-        version: 3.3.1
+        specifier: ~3.4.0
+        version: 3.4.0
       pli-language:
         specifier: workspace:*
         version: link:../language
@@ -1362,17 +1362,17 @@ packages:
   keytar@7.9.0:
     resolution: {integrity: sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==}
 
-  langium-cli@3.3.0:
-    resolution: {integrity: sha512-QWvlOYdLbso8/lv6Ma+SBtvMN9k70JrplLx6VSIcV7gJNDTXeS+tjwC/f6T0aco1fg8uLL8GiAcaMovd1FnneA==}
-    engines: {node: '>=16.0.0'}
+  langium-cli@3.4.0:
+    resolution: {integrity: sha512-7dU5kPlfzwzPLkaaMcBCc0tfnVPHOcxcgMW/l2xRDy9Y/cljTCXSV8y3lJUlHASQa3LZDF0+8bGZX3Noxa+GLw==}
+    engines: {node: '>=18.0.0'}
     hasBin: true
 
-  langium-railroad@3.3.0:
-    resolution: {integrity: sha512-x56CU0KnLoqYLkHEPDJjFoekFoCVbbZbmHduldiXjKD8owt6t5aqgWfg31OeMeR+7XgONZTtmsO76yl6GvEkzQ==}
+  langium-railroad@3.4.0:
+    resolution: {integrity: sha512-dTSTm4+UI2byf+kMnjXBJgcif6XjpvFrFv4HhRONV6ZzQIVWweAycg40q7Wm8D/iagtZa/eFa1l5yCxQf896eA==}
 
-  langium@3.3.1:
-    resolution: {integrity: sha512-QJv/h939gDpvT+9SiLVlY7tZC3xB2qK57v0J04Sh9wpMb6MP1q8gB21L3WIo8T5P1MSMg3Ep14L7KkDCFG3y4w==}
-    engines: {node: '>=16.0.0'}
+  langium@3.4.0:
+    resolution: {integrity: sha512-7xufsaF5jYGFMXHOTka8bN48b9FHn2vZGL2R+PGgyi+JY/xgimUFDKYcz/h4gm5m8p3sSRtZDh+sK2U63K0MNg==}
+    engines: {node: '>=18.0.0'}
 
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
@@ -3699,22 +3699,22 @@ snapshots:
       prebuild-install: 7.1.2
     optional: true
 
-  langium-cli@3.3.0:
+  langium-cli@3.4.0:
     dependencies:
       chalk: 5.3.0
       commander: 11.0.0
       fs-extra: 11.1.1
       jsonschema: 1.4.1
-      langium: 3.3.1
-      langium-railroad: 3.3.0
+      langium: 3.4.0
+      langium-railroad: 3.4.0
       lodash: 4.17.21
 
-  langium-railroad@3.3.0:
+  langium-railroad@3.4.0:
     dependencies:
-      langium: 3.3.1
+      langium: 3.4.0
       railroad-diagrams: 1.0.0
 
-  langium@3.3.1:
+  langium@3.4.0:
     dependencies:
       chevrotain: 11.0.3
       chevrotain-allstar: 0.3.1(chevrotain@11.0.3)
@@ -3819,8 +3819,8 @@ snapshots:
   mkdirp-classic@0.5.3:
     optional: true
 
-  ? monaco-editor-wrapper@6.1.1(monaco-languageclient@9.1.1(@codingame/monaco-vscode-api@11.1.2)(@codingame/monaco-vscode-base-service-override@11.1.2)(@codingame/monaco-vscode-chat-extensions-notebook-common@11.1.2)(@codingame/monaco-vscode-chat-extensions-notebook-task-terminal-testing-common@11.1.2)(@codingame/monaco-vscode-comments-extensions-common@11.1.2)(@codingame/monaco-vscode-configuration-service-override@11.1.2)(@codingame/monaco-vscode-editor-api@11.1.2)(@codingame/monaco-vscode-editor-service-override@11.1.2)(@codingame/monaco-vscode-environment-service-override@11.1.2)(@codingame/monaco-vscode-extensions-service-override@11.1.2)(@codingame/monaco-vscode-files-service-override@11.1.2)(@codingame/monaco-vscode-host-service-override@11.1.2)(@codingame/monaco-vscode-keybindings-service-override@11.1.2)(@codingame/monaco-vscode-language-pack-cs@11.1.2)(@codingame/monaco-vscode-language-pack-de@11.1.2)(@codingame/monaco-vscode-language-pack-es@11.1.2)(@codingame/monaco-vscode-language-pack-fr@11.1.2)(@codingame/monaco-vscode-language-pack-it@11.1.2)(@codingame/monaco-vscode-language-pack-ja@11.1.2)(@codingame/monaco-vscode-language-pack-ko@11.1.2)(@codingame/monaco-vscode-language-pack-pl@11.1.2)(@codingame/monaco-vscode-language-pack-pt-br@11.1.2)(@codingame/monaco-vscode-language-pack-qps-ploc@11.1.2)(@codingame/monaco-vscode-language-pack-ru@11.1.2)(@codingame/monaco-vscode-language-pack-tr@11.1.2)(@codingame/monaco-vscode-language-pack-zh-hans@11.1.2)(@codingame/monaco-vscode-language-pack-zh-hant@11.1.2)(@codingame/monaco-vscode-languages-service-override@11.1.2)(@codingame/monaco-vscode-layout-service-override@11.1.2)(@codingame/monaco-vscode-localization-service-override@11.1.2)(@codingame/monaco-vscode-log-service-override@11.1.2)(@codingame/monaco-vscode-markers-service-override@11.1.2)(@codingame/monaco-vscode-model-service-override@11.1.2)(@codingame/monaco-vscode-monarch-service-override@11.1.2)(@codingame/monaco-vscode-quickaccess-service-override@11.1.2)(@codingame/monaco-vscode-textmate-service-override@11.1.2)(@codingame/monaco-vscode-theme-defaults-default-extension@11.1.2)(@codingame/monaco-vscode-theme-service-override@11.1.2)(@codingame/monaco-vscode-views-service-override@11.1.2)(@codingame/monaco-vscode-workbench-service-override@11.1.2))(vscode-ws-jsonrpc@3.4.0)
-  : dependencies:
+  monaco-editor-wrapper@6.1.1(monaco-languageclient@9.1.1(pr23a6xbqk4pjfo5zls3ianfqe))(vscode-ws-jsonrpc@3.4.0):
+    dependencies:
       '@codingame/monaco-vscode-chat-extensions-notebook-task-terminal-testing-common': 11.1.2
       '@codingame/monaco-vscode-configuration-service-override': 11.1.2
       '@codingame/monaco-vscode-editor-service-override': 11.1.2
@@ -3845,14 +3845,14 @@ snapshots:
       '@codingame/monaco-vscode-views-service-override': 11.1.2
       '@codingame/monaco-vscode-workbench-service-override': 11.1.2
       monaco-editor: '@codingame/monaco-vscode-editor-api@11.1.2'
-      monaco-languageclient: 9.1.1(@codingame/monaco-vscode-api@11.1.2)(@codingame/monaco-vscode-base-service-override@11.1.2)(@codingame/monaco-vscode-chat-extensions-notebook-common@11.1.2)(@codingame/monaco-vscode-chat-extensions-notebook-task-terminal-testing-common@11.1.2)(@codingame/monaco-vscode-comments-extensions-common@11.1.2)(@codingame/monaco-vscode-configuration-service-override@11.1.2)(@codingame/monaco-vscode-editor-api@11.1.2)(@codingame/monaco-vscode-editor-service-override@11.1.2)(@codingame/monaco-vscode-environment-service-override@11.1.2)(@codingame/monaco-vscode-extensions-service-override@11.1.2)(@codingame/monaco-vscode-files-service-override@11.1.2)(@codingame/monaco-vscode-host-service-override@11.1.2)(@codingame/monaco-vscode-keybindings-service-override@11.1.2)(@codingame/monaco-vscode-language-pack-cs@11.1.2)(@codingame/monaco-vscode-language-pack-de@11.1.2)(@codingame/monaco-vscode-language-pack-es@11.1.2)(@codingame/monaco-vscode-language-pack-fr@11.1.2)(@codingame/monaco-vscode-language-pack-it@11.1.2)(@codingame/monaco-vscode-language-pack-ja@11.1.2)(@codingame/monaco-vscode-language-pack-ko@11.1.2)(@codingame/monaco-vscode-language-pack-pl@11.1.2)(@codingame/monaco-vscode-language-pack-pt-br@11.1.2)(@codingame/monaco-vscode-language-pack-qps-ploc@11.1.2)(@codingame/monaco-vscode-language-pack-ru@11.1.2)(@codingame/monaco-vscode-language-pack-tr@11.1.2)(@codingame/monaco-vscode-language-pack-zh-hans@11.1.2)(@codingame/monaco-vscode-language-pack-zh-hant@11.1.2)(@codingame/monaco-vscode-languages-service-override@11.1.2)(@codingame/monaco-vscode-layout-service-override@11.1.2)(@codingame/monaco-vscode-localization-service-override@11.1.2)(@codingame/monaco-vscode-log-service-override@11.1.2)(@codingame/monaco-vscode-markers-service-override@11.1.2)(@codingame/monaco-vscode-model-service-override@11.1.2)(@codingame/monaco-vscode-monarch-service-override@11.1.2)(@codingame/monaco-vscode-quickaccess-service-override@11.1.2)(@codingame/monaco-vscode-textmate-service-override@11.1.2)(@codingame/monaco-vscode-theme-defaults-default-extension@11.1.2)(@codingame/monaco-vscode-theme-service-override@11.1.2)(@codingame/monaco-vscode-views-service-override@11.1.2)(@codingame/monaco-vscode-workbench-service-override@11.1.2)
+      monaco-languageclient: 9.1.1(pr23a6xbqk4pjfo5zls3ianfqe)
       vscode: '@codingame/monaco-vscode-api@11.1.2'
       vscode-languageclient: 9.0.1
       vscode-languageserver-protocol: 3.17.5
       vscode-ws-jsonrpc: 3.4.0
 
-  ? monaco-languageclient@9.1.1(@codingame/monaco-vscode-api@11.1.2)(@codingame/monaco-vscode-base-service-override@11.1.2)(@codingame/monaco-vscode-chat-extensions-notebook-common@11.1.2)(@codingame/monaco-vscode-chat-extensions-notebook-task-terminal-testing-common@11.1.2)(@codingame/monaco-vscode-comments-extensions-common@11.1.2)(@codingame/monaco-vscode-configuration-service-override@11.1.2)(@codingame/monaco-vscode-editor-api@11.1.2)(@codingame/monaco-vscode-editor-service-override@11.1.2)(@codingame/monaco-vscode-environment-service-override@11.1.2)(@codingame/monaco-vscode-extensions-service-override@11.1.2)(@codingame/monaco-vscode-files-service-override@11.1.2)(@codingame/monaco-vscode-host-service-override@11.1.2)(@codingame/monaco-vscode-keybindings-service-override@11.1.2)(@codingame/monaco-vscode-language-pack-cs@11.1.2)(@codingame/monaco-vscode-language-pack-de@11.1.2)(@codingame/monaco-vscode-language-pack-es@11.1.2)(@codingame/monaco-vscode-language-pack-fr@11.1.2)(@codingame/monaco-vscode-language-pack-it@11.1.2)(@codingame/monaco-vscode-language-pack-ja@11.1.2)(@codingame/monaco-vscode-language-pack-ko@11.1.2)(@codingame/monaco-vscode-language-pack-pl@11.1.2)(@codingame/monaco-vscode-language-pack-pt-br@11.1.2)(@codingame/monaco-vscode-language-pack-qps-ploc@11.1.2)(@codingame/monaco-vscode-language-pack-ru@11.1.2)(@codingame/monaco-vscode-language-pack-tr@11.1.2)(@codingame/monaco-vscode-language-pack-zh-hans@11.1.2)(@codingame/monaco-vscode-language-pack-zh-hant@11.1.2)(@codingame/monaco-vscode-languages-service-override@11.1.2)(@codingame/monaco-vscode-layout-service-override@11.1.2)(@codingame/monaco-vscode-localization-service-override@11.1.2)(@codingame/monaco-vscode-log-service-override@11.1.2)(@codingame/monaco-vscode-markers-service-override@11.1.2)(@codingame/monaco-vscode-model-service-override@11.1.2)(@codingame/monaco-vscode-monarch-service-override@11.1.2)(@codingame/monaco-vscode-quickaccess-service-override@11.1.2)(@codingame/monaco-vscode-textmate-service-override@11.1.2)(@codingame/monaco-vscode-theme-defaults-default-extension@11.1.2)(@codingame/monaco-vscode-theme-service-override@11.1.2)(@codingame/monaco-vscode-views-service-override@11.1.2)(@codingame/monaco-vscode-workbench-service-override@11.1.2)
-  : dependencies:
+  monaco-languageclient@9.1.1(pr23a6xbqk4pjfo5zls3ianfqe):
+    dependencies:
       '@codingame/monaco-vscode-api': 11.1.2
       '@codingame/monaco-vscode-configuration-service-override': 11.1.2
       '@codingame/monaco-vscode-editor-api': 11.1.2


### PR DESCRIPTION
Our current grammar contains some ambiguities which prevents us from using a static (i.e. known $k$) lookahead. This PR fixes these issues in the least intrusive way possible. That way, I brought all decisions down to `k=2`. This behavior can be confirmed by running `pnpm test` and ensuring that no `AMBIGUOUS ALTERNATIVE` warning is printed to the console.

Note that I was nevertheless unable to enter the `maxLookahead` property in the Langium config due to our `ID` hack that we're using to parse keywords as IDs of procedures and variables. 
