### PR TITLE
Fix invalid assertion in document symbols

### DIFF
--- a/packages/language/src/language-server/document-symbol-builder.ts
+++ b/packages/language/src/language-server/document-symbol-builder.ts
@@ -55,7 +55,14 @@ class ProcedureSymbolBuilder implements SymbolBuilder {
     textDocument: TextDocument,
     childSymbols: DocumentSymbol[],
   ): DocumentSymbol[] {
-    const labelPrefixStatement = token.payload.element?.container as Statement;
+    const labelPrefixStatement = token.payload.element?.container;
+    // Return early if the label prefix statement is not a valid statement
+    if (
+      labelPrefixStatement?.kind !== SyntaxKind.Statement ||
+      labelPrefixStatement.labels.length === 0
+    ) {
+      return [];
+    }
     const procedureName = labelPrefixStatement.labels
       .map((label) => label.name)
       .join(" ");


### PR DESCRIPTION
In some cases, it seems like the `element?.container` property is actually `null` or `undefined`. Alternatively, some procedures didn't have a valid label. In these cases, the document symbol provider will throw an error which will be propagated to the user.

This change just adds an additional check to ensure that we actually have a non-null statement obj at hand.