### PR TITLE
Compiler options fixes

### DIFF
--- a/packages/language/src/preprocessor/compiler-options/translator.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator.ts
@@ -430,7 +430,7 @@ translator.rule(
 
 /** {@link CompilerOptions.codepage} */
 translator.rule(
-  ["CODEPAGE"],
+  ["CODEPAGE", "CP"],
   plainTranslate((options, value) => {
     options.codepage = value.value;
   }),
@@ -442,7 +442,8 @@ translator.flag("common", ["COMMON"], ["NOCOMMON"]);
 /** {@link CompilerOptions.compile} */
 translator.rule(
   ["COMPILE", "C"],
-  (_, options) => {
+  (option, options) => {
+    ensureArguments(option, 0, 0);
     options.compile = true;
   },
   ["NOCOMPILE", "NC"],
@@ -483,13 +484,14 @@ translator.rule(
     options.copyright = valueOption.value;
   },
   ["NOCOPYRIGHT"],
-  (_, options) => {
+  (option, options) => {
+    ensureArguments(option, 0, 0);
     options.copyright = false;
   },
 );
 
 /** {@link CompilerOptions.csect} */
-translator.flag("csect", ["CSECT"], ["NOCSECT"]);
+translator.flag("csect", ["CSECT", "CSE"], ["NOCSECT", "NOCSE"]);
 
 /** {@link CompilerOptions.csectcut} */
 translator.rule(
@@ -508,7 +510,7 @@ translator.rule(
 
 /** {@link CompilerOptions.currency} */
 translator.rule(
-  ["CURRENCY"],
+  ["CURRENCY", "CURR"],
   stringTranslate((options, value) => {
     if (value.value.length === 0) {
       throw new TranslationError(
@@ -582,7 +584,7 @@ translator.rule(["DDSQL"], (option, options) => {
 });
 
 /** {@link CompilerOptions.decimal} */
-translator.rule(["DECIMAL"], (option, options) => {
+translator.rule(["DECIMAL", "DEC"], (option, options) => {
   options.decimal = {};
   for (const opt of option.values) {
     ensureType(opt, "plain");
@@ -650,7 +652,7 @@ translator.rule(["DECIMAL"], (option, options) => {
 translator.flag("decomp", ["DECOMP"], ["NODECOMP"]);
 
 /** {@link CompilerOptions.default} */
-translator.rule(["DEFAULT"], (option, options) => {
+translator.rule(["DEFAULT", "DFT"], (option, options) => {
   const def: CompilerOptions.Default = (options.default = {});
   for (const opt of option.values) {
     if (opt.kind === SyntaxKind.CompilerOptionText) {

--- a/packages/language/test/compiler/options-parser.test.ts
+++ b/packages/language/test/compiler/options-parser.test.ts
@@ -175,4 +175,44 @@ describe("CompilerOptions translator", () => {
     expect(issues).toHaveLength(1);
     expect(issues[0].message).toMatch("Unknown compiler option");
   });
+
+  test("Produce issue for arguments at COMPILE", () => {
+    const options = parseAbstractCompilerOptions("COMPILE(E)");
+    const issues = translateCompilerOptions(options).issues;
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toBe("Expected 0 arguments, but received 1.");
+  });
+
+  test("Produce issue for arguments at NOCOPYRIGHT", () => {
+    const options = parseAbstractCompilerOptions("NOCOPYRIGHT(E)");
+    const issues = translateCompilerOptions(options).issues;
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toBe("Expected 0 arguments, but received 1.");
+  });
+
+  test("Produce issue for text value when option is expected in DEPRECATE", () => {
+    const options = parseAbstractCompilerOptions("DEPRECATE(BUILTIN)");
+    const issues = translateCompilerOptions(options).issues;
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toBe(
+      "Expected a compiler option with arguments.",
+    );
+  });
+
+  test("Test compiler option abbreviations", () => {
+    const abbreviations = ["CURR", "CP", "CSE", "NOCSE", "DEC", "DFT"];
+    for (const abbr of abbreviations) {
+      const options = parseAbstractCompilerOptions(abbr);
+      const issues = translateCompilerOptions(options).issues;
+      if (
+        issues.some((issue) =>
+          issue.message.includes("Unknown compiler option:"),
+        )
+      ) {
+        throw new Error(
+          `Abbreviation ${abbr} was not recognized as a valid compiler option.`,
+        );
+      }
+    }
+  });
 });


### PR DESCRIPTION
Closes https://github.com/zowe/zowe-pli-language-support/issues/106, https://github.com/zowe/zowe-pli-language-support/issues/104, https://github.com/zowe/zowe-pli-language-support/issues/102

https://github.com/zowe/zowe-pli-language-support/issues/104 was already fixed by https://github.com/zowe/zowe-pli-language-support/pull/143. Added a test.