### PR TITLE
Fixing more preprocessor and normal parser issues

### DIFF
--- a/packages/language/src/preprocessor/pli-preprocessor-error.ts
+++ b/packages/language/src/preprocessor/pli-preprocessor-error.ts
@@ -38,7 +38,7 @@ export class PreprocessorError implements LexingError {
     } else {
       this._range = {
         start: range.startOffset,
-        end: range.endOffset!,
+        end: range.endOffset! + 1,
       };
     }
     this._uri = uri;

--- a/packages/language/src/preprocessor/pli-preprocessor-generator.ts
+++ b/packages/language/src/preprocessor/pli-preprocessor-generator.ts
@@ -301,6 +301,12 @@ export class PliPreprocessorGenerator {
         list.push(token);
       }
     });
+    // if any tokens are left, simply push them
+    if (list.length > 0) {
+      builder.pushInstruction(Instructions.push(list));
+      builder.pushInstruction(Instructions.scan());
+      builder.pushInstruction(Instructions.print());
+    }
   }
 
   handleStatements(

--- a/packages/language/src/preprocessor/pli-preprocessor-interpreter-state.ts
+++ b/packages/language/src/preprocessor/pli-preprocessor-interpreter-state.ts
@@ -226,6 +226,7 @@ export class PliPreprocessorInterpreterState
               value = Values.eq(lhs, rhs);
               break;
             case "<>":
+            case "^=":
               value = Values.neq(lhs, rhs);
               break;
             case "&":

--- a/packages/language/src/preprocessor/pli-preprocessor-lexer.ts
+++ b/packages/language/src/preprocessor/pli-preprocessor-lexer.ts
@@ -14,7 +14,6 @@ import {
   Lexer as ChevrotainLexer,
   TokenTypeDictionary,
   IToken,
-  Lexer,
 } from "chevrotain";
 import {
   AllPreprocessorTokens,

--- a/packages/language/src/preprocessor/pli-preprocessor-parser-state.ts
+++ b/packages/language/src/preprocessor/pli-preprocessor-parser-state.ts
@@ -181,6 +181,7 @@ export class PliPreprocessorParserState implements PreprocessorParserState {
       element,
     };
     this.index++;
+    this.skipHiddenTokens();
     return true;
   }
 
@@ -204,7 +205,14 @@ export class PliPreprocessorParserState implements PreprocessorParserState {
       element,
     };
     this.index++;
+    this.skipHiddenTokens();
     return token;
+  }
+
+  private skipHiddenTokens() {
+    while (this.tokens[this.index]?.tokenType.GROUP) {
+      this.index++;
+    }
   }
 
   canConsumeKeyword(...tokenTypes: TokenType[]): boolean {

--- a/packages/language/src/preprocessor/pli-preprocessor-tokens.ts
+++ b/packages/language/src/preprocessor/pli-preprocessor-tokens.ts
@@ -64,7 +64,10 @@ export const PreprocessorTokens = {
   Or: tokens.Pipe,
   And: tokens.Ampersand,
   Eq: tokens.Equals,
+  // Default not equals token is <>
   Neq: tokens.LessThanGreaterThan,
+  // We have a second "not equals" token ^=, that can be adjusted via compiler options
+  Neq2: tokens.NotEquals,
   LE: tokens.LessThanEquals,
   GE: tokens.GreaterThanEquals,
   GT: tokens.GreaterThan,
@@ -87,6 +90,7 @@ export const PreprocessorBinaryTokens = [
   PreprocessorTokens.GE,
   PreprocessorTokens.Eq,
   PreprocessorTokens.Neq,
+  PreprocessorTokens.Neq2,
   PreprocessorTokens.And,
   PreprocessorTokens.Or,
 ];

--- a/packages/language/src/syntax-tree/ast-iterator.ts
+++ b/packages/language/src/syntax-tree/ast-iterator.ts
@@ -254,7 +254,7 @@ export function forEachNode(
       }
       break;
     case SyntaxKind.DefineStructureStatement:
-      node.substructures.forEach(action);
+      node.items.forEach(action);
       break;
     case SyntaxKind.DelayStatement:
       if (node.delay) {
@@ -666,6 +666,9 @@ export function forEachNode(
     case SyntaxKind.OrdinalTypeAttribute:
       break;
     case SyntaxKind.OrdinalValue:
+      if (node.value) {
+        action(node.value);
+      }
       break;
     case SyntaxKind.OrdinalValueList:
       node.members.forEach(action);

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -426,7 +426,7 @@ export type SyntaxNode =
   | Statement
   | StopStatement
   | StringLiteral
-  | SubStructure
+  | StructureItem
   | TypeAttribute
   | UnaryExpression
   | ValueAttribute
@@ -1095,10 +1095,7 @@ export interface DefineOrdinalStatement extends AstNode {
 export interface DefineStructureStatement extends AstNode {
   kind: SyntaxKind.DefineStructureStatement;
   xDefine: boolean;
-  level: string | null;
-  name: FQN | null;
-  union: boolean;
-  substructures: SubStructure[];
+  items: StructureItem[];
 }
 export interface DelayStatement extends AstNode {
   kind: SyntaxKind.DelayStatement;
@@ -1689,7 +1686,7 @@ export interface OrdinalValue extends AstNode {
   kind: SyntaxKind.OrdinalValue;
   name: string | null;
   nameToken: IToken | null;
-  value: string | null;
+  value: Expression | null;
 }
 export interface OrdinalValueList extends AstNode {
   kind: SyntaxKind.OrdinalValueList;
@@ -2083,7 +2080,7 @@ export function createStringLiteral(): StringLiteral {
     tokens: [],
   };
 }
-export interface SubStructure extends AstNode {
+export interface StructureItem extends AstNode {
   kind: SyntaxKind.SubStructure;
   level: string | null;
   name: string | null;

--- a/packages/language/test/parser/pli-lexer.test.ts
+++ b/packages/language/test/parser/pli-lexer.test.ts
@@ -607,6 +607,62 @@ describe("PL/1 Lexer", () => {
     ).toStrictEqual(["HelloWorld:ID", "=:=", "123:NUMBER", ";:;"]);
   });
 
+  test("Preprocessor statement can appear inside of a random other statement and successfully evaluate #1", () => {
+    expect(
+      tokenize(`
+          MAIN: PROC OPTIONS(
+            MAIN
+            %IF 1 = 1 %THEN %DO;
+            ,ORDER
+            %END;
+            );
+          END MAIN;
+        `),
+    ).toStrictEqual([
+      "MAIN:MAIN",
+      ":::",
+      "PROC:PROCEDURE",
+      "OPTIONS:OPTIONS",
+      "(:(",
+      "MAIN:MAIN",
+      ",:,",
+      "ORDER:ORDER",
+      "):)",
+      ";:;",
+      "END:END",
+      "MAIN:MAIN",
+      ";:;",
+    ]);
+  });
+
+  test("Preprocessor statement can appear inside of a random other statement and successfully evaluate #2", () => {
+    expect(
+      tokenize(`
+          MAIN: PROC OPTIONS(
+            MAIN
+            %IF 1 = 2 %THEN %DO;
+            ,ORDER
+            %END;
+            );
+          END MAIN;
+        `),
+    ).toStrictEqual([
+      "MAIN:MAIN",
+      ":::",
+      "PROC:PROCEDURE",
+      "OPTIONS:OPTIONS",
+      "(:(",
+      "MAIN:MAIN",
+      // In this case, the preprocessor statement is not evaluated since 1 != 2
+      // Therefore, the comma and ORDER tokens are not added
+      "):)",
+      ";:;",
+      "END:END",
+      "MAIN:MAIN",
+      ";:;",
+    ]);
+  });
+
   test.skip("XYZ", () => {
     expect(
       tokenize(`

--- a/packages/language/test/parser/pli-preprocessor-parser-state.test.ts
+++ b/packages/language/test/parser/pli-preprocessor-parser-state.test.ts
@@ -168,10 +168,9 @@ describe("Preprocessor parser state", () => {
       ).toBeTruthy();
       expect(state.eof).toBeFalsy();
       expect(state.current).not.toBeUndefined();
-      expect(state.current!.image).toBe(" ");
-      expect(state.current!.tokenType.name).toBe("WS");
+      expect(state.current!.image).toBe("123");
       expect(state.last).not.toBeUndefined();
-      expect(state.last!.image).toBe("ABC");
+      expect(state.last!.image).toBe(" ");
     });
   });
 });

--- a/packages/language/test/parsing.test.ts
+++ b/packages/language/test/parsing.test.ts
@@ -669,6 +669,32 @@ describe("PL/I Parsing tests", () => {
     });
 
     /**
+     * Ensure we can't accidentally add precision onto signed, should be in separate alternatives
+     */
+    test("Can specify value on ordinal definition", async () => {
+      const doc = parseStmts(`
+      define ordinal day (
+        Monday VALUE(1)
+      );
+       `);
+      assertNoParseErrors(doc);
+      generateAndAssertValidSymbolTable(doc);
+    });
+
+    /**
+     * Ensure we can't accidentally add precision onto signed, should be in separate alternatives
+     */
+    test("Can specify negative value on ordinal definition", async () => {
+      const doc = parseStmts(`
+      define ordinal day (
+        Monday VALUE(-1)
+      );
+       `);
+      assertNoParseErrors(doc);
+      generateAndAssertValidSymbolTable(doc);
+    });
+
+    /**
      * Ensure both forms of precision are parsable
      */
     test("PREC & PRECISION are parsable", async () => {
@@ -902,6 +928,27 @@ describe("PL/I Parsing tests", () => {
         Error otherwise
       );
     `);
+    assertNoParseErrors(doc);
+    generateAndAssertValidSymbolTable(doc);
+  });
+
+  test("Can use non-UNION attributes in DEFINE STRUCTURE statement", () => {
+    // The Enterprise PL/I for z/OS Language Reference specifies that UNION is the only allowed attribute for the first structure item
+    // However, this is not true, we can use non-UNION attributes as well, the compiler will accept it
+    const doc = parse(`
+       DEFINE STRUCTURE                                                               
+        01 MEMORY_USAGE       UNALIGNED
+          ,05 TOT_24B_BYT_CT      BIN FIXED(31)
+          ,05 AVL_24B_BYT_CT      BIN FIXED(31)
+          ,05 USD_24B_BYT_CT      BIN FIXED(31)
+          ,05 TOT_32B_BYT_CT      BIN FIXED(31)
+          ,05 AVL_32B_BYT_CT      BIN FIXED(31)
+          ,05 USD_32B_BYT_CT      BIN FIXED(31)
+          ,05 TOT_64B_BYT_CT      BIN FIXED(63)
+          ,05 AVL_64B_BYT_CT      BIN FIXED(63)
+          ,05 USD_64B_BYT_CT      BIN FIXED(63);
+       ;         
+      `);
     assertNoParseErrors(doc);
     generateAndAssertValidSymbolTable(doc);
   });


### PR DESCRIPTION
As mentioned in #184, this change enables parsing of embedded preprocessor code (see new preprocessor tests).

It also fixes ordinal parsing, since I've noticed that this is also broken.