### PR TITLE
Further Include + Config Improvements

### DIFF
--- a/code_samples/plugin-example/.pliplugin/proc_grps.json
+++ b/code_samples/plugin-example/.pliplugin/proc_grps.json
@@ -9,7 +9,7 @@
       "libs": [
         "cpy"
       ],
-      "copybook-extensions": [
+      "include-extensions": [
         ".pli",
         ".cpy",
         ".inc"

--- a/packages/language/package.json
+++ b/packages/language/package.json
@@ -37,7 +37,8 @@
     "vscode-languageserver": "~9.0.1",
     "vscode-languageserver-types": "^3.17.5",
     "vscode-languageserver-textdocument": "^1.0.12",
-    "vscode-uri": "^3.1.0"
+    "vscode-uri": "^3.1.0",
+    "minimatch": "^10.0.3"
   },
   "devDependencies": {
     "langium-cli": "~3.4.0",

--- a/packages/language/src/language-server/definition-request.ts
+++ b/packages/language/src/language-server/definition-request.ts
@@ -15,10 +15,12 @@ import { Location } from "./types";
 import {
   getNameToken,
   getReference,
+  isIncludeItemToken,
   isNameToken,
   isReferenceToken,
 } from "../linking/tokens";
 import { URI } from "../utils/uri";
+import { SyntaxKind } from "../syntax-tree/ast";
 
 export function definitionRequest(
   compilationUnit: CompilationUnit,
@@ -59,6 +61,20 @@ export function definitionRequest(
         },
       },
     ];
+  } else if (isIncludeItemToken(payload.kind) && payload.element?.kind === SyntaxKind.IncludeItem) {
+    // allow jumping to the resolved file when present
+    const filePath = payload.element.filePath;
+    if (filePath) {
+      return [
+        {
+          uri: filePath,
+          range: {
+            start: 0,
+            end: 0,
+          },
+        },
+      ];
+    }
   }
   return [];
 }

--- a/packages/language/src/linking/tokens.ts
+++ b/packages/language/src/linking/tokens.ts
@@ -63,6 +63,15 @@ export function isReferenceToken(kind: CstNodeKind | undefined): boolean {
   return false;
 }
 
+export function isIncludeItemToken(kind: CstNodeKind | undefined): boolean {
+  switch (kind) {
+    case CstNodeKind.IncludeItem_FileString0:
+    case CstNodeKind.IncludeItem_FileID0:
+      return true;
+  }
+  return false;
+}
+
 /**
  * Returns a reference contained within a node, when present
  */

--- a/packages/language/src/preprocessor/pli-preprocessor-parser.ts
+++ b/packages/language/src/preprocessor/pli-preprocessor-parser.ts
@@ -1374,11 +1374,11 @@ function resolveIncludeFileUri(
     ext !== "" &&
     programConfig &&
     pgroup &&
-    (!pgroup["copybook-extensions"]?.includes(ext) ||
-      !pgroup["copybook-extensions"])
+    (!pgroup["include-extensions"]?.includes(ext) ||
+      !pgroup["include-extensions"])
   ) {
-    const msg = pgroup["copybook-extensions"]?.length
-      ? `expected one of: ${pgroup["copybook-extensions"]?.join(", ")}`
+    const msg = pgroup["include-extensions"]?.length
+      ? `expected one of: ${pgroup["include-extensions"]?.join(", ")}`
       : `expected no extension`;
     throw new PreprocessorError(
       `Unsupported copybook extension for included file, '${item.file}', ${msg}`,

--- a/packages/language/src/preprocessor/pli-preprocessor-parser.ts
+++ b/packages/language/src/preprocessor/pli-preprocessor-parser.ts
@@ -1351,9 +1351,6 @@ function resolveIncludeFileUri(
   item: ast.IncludeItem,
   state: PreprocessorParserState,
 ): URI | undefined {
-  const absPathRegex = /^\/|[A-Z]:|~/i;
-  const relativePathRegex = /^\.\.\/|^\.\//;
-
   const currentDir = UriUtils.dirname(state.uri);
 
   if (!item.file) {
@@ -1387,17 +1384,26 @@ function resolveIncludeFileUri(
     );
   }
 
+  // TODO @montymxb Jun 24th, 2025: Disabled relative & absolute pathing per request, however mainframe tests do show this works w/ the right JCL config
+  // temporarily retaining here until we know we won't need this going forward, or we decide to re-enable it based on some configuration setting
+  /*
+  const absPathRegex = /^\/|[A-Z]:|~/i;
+  const relativePathRegex = /^\.\.\/|^\.\//;
   if (absPathRegex.test(item.file)) {
     // absolute path, use as is
     return URI.parse(item.file);
   } else if (relativePathRegex.test(item.file)) {
     // relative path, combine with currentDir
     return UriUtils.joinPath(currentDir, item.file);
-  } else if (programConfig && pgroup) {
+  } else ....
+  */
+    
+  if (programConfig && pgroup) {
     // lib file as either a string or a member from a known process group
     for (const lib of pgroup.libs ?? []) {
       if (lib === "*") {
         // wildcard lib, use currentDir
+        // TODO @montymxb Disable this wildcard resolution
         return UriUtils.joinPath(currentDir, item.file);
       } else {
         const libFileUri = UriUtils.joinPath(

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -1420,20 +1420,22 @@ export function createIncludeDirective(): IncludeDirective {
 }
 export interface IncludeItem extends AstNode {
   kind: SyntaxKind.IncludeItem;
-  file: string | null;
+  fileName: string | null;
   string: boolean;
   ddname: boolean;
   result: PreprocessorParserResult | null;
+  filePath: string | null;
   token: Token | null;
 }
 export function createIncludeItem(): IncludeItem {
   return {
     kind: SyntaxKind.IncludeItem,
     container: null,
-    file: null,
+    fileName: null,
     string: false,
     ddname: false,
     result: null,
+    filePath: null,
     token: null,
   };
 }

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -39,7 +39,7 @@ export interface ProcessGroup {
   name: string;
   "compiler-options"?: string[];
   libs?: string[];
-  "copybook-extensions"?: string[];
+  "include-extensions"?: string[];
   abstractOptions?: AbstractCompilerOptions;
 
   /**

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -16,6 +16,7 @@ import {
   parseAbstractCompilerOptions,
 } from "../preprocessor/compiler-options/parser";
 import { translateCompilerOptions } from "../preprocessor/compiler-options/translator";
+import { minimatch } from "minimatch";
 
 /**
  * Plugin configuration provider for loading up '.pliplugin' (when it exists), processing its contents,
@@ -218,6 +219,7 @@ class PluginConfigurationProvider {
     partialKey: string,
     programConfigs: ProgramConfig[],
   ): void {
+    this.programConfigs.clear();
     for (const config of programConfigs) {
       // TODO @montymxb Apr. 23rd, 2025: Path sep is not cross-platform
       const workspaceUri = URI.parse(partialKey);
@@ -232,6 +234,7 @@ class PluginConfigurationProvider {
    *  .pliplugin/proc_grps.json (when present)
    */
   public setProcessGroupConfigs(processGroupConfigs: ProcessGroup[]): void {
+    this.processGroupConfigs.clear();
     for (const config of processGroupConfigs) {
       this.processGroupConfigs.set(config.name, config);
     }
@@ -239,19 +242,44 @@ class PluginConfigurationProvider {
   }
 
   /**
-   * Returns the program config for the given program
-   * @param program File name of the program to get a config for (entry point)
+   * Returns the program config for the given program.
+   * If no exact match is found, will attempt to match against
+   * any glob patterns registered as a config keys using minimatch.
+   * See: https://github.com/isaacs/minimatch for ref
+   * @param program Name of the program to get a config for
    * @returns Associated program config, or undefined if not found
    */
   public getProgramConfig(program: string): ProgramConfig | undefined {
-    return this.programConfigs.get(program);
+    // try direct match first
+    const direct = this.programConfigs.get(program);
+    if (direct) {
+      return direct;
+    }
+    // fallback to glob matching
+    for (const [pattern, config] of this.programConfigs.entries()) {
+      if (pattern === program) {
+        continue; // already checked
+      }
+      try {
+        // attempt match on decoded URI
+        if (minimatch(program, decodeURIComponent(pattern))) {
+          return config;
+        }
+      } catch (e) {
+        console.error(
+          `Invalid glob pattern "${pattern}" for program "${program}": ${e}`,
+        );
+      }
+    }
+    // no match
+    return undefined;
   }
 
   /**
    * Returns true if the given program has a config (i.e. is a listed entry point)
    */
   public hasProgramConfig(program: string): boolean {
-    return this.programConfigs.has(program);
+    return this.getProgramConfig(program) !== undefined;
   }
 
   /**

--- a/packages/language/test/fourslash-harness/execute.test.ts
+++ b/packages/language/test/fourslash-harness/execute.test.ts
@@ -24,6 +24,7 @@ import {
 } from "../test-builder";
 import { createTestBuilderHarnessImplementation } from "./implementation/test-builder";
 import { resetDocumentProviders } from "../../src/language-server/text-documents";
+import { PluginConfigurationProviderInstance } from "../../src/workspace/plugin-configuration-provider";
 
 const frameworkFileName = "framework.ts";
 const testsPath = "packages/language/test/fourslash";
@@ -34,10 +35,23 @@ beforeEach(() => {
   vfs = new VirtualFileSystemProvider();
   setFileSystemProvider(vfs);
   resetDocumentProviders();
+  
+  // ensure the 'cpy' directory is always resolvable for includes via config
+  PluginConfigurationProviderInstance.setProgramConfigs("", [{
+    program: "*.pli",
+    pgroup: "default"
+  }]);
+  PluginConfigurationProviderInstance.setProcessGroupConfigs([{
+    name: "default",
+    libs: ["cpy"],
+    "include-extensions": [".pli"],
+  }]);
 });
 
 afterEach(() => {
   setFileSystemProvider(undefined);
+  PluginConfigurationProviderInstance.setProgramConfigs("", []);
+  PluginConfigurationProviderInstance.setProcessGroupConfigs([]);
 });
 
 function getTestFiles() {

--- a/packages/language/test/fourslash/linker/link-from-included-file.ts
+++ b/packages/language/test/fourslash/linker/link-from-included-file.ts
@@ -1,10 +1,10 @@
 /// <reference path="../framework.ts" />
 
-// @filename: file:///include.pli
+// @filename: file:///cpy/include.pli
 //// DCL <|1:Y|> FIXED;
 
 // @filename: file:///main.pli
-//// %INCLUDE "./include.pli";
+//// %INCLUDE "include.pli";
 //// <|1>Y = 42;
 
 linker.expectLinks();

--- a/packages/language/test/fourslash/linker/multiple-files.ts
+++ b/packages/language/test/fourslash/linker/multiple-files.ts
@@ -4,15 +4,15 @@
  * Must link on included files
  */
 
-// @filename: include.pli
+// @filename: cpy/include.pli
 //// DCL <|1:X|> FIXED;
 
-// @filename: include2.pli
+// @filename: cpy/include2.pli
 //// DCL <|2:Y|> FIXED;
 
 // @filename: main.pli
-//// %INCLUDE "./include.pli";
-//// %INCLUDE "./include2.pli";
+//// %INCLUDE "include.pli";
+//// %INCLUDE "include2.pli";
 //// <|1>X = 42;
 //// <|2>Y = 43;
 

--- a/packages/language/test/lsp/definition-requests.test.ts
+++ b/packages/language/test/lsp/definition-requests.test.ts
@@ -15,6 +15,7 @@ import {
   setFileSystemProvider,
 } from "../../src/workspace/file-system-provider";
 import { createTestBuilder, PliTestFile, TestBuilder } from "../test-builder";
+import { PluginConfigurationProviderInstance } from "../../src/workspace/plugin-configuration-provider";
 
 describe("Go To Definition request", () => {
   let vfs: VirtualFileSystemProvider;
@@ -22,6 +23,16 @@ describe("Go To Definition request", () => {
 
   beforeAll(() => {
     vfs = new VirtualFileSystemProvider();
+    // ensure that the Pli plugin provider has the default path set for includes to resolve
+    PluginConfigurationProviderInstance.setProgramConfigs("", [{
+      program: "*.pli",
+      pgroup: "default"
+    }]);
+    PluginConfigurationProviderInstance.setProcessGroupConfigs([{
+      name: "default",
+      libs: ["./"],
+      "include-extensions": [".pli"],
+    }]);
     setFileSystemProvider(vfs);
     createFsTestBuilder = (content: string | PliTestFile[]) =>
       createTestBuilder(content, { fs: vfs });
@@ -29,6 +40,8 @@ describe("Go To Definition request", () => {
 
   afterAll(() => {
     setFileSystemProvider(undefined);
+    PluginConfigurationProviderInstance.setProgramConfigs("", []);
+    PluginConfigurationProviderInstance.setProcessGroupConfigs([]);
   });
 
   it("should resolve definition in same file", () => {
@@ -47,7 +60,7 @@ describe("Go To Definition request", () => {
 
   it("should resolve multiple requests", () => {
     const include = ` DCL <|1:Y|> FIXED;`;
-    const main = ` %INCLUDE "./include.pli";
+    const main = ` %INCLUDE "include.pli";
  <|1>Y = 42;
  <|1>Y = 45;`;
 

--- a/packages/language/test/parser/pli-preprocessor-include.test.ts
+++ b/packages/language/test/parser/pli-preprocessor-include.test.ts
@@ -65,7 +65,7 @@ async function setupPluginConfiguration() {
     {
       name: "testgroup",
       libs: ["cpy"],
-      "copybook-extensions": [".pli"],
+      "include-extensions": [".pli"],
     },
   ];
   PluginConfigurationProviderInstance.setProcessGroupConfigs(processGroups);

--- a/packages/language/test/parser/pli-preprocessor-include.test.ts
+++ b/packages/language/test/parser/pli-preprocessor-include.test.ts
@@ -21,7 +21,7 @@ type TokenizeFunction = (text: string) => string[];
 function setupFileSystemAndLexer(): TokenizeFunction {
   const vtsfs = new VirtualFileSystemProvider();
   setFileSystemProvider(vtsfs);
-  vtsfs.writeFileSync(URI.file("/test/payroll.pli"), " DECLARE PAYROLL FIXED;");
+  vtsfs.writeFileSync(URI.file("/test/cpy/payroll.pli"), " DECLARE PAYROLL FIXED;");
   vtsfs.writeFileSync(
     URI.file("/test/cpy/lib1.pli"),
     " DECLARE LIB1_VAR FIXED;",
@@ -52,7 +52,7 @@ async function setupPluginConfiguration() {
 
   const programConfigs: ProgramConfig[] = [
     {
-      program: "test.pli",
+      program: "*.pli",
       pgroup: "testgroup",
     },
   ];
@@ -82,7 +82,8 @@ describe("PL/1 Includes without Plugin Config", () => {
     setFileSystemProvider(undefined);
   });
 
-  test("Include relative path with extension", () => {
+  // TODO @montymxb relative path looksup are intended to fail currently
+  test.fails("Include relative path with extension", () => {
     expect(
       tokenize(`
             %INCLUDE "./cpy/lib1.pli";
@@ -100,7 +101,8 @@ describe("PL/1 Includes without Plugin Config", () => {
     ]);
   });
 
-  test("Include relative path without extension", () => {
+  // TODO @montymxb relative path looksup are intended to fail currently
+  test.fails("Include relative path without extension", () => {
     expect(
       tokenize(`
             %INCLUDE "./cpy/LIB2";
@@ -118,7 +120,8 @@ describe("PL/1 Includes without Plugin Config", () => {
     ]);
   });
 
-  test("Include relative path with '../'", () => {
+  // TODO @montymxb relative path looksup are intended to fail currently
+  test.fails("Include relative path with '../'", () => {
     expect(
       tokenize(`
             %INCLUDE "../LIB4";
@@ -176,42 +179,6 @@ describe("PL/1 Includes without Plugin Config", () => {
       ";:;",
     ]);
   });
-
-  test("Should include only once with 2 XINCLUDE statements", () => {
-    expect(
-      tokenize(`
-            %XINCLUDE "/test/payroll.pli";
-            %XINCLUDE "/test/payroll.pli";
-        `),
-    ).toStrictEqual(["DECLARE:DECLARE", "PAYROLL:ID", "FIXED:FIXED", ";:;"]);
-  });
-
-  test("Should include twice with INCLUDE after XINCLUDE", () => {
-    expect(
-      tokenize(`
-            %XINCLUDE "/test/payroll.pli";
-            %INCLUDE "/test/payroll.pli";
-        `),
-    ).toStrictEqual([
-      "DECLARE:DECLARE",
-      "PAYROLL:ID",
-      "FIXED:FIXED",
-      ";:;",
-      "DECLARE:DECLARE",
-      "PAYROLL:ID",
-      "FIXED:FIXED",
-      ";:;",
-    ]);
-  });
-
-  test("Should include once with XINCLUDE after INCLUDE", () => {
-    expect(
-      tokenize(`
-            %INCLUDE "/test/payroll.pli";
-            %XINCLUDE "/test/payroll.pli";
-        `),
-    ).toStrictEqual(["DECLARE:DECLARE", "PAYROLL:ID", "FIXED:FIXED", ";:;"]);
-  });
 });
 
 describe("PL/1 Includes with Plugin Config", () => {
@@ -228,14 +195,50 @@ describe("PL/1 Includes with Plugin Config", () => {
     PluginConfigurationProviderInstance.setProcessGroupConfigs([]);
   });
 
+  test("Should include only once with 2 XINCLUDE statements", () => {
+    expect(
+      tokenize(`
+            %XINCLUDE "payroll.pli";
+            %XINCLUDE "payroll.pli";
+        `),
+    ).toStrictEqual(["DECLARE:DECLARE", "PAYROLL:ID", "FIXED:FIXED", ";:;"]);
+  });
+
+  test("Should include twice with INCLUDE after XINCLUDE", () => {
+    expect(
+      tokenize(`
+            %XINCLUDE "payroll.pli";
+            %INCLUDE "payroll.pli";
+        `),
+    ).toStrictEqual([
+      "DECLARE:DECLARE",
+      "PAYROLL:ID",
+      "FIXED:FIXED",
+      ";:;",
+      "DECLARE:DECLARE",
+      "PAYROLL:ID",
+      "FIXED:FIXED",
+      ";:;",
+    ]);
+  });
+
+  test("Should include once with XINCLUDE after INCLUDE", () => {
+    expect(
+      tokenize(`
+            %INCLUDE "payroll.pli";
+            %XINCLUDE "payroll.pli";
+        `),
+    ).toStrictEqual(["DECLARE:DECLARE", "PAYROLL:ID", "FIXED:FIXED", ";:;"]);
+  });
+
   test("Include twice with different IDs", () => {
     expect(
       tokenize(`
             %DECLARE PAYROLL CHARACTER;
             %PAYROLL = 'CUM_PAY';
-            %INCLUDE "./payroll.pli";
+            %INCLUDE "payroll.pli";
             %DEACTIVATE PAYROLL;
-            %INCLUDE "./payroll.pli";
+            %INCLUDE "payroll.pli";
         `),
     ).toStrictEqual([
       "DECLARE:DECLARE",

--- a/packages/language/test/workspace/compilation-unit.test.ts
+++ b/packages/language/test/workspace/compilation-unit.test.ts
@@ -67,4 +67,46 @@ describe("Compilation Unit Tests", () => {
     const unit2 = ch.getOrCreateCompilationUnit(uriEntry);
     expect(unit2).toBeDefined();
   });
+
+  test("Create with wildcard config", () => {
+    const uriEntry1 = URI.parse("file:///test/entry1.pli");
+    const uriEntry2 = URI.parse("file:///test/entry2.pli");
+    const uriOther = URI.parse("file:///other/entry3.pli");
+    const ch = new CompilationUnitHandler();
+
+    // register wildcard config
+    PluginConfigurationProviderInstance.setProgramConfigs("", [
+      {
+        program: "test/*.pli",
+        pgroup: "",
+      },
+    ]);
+
+    // entry 1 should match wildcard config
+    const config1 = PluginConfigurationProviderInstance.getProgramConfig(
+      uriEntry1.toString(),
+    );
+    expect(config1).toBeDefined();
+
+    // entry 2 should also match
+    const config2 = PluginConfigurationProviderInstance.getProgramConfig(
+      uriEntry2.toString(),
+    );
+    expect(config2).toBeDefined();
+    
+    // entry 3 should not match
+    const configOther = PluginConfigurationProviderInstance.getProgramConfig(
+      uriOther.toString(),
+    );
+    expect(configOther).toBeUndefined();
+
+    // compilation units should be created for matching uris
+    const unit1 = ch.getOrCreateCompilationUnit(uriEntry1);
+    expect(unit1).toBeDefined();
+    const unit2 = ch.getOrCreateCompilationUnit(uriEntry2);
+    expect(unit2).toBeDefined();
+    // compilation unit for non-matching uri should still be created
+    const unitOther = ch.getOrCreateCompilationUnit(uriOther);
+    expect(unitOther).toBeDefined();
+  });
 });

--- a/packages/vscode-extension/src/extension/main.ts
+++ b/packages/vscode-extension/src/extension/main.ts
@@ -96,7 +96,7 @@ function registerOnDidOpenTextDocListener() {
               name: "default",
               "compiler-options": [],
               libs: ["cpy", "inc"],
-              "copybook-extensions": [],
+              "include-extensions": [],
             },
           ],
         },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
+      minimatch:
+        specifier: ^10.0.3
+        version: 10.0.3
       vscode-languageserver:
         specifier: ~9.0.1
         version: 9.0.1
@@ -977,6 +980,14 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@isaacs/balanced-match@4.0.1':
+    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
+    engines: {node: 20 || >=22}
+
+  '@isaacs/brace-expansion@5.0.0':
+    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
+    engines: {node: 20 || >=22}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -1964,8 +1975,8 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
-  minimatch@10.0.1:
-    resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
+  minimatch@10.0.3:
+    resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
     engines: {node: 20 || >=22}
 
   minimatch@3.1.2:
@@ -3809,6 +3820,12 @@ snapshots:
   '@esbuild/win32-x64@0.25.5':
     optional: true
 
+  '@isaacs/balanced-match@4.0.1': {}
+
+  '@isaacs/brace-expansion@5.0.0':
+    dependencies:
+      '@isaacs/balanced-match': 4.0.1
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -4521,7 +4538,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.0
       jackspeak: 4.0.2
-      minimatch: 10.0.1
+      minimatch: 10.0.3
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.0
@@ -4909,9 +4926,9 @@ snapshots:
   mimic-response@3.1.0:
     optional: true
 
-  minimatch@10.0.1:
+  minimatch@10.0.3:
     dependencies:
-      brace-expansion: 2.0.1
+      '@isaacs/brace-expansion': 5.0.0
 
   minimatch@3.1.2:
     dependencies:


### PR DESCRIPTION
Supplements upon our existing include/config work with some general improvements:
- renames the config extension option to `include-extensions` from `copybook-extensions` per request
- adds glob matching for program config `program` entries with [minimatch](https://www.npmjs.com/package/minimatch)
- disables relative & absolute include resolution + test updates
- adds go to def support for include items when resolvable