### PR TITLE
Correct Include-Extension Config Option Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The `proc_grps.json` file is formatted as an array of JSON elements, with one JS
     - Specify a name for the processor group.
 - (Optional) **"libs":** (array)  
     - Specify local folders that contain include files. Specify local folders as either absolute or relative local paths.
-- (Optional) **"copybook-extensions":** (array)  
+- (Optional) **"include-extensions":** (array)  
     - Specify file extensions that you use for the include files in programs linked with this processor groups.
 - (Optional) **"compiler-options":** (array)  
     - Specify compiler directives that you want to apply to the programs linked with this processor group. 
@@ -116,7 +116,7 @@ Using the example `pgm_conf.json` file in the section above, the following `proc
       "libs": [
         "lib1"
       ],
-      "copybook-extensions": [
+      "include-extensions": [
         ".cpy", ".copy"
       ]
     },

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -693,7 +693,7 @@ function resolveIncludeFileUri(
     return undefined;
   }
 
-  // check to validate copybook extension, if a program config & process group is available
+  // check to validate include extension, if a program config & process group is available
   const programConfig = PluginConfigurationProviderInstance.getProgramConfig(
     context.uri.toString(),
   );
@@ -714,7 +714,7 @@ function resolveIncludeFileUri(
       ? `expected one of: ${pgroup["include-extensions"]?.join(", ")}`
       : `expected no extension`;
     throw new PreprocessorError(
-      `Unsupported copybook extension for included file, '${item.fileName}', ${msg}`,
+      `Unsupported include extension for included file, '${item.fileName}', ${msg}`,
       item.token,
       context.uri,
     );

--- a/packages/playground/workspace/.pliplugin/proc_grps.json
+++ b/packages/playground/workspace/.pliplugin/proc_grps.json
@@ -6,7 +6,7 @@
       "libs": [
         "lib"
       ],
-      "copybook-extensions": [
+      "include-extensions": [
         ".pli",
         ".pl1",
         ".cpy",


### PR DESCRIPTION
Corrects an issue observed in the playground where files could only be loaded in their member form, not via strings due to no valid extensions being picked up (property name was changed a month or two ago after a request). Documentation containing reference to this has been updated as well.