### PR TITLE
Fix preprocessor parser issue and lexing diagnostics

### DIFF
--- a/packages/language/src/preprocessor/pli-lexer.ts
+++ b/packages/language/src/preprocessor/pli-lexer.ts
@@ -9,7 +9,7 @@
  *
  */
 
-import { ILexingError, IToken, Lexer } from "chevrotain";
+import { IToken, Lexer } from "chevrotain";
 import { MarginsProcessor, PliMarginsProcessor } from "./pli-margins-processor";
 import { PliPreprocessorLexer } from "./pli-preprocessor-lexer";
 import { PliPreprocessorInterpreter } from "./pli-preprocessor-interpreter";
@@ -25,10 +25,17 @@ import {
 import { CompilationUnit } from "../workspace/compilation-unit";
 import { Statement } from "../syntax-tree/ast";
 import { EvaluationResults } from "./pli-preprocessor-interpreter-state";
+import { Range } from "../language-server/types";
+
+export interface LexingError {
+  readonly message: string;
+  readonly range: Range;
+  readonly uri: URI;
+}
 
 export interface LexerResult {
   all: IToken[];
-  errors: ILexingError[];
+  errors: LexingError[];
   compilerOptions: CompilerOptionsProcessorResult;
   statements: Statement[];
   fileTokens: Record<string, IToken[]>;

--- a/packages/language/src/preprocessor/pli-preprocessor-error.ts
+++ b/packages/language/src/preprocessor/pli-preprocessor-error.ts
@@ -9,27 +9,38 @@
  *
  */
 
-import { ILexingError, IToken } from "chevrotain";
+import type { LexingError } from "./pli-lexer";
+import { Range } from "../language-server/types";
+import { URI } from "../utils/uri";
+import { IToken } from "chevrotain";
 
-export class PreprocessorError extends Error implements ILexingError {
-  private readonly token: IToken;
-  public readonly uri: string;
-  constructor(message: string, token: IToken, uri: string) {
-    super(message);
-    this.token = token;
-    this.uri = uri;
+export class PreprocessorError implements LexingError {
+  private _uri: URI;
+  private _range: Range;
+  private _message: string;
+
+  get uri(): URI {
+    return this._uri;
   }
-  readonly type = "error";
-  get offset(): number {
-    return this.token.startOffset;
+
+  get range(): Range {
+    return this._range;
   }
-  get line(): number | undefined {
-    return this.token.startLine;
+
+  get message(): string {
+    return this._message;
   }
-  get column(): number | undefined {
-    return this.token.startColumn;
-  }
-  get length(): number {
-    return this.token.image.length;
+
+  constructor(message: string, range: Range | IToken, uri: URI) {
+    this._message = message;
+    if ("start" in range) {
+      this._range = range;
+    } else {
+      this._range = {
+        start: range.startOffset,
+        end: range.endOffset!,
+      };
+    }
+    this._uri = uri;
   }
 }

--- a/packages/language/src/preprocessor/pli-preprocessor-parser-state.ts
+++ b/packages/language/src/preprocessor/pli-preprocessor-parser-state.ts
@@ -210,7 +210,7 @@ export class PliPreprocessorParserState implements PreprocessorParserState {
         .map((t) => t.tokenType.name ?? "???")
         .join(", ");
       const message = `Expected token type '${tokenType.name}', got '${actualTokenTypes}' instead.`;
-      throw new PreprocessorError(message, token, this.uri.toString());
+      throw new PreprocessorError(message, token || this.last, this.uri);
     }
     token.payload = {
       uri: this.uri,

--- a/packages/language/src/preprocessor/pli-preprocessor-parser.ts
+++ b/packages/language/src/preprocessor/pli-preprocessor-parser.ts
@@ -30,10 +30,11 @@ import {
 } from "../parser/abstract-parser";
 import { CstNodeKind } from "../syntax-tree/cst";
 import { PliPreprocessorLexerState } from "./pli-preprocessor-lexer-state";
+import { LexingError } from "./pli-lexer";
 
 export type PreprocessorParserResult = {
   statements: ast.Statement[];
-  errors: PreprocessorError[];
+  errors: LexingError[];
   perFileTokens: Record<string, IToken[]>;
 };
 
@@ -50,7 +51,7 @@ export class PliPreprocessorParser {
 
   start(state: PreprocessorParserState): PreprocessorParserResult {
     const statements: ast.Statement[] = [];
-    const errors: PreprocessorError[] = [];
+    const errors: LexingError[] = [];
     while (!state.eof) {
       try {
         if (
@@ -209,8 +210,8 @@ export class PliPreprocessorParser {
     if (unit === undefined) {
       throw new PreprocessorError(
         "Unexpected token '" + state.current?.image + "'.",
-        state.current!,
-        state.uri.toString(),
+        state.current || state.last!,
+        state.uri,
       );
     }
     // TODO: We can move this into validation!
@@ -569,8 +570,8 @@ export class PliPreprocessorParser {
     //TODO type-3-do
     throw new PreprocessorError(
       "Unexpected token '" + state.current?.image + "'.",
-      state.current!,
-      state.uri.toString(),
+      state.current || state.last!,
+      state.uri,
     );
   }
 
@@ -656,7 +657,7 @@ export class PliPreprocessorParser {
 
   private statements(state: PreprocessorParserState): ast.Statement[] {
     const statements: ast.Statement[] = [];
-    while (!state.canConsumeKeyword(PreprocessorTokens.End)) {
+    while (!state.eof && !state.canConsumeKeyword(PreprocessorTokens.End)) {
       const statement = this.statement(state);
       statements.push(statement);
     }
@@ -1162,8 +1163,8 @@ export class PliPreprocessorParser {
     }
     throw new PreprocessorError(
       "Cannot handle this type of preprocessor expression yet!",
-      state.current!,
-      state.uri.toString(),
+      state.current || state.last!,
+      state.uri,
     );
   }
 

--- a/packages/language/src/validation/validator.ts
+++ b/packages/language/src/validation/validator.ts
@@ -9,11 +9,7 @@
  *
  */
 
-import {
-  ILexingError,
-  IRecognitionException,
-  MismatchedTokenException,
-} from "chevrotain";
+import { IRecognitionException, MismatchedTokenException } from "chevrotain";
 import { CompilationUnit } from "../workspace/compilation-unit";
 import {
   Diagnostic,
@@ -33,6 +29,7 @@ import {
   registerValidationChecks,
 } from "./pli-validator";
 import * as PLICodes from "../validation/messages/pli-codes";
+import { LexingError } from "../preprocessor/pli-lexer";
 
 /**
  * A function that accepts a diagnostic for PL/I validation
@@ -109,18 +106,15 @@ function validateSyntaxNode(
 }
 
 export function lexerErrorsToDiagnostics(
-  lexerErrors: ILexingError[],
+  lexerErrors: LexingError[],
 ): Diagnostic[] {
   const diagnostics: Diagnostic[] = [];
   for (const error of lexerErrors) {
-    if (error.line && error.column) {
+    if (!isNaN(error.range.start)) {
       diagnostics.push({
-        uri: "",
+        uri: error.uri.toString(),
         severity: Severity.E,
-        range: {
-          start: error.offset,
-          end: error.offset + error.length,
-        },
+        range: error.range,
         message: error.message,
         source: "lexer",
       });

--- a/packages/language/test/parser/pli-lexer.test.ts
+++ b/packages/language/test/parser/pli-lexer.test.ts
@@ -20,7 +20,9 @@ describe("PL/1 Lexer", () => {
       );
       if (errors.length > 0) {
         throw new Error(
-          errors.map((e) => `${e.line}:${e.column}: ${e.message}`).join("\n"),
+          errors
+            .map((e) => `${e.range.start}:${e.range.end}: ${e.message}`)
+            .join("\n"),
         );
       }
       return allTokens.map(


### PR DESCRIPTION
The main fix for the issue is adding `!state.eof` to the `while` loop. However, while debugging this, I've noticed that preprocessor errors are currently being swallowed, because their `uri` is always an empty string. This change fixes both issues.