### PR TITLE
Fix completion offset

### DIFF
--- a/packages/language/src/language-server/completion/completion-request.ts
+++ b/packages/language/src/language-server/completion/completion-request.ts
@@ -82,7 +82,7 @@ function getCompletionItemElements(token: Token | undefined, offset: number) {
     query: token.image.substring(0, offset - token.startOffset),
     range: {
       start: token.startOffset,
-      end: token.endOffset + 1,
+      end: token.endOffset,
     },
   };
 }


### PR DESCRIPTION
Previously, doing a completion on:

```pli
PUT(<|>);
```

Would replace the `)` token.

This PR fixes that by reducing the `endOffset` by one.