### PR TITLE
Add better printing of diagnostics in test builder harness files

### DIFF
--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -98,7 +98,7 @@ function createBuiltinScopeGetter() {
   return (uri: URI): Scope => {
     // Don't load the builtin symbol table for builtin files
     if (isBuiltinFile(uri)) {
-      return new Scope(null);
+      return new Scope();
     }
 
     if (builtinSymbolTable === undefined) {
@@ -108,7 +108,7 @@ function createBuiltinScopeGetter() {
       generateSymbolTable(unit);
 
       builtinSymbolTable =
-        unit.scopeCaches.regular.get(unit.ast) ?? new Scope(null);
+        unit.scopeCaches.regular.get(unit.ast) ?? new Scope();
     }
 
     return builtinSymbolTable;
@@ -118,7 +118,7 @@ function createBuiltinScopeGetter() {
 const getBuiltinScope = createBuiltinScopeGetter();
 
 // TODO: Add preprocessor scope for builtins?
-const getRootPreprocessorScope = () => new Scope(null);
+const getRootPreprocessorScope = () => new Scope();
 
 export function createCompilationUnit(uri: URI): CompilationUnit {
   return {

--- a/packages/language/test/fourslash-harness/harness.test.ts
+++ b/packages/language/test/fourslash-harness/harness.test.ts
@@ -148,8 +148,16 @@ ${content1
 
     const file = parseHarnessTest(commands, "test.ts", {
       wrappers: {
-        main: (content) => content,
-        main2: (content) => content,
+        main: {
+          wrap: (content) => content,
+          headerLength: 0,
+          footerLength: 0,
+        },
+        main2: {
+          wrap: (content) => content,
+          headerLength: 0,
+          footerLength: 0,
+        },
       },
     });
 
@@ -180,7 +188,11 @@ ${content1
 
     const file = parseHarnessTest(commands, "test.ts", {
       wrappers: {
-        main: (content) => `WRAP_BEGIN ${content} WRAP_END`,
+        main: {
+          wrap: (content) => `WRAP_BEGIN ${content} WRAP_END`,
+          headerLength: 1,
+          footerLength: 1,
+        },
       },
     });
 
@@ -195,6 +207,6 @@ ${content1
     const wrapFileContent = `////WRAP_BEGIN <...> WRAP_END`;
     const wrapper = parseWrapperFile(wrapFileContent);
 
-    expect(wrapper("MY CONTENT")).toBe("WRAP_BEGIN MY CONTENT WRAP_END");
+    expect(wrapper.wrap("MY CONTENT")).toBe("WRAP_BEGIN MY CONTENT WRAP_END");
   });
 });

--- a/packages/language/test/fourslash-harness/types.ts
+++ b/packages/language/test/fourslash-harness/types.ts
@@ -16,6 +16,16 @@ export interface HarnessFile {
   fileName: string | undefined;
   wrap: string | undefined;
   content: string;
+
+  /**
+   * The line offset of the file, e.g. the number of lines to skip before the file content
+   */
+  lineOffset: number;
+
+  /**
+   * The general character offset of the file, e.g. the fourslash `////` prefix
+   */
+  characterOffset: number;
 }
 
 export interface HarnessTest {

--- a/packages/language/test/fourslash-harness/wrapper.ts
+++ b/packages/language/test/fourslash-harness/wrapper.ts
@@ -18,7 +18,11 @@ import { HARNESS_FILE_PREFIX } from "./harness-parser";
  */
 const WRAPPER_CONTENT_TAG = "<...>";
 
-export type Wrapper = (content: string) => string;
+export type Wrapper = {
+  wrap: (content: string) => string;
+  headerLength: number;
+  footerLength: number;
+};
 
 /**
  * Parse a wrapper file into a function that can be used to wrap content.
@@ -29,14 +33,23 @@ export type Wrapper = (content: string) => string;
  * @returns A function that can be used to wrap content.
  */
 export function parseWrapperFile(content: string): Wrapper {
-  const wrapperContent = content
+  const wrapperLines = content
     .split("\n")
-    .map((v) => v.substring(HARNESS_FILE_PREFIX.length))
-    .join("\n");
+    .map((v) => v.substring(HARNESS_FILE_PREFIX.length));
+  const wrapperContent = wrapperLines.join("\n");
   const wrapperFunction = (content: string) =>
     wrapperContent.replace(WRAPPER_CONTENT_TAG, content);
 
-  return wrapperFunction;
+  const headerLength = wrapperLines.findIndex((v) =>
+    v.includes(WRAPPER_CONTENT_TAG),
+  );
+  const footerLength = wrapperLines.length - headerLength - 1;
+
+  return {
+    wrap: wrapperFunction,
+    headerLength,
+    footerLength,
+  };
 }
 
 /**


### PR DESCRIPTION
Adds printing error messages with clickable line/character paths inside failing tests when using `verify.noDiagnostics()`:

```
 FAIL  packages/language/test/fourslash-harness/execute.test.ts > Harness tests > linker/implicit-declaration.ts
AssertionError: Expected no diagnostics but received:
- E: Unknown identifier 'A' (packages/language/test/fourslash/linker/implicit-declaration.ts:3:6)
- E: Unknown identifier 'A' (packages/language/test/fourslash/linker/implicit-declaration.ts:4:10)
```

Also shortens harness file path names in test labels.