### PR TITLE
Reduce linking test boilerplate

### DIFF
--- a/packages/language/test/linking.test.ts
+++ b/packages/language/test/linking.test.ts
@@ -31,33 +31,32 @@ ${text}
 describe("Linking tests", () => {
   test("Nested procedure label tests", () =>
     expectLinks(`
- <|1:OUTER|>: procedure options (main); // outer0
-    <|2:INNER|>: procedure;             // inner0
-        call <|3>OUTER;                // callOuter0
-        call <|2>INNER;                // callInner0
+ <|1:OUTER|>: procedure options (main);
+    <|2:INNER|>: procedure;
+        call <|3>OUTER;
+        call <|2>INNER;
 
-        <|3:OUTER|>: procedure;         // outer1
-            call <|3>OUTER;            // callOuter1
-            call <|4>INNER;            // callInner1
+        <|3:OUTER|>: procedure;
+            call <|3>OUTER;
+            call <|4>INNER;
 
-            <|4:INNER|>: procedure;     // inner1
-                call <|3>OUTER;        // callOuter2
-                call <|4>INNER;        // callInner2
+            <|4:INNER|>: procedure;
+                call <|3>OUTER;
+                call <|4>INNER;
             END <|4>INNER;
 
-            call <|3>OUTER;            // callOuter3
-            call <|4>INNER;            // callInner3
-        END <|3>OUTER;                 // callOuter4
+            call <|3>OUTER;
+            call <|4>INNER;
+        END <|3>OUTER;
 
-        call <|3>OUTER;                // callOuter5
-        call <|2>INNER;                // callInner4
-    END <|2>INNER;                     // callInner5
+        call <|3>OUTER;
+        call <|2>INNER;
+    END <|2>INNER;
 
-    call <|1>OUTER;                    // callOuter6
-    call <|2>INNER;                    // callInner6
- end <|1>OUTER;                        // callOuter7
-
- call <|1>OUTER;                       // callOuter8`));
+    call <|1>OUTER;
+    call <|2>INNER;
+ end <|1>OUTER;
+ call <|1>OUTER;`));
 
   test("Must handle implicit declaration (use before declaration)", () =>
     expectLinks(`

--- a/packages/language/test/linking.test.ts
+++ b/packages/language/test/linking.test.ts
@@ -71,15 +71,13 @@ describe("Linking tests", () => {
 
  PUT(<|1>A); // -> "A"
  CALL LABL;
- PUT(<|1>A); // -> "A"
-`));
+ PUT(<|1>A); // -> "A"`));
 
   test("Must handle implicit declaration (use before declaration)", () =>
     expectLinks(`
  PUT(<|1>A);
  DCL <|1:A|> CHAR(8) INIT("A");
- PUT(<|1>A);
-`));
+ PUT(<|1>A);`));
 
   test("Must handle scoping in prodecures", () =>
     expectLinks(`
@@ -92,8 +90,7 @@ describe("Linking tests", () => {
  END OUTER;
 
  DCL ABC;
- CALL <|1>ABC;
-`));
+ CALL <|1>ABC;`));
 
   test("Must ignore redeclarations", () =>
     expectLinks(`
@@ -154,8 +151,7 @@ describe("Linking tests", () => {
  DCL 1 <|1:A|>,
      2 <|2:B|> CHAR(8) VALUE("B");
  PUT(<|2>B);
- PUT(<|1>A.<|2>B);
-`));
+ PUT(<|1>A.<|2>B);`));
 
     test("Declaration must override implicit qualification", () =>
       expectLinks(`
@@ -163,8 +159,7 @@ describe("Linking tests", () => {
      2 <|2:B|> CHAR(8) VALUE("B");
  DCL <|3:B|> CHAR(8) VALUE("B2");
  PUT(<|3>B);
- PUT(<|1>A.<|2>B);
-`));
+ PUT(<|1>A.<|2>B);`));
 
     test("Variable must be partially qualified", () =>
       expectLinks(`
@@ -176,8 +171,7 @@ describe("Linking tests", () => {
         3 <|a2_c_b:B|> CHAR(8) VALUE("B2");
 
   PUT (<|a2_c>C.<|a2_c_b>B);
-  PUT (<|a>A.<|a_b>B);
-`));
+  PUT (<|a>A.<|a_b>B);`));
 
     test("Star name in structure should not need to be qualified", () =>
       expectLinks(`
@@ -185,8 +179,7 @@ describe("Linking tests", () => {
        2 *,
          3 <|b:B|> CHAR(8) VALUE("B");
 
- PUT(A.<|b>B);
-`));
+ PUT(A.<|b>B);`));
 
     /**
      * TODO: Implement star handling in structured names
@@ -198,8 +191,7 @@ describe("Linking tests", () => {
           3 B CHAR(8) VALUE("B"),
         2 <|b:B|> CHAR(8) VALUE("B2");
 
- PUT(A.<|b>B);
-`));
+ PUT(A.<|b>B);`));
   });
 
   test("fetch linking", () => {

--- a/packages/language/test/utils.ts
+++ b/packages/language/test/utils.ts
@@ -291,8 +291,9 @@ export function expectLinks(text: string) {
         end: singleRangeIndex[1],
       };
 
-      const line = output.slice(0, offset).split("\n").length + 1;
+      // Produce a small snippet with a margin of 10 characters to give a hint of where the error is
       const snippet = `${output.slice(offset - 10, offset).trimStart()}<|${label}>${output.slice(offset, offset + 10).trimEnd()}`;
+      const line = output.slice(0, offset).split("\n").length + 1;
 
       expectedFunction(
         definition.range,

--- a/packages/language/test/utils.ts
+++ b/packages/language/test/utils.ts
@@ -122,13 +122,80 @@ interface ExpectedBase {
   rangeEndMarker?: string;
 }
 
-interface ExpectGotoDefinitionParams extends ExpectedBase {
-  index: number;
-  rangeIndex: number | number[];
-}
-
 export function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Strip and extract named indices and ranges from the given text.
+ * Currently supports markers through the following syntax:
+ * - Range: `<|abc:A|>` -> produces output `A` and a named range `abc`
+ * - Index: `<|abc>A` -> produces output `A` and a named index `abc`
+ *
+ * Marker identifiers are limited to alphanumeric characters (`/\w+/`).
+ */
+export function replaceNamedIndices(text: string): {
+  output: string;
+  indices: Record<string, number[]>;
+  ranges: Record<string, Array<[number, number]>>;
+} {
+  const indices: Record<string, number[]> = {};
+  const ranges: Record<string, Array<[number, number]>> = {};
+  const rangeStack: {
+    index: number;
+    label: string;
+  }[] = [];
+
+  const regex = /<\|(?<indexMarker>\w+)>|<\|(?<rangeStartMarker>\w+):|\|>/;
+
+  let matched = true;
+  let input = text;
+
+  while (matched) {
+    const regexMatch = regex.exec(input);
+
+    if (regexMatch?.groups) {
+      if (regexMatch.groups.indexMarker) {
+        const label = regexMatch.groups.indexMarker;
+
+        if (!indices[label]) {
+          indices[label] = [];
+        }
+
+        indices[label].push(regexMatch.index);
+
+        if (!ranges[label]) {
+          ranges[label] = [];
+        }
+      } else if (regexMatch.groups.rangeStartMarker) {
+        rangeStack.push({
+          index: regexMatch.index,
+          label: regexMatch.groups.rangeStartMarker,
+        });
+      } else {
+        const rangeStart = rangeStack.pop();
+        if (!rangeStart) {
+          throw new Error("Range start not found");
+        }
+
+        if (!ranges[rangeStart.label]) {
+          ranges[rangeStart.label] = [];
+        }
+
+        ranges[rangeStart.label].push([rangeStart.index, regexMatch.index]);
+      }
+
+      const matchedString = regexMatch[0];
+
+      input =
+        input.substring(0, regexMatch.index) +
+        input.substring(regexMatch.index + matchedString.length);
+    } else {
+      matched = false;
+    }
+  }
+
+  return { output: input, indices, ranges };
 }
 
 export function replaceIndices(base: ExpectedBase): {
@@ -177,45 +244,63 @@ export function replaceIndices(base: ExpectedBase): {
   return { output: input, indices, ranges: ranges.sort((a, b) => a[0] - b[0]) };
 }
 
-export function expectGotoDefinition(
-  expectedGotoDefinition: ExpectGotoDefinitionParams,
-) {
-  const { index, rangeIndex } = expectedGotoDefinition;
-  const { output, indices, ranges } = replaceIndices(expectedGotoDefinition);
+/**
+ * Extract named range and index information and verify that linking works as expected.
+ *
+ * @param text PL/I text to parse and link, with range and index markers (as specified in `replaceNamedIndices`)
+ *
+ * @example
+ * ```ts
+ * expectLinks(`
+ *  DCL <|1:A|>, <|2:B|>;
+ *  PUT(<|1>A);
+ *  PUT(<|2>B);
+ * `)
+ * ```
+ */
+export function expectLinks(text: string) {
+  const { output, indices, ranges } = replaceNamedIndices(text);
+
+  const requests = Object.entries(indices).flatMap(([index, offsets]) =>
+    offsets.map((offset) => ({
+      label: index,
+      offset,
+      rangeIndex: ranges[index],
+    })),
+  );
+
   const unit = parseAndLink(output);
 
-  const offset = indices[index];
-  const result = definitionRequest(unit, unit.uri, offset);
+  for (const { label, offset, rangeIndex } of requests) {
+    const result = definitionRequest(unit, unit.uri, offset);
 
-  if (Array.isArray(rangeIndex)) {
     expectedFunction(
       result.length,
       rangeIndex.length,
-      `Expected ${rangeIndex.length} definitions but received ${result.length}`,
+      `Expected ${rangeIndex.length} definitions but received ${result.length} for label "${label}"`,
     );
 
-    throw new Error("Range index is not supported yet");
-  } else {
-    expectedFunction(
-      result.length,
-      1,
-      `Expected a single definition but received ${result.length}`,
-    );
+    if (rangeIndex.length > 1) {
+      throw new Error("TODO: Range index is not supported yet");
+    } else if (rangeIndex.length === 1) {
+      const [singleRangeIndex] = rangeIndex;
+      const [definition] = result;
 
-    const [definition] = result;
-    const expectedRange: Range = {
-      start: ranges[rangeIndex][0],
-      end: ranges[rangeIndex][1],
-    };
+      const expectedRange: Range = {
+        start: singleRangeIndex[0],
+        end: singleRangeIndex[1],
+      };
 
-    expectedFunction(
-      definition.range,
-      expectedRange,
-      `Expected range does not match actual range`,
-    );
+      const line = output.slice(0, offset).split("\n").length + 1;
+      const snippet = `${output.slice(offset - 10, offset).trimStart()}<|${label}>${output.slice(offset, offset + 10).trimEnd()}`;
+
+      expectedFunction(
+        definition.range,
+        expectedRange,
+        `Expected range does not match actual range on line ${line} near \`${snippet}\``,
+      );
+    }
   }
-
-  return result;
 }
 
 /**


### PR DESCRIPTION
## Problem

Adding and changing linking tests required a lot of time and mental overhead to keep track of the `index` and `rangeIndexes`.

## Solution

This PR replaces the `expectGotoDefinition` utility function with a `expectLinks(text: string)` with extended marker syntax for specifying linking behavior. The extended marker syntax adds the possibility to add labels to markers.

Example of old tests:

```ts
test("Must ignore redeclarations", async () => {
  const text = `
DCL <|ABC|>;
CALL <|>ABC;
DCL ABC;
CALL <|>ABC;`;

  await expectGotoDefinition({
    text,
    index: 0,
    rangeIndex: 0,
  });

  await expectGotoDefinition({
    text,
    index: 1,
    rangeIndex: 0,
  });
});
```

New:

```ts
test("Must ignore redeclarations", () =>
  expectLinks(`
 DCL <|abc123:ABC|>;
 CALL <|abc123>ABC;
 DCL ABC;
 CALL <|abc123>ABC;`));
```