### PR TITLE
Fixed compiler option issues

### DIFF
--- a/packages/language/src/preprocessor/compiler-options/parser.ts
+++ b/packages/language/src/preprocessor/compiler-options/parser.ts
@@ -90,10 +90,13 @@ class CompilerOptionsParser extends EmbeddedActionsParser {
               };
             });
           });
+
           const subsequentResult = this.SUBRULE2(this.compilerOption, {
             ARGS: [false],
           });
-          options.push(subsequentResult as CompilerOption);
+          if (subsequentResult) {
+            options.push(subsequentResult as CompilerOption);
+          }
         });
       });
       return {
@@ -108,7 +111,7 @@ class CompilerOptionsParser extends EmbeddedActionsParser {
   );
 
   compilerOption = this.RULE<
-    (text: boolean) => CompilerOption | CompilerOptionText
+    (text: boolean) => CompilerOption | CompilerOptionText | undefined
   >(
     "compilerOption",
     (text) => {
@@ -172,14 +175,15 @@ class CompilerOptionsParser extends EmbeddedActionsParser {
           });
           values.push(firstValue);
           this.MANY(() => {
-            // TODO: This comma might also be optional?
-            const comma = this.CONSUME(commaToken);
-            this.ACTION(() => {
-              comma.payload = {
-                uri: undefined,
-                kind: CstNodeKind.CompilerOption_Comma,
-                element,
-              };
+            this.OPTION4(() => {
+              const comma = this.CONSUME(commaToken);
+              this.ACTION(() => {
+                comma.payload = {
+                  uri: undefined,
+                  kind: CstNodeKind.CompilerOption_Comma,
+                  element,
+                };
+              });
             });
             const subsequentValue = this.SUBRULE2(this.compilerValue);
             this.ACTION(() => {
@@ -200,12 +204,7 @@ class CompilerOptionsParser extends EmbeddedActionsParser {
       return element;
     },
     {
-      recoveryValueFunc: () => ({
-        container: null,
-        kind: SyntaxKind.CompilerOptionText,
-        token: this.LA(1),
-        value: "",
-      }),
+      recoveryValueFunc: () => undefined,
     },
   );
 

--- a/packages/language/src/validation/validator.ts
+++ b/packages/language/src/validation/validator.ts
@@ -30,6 +30,10 @@ import { LexingError } from "../preprocessor/pli-lexer";
 import { isMainProcedure, labelPrefixPointsToPackage } from "./utils";
 import { ScopeCache, ScopeCacheGroups } from "../linking/scope";
 import { LinkerErrorReporter } from "../linking/error";
+import {
+  CompilerOptionIssue,
+  compilerOptionIssueToDiagnostics,
+} from "../preprocessor/compiler-options/options";
 
 /**
  * A function that accepts a diagnostic for PL/I validation
@@ -103,6 +107,22 @@ function validateSyntaxNode(
   forEachNode(node, (childNode: SyntaxNode) => {
     validateSyntaxNode(childNode, acceptor, handlers);
   });
+}
+
+export function compilerOptionIssuesToDiagnostics(
+  compilerOptionIssues: CompilerOptionIssue[] | undefined,
+  uri: string,
+): Diagnostic[] {
+  if (!compilerOptionIssues) {
+    return [];
+  }
+  const diagnostics: Diagnostic[] = [];
+  for (const issue of compilerOptionIssues) {
+    if (!isNaN(issue.range.start)) {
+      diagnostics.push(compilerOptionIssueToDiagnostics(issue, uri));
+    }
+  }
+  return diagnostics;
 }
 
 export function lexerErrorsToDiagnostics(

--- a/packages/language/src/workspace/lifecycle.ts
+++ b/packages/language/src/workspace/lifecycle.ts
@@ -15,6 +15,7 @@ import { PliParserInstance } from "../parser/parser";
 import { CompilationUnit } from "./compilation-unit";
 import { PliProgram } from "../syntax-tree/ast";
 import {
+  compilerOptionIssuesToDiagnostics,
   generateValidationDiagnostics,
   lexerErrorsToDiagnostics,
   linkingErrorsToDiagnostics,
@@ -22,7 +23,6 @@ import {
 } from "../validation/validator";
 import { LexerResult, PliLexer } from "../preprocessor/pli-lexer";
 import { URI } from "../utils/uri";
-import { compilerOptionIssueToDiagnostics } from "../preprocessor/compiler-options/options";
 import { assignDebugKinds } from "../utils/debug-kinds";
 
 export function lifecycle(
@@ -59,9 +59,10 @@ export function tokenize(
   const uri = compilationUnit.uri.toString();
   compilationUnit.diagnostics.lexer = lexerErrorsToDiagnostics(result.errors);
   compilationUnit.diagnostics.compilerOptions =
-    result.compilerOptions.result?.issues.map((e) =>
-      compilerOptionIssueToDiagnostics(e, uri),
-    ) ?? [];
+    compilerOptionIssuesToDiagnostics(
+      result.compilerOptions.result?.issues,
+      uri,
+    );
   return result;
 }
 


### PR DESCRIPTION
Fixed compiler option with empty token name
Made compiler option value comma optional
Fixed validation on BLANK, BRACKETS, CHECK, DECIMAL, DEFAULT, DDSQL (https://github.com/zowe/zowe-pli-language-support/issues/247)