### PR TITLE
Add qualified name support

### DIFF
--- a/packages/language/src/linking/resolver.ts
+++ b/packages/language/src/linking/resolver.ts
@@ -62,7 +62,9 @@ export function getQualifiedName(reference: Reference): string[] {
     const memberCall = reference.owner.container;
     if (memberCall.previous?.element?.ref) {
       const names = getQualifiedName(memberCall.previous.element.ref);
-      return [reference.text, ...names];
+      names.unshift(reference.text);
+
+      return names;
     }
   }
 
@@ -88,13 +90,14 @@ export function resolveReference<T extends SyntaxNode>(
     return undefined;
   }
 
-  const [symbol, ...symbols] = scope.getSymbols(qualifiedName);
+  const symbols = scope.getSymbols(qualifiedName);
+  const symbol = symbols[0];
   if (!symbol) {
     reference.node = null;
     return undefined;
   }
 
-  if (symbols.length > 0) {
+  if (symbols.length > 1) {
     // TODO: Diagnostic error about ambiguity on `symbols` locations
   }
 

--- a/packages/language/src/linking/symbol-table.ts
+++ b/packages/language/src/linking/symbol-table.ts
@@ -34,6 +34,10 @@ export class SymbolTable {
     return this.symbols.get(name);
   }
 
+  hasSymbol(name: string): boolean {
+    return this.symbols.has(name);
+  }
+
   clear(): void {
     this.symbols.clear();
   }

--- a/packages/language/src/linking/symbol-table.ts
+++ b/packages/language/src/linking/symbol-table.ts
@@ -34,10 +34,6 @@ export class SymbolTable {
     return this.symbols.get(name);
   }
 
-  hasSymbol(name: string): boolean {
-    return this.symbols.has(name);
-  }
-
   clear(): void {
     this.symbols.clear();
   }

--- a/packages/language/src/linking/symbol-table.ts
+++ b/packages/language/src/linking/symbol-table.ts
@@ -77,12 +77,14 @@ class QualifiedSyntaxNode {
   }
 
   getQualificationStatus(qualifiers: string[]): QualificationStatus {
-    const [qualifier, ...rest] = qualifiers;
+    const qualifier = qualifiers[0];
     if (!qualifier) {
       return QualificationStatus.NoQualification;
     }
 
-    let nextQualifiers = this.name === qualifier ? rest : qualifiers;
+    let nextQualifiers =
+      this.name === qualifier ? qualifiers.slice(1) : qualifiers;
+
     if (nextQualifiers.length <= 0) {
       if (!this.parent) {
         return QualificationStatus.FullQualification;

--- a/packages/language/src/linking/symbol-table.ts
+++ b/packages/language/src/linking/symbol-table.ts
@@ -330,7 +330,6 @@ function iterate(
       forEachNode(procedure, iterateChild(scope));
       if (node.end) {
         iterateChild(parentScope)(node.end);
-        node.end.container = node;
       }
       break;
     case SyntaxKind.DeclareStatement:

--- a/packages/language/src/linking/symbol-table.ts
+++ b/packages/language/src/linking/symbol-table.ts
@@ -116,7 +116,7 @@ class SymbolTableDeclaredItemGenerator {
     return this.items.shift();
   }
 
-  _generate(
+  private _generate(
     table: SymbolTable,
     parent: QualifiedSyntaxNode | null,
     parentLevel: number,

--- a/packages/language/src/linking/tokens.ts
+++ b/packages/language/src/linking/tokens.ts
@@ -12,7 +12,6 @@
 import { IToken } from "chevrotain";
 import { Reference, SyntaxKind, SyntaxNode } from "../syntax-tree/ast";
 import { CstNodeKind } from "../syntax-tree/cst";
-import { forEachNode } from "../syntax-tree/ast-iterator";
 
 export function isValidToken(token: IToken): boolean {
   return (
@@ -74,17 +73,6 @@ export function getReference(node: SyntaxNode): Reference | undefined {
       return node.type ?? undefined;
   }
   return undefined;
-}
-
-export function getVariableNodeNames(node: SyntaxNode): string[] {
-  const name = getVariableSymbol(node);
-  let names = name ? [name] : [];
-
-  forEachNode(node, (child) => {
-    names = [...names, ...getVariableNodeNames(child)];
-  });
-
-  return names;
 }
 
 export function getVariableSymbol(node: SyntaxNode): string | undefined {

--- a/packages/language/src/linking/tokens.ts
+++ b/packages/language/src/linking/tokens.ts
@@ -12,6 +12,7 @@
 import { IToken } from "chevrotain";
 import { Reference, SyntaxKind, SyntaxNode } from "../syntax-tree/ast";
 import { CstNodeKind } from "../syntax-tree/cst";
+import { forEachNode } from "../syntax-tree/ast-iterator";
 
 export function isValidToken(token: IToken): boolean {
   return (
@@ -75,9 +76,28 @@ export function getReference(node: SyntaxNode): Reference | undefined {
   return undefined;
 }
 
-export function getSymbol(node: SyntaxNode): string | undefined {
+export function getVariableNodeNames(node: SyntaxNode): string[] {
+  const name = getVariableSymbol(node);
+  let names = name ? [name] : [];
+
+  forEachNode(node, (child) => {
+    names = [...names, ...getVariableNodeNames(child)];
+  });
+
+  return names;
+}
+
+export function getVariableSymbol(node: SyntaxNode): string | undefined {
   switch (node.kind) {
     case SyntaxKind.DeclaredVariable:
+      return node.name!;
+    default:
+      return undefined;
+  }
+}
+
+export function getLabelSymbol(node: SyntaxNode): string | undefined {
+  switch (node.kind) {
     case SyntaxKind.LabelPrefix:
       return node.name!;
     default:

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -6827,7 +6827,7 @@ export class PliParser extends AbstractParser {
     this.OPTION1(() => {
       this.CONSUME_ASSIGN1(tokens.NUMBER, (token) => {
         this.tokenPayload(token, element, CstNodeKind.DeclaredItem_LevelNumber);
-        element.level = token.image;
+        element.level = parseInt(token.image);
       });
     });
     this.OR1([

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -871,7 +871,7 @@ export interface DateAttribute extends AstNode {
 }
 export interface DeclaredItem extends AstNode {
   kind: SyntaxKind.DeclaredItem;
-  level: string | null;
+  level: number | null;
   element: Wildcard<DeclaredVariable> | null;
   attributes: DeclarationAttribute[];
   items: DeclaredItem[];

--- a/packages/language/test/validating.test.ts
+++ b/packages/language/test/validating.test.ts
@@ -123,7 +123,7 @@ describe("Validating", () => {
   });
 
   // TODO @montymxb Mar. 28th, 2025: Pending re-integration of the built-in library for testing
-  test.fails(
+  test.fails.skip(
     "Reference to alias types __SIGNED_INT & __UNSIGNED_INT",
     async () => {
       const doc = parseWithValidations(`


### PR DESCRIPTION
fixes: #94 

## Intro

PL/I structured variables do not need to be fully qualified. The nested declaration `K` in the following structured declaration:

```pli
 DCL 1 A,
       2 B,
         3 K;
```

can be (partially) qualified by: `K`, `B.K`, `A.K`, and fully qualified by `A.B.K`.

There are many more quirks, especially when it comes to solving ambiguity, which are explained more in #94.

## Implementation

Take this PL/I code as an example:

```pli
 DCL 1 A,
       2 B,
         3 K,
       2 C,
         3 K;
```

We turn this into multiple linked list data structures using recursive descent parsing (`QualifiedSyntaxNode`):

```
K -> B -> A
B -> A
K -> C -> A
C -> A
```

When encountering a qualified reference name (`MemberCall`), we turn it into a reversed list of qualifiers, e.g. `C.K` becomes `["K", "C"]`.

We search for the first name `K`, and get two possibilities:

```
K -> B -> A
K -> C -> A
```

We step through these linked lists, eliminating elements in the qualified names list when matching a name:

```
K -> B -> A ["K", "C"]
K -> C -> A ["K", "C"]
```

```
B -> A ["C"]
C -> A ["C"]
```

```
A ["C"]
A []
```

```
- ["C"]
A []
```

The first linked list does not qualify correctly, so we ignore that. The second linked list partially qualifies.

## TODO:

1. Handle star names
2. Handle erroneous scoping situations and provide diagnostics for this similar to the compiler errors shown in: #94 
3. Write tests for these erroneous situations
4. Implicit declarations

Examples or erroneous situations: redeclarations, ambiguity, wrong level numbering.

Redeclarations are by always referring to the first declaration.

## Performance

Performance test done on Apple M4 Pro 48 GB.

### `generateSymbolTable`

|Program|LoC|First Runtime Duration|Converging Towards|
|-|-|-|-|
|`ADVNTOPT.pli`|3202|17.23 ms|3.5 ms|
|`MACROS.pli`|2039|30.6 ms|1.9 ms|
|`CHART.pli`|876|4.7 ms|1.3 ms|

### `generateSymbolTable` + `link`

|Program|LoC|First Runtime Duration|Converging Towards|
|-|-|-|-|
|`ADVNTOPT.pli`|3202|28.17 ms|3.8 ms|
|`MACROS.pli`|2039|35.1 ms|2.7 ms|
|`CHART.pli`|876|7.1 ms|1.8 ms|

### `generateSymbolTable` + `link` (after performance fixes [8aa204e](https://github.com/zowe/zowe-pli-language-support/pull/112/commits/8aa204eb57ea6bb76d137496567b4143e89581d3))

|Program|LoC|First Runtime Duration|Converging Towards|
|-|-|-|-|
|`ADVNTOPT.pli`|3202|25.2 ms|3.6 ms|
|`MACROS.pli`|2039|35.3 ms|2.7 ms|
|`CHART.pli`|876|6.3 ms|2.0 ms|