### PR TITLE
Add reference of preprocessor variables in PL/I code

### DIFF
--- a/code_samples/preprocessor/do.pli
+++ b/code_samples/preprocessor/do.pli
@@ -5,7 +5,7 @@
  %DO
    /* Synthesize 3 new declarations */
    %WHILE(X <= 3);
-     DCL Variable%X FIXED;
+     DCL Variable%;X FIXED;
      %X = X + 1;
  %END;
 

--- a/packages/language/src/linking/resolver.ts
+++ b/packages/language/src/linking/resolver.ts
@@ -106,6 +106,10 @@ export class ReferencesCache {
     this.list.push(reference);
   }
 
+  addAll(references: Reference[]): void {
+    this.list.push(...references);
+  }
+
   addInverse(reference: Reference): void {
     if (reference.node) {
       let list = this.reverseMap.get(reference.node);

--- a/packages/language/src/preprocessor/instruction-generator.ts
+++ b/packages/language/src/preprocessor/instruction-generator.ts
@@ -203,7 +203,13 @@ function generateDeclareInstruction(
       visibility = inst.VariableVisibility.External;
     }
     instructions.push(
-      inst.createDeclareInstruction(item.name, type, scanMode, visibility),
+      inst.createDeclareInstruction(
+        item.name,
+        type,
+        scanMode,
+        visibility,
+        item,
+      ),
     );
   }
   return inst.createCompoundInstruction(instructions);
@@ -533,7 +539,7 @@ function generateReferenceItemInstruction(
   return {
     kind: inst.InstructionKind.ReferenceItem,
     variable: node.ref?.text ?? "",
-    token: node.ref?.token ?? null,
+    reference: node.ref,
     args,
   };
 }

--- a/packages/language/src/preprocessor/instructions.ts
+++ b/packages/language/src/preprocessor/instructions.ts
@@ -160,7 +160,7 @@ export interface StringInstruction {
 export interface ReferenceItemInstruction {
   kind: InstructionKind.ReferenceItem;
   variable: string;
-  token: Token | null;
+  reference: ast.Reference | null;
   args: ExpressionInstruction[];
 }
 
@@ -223,6 +223,7 @@ export enum VariableVisibility {
 export interface DeclareInstruction {
   kind: InstructionKind.Declare;
   name: string;
+  node: ast.SyntaxNode | null;
   type: DeclaredType;
   mode: ScanMode;
   visibility: VariableVisibility | null;
@@ -233,12 +234,14 @@ export function createDeclareInstruction(
   type: DeclaredType,
   mode: ScanMode,
   visibility?: VariableVisibility | null,
+  node: ast.SyntaxNode | null = null,
 ): DeclareInstruction {
   return {
     kind: InstructionKind.Declare,
     name,
     type,
     mode,
+    node,
     visibility: visibility ?? null,
   };
 }

--- a/packages/language/src/preprocessor/pli-lexer.ts
+++ b/packages/language/src/preprocessor/pli-lexer.ts
@@ -19,7 +19,7 @@ import {
   CompilerOptionsProcessorResult,
 } from "./compiler-options-processor";
 import { CompilationUnit } from "../workspace/compilation-unit";
-import { Statement } from "../syntax-tree/ast";
+import { Reference, Statement } from "../syntax-tree/ast";
 import { Range } from "../language-server/types";
 import { Token } from "../parser/tokens";
 import { recursivelySetContainer } from "../linking/symbol-table";
@@ -39,6 +39,7 @@ export interface LexerResult {
   statements: Statement[];
   fileTokens: Record<string, Token[]>;
   evaluationResults: EvaluationResults;
+  tokenReferences: Reference[];
 }
 
 /**
@@ -90,9 +91,7 @@ export class PliLexer {
         ...compilerOptionsResult.result.tokens,
       );
     }
-    if (output.errors) {
-      errors.push(...output.errors);
-    }
+    errors.push(...output.errors);
     return {
       all: output.all,
       compilerOptions: compilerOptionsResult,
@@ -100,6 +99,7 @@ export class PliLexer {
       statements,
       fileTokens: output.fileTokens,
       evaluationResults: output.evaluationResults,
+      tokenReferences: output.references,
     };
   }
 }

--- a/packages/language/src/workspace/lifecycle.ts
+++ b/packages/language/src/workspace/lifecycle.ts
@@ -53,6 +53,7 @@ export function tokenize(
   compilationUnit.tokens.fileTokens = result.fileTokens;
   compilationUnit.preprocessorAst.statements = result.statements;
   compilationUnit.preprocessorEvaluationResults = result.evaluationResults;
+  compilationUnit.referencesCache.addAll(result.tokenReferences);
   compilationUnit.compilerOptions =
     result.compilerOptions.result?.options ?? {};
   const uri = compilationUnit.uri.toString();

--- a/packages/language/test/fourslash/linker/preprocessor-token-variable.ts
+++ b/packages/language/test/fourslash/linker/preprocessor-token-variable.ts
@@ -9,16 +9,14 @@
  *
  */
 
-export function formatCodeBlock(language: string) {
-  return (text: string): string => {
-    return `\`\`\`${language}\n${text}\n\`\`\`\n`;
-  };
-}
+/// <reference path="../framework.ts" />
 
 /**
- * Format a code block for Pli.
- *
- * @example
- * formatPliCodeBlock("DCL A") === "```pli\nDCL A\n```\n"
+ Preprocessor variables can be linked from PL/I code.
  */
-export const formatPliCodeBlock = formatCodeBlock("pli");
+// @wrap: main
+//// %DECLARE <|1:ABC|> CHARACTER;
+//// %ABC = 'PAY_ROLL';
+//// PUT(<|1>ABC);
+
+linker.expectLinks();

--- a/packages/language/test/lsp/find-references.test.ts
+++ b/packages/language/test/lsp/find-references.test.ts
@@ -35,4 +35,10 @@ describe("Find references", () => {
      2 <|2><|2:B|> CHAR(8) VALUE("B");
  PUT(<|2:B|>);
  PUT(<|1:A|><|1>.<|2:B|>);`));
+
+  test("Can find references of processor variables", () =>
+    expectReferences(`
+ %DECLARE <|1><|1:ABC|> CHARACTER;
+ %<|1:ABC|> = 'PAY_ROLL';
+ PUT(<|1:ABC|>);`));
 });


### PR DESCRIPTION
Allows users to use "Find Definition" and "Find References" on PL/I tokens that are actually references to preprocessor variables.