### PR TITLE
Add AST debug annotator

### DIFF
--- a/packages/language/test/utils.ts
+++ b/packages/language/test/utils.ts
@@ -18,6 +18,22 @@ interface AssertNoDiagnosticsOptions {
   ignoreSeverity?: Severity[];
 }
 
+const SyntaxKindReverseLookup: Map<SyntaxKind, string> = new Map(
+  Object.values(SyntaxKind)
+    .filter((key) => typeof key === "number")
+    .map((key) => [key, SyntaxKind[key]]),
+);
+
+/**
+ * This function assigns a `_kind: string` to each node that
+ * alleviates debugging by allowing the user to see the kind
+ * of the node in the debugger.
+ */
+export function assignDebugKind(node: SyntaxNode) {
+  (node as any)._kind = SyntaxKindReverseLookup.get(node.kind);
+  forEachNode(node, assignDebugKind);
+}
+
 function expectNoDiagnostics(
   diagnostics: Diagnostic[],
   { ignoreSeverity = [] }: AssertNoDiagnosticsOptions,
@@ -181,10 +197,14 @@ export function expectedFunction(
 }
 
 export function parseAndLink(text: string): CompilationUnit {
-  const sourceFile = parse(text);
-  lifecycle.generateSymbolTable(sourceFile);
-  lifecycle.link(sourceFile);
-  return sourceFile;
+  const unit = parse(text);
+  lifecycle.generateSymbolTable(unit);
+  lifecycle.link(unit);
+
+  assignDebugKind(unit.ast);
+  assignDebugKind(unit.preprocessorAst);
+
+  return unit;
 }
 
 interface ExpectedBase {

--- a/packages/language/test/utils.ts
+++ b/packages/language/test/utils.ts
@@ -25,13 +25,13 @@ const SyntaxKindReverseLookup: Map<SyntaxKind, string> = new Map(
 );
 
 /**
- * This function assigns a `_kind: string` to each node that
+ * This function assigns a `_debugKind: string` to each node that
  * alleviates debugging by allowing the user to see the kind
  * of the node in the debugger.
  */
-export function assignDebugKind(node: SyntaxNode) {
-  (node as any)._kind = SyntaxKindReverseLookup.get(node.kind);
-  forEachNode(node, assignDebugKind);
+export function assignDebugKinds(node: SyntaxNode) {
+  (node as any)._debugKind = SyntaxKindReverseLookup.get(node.kind);
+  forEachNode(node, assignDebugKinds);
 }
 
 function expectNoDiagnostics(
@@ -201,8 +201,8 @@ export function parseAndLink(text: string): CompilationUnit {
   lifecycle.generateSymbolTable(unit);
   lifecycle.link(unit);
 
-  assignDebugKind(unit.ast);
-  assignDebugKind(unit.preprocessorAst);
+  assignDebugKinds(unit.ast);
+  assignDebugKinds(unit.preprocessorAst);
 
   return unit;
 }


### PR DESCRIPTION
An AST node's `kind` is a number. While performant, it is hard to debug. This PR adds a debuggable `_kind`, containing the string name of the AST node kind:

![CleanShot 2025-05-08 at 11 30 35](https://github.com/user-attachments/assets/70e863a8-8a77-4bdb-b202-17050148f925)
