### PR TITLE
Fix reference lookup for qualified names

### DIFF
--- a/packages/language/src/linking/resolver.ts
+++ b/packages/language/src/linking/resolver.ts
@@ -187,9 +187,6 @@ function resolveReference(
   // Assign the resolved symbol to the reference.
   // This function handles assigning references to member calls.
   assignReference(reference, symbol);
-
-  // Add the inverse reference to the cache.
-  unit.references.addInverse(reference);
 }
 
 export function resolveReferences(unit: CompilationUnit): Diagnostic[] {
@@ -198,6 +195,8 @@ export function resolveReferences(unit: CompilationUnit): Diagnostic[] {
 
   for (const reference of unit.references.allReferences()) {
     resolveReference(unit, reference, acceptor);
+    // Add the reference to the reverse map so we can use it for LSP services
+    unit.references.addInverse(reference);
   }
 
   return validationBuffer.getDiagnostics();

--- a/packages/language/src/utils/search.ts
+++ b/packages/language/src/utils/search.ts
@@ -22,20 +22,17 @@ export function binaryTokenIndexSearch(
     const end = token.endOffset!;
     if (start === offset) {
       const previousToken = tokens[mid - 1];
-      if (
-        previousToken?.endOffset === offset - 1 &&
-        /\w$/u.test(previousToken.image)
-      ) {
+      if (previousToken && isAtTokenEnd(previousToken, offset)) {
         // If the offset is right after the end of a word token, return that token
-        return previousToken;
+        return mid - 1;
       } else {
-        return token;
+        return mid;
       }
     } else if (start < offset && offset <= end) {
-      return token;
-    } else if (offset - end === 1 && /\w$/u.test(token.image)) {
+      return mid;
+    } else if (isAtTokenEnd(token, offset)) {
       // If the offset is right after the end of a word token, return that token
-      return token;
+      return mid;
     } else if (start > offset) {
       high = mid - 1;
     } else {

--- a/packages/language/src/utils/search.ts
+++ b/packages/language/src/utils/search.ts
@@ -20,8 +20,22 @@ export function binaryTokenIndexSearch(
     token = tokens[mid];
     const start = token.startOffset;
     const end = token.endOffset!;
-    if ((start <= offset && offset <= end) || isAtTokenEnd(token, offset)) {
-      return mid;
+    if (start === offset) {
+      const previousToken = tokens[mid - 1];
+      if (
+        previousToken?.endOffset === offset - 1 &&
+        /\w$/u.test(previousToken.image)
+      ) {
+        // If the offset is right after the end of a word token, return that token
+        return previousToken;
+      } else {
+        return token;
+      }
+    } else if (start < offset && offset <= end) {
+      return token;
+    } else if (offset - end === 1 && /\w$/u.test(token.image)) {
+      // If the offset is right after the end of a word token, return that token
+      return token;
     } else if (start > offset) {
       high = mid - 1;
     } else {

--- a/packages/language/test/lsp/find-references.test.ts
+++ b/packages/language/test/lsp/find-references.test.ts
@@ -25,9 +25,11 @@ describe("Find references", () => {
  DCL 1 <|1:A|>,
      2 <|2><|2:B|> CHAR(8) VALUE("B");
  PUT(<|2:B|>);
- PUT(<|1:<|1>A|>.<|2:B|>);`));
+ PUT(<|1><|1:A|>.<|2:B|>);`));
 
   test("Can find references of qualified name variables on reference #2", () =>
+    // Note that the marker is placed after the variable name
+    // However, it should still be able to perform the request
     expectReferences(`
  DCL 1 <|1:A|>,
      2 <|2><|2:B|> CHAR(8) VALUE("B");

--- a/packages/language/test/lsp/find-references.test.ts
+++ b/packages/language/test/lsp/find-references.test.ts
@@ -1,0 +1,36 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { describe, test } from "vitest";
+import { expectReferences } from "../utils";
+
+describe("Find references", () => {
+  test("Can find references of qualified name variables on declaration", () =>
+    expectReferences(`
+ DCL 1 <|1><|1:A|>,
+     2 <|2><|2:B|> CHAR(8) VALUE("B");
+ PUT(<|2:B|>);
+ PUT(<|1:A|>.<|2:B|>);`));
+
+  test("Can find references of qualified name variables on reference #1", () =>
+    expectReferences(`
+ DCL 1 <|1:A|>,
+     2 <|2><|2:B|> CHAR(8) VALUE("B");
+ PUT(<|2:B|>);
+ PUT(<|1:<|1>A|>.<|2:B|>);`));
+
+  test("Can find references of qualified name variables on reference #2", () =>
+    expectReferences(`
+ DCL 1 <|1:A|>,
+     2 <|2><|2:B|> CHAR(8) VALUE("B");
+ PUT(<|2:B|>);
+ PUT(<|1:A|><|1>.<|2:B|>);`));
+});

--- a/packages/language/test/utils.ts
+++ b/packages/language/test/utils.ts
@@ -19,7 +19,6 @@ import * as lifecycle from "../src/workspace/lifecycle";
 import { URI } from "vscode-uri";
 import { Diagnostic, Range, Severity } from "../src/language-server/types";
 import { definitionRequest } from "../src/language-server/definition-request";
-import assert from "node:assert";
 import { SyntaxKind, SyntaxNode } from "../src/syntax-tree/ast";
 import { forEachNode } from "../src/syntax-tree/ast-iterator";
 import { IntermediateBinaryExpression } from "../src/parser/abstract-parser";
@@ -249,14 +248,6 @@ export function generateAndAssertValidSymbolTable(
  * ---------- Linking utilities ----------
  */
 
-export function expectedFunction(
-  actual: any,
-  expected: any,
-  message: string | Error,
-) {
-  assert.deepStrictEqual(actual, expected, message);
-}
-
 export function parseAndLink(text: string): CompilationUnit {
   const unit = parse(text);
   lifecycle.generateSymbolTable(unit);
@@ -440,11 +431,10 @@ export function expectLinks(text: string) {
     const snippet = `${output.slice(offset - 10, offset).trimStart()}<|${label}>${output.slice(offset, offset + 10).trimEnd()}`;
     const line = output.slice(0, offset).split("\n").length + 1;
 
-    expectedFunction(
-      result.length,
-      rangeIndex.length,
+    expect(
+      result,
       `Expected ${rangeIndex.length} definitions but received ${result.length} on line ${line} for label "${label}" near \`${snippet}\``,
-    );
+    ).toHaveLength(rangeIndex.length);
 
     if (rangeIndex.length > 1) {
       throw new Error("TODO: Range index is not supported yet");
@@ -457,15 +447,30 @@ export function expectLinks(text: string) {
         end: singleRangeIndex[1],
       };
 
-      expectedFunction(
+      expect(
         definition.range,
-        expectedRange,
         `Expected range does not match actual range for label "${label}" on line ${line} near \`${snippet}\``,
-      );
+      ).toEqual(expectedRange);
     }
   }
 }
 
+/**
+ * Extract named range and index information and verify that the "find references" request works as expected.
+ *
+ * Note that there are multiple references for each index, see the example below.
+ *
+ * @param text PL/I text to parse and link, with range and index markers (as specified in `replaceNamedIndices`)
+ *
+ * @example
+ * ```ts
+ * expectReferences(`
+ *  DCL <|1:A|>, <|2:B|>;
+ *  PUT(<|1><|1:A|>);
+ *  PUT(<|2><|2:B|>);
+ * `)
+ * ```
+ */
 export function expectReferences(text: string) {
   const { output, indices, ranges } = replaceNamedIndices(text);
 
@@ -482,11 +487,10 @@ export function expectReferences(text: string) {
   for (const { label, offset, rangeIndex } of requests) {
     const result = referencesRequest(unit, unit.uri, offset);
 
-    expectedFunction(
-      result.length,
-      rangeIndex.length,
+    expect(
+      result,
       `Expected ${rangeIndex.length} references but received ${result.length} for label "${label}"`,
-    );
+    ).toHaveLength(rangeIndex.length);
 
     for (const reference of result) {
       const expectedIndex = rangeIndex.findIndex(


### PR DESCRIPTION
Closes https://github.com/zowe/zowe-pli-language-support/issues/133

We didn't add the inverse references at the correct spot. This led us to miss the inverse references for parts of fully qualified variable declarations. This change ensures that all references end up in the correct spot.

This change also adds tests to the reference search feature.