### PR TITLE
Initial code completion feature

### DIFF
--- a/packages/language/src/language-server/completion/completion-generator.ts
+++ b/packages/language/src/language-server/completion/completion-generator.ts
@@ -1,0 +1,96 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { CompletionItemKind } from "vscode-languageserver-types";
+import { Statement, SyntaxKind, SyntaxNode } from "../../syntax-tree/ast";
+import { CompilationUnit } from "../../workspace/compilation-unit";
+import { CompletionItem } from "../types";
+import { FollowElement, FollowKind } from "./follow-elements";
+import { getQualifiedName } from "../../linking/resolver";
+
+export interface SimpleCompletionItem extends Omit<CompletionItem, "edit"> {
+  text: string;
+}
+
+export function generateCompletionItems(
+  unit: CompilationUnit,
+  context: SyntaxNode | undefined,
+  followElement: FollowElement,
+): SimpleCompletionItem[] {
+  const items: SimpleCompletionItem[] = [];
+  if (followElement.kind === FollowKind.CstNode) {
+    // TODO: implement completion for keywords
+    return [];
+  }
+  if (followElement.kind === FollowKind.QualifiedReference) {
+    context = followElement.previous;
+  } else if (!context) {
+    return [];
+  }
+  const scopeCache = isPreprocessorNode(context, unit)
+    ? unit.scopeCaches.preprocessor
+    : unit.scopeCaches.regular;
+  const scope = scopeCache.get(context);
+  if (!scope) {
+    return [];
+  }
+  if (followElement.kind === FollowKind.LocalReference) {
+    const symbols = scope.allDistinctSymbols([]);
+    for (const symbol of symbols) {
+      if (symbol.name) {
+        items.push({
+          label: symbol.name,
+          kind: getCompletionKind(symbol.node),
+          text: symbol.name,
+        });
+      }
+    }
+  } else if (followElement.kind === FollowKind.QualifiedReference) {
+    const ref = followElement.previous.element?.ref;
+    if (!ref) {
+      return [];
+    }
+    const qualifiedName = getQualifiedName(ref);
+    const symbols = scope.allDistinctSymbols(qualifiedName);
+    for (const symbol of symbols) {
+      if (symbol.name) {
+        items.push({
+          label: symbol.name,
+          kind: getCompletionKind(symbol.node),
+          text: symbol.name,
+        });
+      }
+    }
+  }
+  return items;
+}
+
+function getCompletionKind(node: SyntaxNode): CompletionItemKind {
+  switch (node.kind) {
+    case SyntaxKind.LabelPrefix: {
+      const statement = node.container as Statement;
+      const value = statement.value;
+      if (value && value.kind === SyntaxKind.ProcedureStatement) {
+        return CompletionItemKind.Function;
+      }
+      return CompletionItemKind.Variable;
+    }
+  }
+  return CompletionItemKind.Variable;
+}
+
+function isPreprocessorNode(node: SyntaxNode, unit: CompilationUnit): boolean {
+  let parent = node;
+  while (parent.container) {
+    parent = parent.container;
+  }
+  return unit.preprocessorAst === parent;
+}

--- a/packages/language/src/language-server/completion/completion-request.ts
+++ b/packages/language/src/language-server/completion/completion-request.ts
@@ -1,0 +1,104 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { IToken } from "chevrotain";
+import {
+  binaryTokenSearch,
+  completionTokenIndexSearch,
+} from "../../utils/search";
+import { URI } from "../../utils/uri";
+import { CompilationUnit } from "../../workspace/compilation-unit";
+import { CompletionItem, Range } from "../types";
+import { SyntaxNode } from "../../syntax-tree/ast";
+import {
+  FollowElement,
+  getFollowElements,
+  provideEntryPointFollowElements,
+} from "./follow-elements";
+import {
+  generateCompletionItems,
+  SimpleCompletionItem,
+} from "./completion-generator";
+
+export function completionRequest(
+  unit: CompilationUnit,
+  uri: URI,
+  offset: number,
+): CompletionItem[] {
+  const tokens = unit.tokens.fileTokens[uri.toString()] ?? [];
+  const tokenIndex = completionTokenIndexSearch(tokens, offset);
+  const cursorToken = binaryTokenSearch(tokens, offset);
+  const token = tokens[tokenIndex];
+  const followElements: FollowElement[] = [];
+  let context: SyntaxNode | undefined;
+  if (token) {
+    context = getTokenContext(tokens, tokenIndex);
+    followElements.push(...getFollowElements(context, token));
+  } else {
+    followElements.push(...provideEntryPointFollowElements());
+  }
+  const items = followElements.flatMap((element) =>
+    generateCompletionItems(unit, context, element),
+  );
+  return convertSimpleToItem(items, offset, cursorToken);
+}
+
+function getTokenContext(
+  tokens: IToken[],
+  index: number,
+): SyntaxNode | undefined {
+  // Random magic number to get the context of the current completion request
+  // If we don't find a context within those 5 tokens, the input is probably massively malformed
+  // This prevents us from giving a completion for cross references, but that's ok
+  for (let i = 0; i < 5; i++) {
+    let token = tokens[index - i];
+    if (!token) {
+      return undefined;
+    } else if (token.payload?.element) {
+      return token.payload.element;
+    }
+  }
+  return undefined;
+}
+
+function convertSimpleToItem(
+  items: SimpleCompletionItem[],
+  offset: number,
+  token?: IToken,
+): CompletionItem[] {
+  let existingText = "";
+  let range: Range = {
+    start: offset,
+    end: offset,
+  };
+  if (token) {
+    existingText = token.image.substring(0, offset - token.startOffset);
+    range.start = token.startOffset;
+    range.end = token.endOffset! + 1;
+  }
+  const completionItems: CompletionItem[] = [];
+  for (const item of items) {
+    if (item.text.startsWith(existingText)) {
+      const completionItem: CompletionItem = {
+        label: item.label,
+        kind: item.kind,
+        detail: item.detail,
+        documentation: item.documentation,
+        edit: {
+          range: range,
+          text: item.text,
+        },
+      };
+      completionItems.push(completionItem);
+    }
+  }
+  return completionItems;
+}

--- a/packages/language/src/language-server/completion/follow-elements.ts
+++ b/packages/language/src/language-server/completion/follow-elements.ts
@@ -1,0 +1,76 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { IToken } from "chevrotain";
+import { MemberCall, SyntaxKind, SyntaxNode } from "../../syntax-tree/ast";
+import { CstNodeKind } from "../../syntax-tree/cst";
+
+export enum FollowKind {
+  CstNode,
+  LocalReference,
+  QualifiedReference,
+}
+
+export interface FollowCstNode {
+  kind: FollowKind.CstNode;
+  types: CstNodeKind[];
+}
+
+export interface FollowLocalReference {
+  kind: FollowKind.LocalReference;
+}
+
+export interface FollowQualifiedReference {
+  kind: FollowKind.QualifiedReference;
+  previous: MemberCall;
+}
+
+export type FollowElement =
+  | FollowCstNode
+  | FollowLocalReference
+  | FollowQualifiedReference;
+
+export function getFollowElements(
+  context: SyntaxNode | undefined,
+  token: IToken,
+): FollowElement[] {
+  const elements: FollowElement[] = [];
+  const kind = token.payload?.kind as CstNodeKind | undefined;
+  switch (kind) {
+    // TODO: add more entry points for the completion of expressions
+    case CstNodeKind.AssignmentStatement_Operator:
+    case CstNodeKind.BinaryExpression_Operator:
+    case CstNodeKind.UnaryExpression_Operator:
+    case CstNodeKind.InitialAttribute_OpenParenDirect:
+    // TODO: Percentage can be followed by all the preprocessor directives
+    case CstNodeKind.Percentage:
+      elements.push({
+        kind: FollowKind.LocalReference,
+      });
+      break;
+    case CstNodeKind.MemberCall_Dot:
+      if (context?.kind === SyntaxKind.MemberCall) {
+        const parent = context.previous;
+        if (parent) {
+          elements.push({
+            kind: FollowKind.QualifiedReference,
+            previous: parent,
+          });
+        }
+      }
+      break;
+  }
+  return elements;
+}
+
+export function provideEntryPointFollowElements(): FollowElement[] {
+  return [];
+}

--- a/packages/language/src/language-server/types.ts
+++ b/packages/language/src/language-server/types.ts
@@ -161,3 +161,43 @@ export function diagnosticToLSP(diagnostic: Diagnostic): lsp.Diagnostic {
     source: diagnostic.source ?? "pli",
   };
 }
+
+export interface CompletionItem {
+  label: string;
+  kind: lsp.CompletionItemKind;
+  detail?: string;
+  documentation?: string;
+  sortText?: string;
+  filterText?: string;
+  edit: TextEdit;
+}
+
+export function completionItemToLSP(
+  textDocument: TextDocument,
+  item: CompletionItem,
+): lsp.CompletionItem {
+  return {
+    label: item.label,
+    kind: item.kind,
+    detail: item.detail,
+    documentation: item.documentation,
+    sortText: item.sortText,
+    filterText: item.filterText,
+    textEdit: textEditToLSP(textDocument, item.edit),
+  };
+}
+
+export interface TextEdit {
+  range: Range;
+  text: string;
+}
+
+export function textEditToLSP(
+  textDocument: TextDocument,
+  edit: TextEdit,
+): lsp.TextEdit {
+  return {
+    range: rangeToLSP(textDocument, edit.range),
+    newText: edit.text,
+  };
+}

--- a/packages/language/src/linking/resolver.ts
+++ b/packages/language/src/linking/resolver.ts
@@ -77,7 +77,7 @@ export class ReferencesCache {
 }
 
 // Returns the qualified name in reverse order, e.g. "A.B.C" -> ["C", "B", "A"]
-function getQualifiedName(reference: Reference): string[] {
+export function getQualifiedName(reference: Reference): string[] {
   if (reference.owner.container?.kind === SyntaxKind.MemberCall) {
     const memberCall = reference.owner.container;
     if (memberCall.previous?.element?.ref) {

--- a/packages/language/src/linking/scope.ts
+++ b/packages/language/src/linking/scope.ts
@@ -35,6 +35,19 @@ export class Scope {
     );
   }
 
+  allDistinctSymbols(
+    qualifiedName: string[],
+    symbols: QualifiedSyntaxNode[] = [],
+  ): QualifiedSyntaxNode[] {
+    if (this._symbolTable) {
+      symbols.push(...this._symbolTable.allDistinctSymbols(qualifiedName));
+    }
+    if (this.parent) {
+      this.parent.allDistinctSymbols(qualifiedName, symbols);
+    }
+    return symbols;
+  }
+
   // This is a lazy getter for the symbol table to
   // prevent unnecessary memory allocation for scopes
   // that do not have a symbol table.

--- a/packages/language/src/utils/search.ts
+++ b/packages/language/src/utils/search.ts
@@ -4,23 +4,57 @@ export function binaryTokenSearch(
   tokens: IToken[],
   offset: number,
 ): IToken | undefined {
+  return tokens[binaryTokenIndexSearch(tokens, offset)];
+}
+
+export function binaryTokenIndexSearch(
+  tokens: IToken[],
+  offset: number,
+): number {
   let low = 0;
   let high = tokens.length - 1;
+  let token: IToken | undefined;
+  let mid = -1;
   while (low <= high) {
-    const mid = Math.floor((low + high) / 2);
-    const token = tokens[mid];
+    mid = Math.floor((low + high) / 2);
+    token = tokens[mid];
     const start = token.startOffset;
     const end = token.endOffset!;
-    if (start <= offset && offset <= end) {
-      return token;
-    } else if (offset - end === 1 && /\w$/u.test(token.image)) {
-      // If the offset is right after the end of a word token, return that token
-      return token;
+    if ((start <= offset && offset <= end) || isAtTokenEnd(token, offset)) {
+      return mid;
     } else if (start > offset) {
       high = mid - 1;
     } else {
       low = mid + 1;
     }
   }
-  return undefined;
+  return -1;
+}
+
+function isAtTokenEnd(token: IToken, offset: number): boolean {
+  const end = token.endOffset!;
+  // If the offset is right after the end of a word token, return that token
+  return offset - end === 1 && /\w$/u.test(token.image);
+}
+
+function isBeforeTokenEnd(token: IToken, offset: number): boolean {
+  return token.endOffset! >= offset || isAtTokenEnd(token, offset);
+}
+
+export function completionTokenIndexSearch(
+  tokens: IToken[],
+  offset: number,
+): number {
+  if (tokens.length === 0) {
+    return -1;
+  }
+  const end = tokens.length - 1;
+  // Start at -1 to return undefined if the offset is before the end of the first token
+  for (let i = -1; i < end; i++) {
+    const nextToken = tokens[i + 1];
+    if (isBeforeTokenEnd(nextToken, offset)) {
+      return i;
+    }
+  }
+  return end;
 }

--- a/packages/language/test/lsp/completion.test.ts
+++ b/packages/language/test/lsp/completion.test.ts
@@ -1,0 +1,49 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { describe, test } from "vitest";
+import { expectCompletions } from "../utils";
+
+describe("Completion", () => {
+  test("Provides completion for local references", () => {
+    expectCompletions(
+      `
+      DCL A char(10);
+      DCL B char(10);
+      DCL C char(10);
+      A = <|>123;
+    `,
+      [["A", "B", "C"]],
+    );
+  });
+
+  test("Provides completion for fully qualified references", () => {
+    expectCompletions(
+      `
+      DCL 1 A, 2 B, 3 C, 4 D char(10);
+      DCL X char(10);
+      X = <|>A.<|>B.<|>C.<|>D;
+    `,
+      [["A", "B", "C", "D", "X"], ["B", "C", "D"], ["C", "D"], ["D"]],
+    );
+  });
+
+  test("Provides completion for partially qualified references", () => {
+    expectCompletions(
+      `
+      DCL 1 A, 2 B, 3 C, 4 D char(10);
+      DCL X char(10);
+      X = <|>C.<|>D;
+    `,
+      [["A", "B", "C", "D", "X"], ["D"]],
+    );
+  });
+});


### PR DESCRIPTION
Related to https://github.com/zowe/zowe-pli-language-support/issues/26.

Adds initial support for the completion feature of PL/I. Currently only allows for completion of local and fully qualified references within expressions.

Eventually this infrastructure should support more completion for keywords of the language and snippets.