### PR TITLE
Support Extension-less Libs Resolution

### DIFF
--- a/code_samples/plugin-example/a.pli
+++ b/code_samples/plugin-example/a.pli
@@ -5,3 +5,5 @@
  VARC = 3;
  %INCLUDE LIB;
  LIBREF = 44;
+ %INCLUDE LIB2; // resolves w/out extension
+ ABC = 24;

--- a/code_samples/plugin-example/cpy/LIB2.pli
+++ b/code_samples/plugin-example/cpy/LIB2.pli
@@ -1,0 +1,1 @@
+ DCL ABC FIXED;

--- a/packages/language/src/preprocessor/pli-preprocessor-parser.ts
+++ b/packages/language/src/preprocessor/pli-preprocessor-parser.ts
@@ -1395,6 +1395,14 @@ function resolveIncludeFileUri(
         if (FileSystemProviderInstance.fileExistsSync(libFileUri)) {
           // match found in this lib, take it
           return libFileUri;
+        } else {
+          // Perform additional lookup using the new glob method
+          const patt = `${libFileUri.path}\\.*`;
+          const matches = FileSystemProviderInstance.findFilesByGlobSync(patt);
+          if (matches.length > 0) {
+            // Return the first match found
+            return URI.file(matches[0]);
+          }
         }
       }
     }

--- a/packages/language/src/workspace/file-system-provider.ts
+++ b/packages/language/src/workspace/file-system-provider.ts
@@ -15,6 +15,15 @@ export interface FileSystemProvider {
   readFileSync(uri: URI): string | undefined;
   fileExistsSync(uri: URI): boolean;
   writeFileSync(uri: URI, value: string): void;
+
+  /**
+   * Synchronously find files matching a glob pattern
+   * (used for lib lookups where `%INCLUDE ABC` could be `cpy/ABC` or `cpy/ABC.xyz`, among others)
+   *
+   * @param pattern - The glob pattern to search for.
+   * @returns Array of file paths that match, if any
+   */
+  findFilesByGlobSync(pattern: string): string[];
 }
 
 /**
@@ -31,6 +40,10 @@ class _EmptyFileSystemProvider implements FileSystemProvider {
 
   writeFileSync(_uri: URI, _value: string): void {
     return;
+  }
+
+  findFilesByGlobSync(_pattern: string): string[] {
+    return [];
   }
 }
 
@@ -68,6 +81,14 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
    */
   fileExistsSync(uri: URI): boolean {
     return this.files.has(uri.path);
+  }
+
+  /**
+   * Simulates a glob lookup in the virtual file system
+   */
+  findFilesByGlobSync(pattern: string): string[] {
+    const regex = new RegExp(pattern.replace(/\*/g, ".*"));
+    return Array.from(this.files.keys()).filter((fp) => regex.test(fp));
   }
 }
 

--- a/packages/language/test/parser/pli-preprocessor-include.test.ts
+++ b/packages/language/test/parser/pli-preprocessor-include.test.ts
@@ -27,6 +27,7 @@ function setupFileSystemAndLexer(): TokenizeFunction {
     " DECLARE LIB1_VAR FIXED;",
   );
   vtsfs.writeFileSync(URI.file("/test/cpy/LIB2"), " DECLARE LIB2_VAR FIXED;");
+  vtsfs.writeFileSync(URI.file("/test/cpy/PLILIB.pli"), " DECLARE PLILIB_VAR FIXED;");
   vtsfs.writeFileSync(URI.file("/test/LIB3"), " DECLARE LIB3_VAR FIXED;");
   vtsfs.writeFileSync(URI.file("/LIB4"), " DECLARE LIB4_VAR FIXED;");
 
@@ -259,6 +260,59 @@ describe("PL/1 Includes with Plugin Config", () => {
       "LIB2_VAR:ID",
       "=:=",
       "3:NUMBER",
+      ";:;",
+    ]);
+  });
+
+  test("Include using non-quoted identifier syntax w/out extension", () => {
+    // lib includes should resolve with or w/out their extension
+    expect(
+      tokenize(`
+            %INCLUDE PLILIB;
+            PLILIB_VAR = 32;
+        `),
+    ).toStrictEqual([
+      "DECLARE:DECLARE",
+      "PLILIB_VAR:ID",
+      "FIXED:FIXED",
+      ";:;",
+      "PLILIB_VAR:ID",
+      "=:=",
+      "32:NUMBER",
+      ";:;",
+    ]);
+  });
+
+  test("Include using quoted identifier syntax w/out extension", () => {
+    // lib includes should resolve with or w/out their extension
+    expect(
+      tokenize(`
+            %INCLUDE 'PLILIB';
+            PLILIB_VAR = 32;
+        `),
+    ).toStrictEqual([
+      "DECLARE:DECLARE",
+      "PLILIB_VAR:ID",
+      "FIXED:FIXED",
+      ";:;",
+      "PLILIB_VAR:ID",
+      "=:=",
+      "32:NUMBER",
+      ";:;",
+    ]);
+  });
+
+  test("Include doesn't pickup wrong file", () => {
+    // incomplete identifier, should not resolve (skipping included contents here) even w/ glob lookup
+    expect(
+      tokenize(`
+            %INCLUDE PLIL;
+            PLILIB_VAR = 32;
+        `),
+    ).toStrictEqual([
+      "PLILIB_VAR:ID",
+      "=:=",
+      "32:NUMBER",
       ";:;",
     ]);
   });

--- a/packages/language/test/parser/pli-preprocessor-include.test.ts
+++ b/packages/language/test/parser/pli-preprocessor-include.test.ts
@@ -27,7 +27,10 @@ function setupFileSystemAndLexer(): TokenizeFunction {
     " DECLARE LIB1_VAR FIXED;",
   );
   vtsfs.writeFileSync(URI.file("/test/cpy/LIB2"), " DECLARE LIB2_VAR FIXED;");
-  vtsfs.writeFileSync(URI.file("/test/cpy/PLILIB.pli"), " DECLARE PLILIB_VAR FIXED;");
+  vtsfs.writeFileSync(
+    URI.file("/test/cpy/PLILIB.pli"),
+    " DECLARE PLILIB_VAR FIXED;",
+  );
   vtsfs.writeFileSync(URI.file("/test/LIB3"), " DECLARE LIB3_VAR FIXED;");
   vtsfs.writeFileSync(URI.file("/LIB4"), " DECLARE LIB4_VAR FIXED;");
 
@@ -309,11 +312,6 @@ describe("PL/1 Includes with Plugin Config", () => {
             %INCLUDE PLIL;
             PLILIB_VAR = 32;
         `),
-    ).toStrictEqual([
-      "PLILIB_VAR:ID",
-      "=:=",
-      "32:NUMBER",
-      ";:;",
-    ]);
+    ).toStrictEqual(["PLILIB_VAR:ID", "=:=", "32:NUMBER", ";:;"]);
   });
 });

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -85,6 +85,7 @@
   },
   "dependencies": {
     "browserify-fs": "^1.0.0",
+    "glob": "^11.0.2",
     "langium": "~3.4.0",
     "path-browserify": "^1.0.1",
     "pli-language": "workspace:*",

--- a/packages/vscode-extension/src/language/main.ts
+++ b/packages/vscode-extension/src/language/main.ts
@@ -20,6 +20,7 @@ import {
   setFileSystemProvider,
 } from "pli-language";
 import * as fs from "fs";
+import * as glob from "glob";
 
 class NodeFileSystemProvider implements FileSystemProvider {
   readFileSync(uri: URI): string {
@@ -31,6 +32,12 @@ class NodeFileSystemProvider implements FileSystemProvider {
   writeFileSync(uri: URI, value: string): void {
     // Do nothing for now.
     // Todo (ssmifi): Should we throw an error here?
+  }
+  findFilesByGlobSync(pattern: string): string[] {
+    return glob.sync(pattern, {
+      nodir: true,
+      absolute: true,
+    });
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,9 @@ importers:
       browserify-fs:
         specifier: ^1.0.0
         version: 1.0.0
+      glob:
+        specifier: ^11.0.2
+        version: 11.0.2
       langium:
         specifier: ~3.4.0
         version: 3.4.0
@@ -1614,8 +1617,8 @@ packages:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
     hasBin: true
 
-  glob@11.0.0:
-    resolution: {integrity: sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==}
+  glob@11.0.2:
+    resolution: {integrity: sha512-YT7U7Vye+t5fZ/QMkBFrTJ7ZQxInIUjwyAjVj84CYXqgBdv30MFUPGnBR6sQaVq6Is15wYJUsnzTuWaGRBhBAQ==}
     engines: {node: 20 || >=22}
     hasBin: true
 
@@ -4024,7 +4027,7 @@ snapshots:
       cockatiel: 3.2.1
       commander: 6.2.1
       form-data: 4.0.1
-      glob: 11.0.0
+      glob: 11.0.2
       hosted-git-info: 4.1.0
       jsonc-parser: 3.3.1
       leven: 3.1.0
@@ -4514,7 +4517,7 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
-  glob@11.0.0:
+  glob@11.0.2:
     dependencies:
       foreground-child: 3.3.0
       jackspeak: 4.0.2


### PR DESCRIPTION
Resolves an issue where we couldn't include a file with an extension `LIB.pli` when referring to its extension-less identifier `%INCLUDE LIB;`. Same change is applied for `%INCLUDE 'LIB';` as well.

This also opens up the path to solving #156 as well through glob pattern support, but that's not resolved in this PR.

Adds in the [glob](https://www.npmjs.com/package/glob) package to make this work. There are ways to do this ourselves, but considering we want to support glob patterns in general (and across systems as well), I looked around for a decent enough package. This appears to be one of the better choices from a stability standpoint, but it still pulls in several other dependencies as well. I'm open to suggestions if there's a better alternative that I'm not aware of.