### PR TITLE
Improve symbol table and linking performance

### DIFF
--- a/packages/language/src/linking/scope.ts
+++ b/packages/language/src/linking/scope.ts
@@ -22,8 +22,8 @@ export class Scope {
   public symbolTable: SymbolTable;
   private parent: Scope | null;
 
-  constructor(parent: Scope | null, symbolTable: SymbolTable | null = null) {
-    this.parent = parent;
+  constructor(parent?: Scope | null, symbolTable?: SymbolTable) {
+    this.parent = parent ?? null;
     this.symbolTable = symbolTable ?? new SymbolTable();
   }
 
@@ -68,9 +68,11 @@ export class ScopeCacheGroups {
  */
 export class ScopeCache {
   private scopes: Map<SyntaxNode, Scope> = new Map();
+  private uniqueScopes = new Set<Scope>();
 
   add(node: SyntaxNode, scope: Scope): void {
     this.scopes.set(node, scope);
+    this.uniqueScopes.add(scope);
   }
 
   get(node: SyntaxNode): Scope | undefined {
@@ -79,9 +81,10 @@ export class ScopeCache {
 
   clear(): void {
     this.scopes.clear();
+    this.uniqueScopes.clear();
   }
 
   values(): Scope[] {
-    return Array.from(this.scopes.values());
+    return Array.from(this.uniqueScopes);
   }
 }

--- a/packages/language/src/linking/symbol-table.ts
+++ b/packages/language/src/linking/symbol-table.ts
@@ -179,10 +179,6 @@ type IterateSymbolsOptions = {
   rootPreprocessorScope?: Scope;
 };
 
-function getDefaultScope(): Scope {
-  return new Scope(null, new SymbolTable());
-}
-
 export function iterateSymbols(
   unit: CompilationUnit,
   { rootScope, rootPreprocessorScope }: IterateSymbolsOptions = {},
@@ -196,23 +192,29 @@ export function iterateSymbols(
   const validationBuffer = new PliValidationBuffer();
   const acceptor = validationBuffer.getAcceptor();
 
+  const preprocessorScope = new Scope(rootPreprocessorScope);
+
   // Iterate over the PLI program creating the symbol table.
   iterateSymbolTable(
     scopeCaches.preprocessor,
     references,
     acceptor,
     unit.preprocessorAst,
-    rootPreprocessorScope ?? getDefaultScope(),
+    preprocessorScope,
   );
   // TODO: Active this when we have some tests
   // assignRedeclaredSymbols(scopeCaches.preprocessor);
+
+  // Generate a new scope
+  // Otherwise we will add symbols to the root scope (which contains builtins)
+  const regularScope = new Scope(rootScope);
 
   iterateSymbolTable(
     scopeCaches.regular,
     references,
     acceptor,
     unit.ast,
-    rootScope ?? getDefaultScope(),
+    regularScope,
   );
   assignRedeclaredSymbols(scopeCaches.regular);
 

--- a/packages/language/src/workspace/lifecycle.ts
+++ b/packages/language/src/workspace/lifecycle.ts
@@ -66,14 +66,20 @@ export function parse(compilationUnit: CompilationUnit): PliProgram {
   return ast;
 }
 
+let builtinsScope: Scope | undefined;
+
 function loadBuiltinSymbolTable(): Scope {
+  if (builtinsScope) {
+    return builtinsScope;
+  }
   const unit = createCompilationUnit(URI.parse(BuiltinsUri));
   tokenize(unit, Builtins);
   parse(unit);
   generateSymbolTable(unit);
 
   // Get the root scope of the builtins
-  return unit.scopeCaches.regular.get(unit.ast)!;
+  builtinsScope = unit.scopeCaches.regular.get(unit.ast)!;
+  return builtinsScope;
 }
 
 export function generateSymbolTable(compilationUnit: CompilationUnit) {


### PR DESCRIPTION
Performs three main changes:

1. Caches the builtin scope to prevent re-computation on every change.
2. Due to 1. we need to overlay the builtins scope with a new scope for every compilation unit.
3. Instead of iterating over each scope of **each node** in the symbol table, we now only iterate over each unique scope once. This is the main performance improvement of this PR.

The changes cannot be independently tested. Large files should simply be evaluated much faster by the language server. All tests should still pass, since nothing changed on a functional level.