### PR TITLE
Auto-Set Doc Language for PLI Lib & Program Files

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -97,7 +97,8 @@
     "stream-browserify": "^3.0.0",
     "util": "^0.12.5",
     "vscode-languageclient": "~9.0.1",
-    "vscode-languageserver": "~9.0.1"
+    "vscode-languageserver": "~9.0.1",
+    "minimatch": "^10.0.3"
   },
   "devDependencies": {
     "@types/vscode": "~1.67.0",

--- a/packages/vscode-extension/src/extension/pli-config-cache.ts
+++ b/packages/vscode-extension/src/extension/pli-config-cache.ts
@@ -1,0 +1,133 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import * as path from "node:path";
+import * as fs from "node:fs";
+import { minimatch } from "minimatch";
+
+/**
+ * Process groups cache
+ * This cache holds the latest process group configuration loaded from .pliplugin/proc_grps.json
+ */
+let cachedProcGrps: any = undefined;
+
+/**
+ * Program configs cache
+ * This cache holds the list of program config 'program' entries (glob patterns) loaded from
+ * .pliplugin/pgm_conf.json
+ */
+let cachedProgramConfigs: string[] = [];
+
+/**
+ * Caches the latest process group config from .pliplugin/proc_grps.json.
+ * Intended to be called when the .pliplugin folder changes or on extension activation.
+ * @param workspaceFolder - The workspace folder to resolve relative paths
+ */
+export function loadProcessGroupsCache(workspaceFolder: string) {
+  const procGrpsPath = path.join(
+    workspaceFolder,
+    ".pliplugin",
+    "proc_grps.json",
+  );
+  if (!fs.existsSync(procGrpsPath)) {
+    cachedProcGrps = undefined;
+  } else {
+    try {
+      cachedProcGrps = JSON.parse(fs.readFileSync(procGrpsPath, "utf8"));
+    } catch {
+      cachedProcGrps = undefined;
+      console.warn(
+        `Failed to parse ${procGrpsPath}. Process groups cache is now empty.`,
+      );
+    }
+  }
+}
+
+/**
+ * Caches the list of program config 'program' entries (glob patterns) from .pliplugin/pgm_conf.json
+ * Intended to be called when the .pliplugin folder changes or on extension activation.
+ * @param workspaceFolder - The workspace folder to resolve relative paths
+ */
+export function loadProgramConfigsCache(workspaceFolder: string) {
+  const pgmConfPath = path.join(workspaceFolder, ".pliplugin", "pgm_conf.json");
+  cachedProgramConfigs = [];
+  if (!fs.existsSync(pgmConfPath)) return;
+  try {
+    const pgmConf = JSON.parse(fs.readFileSync(pgmConfPath, "utf8"));
+    for (const entry of pgmConf.pgms ?? []) {
+      if (typeof entry.program === "string") {
+        cachedProgramConfigs.push(entry.program);
+      }
+    }
+  } catch {
+    console.warn(
+      `Failed to parse ${pgmConfPath}. Program configs cache is now empty.`,
+    );
+    cachedProgramConfigs = [];
+  }
+}
+
+/**
+ * Indicates whether the given path corresponds to a PL/I library file
+ * based on the cached process groups config
+ * @param filePath - The file path to check
+ * @param workspaceFolder - The workspace folder to resolve relative paths
+ * @returns Whether the file is a PL/I library file
+ */
+export function isPLILibFile(
+  filePath: string,
+  workspaceFolder: string,
+): boolean {
+  if (!cachedProcGrps) {
+    loadProcessGroupsCache(workspaceFolder);
+  }
+  for (const group of cachedProcGrps?.pgroups ?? []) {
+    for (const lib of group.libs ?? []) {
+      const libDir = path.join(workspaceFolder, lib);
+      if (filePath.startsWith(libDir + path.sep)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Returns true if the given file path (extension-less) matches any program config 'program' entry (glob pattern)
+ * @param filePath - The file path to check
+ * @param workspaceFolder - The workspace folder to resolve relative paths
+ * @returns Whether the file path matches any program config entry
+ */
+export function isExtensionlessProgramEntry(
+  filePath: string,
+  workspaceFolder: string,
+): boolean {
+  if (!cachedProgramConfigs.length) {
+    loadProgramConfigsCache(workspaceFolder);
+    if (!cachedProgramConfigs.length) {
+      return false;
+    }
+  }
+
+  // only consider extension-less files for program entries
+  if (path.extname(filePath)) {
+    return false;
+  }
+
+  // check for a match against any program config entry
+  const relPath = path.relative(workspaceFolder, filePath);
+  for (const pattern of cachedProgramConfigs) {
+    if (minimatch(relPath, pattern)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,6 +163,9 @@ importers:
       langium:
         specifier: ~3.4.0
         version: 3.4.0
+      minimatch:
+        specifier: ^10.0.3
+        version: 10.0.3
       path-browserify:
         specifier: ^1.0.1
         version: 1.0.1


### PR DESCRIPTION
This resolves an issue where extension-less PLI files (like `MYLIB`) or files with different extensions than .pli/pl1 would not be recognized as PL/I files within vscode. This change optimistically assigns PL/I as the language for a document when the file is:
- located in a known PL/I libs folder declared in any process group with any extension (ex. `MYLIB.pli`, `MYLIB.txt`, or `MYLIB`)
- or is reachable as a program config entry (by literal or glob match) as a an extension-less file (ex. `MYLIB.pli` or `MYLIB`)

Assignment is done lazily when the file is opened, so up to that point the file may still be recognized with a different language type.

The differentiation on the later case is to avoid accidentally picking up other legitimate program types that may live alongside pli files, such as for COBOL. However we'll likely to have to observe how usage is impacted by this, and will adjust as needed.

