### PR TITLE
Flag Duplicate & Mutually Exclusive Compiler Opts

### DIFF
--- a/packages/language/src/preprocessor/compiler-options/translator.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator.ts
@@ -1147,6 +1147,7 @@ export function translateCompilerOptions(
   input: AbstractCompilerOptions,
 ): CompilerOptionResult {
   translator.options = {};
+  translator.optionSet.clear();
   translator.issues = [...input.issues];
   for (const option of input.options) {
     translator.translate(option);

--- a/packages/language/test/compiler/options-parser.test.ts
+++ b/packages/language/test/compiler/options-parser.test.ts
@@ -146,6 +146,8 @@ describe("CompilerOptions translator", () => {
     const options = parseAbstractCompilerOptions("UNKNOWNOPTION");
     const issues = translateCompilerOptions(options).issues;
     expect(issues).toHaveLength(1);
-    expect(issues[0].message).toMatch("Unknown compiler option");
+    expect(issues[0].message).toMatch(
+      "The string UNKNOWNOPTION is not recognized as a valid option keyword and is ignored."
+    );
   });
 });

--- a/packages/language/test/compiler/options-parser.test.ts
+++ b/packages/language/test/compiler/options-parser.test.ts
@@ -147,7 +147,7 @@ describe("CompilerOptions translator", () => {
     const issues = translateCompilerOptions(options).issues;
     expect(issues).toHaveLength(1);
     expect(issues[0].message).toMatch(
-      "The string UNKNOWNOPTION is not recognized as a valid option keyword and is ignored."
+      "The string UNKNOWNOPTION is not recognized as a valid option keyword and is ignored.",
     );
   });
 });

--- a/packages/language/test/utils.ts
+++ b/packages/language/test/utils.ts
@@ -65,6 +65,16 @@ export function assertNoLinkingErrors(
 }
 
 /**
+ * Asserts the absence of compiler option errors in the given source file
+ */
+export function assertNoCompilerOptionErrors(
+  sourceFile: CompilationUnit,
+  options: AssertNoDiagnosticsOptions = {},
+) {
+  expectNoDiagnostics(sourceFile.diagnostics.compilerOptions, options);
+}
+
+/**
  * Asserts the absence of validation errors in the given source file
  */
 export function assertNoValidationErrors(
@@ -83,6 +93,7 @@ export function assertNoDiagnostics(
 ) {
   assertNoParseErrors(sourceFile, options);
   assertNoLinkingErrors(sourceFile, options);
+  assertNoCompilerOptionErrors(sourceFile, options);
   assertNoValidationErrors(sourceFile, options);
 }
 

--- a/packages/language/test/validating.test.ts
+++ b/packages/language/test/validating.test.ts
@@ -277,7 +277,7 @@ describe("Validating", () => {
         `);
       assertDiagnostic(doc, {
         message:
-          "Mutually exclusive compiler options NOAGGREGATE & AGGREGATE, only the last one will take effect.",
+          "Mutually exclusive compiler options found for AGGREGATE, only the last one will take effect.",
         severity: Severity.W,
       });
     });
@@ -306,13 +306,36 @@ describe("Validating", () => {
 
     test("Warn on complex case w/ mutex opt", async () => {
       const doc =
-        parseWithValidations(`*PROCESS OBJECT, PPTRACE, AGGREGATE, NULLDATE, NOPPTRACE;
+        parseWithValidations(`*PROCESS NODBRMLIB, COMPILE, AGGREGATE, NOCOMPILE;
         EP: PROC OPTIONS (MAIN);
         END EP;
         `);
       assertDiagnostic(doc, {
         message:
-          "Mutually exclusive compiler options PPTRACE & NOPPTRACE, only the last one will take effect.",
+          "Mutually exclusive compiler options found for NOCOMPILE, only the last one will take effect.",
+        severity: Severity.W,
+      });
+    });
+
+    test("Warn on duplicate w/ aliased form", async () => {
+      const doc = parseWithValidations(`*PROCESS AG, AGGREGATE;
+        EP: PROC OPTIONS (MAIN);
+        END EP;
+        `);
+      assertDiagnostic(doc, {
+        message: "Duplicate compiler option AGGREGATE",
+        severity: Severity.W,
+      });
+    });
+
+    test("Warn on mutex case w/ aliased form", async () => {
+      const doc = parseWithValidations(`*PROCESS NAG, AGGREGATE;
+        EP: PROC OPTIONS (MAIN);
+        END EP;
+        `);
+      assertDiagnostic(doc, {
+        message:
+          "Mutually exclusive compiler options found for AGGREGATE, only the last one will take effect.",
         severity: Severity.W,
       });
     });

--- a/packages/language/test/validating.test.ts
+++ b/packages/language/test/validating.test.ts
@@ -276,7 +276,8 @@ describe("Validating", () => {
         END EP;
         `);
       assertDiagnostic(doc, {
-        message: "Mutually exclusive compiler options NOAGGREGATE & AGGREGATE, only the last one will take effect.",
+        message:
+          "Mutually exclusive compiler options NOAGGREGATE & AGGREGATE, only the last one will take effect.",
         severity: Severity.W,
       });
     });
@@ -304,18 +305,21 @@ describe("Validating", () => {
     });
 
     test("Warn on complex case w/ mutex opt", async () => {
-      const doc = parseWithValidations(`*PROCESS OBJECT, PPTRACE, AGGREGATE, NULLDATE, NOPPTRACE;
+      const doc =
+        parseWithValidations(`*PROCESS OBJECT, PPTRACE, AGGREGATE, NULLDATE, NOPPTRACE;
         EP: PROC OPTIONS (MAIN);
         END EP;
         `);
       assertDiagnostic(doc, {
-        message: "Mutually exclusive compiler options PPTRACE & NOPPTRACE, only the last one will take effect.",
+        message:
+          "Mutually exclusive compiler options PPTRACE & NOPPTRACE, only the last one will take effect.",
         severity: Severity.W,
       });
     });
 
     test("Valid on complex case w/ no issues", async () => {
-      const doc = parseWithValidations(`*PROCESS OBJECT, PPTRACE, AGGREGATE, NULLDATE;
+      const doc =
+        parseWithValidations(`*PROCESS OBJECT, PPTRACE, AGGREGATE, NULLDATE;
         EP: PROC OPTIONS (MAIN);
         END EP;
         `);

--- a/packages/language/test/validating.test.ts
+++ b/packages/language/test/validating.test.ts
@@ -342,7 +342,7 @@ describe("Validating", () => {
 
     test("Valid on complex case w/ no issues", async () => {
       const doc =
-        parseWithValidations(`*PROCESS OBJECT, PPTRACE, AGGREGATE, NULLDATE;
+        parseWithValidations(`*PROCESS COMPILE, NODBRMLIB, AGGREGATE, MARGINS(2,72);
         EP: PROC OPTIONS (MAIN);
         END EP;
         `);


### PR DESCRIPTION
Closes #105 by adding:
- warning diagnostic for duplicate options `(AG, AG)`
- warning diagnostic for mutually exclusive options `(NOEXIT, EXIT)`
- warning for dupes in short & long form `(AG, AGGREGATE)`
- warning for mutually exclusive options in long & short form `(NAG, AGGREGATE)`
- updated the existing diagnostic for unrecognized options to conform to PLI's compiler code for that
- updated `assertNoDiagnostics` to factor in compiler option diagnostics as well

In all cases the compiler only emits a warning rather than an error. And in cases of duplicate / mutex options the compiler always appears to take the last option seen (verified in listings output).