### PR TITLE
Use reference in do-type-3

### DIFF
--- a/packages/language/src/linking/tokens.ts
+++ b/packages/language/src/linking/tokens.ts
@@ -26,7 +26,6 @@ export function isNameToken(kind: CstNodeKind): boolean {
   switch (kind) {
     case CstNodeKind.DeclaredVariable_Name:
     case CstNodeKind.LabelPrefix_Name:
-    case CstNodeKind.DoType3Variable_Name:
     case CstNodeKind.OrdinalValue_Name:
       return true;
   }
@@ -41,8 +40,6 @@ export function getNameToken(node: SyntaxNode): IToken | undefined {
     case SyntaxKind.DeclaredVariable:
       return node.nameToken ?? undefined;
     case SyntaxKind.LabelPrefix:
-      return node.nameToken ?? undefined;
-    case SyntaxKind.DoType3Variable:
       return node.nameToken ?? undefined;
     case SyntaxKind.OrdinalValue:
       return node.nameToken ?? undefined;
@@ -104,7 +101,6 @@ export function getVariableSymbol(node: SyntaxNode): string | undefined {
 export function getLabelSymbol(node: SyntaxNode): string | undefined {
   switch (node.kind) {
     case SyntaxKind.LabelPrefix:
-    case SyntaxKind.DoType3Variable:
     case SyntaxKind.OrdinalValue:
       return node.name!;
     default:

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -336,7 +336,7 @@ export class PliParser extends AbstractParser {
   });
 
   OptionsItem = this.RULE("OptionsItem", () => {
-    let element = this.push<ast.OptionsItem>(undefined!);
+    let element = this.push<ast.OptionsItem>(null!);
 
     this.OR1([
       {
@@ -2903,7 +2903,7 @@ export class PliParser extends AbstractParser {
   DoType3 = this.RULE("DoType3", () => {
     let element = this.push(ast.createDoType3());
 
-    this.SUBRULE_ASSIGN1(this.DoType3Variable, {
+    this.SUBRULE_ASSIGN1(this.ReferenceItem, {
       assign: (result) => {
         element.variable = result;
       },
@@ -2928,27 +2928,6 @@ export class PliParser extends AbstractParser {
     });
 
     return this.pop<ast.DoType3>();
-  });
-
-  private createDoType3Variable(): ast.DoType3Variable {
-    return {
-      kind: ast.SyntaxKind.DoType3Variable,
-      container: null,
-      name: null,
-      nameToken: null,
-    };
-  }
-
-  DoType3Variable = this.RULE("DoType3Variable", () => {
-    let element = this.push(this.createDoType3Variable());
-
-    this.CONSUME_ASSIGN1(tokens.ID, (token) => {
-      this.tokenPayload(token, element, CstNodeKind.DoType3Variable_Name);
-      element.name = token.image;
-      element.nameToken = token;
-    });
-
-    return this.pop<ast.DoType3Variable>();
   });
 
   private createDoSpecification(): ast.DoSpecification {

--- a/packages/language/src/syntax-tree/ast-iterator.ts
+++ b/packages/language/src/syntax-tree/ast-iterator.ts
@@ -338,8 +338,6 @@ export function forEachNode(
       }
       node.specifications.forEach(action);
       break;
-    case SyntaxKind.DoType3Variable:
-      break;
     case SyntaxKind.DoUntil:
       if (node.until) {
         action(node.until);

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -307,7 +307,6 @@ export type SyntaxNode =
   | DoSpecification
   | DoStatement
   | DoType3
-  | DoType3Variable
   | DoUntil
   | DoWhile
   | EFormatItem
@@ -641,11 +640,7 @@ export type InitialAttributeSpecificationIteration =
   | InitialAttributeItemStar
   | InitialAttributeSpecificationIterationValue;
 export type LiteralValue = NumberLiteral | StringLiteral;
-export type NamedElement =
-  | DeclaredVariable
-  | DoType3Variable
-  | OrdinalValue
-  | ProcedureStatement;
+export type NamedElement = DeclaredVariable | OrdinalValue | ProcedureStatement;
 export type NamedType = DefineAliasStatement;
 export type OptionsItem =
   | CMPATOptionsItem
@@ -1174,29 +1169,8 @@ export function createDoStatement(): DoStatement {
 }
 export interface DoType3 extends AstNode {
   kind: SyntaxKind.DoType3;
-  variable: DoType3Variable | null;
+  variable: ReferenceItem | null;
   specifications: DoSpecification[];
-}
-export function createDoType3(): DoType3 {
-  return {
-    kind: SyntaxKind.DoType3,
-    container: null,
-    variable: null,
-    specifications: [],
-  };
-}
-export interface DoType3Variable extends AstNode {
-  kind: SyntaxKind.DoType3Variable;
-  name: string | null;
-  nameToken: IToken | null;
-}
-export function createDoType3Variable(): DoType3Variable {
-  return {
-    kind: SyntaxKind.DoType3Variable,
-    container: null,
-    name: null,
-    nameToken: null,
-  };
 }
 export interface DoUntil extends AstNode {
   kind: SyntaxKind.DoUntil;

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -1172,6 +1172,14 @@ export interface DoType3 extends AstNode {
   variable: ReferenceItem | null;
   specifications: DoSpecification[];
 }
+export function createDoType3(): DoType3 {
+  return {
+    kind: SyntaxKind.DoType3,
+    container: null,
+    variable: null,
+    specifications: [],
+  };
+}
 export interface DoUntil extends AstNode {
   kind: SyntaxKind.DoUntil;
   until: Expression | null;

--- a/packages/language/src/syntax-tree/cst.ts
+++ b/packages/language/src/syntax-tree/cst.ts
@@ -241,7 +241,6 @@ export enum CstNodeKind {
   DoUntil_CloseParenWhile,
   DoType3_Equals,
   DoType3_Comma,
-  DoType3Variable_Name,
   DoSpecification_TO0,
   DoSpecification_BY0,
   DoSpecification_BY1,

--- a/packages/language/test/linking.test.ts
+++ b/packages/language/test/linking.test.ts
@@ -148,6 +148,13 @@ describe("Linking tests", () => {
  PUT(<|a>A);
  CALL <|proc>MYPROC;`));
 
+ test("DO TYPE 3 links to proper var", () =>
+    expectLinks(`
+      DCL <|I:I> FIXED;
+      DO <|I>I = 0 TO 10;
+        PUT(<|I>I);
+      END;`));
+
   describe("Qualified names", () => {
     test("Must work in structured declaration", () =>
       expectLinks(`

--- a/packages/language/test/linking.test.ts
+++ b/packages/language/test/linking.test.ts
@@ -148,7 +148,7 @@ describe("Linking tests", () => {
  PUT(<|a>A);
  CALL <|proc>MYPROC;`));
 
- test("DO TYPE 3 links to proper var", () =>
+  test("DO TYPE 3 links to proper var", () =>
     expectLinks(`
       DCL <|I:I> FIXED;
       DO <|I>I = 0 TO 10;


### PR DESCRIPTION
In the `DO index = 0 TO ...` syntax, the `index` is actually a reference to a previously declared variable and not a variable on its own. This change aligns our parser/AST to this design.