### PR TITLE
Fix stack size error on large pushes

### DIFF
--- a/packages/vscode-extension/syntaxes/pli.merged.json
+++ b/packages/vscode-extension/syntaxes/pli.merged.json
@@ -11,7 +11,7 @@
     },
     {
       "name": "keyword.control.pli",
-      "match": "(?i)\\b(if|else|then|do|end|select|otherwise|on|while|next|go|to|goto|return|when|begin|process|include|deactivate|activate)\\b"
+      "match": "(?i)\\b(if|else|then|do|end|select|otherwise|on|while|next|go|to|goto|return|when|begin|process|include|xinclude|inscan|xinscan|deactivate|activate)\\b"
     },
     {
       "include": "#comments"


### PR DESCRIPTION
When attempting to push *a lot* of tokens (> 100k) into the context using the `...` (spread) operator, the runtime would throw an error, since each element is put into the stack before being pushed to the array.

This change fixes this by pushing the elements one by one.