### PR TITLE
Add document highlight

### DIFF
--- a/packages/language/src/language-server/connection-handler.ts
+++ b/packages/language/src/language-server/connection-handler.ts
@@ -36,6 +36,7 @@ export function startLanguageServer(connection: Connection): void {
         },
         definitionProvider: true,
         referencesProvider: true,
+        documentHighlightProvider: true,
         semanticTokensProvider: {
           legend: semanticTokenLegend,
           full: true,
@@ -90,6 +91,23 @@ export function startLanguageServer(connection: Connection): void {
     return {
       data: [],
     };
+  });
+  connection.onDocumentHighlight((params) => {
+    const uri = params.textDocument.uri;
+    const position = params.position;
+    const textDocument = TextDocuments.get(uri);
+    const sourceFile = sourceFileHandler.getSourceFile(URI.parse(uri));
+    if (textDocument && sourceFile) {
+      const offset = textDocument.offsetAt(position);
+      const definition = referencesRequest(sourceFile, offset);
+      return definition.map((def) => {
+        return {
+          uri: def.uri,
+          range: rangeToLSP(textDocument, def.range),
+        };
+      });
+    }
+    return [];
   });
   connection.listen();
 }

--- a/packages/language/src/language-server/connection-handler.ts
+++ b/packages/language/src/language-server/connection-handler.ts
@@ -9,7 +9,11 @@
  *
  */
 
-import { Connection, TextDocumentSyncKind } from "vscode-languageserver";
+import {
+  Connection,
+  DocumentHighlight,
+  TextDocumentSyncKind,
+} from "vscode-languageserver";
 import { URI } from "../utils/uri";
 import { SourceFileHandler } from "../workspace/source-file";
 import { definitionRequest } from "./definition-request";
@@ -99,13 +103,10 @@ export function startLanguageServer(connection: Connection): void {
     const sourceFile = sourceFileHandler.getSourceFile(URI.parse(uri));
     if (textDocument && sourceFile) {
       const offset = textDocument.offsetAt(position);
-      const definition = referencesRequest(sourceFile, offset);
-      return definition.map((def) => {
-        return {
-          uri: def.uri,
-          range: rangeToLSP(textDocument, def.range),
-        };
-      });
+      const definitions = referencesRequest(sourceFile, offset);
+      return definitions.map((def) =>
+        DocumentHighlight.create(rangeToLSP(textDocument, def.range)),
+      );
     }
     return [];
   });


### PR DESCRIPTION
This feature currently reuses the existing `referencesRequest`, since it contains a lot of specialized name/reference handling logic. Let me know if this is wrong.