### PR TITLE
Refactor linking system

### DIFF
--- a/packages/language/src/linking/declared-item-parser.ts
+++ b/packages/language/src/linking/declared-item-parser.ts
@@ -1,0 +1,174 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { Severity, tokenToRange, tokenToUri } from "../language-server/types";
+import { DeclaredItem } from "../syntax-tree/ast";
+import { PliValidationAcceptor } from "../validation/validator";
+import * as PLICodes from "../validation/messages/pli-codes";
+import { SymbolTable } from "./symbol-table";
+import { QualifiedSyntaxNode } from "./qualified-syntax-node";
+import { MultiMap } from "../utils/collections";
+import { forEachNode } from "../syntax-tree/ast-iterator";
+import { getNameToken } from "./tokens";
+
+/**
+ * Handles "parsing" the hierarchy of a list of `DeclaredItem`s.
+ *
+ * This is done by reversing the following declarations:
+ *
+ * ```pli
+ * DCL 1 A1,
+ *       2 B,
+ *         3 K,
+ *       2 C,
+ *         3 K;
+ * ```
+ *
+ * Into this kind of linked list data structure:
+ *
+ * ```
+ * K -> B -> A1
+ * B -> A1
+ * K -> C -> A1
+ * C -> A1
+ * ```
+ */
+
+export class DeclaredItemParser {
+  private items: DeclaredItem[];
+  private accept: PliValidationAcceptor;
+
+  constructor(items: DeclaredItem[], accept: PliValidationAcceptor) {
+    this.items = items.slice(); // Explicitly make a copy of the items, to use `.shift()` in `this.pop()`
+    this.accept = accept;
+  }
+
+  private peek(): DeclaredItem | undefined {
+    return this.items[0];
+  }
+
+  private pop(): DeclaredItem | undefined {
+    return this.items.shift();
+  }
+
+  private getLevel(item: DeclaredItem): number {
+    // When level is not set, we assume 1 like the PL1 compiler seems to do.
+    // TODO: When creating a structured declaration, throw a IBM1364I E if level is not set.
+    let level = item.level ?? 1;
+
+    // TODO: get max level from compilation unit? If e.g. compilation flags can change this.
+    if (level > 255) {
+      level = 255;
+
+      this.accept(Severity.E, PLICodes.Error.IBM1363I.message, {
+        code: PLICodes.Error.IBM1363I.fullCode,
+        range: tokenToRange(item.levelToken!),
+        uri: tokenToUri(item.levelToken!) ?? "",
+      });
+    }
+
+    return level;
+  }
+
+  private _generate(
+    table: SymbolTable,
+    parent: QualifiedSyntaxNode | null,
+    parentLevel: number,
+  ) {
+    // Keep track of all nodes we've seen on the current level, for redeclaration detection.
+    const nodes = new MultiMap<string, QualifiedSyntaxNode>();
+
+    // Consume many items on the same level.
+    while (true) {
+      const item = this.peek();
+      if (!item) {
+        break;
+      }
+
+      const level = this.getLevel(item);
+      // The item we're looking at is not a part of the current scope, let's exit.
+      if (level <= parentLevel) {
+        break;
+      }
+
+      // This item is part of the current scope, let's consume it.
+      this.pop();
+
+      // In the case of factorized variables, a single
+      // DeclaredItem can contain multiple names.
+      // TODO: Unroll factorized declarations, e.g.:
+      // ```
+      // DCL 1 A,
+      //       2 (B,C,D),
+      //          3 E;
+      // ```
+      // Appears to be handled like this in the PL/I compiler:
+      // ```
+      //   DCL 1 A,
+      //         2 B,
+      //         2 C,
+      //         2 D,
+      //           3 E;
+      // ```
+      forEachNode(item, (child) => {
+        const nameToken = getNameToken(child);
+        if (!nameToken) {
+          return;
+        }
+
+        const name = nameToken.image;
+
+        // TODO: Replace name by asterix, somehow ...
+        const isRedeclared = nodes.get(name).length > 0;
+        if (isRedeclared) {
+          this.accept(Severity.E, PLICodes.Error.IBM1308I.message(name), {
+            code: PLICodes.Error.IBM1308I.fullCode,
+            range: tokenToRange(nameToken),
+            uri: tokenToUri(nameToken) ?? "",
+          });
+        }
+
+        // Otherwise, we can add the node to the symbol table.
+        const node = new QualifiedSyntaxNode(nameToken, child, parent, level);
+
+        nodes.add(name, node);
+        table.addSymbolDeclaration(name, node);
+        this._generate(table, node, level);
+
+        // const isRootLevel = level === 1;
+
+        // if (nodes.get(name).length > 0) {
+        //   // If we've already seen this name on the current level, we have a redeclaration.
+        //   this.reportRedeclarationError(nameToken, level);
+        // } else if (isRootLevel && table.getRootDeclarations(name).length > 0) {
+        //   // If we've already seen this name in the root scope, we have a redeclaration.
+        //   this.reportRedeclarationError(nameToken, level);
+        // } else {
+        //   // Otherwise, we can add the node to the symbol table.
+        //   const node = new QualifiedSyntaxNode(name, child, {
+        //     parent,
+        //     level,
+        //   });
+
+        //   nodes.add(name, node);
+        //   table.addSymbolDeclaration(name, node);
+        //   this._generate(table, node, level);
+        // }
+      });
+    }
+  }
+
+  generate(table: SymbolTable) {
+    // Use 0 as a default level to start the generation.
+    // TODO: Maybe make this `null` to represent the root scope.
+    this._generate(table, null, 0);
+  }
+}

--- a/packages/language/src/linking/declared-item-parser.ts
+++ b/packages/language/src/linking/declared-item-parser.ts
@@ -46,7 +46,7 @@ export class DeclaredItemParser {
   private items: DeclaredItem[];
   private accept: PliValidationAcceptor;
 
-  constructor(items: DeclaredItem[], accept: PliValidationAcceptor) {
+  constructor(items: readonly DeclaredItem[], accept: PliValidationAcceptor) {
     this.items = items.slice(); // Explicitly make a copy of the items, to use `.shift()` in `this.pop()`
     this.accept = accept;
   }

--- a/packages/language/src/linking/declared-item-parser.ts
+++ b/packages/language/src/linking/declared-item-parser.ts
@@ -142,26 +142,6 @@ export class DeclaredItemParser {
         nodes.add(name, node);
         table.addSymbolDeclaration(name, node);
         this._generate(table, node, level);
-
-        // const isRootLevel = level === 1;
-
-        // if (nodes.get(name).length > 0) {
-        //   // If we've already seen this name on the current level, we have a redeclaration.
-        //   this.reportRedeclarationError(nameToken, level);
-        // } else if (isRootLevel && table.getRootDeclarations(name).length > 0) {
-        //   // If we've already seen this name in the root scope, we have a redeclaration.
-        //   this.reportRedeclarationError(nameToken, level);
-        // } else {
-        //   // Otherwise, we can add the node to the symbol table.
-        //   const node = new QualifiedSyntaxNode(name, child, {
-        //     parent,
-        //     level,
-        //   });
-
-        //   nodes.add(name, node);
-        //   table.addSymbolDeclaration(name, node);
-        //   this._generate(table, node, level);
-        // }
       });
     }
   }

--- a/packages/language/src/linking/qualified-syntax-node.ts
+++ b/packages/language/src/linking/qualified-syntax-node.ts
@@ -27,30 +27,6 @@ export class QualifiedSyntaxNode {
   level: number;
   nameToken: IToken;
 
-  /**
-   * The symbol is redeclared in the same scope.
-   * For example:
-   *
-   * ```pli
-   * // Case 1
-   * DCL A;
-   * DCL A;
-   *
-   * // Case 2
-   * DCL A, A;
-   *
-   * // Case 3
-   * A: PROCEDURE;
-   * A: PROCEDURE;
-   *
-   * // Case 4
-   * DCL 1 A,
-   *       2 B,
-   *       2 B;
-   * ```
-   */
-  // isRedeclared: boolean;
-
   constructor(
     nameToken: IToken,
     node: SyntaxNode,

--- a/packages/language/src/linking/qualified-syntax-node.ts
+++ b/packages/language/src/linking/qualified-syntax-node.ts
@@ -1,0 +1,114 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import type { IToken } from "chevrotain";
+import type { SyntaxNode } from "../syntax-tree/ast";
+
+/**
+ * Always take full qualification over partial qualification.
+ */
+export enum QualificationStatus {
+  NoQualification,
+  FullQualification,
+  PartialQualification,
+}
+
+export class QualifiedSyntaxNode {
+  node: SyntaxNode;
+  parent: QualifiedSyntaxNode | null;
+  level: number;
+  nameToken: IToken;
+
+  /**
+   * The symbol is redeclared in the same scope.
+   * For example:
+   *
+   * ```pli
+   * // Case 1
+   * DCL A;
+   * DCL A;
+   *
+   * // Case 2
+   * DCL A, A;
+   *
+   * // Case 3
+   * A: PROCEDURE;
+   * A: PROCEDURE;
+   *
+   * // Case 4
+   * DCL 1 A,
+   *       2 B,
+   *       2 B;
+   * ```
+   */
+  // isRedeclared: boolean;
+
+  constructor(
+    nameToken: IToken,
+    node: SyntaxNode,
+    parent: QualifiedSyntaxNode | null = null,
+    level: number = 1,
+  ) {
+    this.nameToken = nameToken;
+    this.node = node;
+    this.parent = parent;
+    this.level = level;
+  }
+
+  get name(): string {
+    return this.nameToken.image;
+  }
+
+  getParent(): QualifiedSyntaxNode | null {
+    return this.parent;
+  }
+
+  /**
+   * By walking the qualification chain, we can determine the qualification status of the current node.
+   *
+   * Example:
+   *
+   * ```
+   * DCL 1 A, 2 B, 3 C;
+   * PUT (A.B.C); // `C` has `FullQualification`
+   * PUT (A.C);   // `C` has `PartialQualification`
+   * ```
+   */
+  getQualificationStatus(qualifiers: string[]): QualificationStatus {
+    const qualifier = qualifiers[0];
+    if (!qualifier) {
+      return QualificationStatus.NoQualification;
+    }
+
+    // If the current node is the same as the qualifier, we can remove it from the list.
+    const nextQualifiers =
+      this.name === qualifier ? qualifiers.slice(1) : qualifiers;
+
+    // If there are no qualifiers left, we can determine the qualification status.
+    if (nextQualifiers.length <= 0) {
+      if (!this.parent) {
+        // If there is no parent, the current node is the root node.
+        return QualificationStatus.FullQualification;
+      } else {
+        // If there are parents left, the current node is partially qualified.
+        return QualificationStatus.PartialQualification;
+      }
+    }
+
+    // We have qualifiers left, but no parent. This does not qualify.
+    if (!this.parent) {
+      return QualificationStatus.NoQualification;
+    }
+
+    // We have qualifiers left, and a parent. We continue the search.
+    return this.parent.getQualificationStatus(nextQualifiers);
+  }
+}

--- a/packages/language/src/linking/qualified-syntax-node.ts
+++ b/packages/language/src/linking/qualified-syntax-node.ts
@@ -82,7 +82,7 @@ export class QualifiedSyntaxNode {
    * PUT (A.C);   // `C` has `PartialQualification`
    * ```
    */
-  getQualificationStatus(qualifiers: string[]): QualificationStatus {
+  getQualificationStatus(qualifiers: readonly string[]): QualificationStatus {
     const qualifier = qualifiers[0];
     if (!qualifier) {
       return QualificationStatus.NoQualification;

--- a/packages/language/src/linking/resolver.ts
+++ b/packages/language/src/linking/resolver.ts
@@ -32,12 +32,12 @@ import {
 } from "./tokens";
 import { URI } from "../utils/uri";
 import { CompilationUnit } from "../workspace/compilation-unit";
-import { QualifiedSyntaxNode } from "./symbol-table";
 import {
   PliValidationAcceptor,
   PliValidationBuffer,
 } from "../validation/validator";
 import * as PLICodes from "../validation/messages/pli-codes";
+import { QualifiedSyntaxNode } from "./qualified-syntax-node";
 
 export class ReferencesCache {
   private list: Reference[] = [];

--- a/packages/language/src/linking/scope.ts
+++ b/packages/language/src/linking/scope.ts
@@ -1,0 +1,79 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { SyntaxNode } from "../syntax-tree/ast";
+import { QualifiedSyntaxNode } from "./qualified-syntax-node";
+import { SymbolTable } from "./symbol-table";
+
+/**
+ * The Scope class is used to store the symbol table for a given scope.
+ * When getting a symbol, the scope will check its own symbol table first,
+ * then the parent scope, and so on.
+ */
+export class Scope {
+  private _symbolTable: SymbolTable | null;
+  private parent: Scope | null;
+
+  constructor(parent: Scope | null, symbolTable: SymbolTable | null = null) {
+    this.parent = parent;
+    this._symbolTable = symbolTable;
+  }
+
+  getSymbols(qualifiedName: string[]): readonly QualifiedSyntaxNode[] {
+    return (
+      this._symbolTable?.getSymbols(qualifiedName) ??
+      this.parent?.getSymbols(qualifiedName) ??
+      []
+    );
+  }
+
+  // This is a lazy getter for the symbol table to
+  // prevent unnecessary memory allocation for scopes
+  // that do not have a symbol table.
+  get symbolTable(): SymbolTable {
+    if (!this._symbolTable) {
+      this._symbolTable = new SymbolTable();
+    }
+
+    return this._symbolTable;
+  }
+}
+
+export class ScopeCacheGroups {
+  regular = new ScopeCache();
+  preprocessor = new ScopeCache();
+
+  clear(): void {
+    this.regular.clear();
+    this.preprocessor.clear();
+  }
+
+  get(node: SyntaxNode): Scope | undefined {
+    return this.regular.get(node) ?? this.preprocessor.get(node);
+  }
+}
+
+// The scope cache is used to relate a syntax node to its scope.
+export class ScopeCache {
+  private scopes: Map<SyntaxNode, Scope> = new Map();
+
+  add(node: SyntaxNode, scope: Scope): void {
+    this.scopes.set(node, scope);
+  }
+
+  get(node: SyntaxNode): Scope | undefined {
+    return this.scopes.get(node);
+  }
+
+  clear(): void {
+    this.scopes.clear();
+  }
+}

--- a/packages/language/src/linking/scope.ts
+++ b/packages/language/src/linking/scope.ts
@@ -27,7 +27,7 @@ export class Scope {
     this._symbolTable = symbolTable;
   }
 
-  getSymbols(qualifiedName: string[]): readonly QualifiedSyntaxNode[] {
+  getSymbols(qualifiedName: readonly string[]): readonly QualifiedSyntaxNode[] {
     return (
       this._symbolTable?.getSymbols(qualifiedName) ??
       this.parent?.getSymbols(qualifiedName) ??

--- a/packages/language/src/linking/symbol-table.ts
+++ b/packages/language/src/linking/symbol-table.ts
@@ -58,7 +58,7 @@ export class SymbolTable {
 
   // Return all qualified symbols
   getSymbols(
-    qualifiedName: string[],
+    qualifiedName: readonly string[],
   ): readonly QualifiedSyntaxNode[] | undefined {
     const [name] = qualifiedName;
     if (!name) {

--- a/packages/language/src/linking/tokens.ts
+++ b/packages/language/src/linking/tokens.ts
@@ -85,25 +85,3 @@ export function getReference(node: SyntaxNode): Reference | undefined {
   }
   return undefined;
 }
-
-/**
- * Gets a referenceable symbol name for the given node, when present
- */
-export function getVariableSymbol(node: SyntaxNode): string | undefined {
-  switch (node.kind) {
-    case SyntaxKind.DeclaredVariable:
-      return node.name!;
-    default:
-      return undefined;
-  }
-}
-
-export function getLabelSymbol(node: SyntaxNode): string | undefined {
-  switch (node.kind) {
-    case SyntaxKind.LabelPrefix:
-    case SyntaxKind.OrdinalValue:
-      return node.name!;
-    default:
-      return undefined;
-  }
-}

--- a/packages/language/src/utils/collections.ts
+++ b/packages/language/src/utils/collections.ts
@@ -1,0 +1,161 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/**
+ * MultiMap taken from Langium.
+ */
+
+export class MultiMap<K, V> {
+  private map = new Map<K, V[]>();
+
+  constructor();
+  constructor(elements: Array<[K, V]>);
+  constructor(elements?: Array<[K, V]>) {
+    if (elements) {
+      for (const [key, value] of elements) {
+        this.add(key, value);
+      }
+    }
+  }
+
+  /**
+   * Clear all entries in the multimap.
+   */
+  clear(): void {
+    this.map.clear();
+  }
+
+  /**
+   * Operates differently depending on whether a `value` is given:
+   *  * With a value, this method deletes the specific key / value pair from the multimap.
+   *  * Without a value, all values associated with the given key are deleted.
+   *
+   * @returns `true` if a value existed and has been removed, or `false` if the specified
+   *     key / value does not exist.
+   */
+  delete(key: K, value?: V): boolean {
+    if (value === undefined) {
+      return this.map.delete(key);
+    } else {
+      const values = this.map.get(key);
+      if (values) {
+        const index = values.indexOf(value);
+        if (index >= 0) {
+          if (values.length === 1) {
+            this.map.delete(key);
+          } else {
+            values.splice(index, 1);
+          }
+          return true;
+        }
+      }
+      return false;
+    }
+  }
+
+  /**
+   * Returns an array of all values associated with the given key. If no value exists,
+   * an empty array is returned.
+   *
+   * _Note:_ The returned array is assumed not to be modified. Use the `set` method to add a
+   * value and `delete` to remove a value from the multimap.
+   */
+  get(key: K): readonly V[] {
+    return this.map.get(key) ?? [];
+  }
+
+  /**
+   * Operates differently depending on whether a `value` is given:
+   *  * With a value, this method returns `true` if the specific key / value pair is present in the multimap.
+   *  * Without a value, this method returns `true` if the given key is present in the multimap.
+   */
+  has(key: K, value?: V): boolean {
+    if (value === undefined) {
+      return this.map.has(key);
+    } else {
+      const values = this.map.get(key);
+      if (values) {
+        return values.indexOf(value) >= 0;
+      }
+      return false;
+    }
+  }
+
+  /**
+   * Add the given key / value pair to the multimap.
+   */
+  add(key: K, value: V): this {
+    if (this.map.has(key)) {
+      this.map.get(key)!.push(value);
+    } else {
+      this.map.set(key, [value]);
+    }
+    return this;
+  }
+
+  /**
+   * Add the given set of key / value pairs to the multimap.
+   */
+  addAll(key: K, values: Iterable<V>): this {
+    if (this.map.has(key)) {
+      this.map.get(key)!.push(...values);
+    } else {
+      this.map.set(key, Array.from(values));
+    }
+    return this;
+  }
+
+  /**
+   * Invokes the given callback function for every key / value pair in the multimap.
+   */
+  forEach(callbackfn: (value: V, key: K, map: this) => void): void {
+    this.map.forEach((array, key) =>
+      array.forEach((value) => callbackfn(value, key, this)),
+    );
+  }
+
+  /**
+   * Returns an iterator of key, value pairs for every entry in the map.
+   */
+  [Symbol.iterator](): Iterator<[K, V]> {
+    return this.entries();
+  }
+
+  /**
+   * Returns a stream of key, value pairs for every entry in the map.
+   */
+  entries(): MapIterator<[K, V]> {
+    return this.map
+      .entries()
+      .flatMap(([key, array]) => array.map((value) => [key, value] as [K, V]));
+  }
+
+  /**
+   * Returns a stream of keys in the map.
+   */
+  keys(): MapIterator<K> {
+    return this.map.keys();
+  }
+
+  /**
+   * Returns a stream of values in the map.
+   */
+  values(): MapIterator<V> {
+    return this.map.values().flatMap((a) => a);
+  }
+
+  /**
+   * Returns a stream of key, value set pairs for every key in the map.
+   */
+  entriesGroupedByKey(): MapIterator<[K, V[]]> {
+    return this.map.entries();
+  }
+}

--- a/packages/language/src/utils/common.ts
+++ b/packages/language/src/utils/common.ts
@@ -2,7 +2,7 @@
  * Group an array of items by a key.
  */
 export function groupBy<T, K extends string | number | symbol>(
-  array: T[],
+  array: readonly T[],
   key: (item: T) => K,
 ): Record<K, T[]> {
   return array.reduce(

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -12,7 +12,6 @@
 import { IToken } from "chevrotain";
 import { PliProgram, SyntaxKind } from "../syntax-tree/ast.js";
 import { URI } from "../utils/uri.js";
-import { ScopeCacheGroups } from "../linking/symbol-table.js";
 import { TextDocuments } from "../language-server/text-documents.js";
 import { Connection } from "vscode-languageserver";
 import { ReferencesCache } from "../linking/resolver.js";
@@ -24,6 +23,7 @@ import { EvaluationResults } from "../preprocessor/pli-preprocessor-interpreter-
 import { marginIndicator } from "../language-server/margin-indicator.js";
 import { createLSRequestCaches, LSRequestCache } from "../utils/cache.js";
 import { PluginConfigurationProviderInstance } from "./plugin-configuration-provider.js";
+import { ScopeCacheGroups } from "../linking/scope.js";
 
 /**
  * A compilation unit is a representation of a PL/I program in the language server.


### PR DESCRIPTION
The linking system was getting hard to reason about, so this PR refactors it.

This PR:

- Adds the Langium `MultiMap`
- Moves scope, qualified syntax nodes, and declared item parsers, from `symbol-table.ts`, into their own files
- Changes flow of deep linking code (`iterateSymbolTable`), but keeps the same behavior.