### PR TITLE
Add margin indicators

### DIFF
--- a/packages/language/src/language-server/margin-indicator.ts
+++ b/packages/language/src/language-server/margin-indicator.ts
@@ -1,0 +1,50 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { Connection, NotificationType } from "vscode-languageserver";
+import { CompilationUnit } from "../workspace/compilation-unit";
+import { TextDocument } from "vscode-languageserver-textdocument";
+
+export interface MarginIndicatorNotificationParams {
+  uri: string;
+  m: number | undefined;
+  n: number | undefined;
+}
+
+export const MarginIndicatorNotification =
+  new NotificationType<MarginIndicatorNotificationParams>(
+    "pli/marginIndicator",
+  );
+
+export function marginIndicator(
+  connection: Connection,
+  uri: string,
+  compilationUnit: CompilationUnit,
+  textDocument: TextDocument,
+) {
+  let indicator: MarginIndicatorNotificationParams = {
+    uri: uri,
+    m: undefined,
+    n: undefined,
+  };
+
+  if (compilationUnit) {
+    if (compilationUnit.compilerOptions.margins) {
+      indicator.m = compilationUnit.compilerOptions.margins.m;
+      indicator.n = compilationUnit.compilerOptions.margins.n;
+    } else {
+      indicator.m = 2;
+      indicator.n = 72;
+    }
+  }
+
+  connection.sendNotification(MarginIndicatorNotification, indicator);
+}

--- a/packages/language/src/language-server/skipped-code.ts
+++ b/packages/language/src/language-server/skipped-code.ts
@@ -15,13 +15,13 @@ import { TextDocument } from "vscode-languageserver-textdocument";
 import { CstNodeKind } from "../syntax-tree/cst";
 import { Range } from "vscode-languageserver-types";
 
-export interface SkippedPliCodeNotificationParams {
+export interface SkippedCodeNotificationParams {
   uri: string;
   ranges: Range[];
 }
 
-export const SkippedPliCodeNotification =
-  new NotificationType<SkippedPliCodeNotificationParams>("pli/skippedCode");
+export const SkippedCodeNotification =
+  new NotificationType<SkippedCodeNotificationParams>("pli/skippedCode");
 
 /**
  * Sends a notification to the client with the ranges of skipped code in the given compilation unit.
@@ -39,7 +39,7 @@ export function skippedCode(
     ranges = skippedCodeRanges(uri, compilationUnit, textDocument);
   }
 
-  connection.sendNotification(SkippedPliCodeNotification, {
+  connection.sendNotification(SkippedCodeNotification, {
     uri: uri,
     ranges: ranges,
   });

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -21,6 +21,7 @@ import { lifecycle } from "./lifecycle.js";
 import { CompilerOptions } from "../preprocessor/compiler-options/options.js";
 import { skippedCode } from "../language-server/skipped-code.js";
 import { EvaluationResults } from "../preprocessor/pli-preprocessor-interpreter-state.js";
+import { marginIndicator } from "../language-server/margin-indicator.js";
 
 /**
  * A compilation unit is a representation of a PL/I program in the language server.
@@ -155,6 +156,7 @@ export class CompletionUnitHandler {
         });
       }
       skippedCode(connection, event.document.uri, unit, document);
+      marginIndicator(connection, event.document.uri, unit, document);
     });
     textDocuments.onDidClose((event) => {
       this.compilationUnits.delete(event.document.uri);

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -46,7 +46,7 @@
         "pli.skippedCode.enabled": {
           "type": "boolean",
           "default": true,
-          "description": "Enable/disable the skipped code feature"
+          "description": "Enable/disable the skipped code feature."
         },
         "pli.skippedCode.opacity": {
           "type": "number",
@@ -54,6 +54,12 @@
           "minimum": 0,
           "maximum": 1,
           "description": "Opacity level for skipped code (0-1)"
+        },
+        "pli.marginIndicator.rulers": {
+          "type": "string",
+          "enum": ["off", "default", "automatic"],
+          "default": "automatic",
+          "description": "Controls the rulers for the margin compiler option. 'off' disables rulers, 'default' shows the PL/I default rulers [2, 72], 'automatic' adds rulers based on margin compiler options."
         }
       }
     }

--- a/packages/vscode-extension/src/extension/main.ts
+++ b/packages/vscode-extension/src/extension/main.ts
@@ -18,7 +18,7 @@ import * as path from "node:path";
 import { LanguageClient, TransportKind } from "vscode-languageclient/node.js";
 import { BuiltinFileSystemProvider } from "./builtin-files";
 import { Settings } from "./settings";
-import { SkippedCodeDecorator } from "./decorators";
+import { registerCustomDecorators } from "./decorators";
 
 let client: LanguageClient;
 let settings: Settings;
@@ -80,7 +80,7 @@ function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
   );
 
   // Register custom decorator types.
-  SkippedCodeDecorator.register(client, settings);
+  registerCustomDecorators(client, settings);
 
   // Start the client. This will also launch the server
   client.start();

--- a/packages/vscode-extension/src/extension/settings.ts
+++ b/packages/vscode-extension/src/extension/settings.ts
@@ -10,7 +10,7 @@
  */
 
 import * as vscode from "vscode";
-import { SkippedCodeDecorator } from "./decorators";
+import { SkippedCodeDecorator, MarginIndicatorDecorator } from "./decorators";
 
 export class Settings {
   private static instance: Settings;
@@ -42,7 +42,8 @@ export class Settings {
   }
 
   private updateSettings(): void {
-    SkippedCodeDecorator.updateType(this);
+    SkippedCodeDecorator.updateDecoratorType(this);
+    MarginIndicatorDecorator.updateRulers(this);
   }
 
   public get skippedCodeEnabled(): boolean {
@@ -51,5 +52,13 @@ export class Settings {
 
   public get skippedCodeOpacity(): number {
     return this.getConfiguration().get("skippedCode.opacity") ?? 0.55;
+  }
+
+  public get marginIndicatorRulersEnabled(): boolean {
+    return this.marginIndicatorRulers !== "off";
+  }
+
+  public get marginIndicatorRulers(): "off" | "default" | "automatic" {
+    return this.getConfiguration().get("marginIndicator.rulers") ?? "off";
   }
 }


### PR DESCRIPTION
Closes https://github.com/zowe/zowe-pli-language-support/issues/78

I implemented two complementary methods to visualize margins:
- VS Code rulers: These rulers are visible across the entire document and are configured globally for the language. As a result, they appear in all open PL/I editors, even if the margin settings differ between files.
- Decorators: This method applies individual decorators when the configured margins are exceeded, allowing for file-specific margin visualization.

Both features are toggleable via the settings and are compatible with each other.
If working with PL/I files that have differing margins turns out to be rare, we can consider disabling the less-used feature.