### PR TITLE
Update Open Files on Config Change

### DIFF
--- a/packages/language/src/language-server/connection-handler.ts
+++ b/packages/language/src/language-server/connection-handler.ts
@@ -9,7 +9,10 @@
  *
  */
 
-import { CompilationUnitHandler } from "../workspace/compilation-unit";
+import {
+  CompilationUnitHandler,
+  collectDiagnostics,
+} from "../workspace/compilation-unit";
 import {
   Connection,
   DocumentHighlight,
@@ -20,7 +23,7 @@ import { definitionRequest } from "./definition-request";
 import { referencesRequest } from "./references-request";
 import { semanticTokenLegend, semanticTokens } from "./semantic-tokens";
 import { Location, TextEdit } from "vscode-languageserver-types";
-import { completionItemToLSP, rangeToLSP } from "./types";
+import { completionItemToLSP, rangeToLSP, diagnosticsToLSP } from "./types";
 import { renameRequest } from "./rename-request";
 import { mapValues } from "../utils/common";
 import { getReferenceLocations } from "../linking/resolver";
@@ -30,6 +33,7 @@ import { PluginConfigurationProviderInstance } from "../workspace/plugin-configu
 import { completionRequest } from "./completion/completion-request";
 import { BuiltinsTextDocument } from "../workspace/builtins";
 import { BuiltinDocuments, TextDocuments } from "./text-documents";
+import { lifecycle } from "../workspace/lifecycle";
 
 /**
  * Notification sent to the LS when the workspace's plugin configuration changes.
@@ -231,6 +235,28 @@ export function startLanguageServer(connection: Connection): void {
     () => {
       // handle changes to the .pliplugin config folder's contents
       PluginConfigurationProviderInstance.reloadConfigurations();
+
+      // re-parse all compilation units for open files, and update diagnostics (so we can see config updates in realtime)
+      for (const unit of compilationUnitHandler.getAllCompilationUnits()) {
+        const textDocument = TextDocuments.get(unit.uri.toString());
+        let text: string | undefined = undefined;
+
+        if (textDocument) {
+          text = textDocument.getText();
+        }
+
+        if (text !== undefined) {
+          lifecycle(unit, text);
+          const allDiagnostics = diagnosticsToLSP(collectDiagnostics(unit));
+          for (const file of unit.files) {
+            const fileDiagnostics = allDiagnostics.get(file.toString());
+            connection.sendDiagnostics({
+              uri: file.toString(),
+              diagnostics: fileDiagnostics ?? [],
+            });
+          }
+        }
+      }
     },
   );
   connection.listen();

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -231,7 +231,7 @@ export class CompilationUnitHandler {
   /**
    * Process a unit by running it through the lifecycle and generating diagnostics to report back.
    * @param unit The compilation unit
-   * @param text Program content content to use for the lifecycle
+   * @param text Program content to use for the lifecycle
    * @param connection The connection to send diagnostics to
    */
   private process(
@@ -255,7 +255,7 @@ export class CompilationUnitHandler {
 
   /**
    * Reindexes all compilation units that are reachable, and reports fresh diagnostics.
-   * Reachable as in the compilation units that are currently open in the editor.
+   * Reachable as in the units w/ associated docs that are currently open in the editor.
    * @param connection The connection to send diagnostics to
    */
   reindex(connection: Connection): void {

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -27,7 +27,10 @@ import { marginIndicator } from "../language-server/margin-indicator.js";
 import { createLSRequestCaches, LSRequestCache } from "../utils/cache.js";
 import { Scope, ScopeCacheGroups } from "../linking/scope.js";
 import { Token } from "../parser/tokens.js";
-import { EditorDocuments } from "../language-server/text-documents.js";
+import {
+  EditorDocuments,
+  TextDocuments,
+} from "../language-server/text-documents.js";
 import { Builtins, BuiltinsUri, BuiltinsUriSchema } from "./builtins.js";
 
 /**
@@ -213,18 +216,7 @@ export class CompilationUnitHandler {
         URI.parse(event.document.uri),
       );
       const document = textDocuments.get(unit.uri) ?? event.document;
-      lifecycle(unit, document.getText());
-      unit.files.forEach((file) => {
-        this.compilationUnits.set(file.toString(), unit);
-      });
-      const allDiagnostics = diagnosticsToLSP(collectDiagnostics(unit));
-      for (const file of unit.files) {
-        const fileDiagnostics = allDiagnostics.get(file.toString());
-        connection.sendDiagnostics({
-          uri: file.toString(),
-          diagnostics: fileDiagnostics ?? [],
-        });
-      }
+      this.process(unit, document.getText(), connection);
       unit.requestCaches.revalidateAll({ connection, unit });
     });
     textDocuments.onDidClose((event) => {
@@ -234,5 +226,44 @@ export class CompilationUnitHandler {
         diagnostics: [],
       });
     });
+  }
+
+  /**
+   * Process a unit by running it through the lifecycle and generating diagnostics to report back.
+   * @param unit The compilation unit
+   * @param text Program content content to use for the lifecycle
+   * @param connection The connection to send diagnostics to
+   */
+  private process(
+    unit: CompilationUnit,
+    text: string,
+    connection: Connection,
+  ): void {
+    lifecycle(unit, text);
+    for (const file of unit.files) {
+      this.compilationUnits.set(file.toString(), unit);
+    }
+    const allDiagnostics = diagnosticsToLSP(collectDiagnostics(unit));
+    for (const file of unit.files) {
+      const fileDiagnostics = allDiagnostics.get(file.toString());
+      connection.sendDiagnostics({
+        uri: file.toString(),
+        diagnostics: fileDiagnostics ?? [],
+      });
+    }
+  }
+
+  /**
+   * Reindexes all compilation units that are reachable, and reports fresh diagnostics.
+   * Reachable as in the compilation units that are currently open in the editor.
+   * @param connection The connection to send diagnostics to
+   */
+  reindex(connection: Connection): void {
+    for (const unit of this.getAllCompilationUnits()) {
+      const textDocument = TextDocuments.get(unit.uri.toString());
+      if (textDocument) {
+        this.process(unit, textDocument.getText(), connection);
+      }
+    }
   }
 }


### PR DESCRIPTION
Corrects an issue where documents weren't updating when the .pliplugin folder's contents were being changed. This triggers a re-processing of open documents when the `workspace/didChangePlipluginConfig` notification is received by the server to amend that.