### PR TITLE
Run LS lifecycle on entry document

### DIFF
--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -128,7 +128,8 @@ export class CompletionUnitHandler {
       const unit = this.getOrCreateCompilationUnit(
         URI.parse(event.document.uri),
       );
-      lifecycle(unit, event.document.getText());
+      const document = textDocuments.get(unit.uri) ?? event.document;
+      lifecycle(unit, document.getText());
       unit.files.forEach((file) => {
         this.compilationUnits.set(file.toString(), unit);
       });


### PR DESCRIPTION
Closes https://github.com/zowe/zowe-pli-language-support/issues/98
Closes https://github.com/zowe/zowe-pli-language-support/pull/97

Fixes the issue by actually using the code of the entry file as the source code of the compilation unit.