### PR TITLE
fix: Explicitly copy declared items for shifting

### DIFF
--- a/packages/language/src/linking/symbol-table.ts
+++ b/packages/language/src/linking/symbol-table.ts
@@ -105,7 +105,7 @@ class SymbolTableDeclaredItemGenerator {
   private items: DeclaredItem[];
 
   constructor(items: DeclaredItem[]) {
-    this.items = items;
+    this.items = items.slice(); // Explicitly make a copy of the items, to use `.shift()` in `this.pop()`
   }
 
   private peek(): DeclaredItem | undefined {


### PR DESCRIPTION
Because we're using `.shift()` in the `pop()` method, `DeclaredItem`s were actually disappearing from the AST after the symbolization step. We now explicitly copy the items array.