### PR TITLE
Run PR previews on target branch

### DIFF
--- a/.github/workflows/pr-previews.yml
+++ b/.github/workflows/pr-previews.yml
@@ -6,7 +6,7 @@ permissions:
   contents: write
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened


### PR DESCRIPTION
PR previews from outside contributors (from forks) currently don't work because the resources required to push to GitHub Pages aren't accessible to them. This PR fixes that by running the PR previews on the target branch (instead of on the source branch).