### PR TITLE
Inconsistency in compilation units

### DIFF
--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -129,9 +129,7 @@ export class CompletionUnitHandler {
         URI.parse(event.document.uri),
       );
       lifecycle(unit, event.document.getText());
-      unit.files.forEach((file) => {
-        this.compilationUnits.set(file.toString(), unit);
-      });
+      this.compilationUnits.set(unit.uri.toString(), unit);
       const allDiagnostics = diagnosticsToLSP(collectDiagnostics(unit));
       for (const file of unit.files) {
         const fileDiagnostics = allDiagnostics.get(file.toString());


### PR DESCRIPTION
The marked code location introduces an inconsistency in the handling of compilation units.

- If the _to be included_ file is opened first, it will be added with its unit.
- If the _include_ file is opened first, both will be added with the unit of the _include_ file and used when the _to be included_ files is opened afterwards.
- If the _to be included_ file is then closed again, the unit will be deleted entirely.

This makes it difficult for the LS to react correctly. Let us discuss how this should be handled in the future.

I suggest to remove the included files from the `CompletionUnitHandler` for now to remove the inconsistency and to optimize later if necessary.

Blocks https://github.com/zowe/zowe-pli-language-support/issues/73