### PR TITLE
Reintroduce linking tests

### DIFF
--- a/packages/language/test/linking.test.ts
+++ b/packages/language/test/linking.test.ts
@@ -9,258 +9,229 @@
  *
  */
 
-import { test } from "vitest";
+import { describe, test } from "vitest";
+import { expectGotoDefinition as expectGotoDefinitionRoot } from "./utils";
 
-test("TODO", () => {});
+/**
+ * Helper function to parse a string of PL/I statements,
+ * wrapping them in a procedure to ensure they are valid
+ */
+function expectGotoDefinition(
+  params: Parameters<typeof expectGotoDefinitionRoot>[0],
+) {
+  const text = ` STARTPR: PROCEDURE OPTIONS (MAIN);
+${params.text}
+ END STARTPR;`;
 
-// import { beforeAll, describe, test } from "vitest";
-// import { EmptyFileSystem } from "langium";
-// import { ExpectedGoToDefinition, expectGoToDefinition } from "langium/test";
-// import { createPliServices } from "../src";
+  return expectGotoDefinitionRoot({
+    ...params,
+    text,
+  });
+}
 
-// let services: ReturnType<typeof createPliServices>;
-// let gotoDefinition: ReturnType<typeof expectGoToDefinition>;
+describe("Linking tests", async () => {
+  describe("Structured tests", async () => {
+    describe("NamedType", async () => {
+      // Didrik: I'm unsure what the expected behavior on the mainframe is here.
+      test("Must find the type declaration", async () => {
+        const text = `
+ DEFINE ALIAS AAA;
+ DCL <|AAA|> CHAR(1);
+ DCL BBB TYPE(<|>AAA);`;
 
-// beforeAll(async () => {
-//   services = createPliServices(EmptyFileSystem);
-//   const _gotoDefinition = expectGoToDefinition(services.pli);
+        await expectGotoDefinition({
+          text,
+          index: 0,
+          rangeIndex: 0,
+        });
+      });
+    });
+  });
 
-//   /**
-//    * Helper function to parse a string of PL/I statements,
-//    * wrapping them in a procedure to ensure they are valid
-//    */
-//   gotoDefinition = (expectedGoToDefinition: ExpectedGoToDefinition) => {
-//     const text = ` STARTPR: PROCEDURE OPTIONS (MAIN);
-// ${expectedGoToDefinition.text}
-//  end STARTPR;`;
+  describe("Unstructured tests", async () => {
+    // IMPORTANT: These tests are currently skipped. Unskip when scoping is resolved.
+    // https://github.com/zowe/zowe-pli-language-support/issues/29#issuecomment-2623842079
+    describe("Nested procedure label tests", async () => {
+      const text = `
+ <|OUTER|>: procedure options (main); // outer0
+    <|INNER|>: procedure;             // inner0
+        call <|>OUTER;                // callOuter0
+        call <|>INNER;                // callInner0
 
-//     return _gotoDefinition({
-//       ...expectedGoToDefinition,
-//       text,
-//     });
-//   };
+        <|OUTER|>: procedure;         // outer1
+            call <|>OUTER;            // callOuter1
+            call <|>INNER;            // callInner1
 
-//   // activate the following if your linking test requires elements from a built-in library, for example
-//   await services.shared.workspace.WorkspaceManager.initializeWorkspace([]);
-// });
+            <|INNER|>: procedure;     // inner1
+                call <|>OUTER;        // callOuter2
+                call <|>INNER;        // callInner2
+            END INNER;
 
-// describe("Linking tests", () => {
-//   describe("Structured tests", async () => {
-//     describe("NamedType", async () => {
-//       test("Must find the type declaration", async () => {
-//         const text = `
-//  DEFINE ALIAS <|AAA|>;
-//  DCL AAA CHAR(1);
-//  DCL BBB TYPE(<|>AAA);`;
+            call <|>OUTER;            // callOuter3
+            call <|>INNER;            // callInner3
+        END OUTER;
 
-//         await gotoDefinition({
-//           text: text,
-//           index: 0,
-//           rangeIndex: 0,
-//         });
-//       });
+        call <|>OUTER;                // callOuter4
+        call <|>INNER;                // callInner4
+    END INNER;
 
-//       // Didrik: I'm unsure what the expected behavior on the mainframe is here.
-//       test("Must find the first type declaration", async () => {
-//         const text = `
-//  DEFINE ALIAS <|AAA|>;
-//  DEFINE ALIAS <|AAA|>;
-//  DCL AAA CHAR(1);
-//  DCL BBB TYPE(<|>AAA); // Should refer to the first type declaration`;
+    call <|>OUTER;                    // callOuter5
+    call <|>INNER;                    // callInner5
+ end OUTER;
 
-//         await gotoDefinition({
-//           text: text,
-//           index: 0,
-//           rangeIndex: 0,
-//         });
-//       });
-//     });
-//   });
+ call <|>OUTER;                       // callOuter6
+        `;
+      const procedures = {
+        outer0: 0,
+        inner0: 1,
+        outer1: 2,
+        inner1: 3,
+      };
 
-//   describe("Unstructured tests", async () => {
-//     // IMPORTANT: These tests are currently skipped. Unskip when scoping is resolved.
-//     // https://github.com/zowe/zowe-pli-language-support/issues/29#issuecomment-2623842079
-//     describe("Nested procedure label tests", async () => {
-//       const text = `
-//  <|OUTER|>: procedure options (main); // outer0
-//     <|INNER|>: procedure;             // inner0
-//         call <|>OUTER;                // callOuter0
-//         call <|>INNER;                // callInner0
+      const calls = {
+        callOuter0: 0,
+        callInner0: 1,
+        callOuter1: 2,
+        callInner1: 3,
+        callOuter2: 4,
+        callInner2: 5,
+        callOuter3: 6,
+        callInner3: 7,
+        callOuter4: 8,
+        callInner4: 9,
+        callOuter5: 10,
+        callInner5: 11,
+        callOuter6: 12,
+      };
 
-//         <|OUTER|>: procedure;         // outer1
-//             call <|>OUTER;            // callOuter1
-//             call <|>INNER;            // callInner1
+      const links: Record<number, number[]> = {
+        [procedures.outer0]: [
+          calls.callOuter0,
+          calls.callOuter5,
+          calls.callOuter6,
+        ],
+        [procedures.inner0]: [
+          calls.callInner0,
+          calls.callInner1,
+          calls.callInner4,
+          calls.callInner5,
+        ],
+        [procedures.outer1]: [
+          calls.callOuter1,
+          calls.callOuter2,
+          calls.callOuter3,
+          calls.callOuter4,
+        ],
+        [procedures.inner1]: [calls.callInner2, calls.callInner3],
+      };
 
-//             <|INNER|>: procedure;     // inner1
-//                 call <|>OUTER;        // callOuter2
-//                 call <|>INNER;        // callInner2
-//             END INNER;
+      for (const [procedure, calls] of Object.entries(links)) {
+        for (const call of calls) {
+          test.skip("Must find link correct procedure label", async () => {
+            await expectGotoDefinition({
+              text,
+              index: call,
+              rangeIndex: +procedure,
+            });
+          });
+        }
+      }
+    });
 
-//             call <|>OUTER;            // callOuter3
-//             call <|>INNER;            // callInner3
-//         END OUTER;
+    describe("Declaration tests", async () => {
+      test("Must find declaration in SELECT/WHEN construct", async () => {
+        // Taken from code_samples/PLI0001.pli
+        const text = `
+ SELECT (123);
+    WHEN (123)
+    DO;
+        DCL <|BFSTRING|> CHAR(255);
+        PUT SKIP LIST(<|>BFSTRING);
+    END;
+ END;`;
 
-//         call <|>OUTER;                // callOuter4
-//         call <|>INNER;                // callInner4
-//     END INNER;
+        await expectGotoDefinition({
+          text,
+          index: 0,
+          rangeIndex: 0,
+        });
+      });
+    });
 
-//     call <|>OUTER;                    // callOuter5
-//     call <|>INNER;                    // callInner5
-//  end OUTER;
+    describe("Declarations and labels combined", async () => {
+      const text = `
+ Control: procedure options(main);
+  call <|>A('ok!'); // invoke the 'A' subroutine
+ end Control;
+ <|A|>: procedure (VAR1);
+ declare <|VAR1|> char(3);
+ put skip list(V<|>AR1);
+ end <|>A;`;
 
-//  call <|>OUTER;                       // callOuter6
-//         `;
-//       const procedures = {
-//         outer0: 0,
-//         inner0: 1,
-//         outer1: 2,
-//         inner1: 3,
-//       };
+      test("Must find declared procedure label in CALL", async () => {
+        await expectGotoDefinition({
+          text,
+          index: 0,
+          rangeIndex: 0,
+        });
+      });
 
-//       const calls = {
-//         callOuter0: 0,
-//         callInner0: 1,
-//         callOuter1: 2,
-//         callInner1: 3,
-//         callOuter2: 4,
-//         callInner2: 5,
-//         callOuter3: 6,
-//         callInner3: 7,
-//         callOuter4: 8,
-//         callInner4: 9,
-//         callOuter5: 10,
-//         callInner5: 11,
-//         callOuter6: 12,
-//       };
+      test("Must find declared procedure label in END", async () => {
+        await expectGotoDefinition({
+          text,
+          index: 2,
+          rangeIndex: 0,
+        });
+      });
 
-//       const links = {
-//         [procedures.outer0]: [
-//           calls.callOuter0,
-//           calls.callOuter5,
-//           calls.callOuter6,
-//         ],
-//         [procedures.inner0]: [
-//           calls.callInner0,
-//           calls.callInner1,
-//           calls.callInner4,
-//           calls.callInner5,
-//         ],
-//         [procedures.outer1]: [
-//           calls.callOuter1,
-//           calls.callOuter2,
-//           calls.callOuter3,
-//           calls.callOuter4,
-//         ],
-//         [procedures.inner1]: [calls.callInner2, calls.callInner3],
-//       };
+      test("Must find declared variable", async () => {
+        await expectGotoDefinition({
+          text,
+          index: 1,
+          rangeIndex: 1,
+        });
+      });
+    });
 
-//       for (const [procedure, calls] of Object.entries(links)) {
-//         for (const call of calls) {
-//           test.skip("Must find link correct procedure label", async () => {
-//             await gotoDefinition({
-//               text: text,
-//               index: call,
-//               rangeIndex: +procedure,
-//             });
-//           });
-//         }
-//       }
-//     });
+    describe("Qualified names", async () => {
+      const text = `
+0DCL 1  <|TWO_DIM_TABLE|>,
+        2  <|TWO_DIM_TABLE_ENTRY|>          CHAR(32);
+0DCL 1  TABLE_WITH_ARRAY,
+        2  ARRAY_ENTRY(0:1000),
+           3  NAME                          CHAR(32) VARYING,
+           3  TYPE#                         CHAR(8),
+        2  NON_ARRAY_ENTRY,
+           3  NAME                          CHAR(32) VARYING,
+           3  <|TYPE#|>                     CHAR(8);
 
-//     describe("Declaration tests", async () => {
-//       test("Must find declaration in SELECT/WHEN construct", async () => {
-//         // Taken from code_samples/PLI0001.pli
-//         const text = `
-//  SELECT (123);
-//     WHEN (123)
-//     DO;
-//         DCL <|BFSTRING|> CHAR(255);
-//         PUT SKIP LIST(<|>BFSTRING);
-//     END;
-//  END;`;
+ PUT (<|>TWO_DIM_TABLE);
+ PUT (TWO_DIM_TABLE.<|>TWO_DIM_TABLE_ENTRY);
+ PUT (TABLE_WITH_ARRAY.ARRAY_ENTRY(0).<|>TYPE#);`;
 
-//         await gotoDefinition({
-//           text: text,
-//           index: 0,
-//           rangeIndex: 0,
-//         });
-//       });
-//     });
+      test("Must find table name in table", async () => {
+        await expectGotoDefinition({
+          text,
+          index: 0,
+          rangeIndex: 0,
+        });
+      });
 
-//     describe("Declarations and labels combined", async () => {
-//       const text = `
-//  Control: procedure options(main);
-//   call <|>A('ok!'); // invoke the 'A' subroutine
-//  end Control;
-//  <|A|>: procedure (VAR1);
-//  declare <|VAR1|> char(3);
-//  put skip list(V<|>AR1);
-//  end <|>A;`;
+      test("Must find qualified name in table", async () => {
+        await expectGotoDefinition({
+          text,
+          index: 1,
+          rangeIndex: 1,
+        });
+      });
 
-//       test("Must find declared procedure label in CALL", async () => {
-//         await gotoDefinition({
-//           text: text,
-//           index: 0,
-//           rangeIndex: 0,
-//         });
-//       });
-
-//       test("Must find declared procedure label in END", async () => {
-//         await gotoDefinition({
-//           text: text,
-//           index: 2,
-//           rangeIndex: 0,
-//         });
-//       });
-
-//       test("Must find declared variable", async () => {
-//         await gotoDefinition({
-//           text: text,
-//           index: 1,
-//           rangeIndex: 1,
-//         });
-//       });
-//     });
-
-//     describe("Qualified names", async () => {
-//       const text = `
-// 0DCL 1  <|TWO_DIM_TABLE|>,
-//         2  <|TWO_DIM_TABLE_ENTRY|>               CHAR(32);
-// 0DCL 1  TABLE_WITH_ARRAY,
-//         2  ARRAY_ENTRY(0:1000),
-//            3  NAME                          CHAR(32) VARYING,
-//            3  <|TYPE#|>                         CHAR(8),
-//         2  NON_ARRAY_ENTRY,
-//            3  NAME                          CHAR(32) VARYING,
-//            3  TYPE#                         CHAR(8);
-
-//  PUT (<|>TWO_DIM_TABLE);
-//  PUT (TWO_DIM_TABLE.<|>TWO_DIM_TABLE_ENTRY);
-//  PUT (TABLE_WITH_ARRAY.ARRAY_ENTRY(0).<|>TYPE#);`;
-
-//       test("Must find table name in table", async () => {
-//         await gotoDefinition({
-//           text: text,
-//           index: 0,
-//           rangeIndex: 0,
-//         });
-//       });
-
-//       test("Must find qualified name in table", async () => {
-//         await gotoDefinition({
-//           text: text,
-//           index: 1,
-//           rangeIndex: 1,
-//         });
-//       });
-
-//       test("Must find qualified name in array", async () => {
-//         await gotoDefinition({
-//           text: text,
-//           index: 2,
-//           rangeIndex: 2,
-//         });
-//       });
-//     });
-//   });
-// });
+      test("Must find qualified name in array", async () => {
+        await expectGotoDefinition({
+          text,
+          index: 2,
+          rangeIndex: 2,
+        });
+      });
+    });
+  });
+});

--- a/packages/language/test/utils.ts
+++ b/packages/language/test/utils.ts
@@ -1,12 +1,14 @@
 import { expect } from "vitest";
 import { URI } from "vscode-uri";
-import { Diagnostic } from "../src/language-server/types";
+import { Diagnostic, Range } from "../src/language-server/types";
 import * as lifecycle from "../src/workspace/lifecycle";
 import {
   SourceFile,
   collectDiagnostics,
   createSourceFile,
 } from "../src/workspace/source-file";
+import { definitionRequest } from "../src/language-server/definition-request";
+import assert from "node:assert";
 
 export function assertNoParseErrors(sourceFile: SourceFile) {
   expect(sourceFile.diagnostics.lexer).toHaveLength(0);
@@ -74,3 +76,142 @@ export function parseStmts(text: string): SourceFile {
 ${text}
  end STARTPR;`);
 }
+
+/**
+ * ---------- Linking utilities ----------
+ */
+
+export function expectedFunction(
+  actual: any,
+  expected: any,
+  message: string | Error,
+) {
+  assert.deepStrictEqual(actual, expected, message);
+}
+
+export function parseAndLink(text: string): SourceFile {
+  const sourceFile = parse(text);
+  lifecycle.generateSymbolTable(sourceFile);
+  lifecycle.link(sourceFile);
+  return sourceFile;
+}
+
+interface ExpectedBase {
+  /**
+   * Document content.
+   * Use `<|>` and `<|...|>` to mark special items that are relevant to the test case.
+   */
+  text: string;
+  /**
+   * String to mark indices for test cases. `<|>` by default.
+   */
+  indexMarker?: string;
+  /**
+   * String to mark start indices for test cases. `<|` by default.
+   */
+  rangeStartMarker?: string;
+  /**
+   * String to mark end indices for test cases. `|>` by default.
+   */
+  rangeEndMarker?: string;
+}
+
+interface ExpectGotoDefinitionParams extends ExpectedBase {
+  index: number;
+  rangeIndex: number | number[];
+}
+
+export function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function replaceIndices(base: ExpectedBase): {
+  output: string;
+  indices: number[];
+  ranges: Array<[number, number]>;
+} {
+  const indices: number[] = [];
+  const ranges: Array<[number, number]> = [];
+  const rangeStack: number[] = [];
+  const indexMarker = base.indexMarker || "<|>";
+  const rangeStartMarker = base.rangeStartMarker || "<|";
+  const rangeEndMarker = base.rangeEndMarker || "|>";
+  const regex = new RegExp(
+    `${escapeRegExp(indexMarker)}|${escapeRegExp(rangeStartMarker)}|${escapeRegExp(rangeEndMarker)}`,
+  );
+
+  let matched = true;
+  let input = base.text;
+
+  while (matched) {
+    const regexMatch = regex.exec(input);
+    if (regexMatch) {
+      const matchedString = regexMatch[0];
+      switch (matchedString) {
+        case indexMarker:
+          indices.push(regexMatch.index);
+          break;
+        case rangeStartMarker:
+          rangeStack.push(regexMatch.index);
+          break;
+        case rangeEndMarker: {
+          const rangeStart = rangeStack.pop() || 0;
+          ranges.push([rangeStart, regexMatch.index]);
+          break;
+        }
+      }
+      input =
+        input.substring(0, regexMatch.index) +
+        input.substring(regexMatch.index + matchedString.length);
+    } else {
+      matched = false;
+    }
+  }
+
+  return { output: input, indices, ranges: ranges.sort((a, b) => a[0] - b[0]) };
+}
+
+export function expectGotoDefinition(
+  expectedGotoDefinition: ExpectGotoDefinitionParams,
+) {
+  const { index, rangeIndex } = expectedGotoDefinition;
+  const { output, indices, ranges } = replaceIndices(expectedGotoDefinition);
+  const sourceFile = parseAndLink(output);
+
+  const offset = indices[index];
+  const result = definitionRequest(sourceFile, offset);
+
+  if (Array.isArray(rangeIndex)) {
+    expectedFunction(
+      result.length,
+      rangeIndex.length,
+      `Expected ${rangeIndex.length} definitions but received ${result.length}`,
+    );
+
+    throw new Error("Range index is not supported yet");
+  } else {
+    expectedFunction(
+      result.length,
+      1,
+      `Expected a single definition but received ${result.length}`,
+    );
+
+    const [definition] = result;
+    const expectedRange: Range = {
+      start: ranges[rangeIndex][0],
+      end: ranges[rangeIndex][1],
+    };
+
+    expectedFunction(
+      definition.range,
+      expectedRange,
+      `Expected range does not match actual range`,
+    );
+  }
+
+  return result;
+}
+
+/**
+ * ---------- End of Linking utilities ----------
+ */


### PR DESCRIPTION
The linking test system is using hand-picked utility functions from the Langium project to enable easy definition test.

Let me know if you prefer that some of these utility functions be moved to other files.