### PR TITLE
Fix fully qualified naming bug

### DIFF
--- a/packages/language/src/linking/qualified-syntax-node.ts
+++ b/packages/language/src/linking/qualified-syntax-node.ts
@@ -71,14 +71,16 @@ export class QualifiedSyntaxNode {
       return QualificationStatus.NoQualification;
     }
 
-    // If the current node is the same as the qualifier, we can remove it from the list.
-    const nextQualifiers =
-      this.name === qualifier ? qualifiers.slice(1) : qualifiers;
+    // If the current name matches the qualifier, we can remove it from the list.
+    const nameMatches = this.name === qualifier;
+    const nextQualifiers = nameMatches ? qualifiers.slice(1) : qualifiers;
 
     // If there are no qualifiers left, we can determine the qualification status.
-    if (nextQualifiers.length <= 0) {
-      if (!this.parent) {
-        // If there is no parent, the current node is the root node.
+    const noQualifiersLeft = nextQualifiers.length <= 0;
+    if (noQualifiersLeft) {
+      // If there is no parent, the current node is the root node.
+      const isRootNode = !this.parent;
+      if (isRootNode) {
         return QualificationStatus.FullQualification;
       } else {
         // If there are parents left, the current node is partially qualified.
@@ -92,6 +94,15 @@ export class QualifiedSyntaxNode {
     }
 
     // We have qualifiers left, and a parent. We continue the search.
-    return this.parent.getQualificationStatus(nextQualifiers);
+    const parentStatus = this.parent.getQualificationStatus(nextQualifiers);
+    switch (parentStatus) {
+      // If the parent is fully qualified, but our name didn't match, we are partially qualified.
+      case QualificationStatus.FullQualification:
+        return nameMatches
+          ? QualificationStatus.FullQualification
+          : QualificationStatus.PartialQualification;
+      default:
+        return parentStatus;
+    }
   }
 }

--- a/packages/language/test/linking.test.ts
+++ b/packages/language/test/linking.test.ts
@@ -276,6 +276,15 @@ describe("Linking tests", () => {
   PUT (<|a2_c>C.<|a2_c_b>B);
   PUT (<|a>A.<|a_b>B);`));
 
+    test("Full qualification should take precedence over partial qualification", () =>
+      expectLinks(`
+ DCL 1 A,
+        2 B,
+          3 C,
+        2 <|1:C|>;
+
+ PUT(A.<|1>C);`));
+
     test("Star name in structure should not need to be qualified", () =>
       expectLinks(`
  DCL 1 A,


### PR DESCRIPTION
Fixes a fully qualified naming bug, where `A.B` would count as fully qualified on any `A.A1.A2...B` declaration