### PR TITLE
Clear statement order cache on reparse

### DIFF
--- a/packages/language/src/linking/resolver.ts
+++ b/packages/language/src/linking/resolver.ts
@@ -65,6 +65,11 @@ export class StatementOrderCache {
     return this.map.get(node);
   }
 
+  clear(): void {
+    this.id = 0;
+    this.map.clear();
+  }
+
   /**
    * Returns true if `a` is before `b` in the statement order.
    *
@@ -75,12 +80,12 @@ export class StatementOrderCache {
    */
   isBefore(a: SyntaxNode, b: SyntaxNode) {
     const aId = this.get(getParentStatement(a));
-    if (!aId) {
+    if (aId === undefined) {
       throw new Error("Node not found in statement order cache");
     }
 
     const bId = this.get(getParentStatement(b));
-    if (!bId) {
+    if (bId === undefined) {
       throw new Error("Node not found in statement order cache");
     }
 

--- a/packages/language/src/workspace/lifecycle.ts
+++ b/packages/language/src/workspace/lifecycle.ts
@@ -29,6 +29,7 @@ export function lifecycle(
   compilationUnit: CompilationUnit,
   text: string,
 ): void {
+  compilationUnit.statementOrderCache.clear();
   compilationUnit.referencesCache.clear();
   compilationUnit.scopeCaches.clear();
   tokenize(compilationUnit, text);


### PR DESCRIPTION
Since the statement order cache was only growing, this led to an eventual crash of the language server due to being out of memory.