### PR TITLE
Avoid missing file tokens

### DIFF
--- a/packages/language/src/language-server/completion/completion-request.ts
+++ b/packages/language/src/language-server/completion/completion-request.ts
@@ -31,7 +31,10 @@ export function completionRequest(
   uri: URI,
   offset: number,
 ): CompletionItem[] {
-  const tokens = unit.tokens.fileTokens[uri.toString()] ?? [];
+  const tokens = unit.tokens.fileTokens.get(uri.toString());
+  if (!tokens) {
+    return [];
+  }
   const tokenIndex = completionTokenIndexSearch(tokens, offset);
   const cursorToken = binaryTokenSearch(tokens, offset);
   const token = tokens[tokenIndex];

--- a/packages/language/src/language-server/definition-request.ts
+++ b/packages/language/src/language-server/definition-request.ts
@@ -27,7 +27,10 @@ export function definitionRequest(
   uri: URI,
   offset: number,
 ): Location[] {
-  const tokens = compilationUnit.tokens.fileTokens[uri.toString()] ?? [];
+  const tokens = compilationUnit.tokens.fileTokens.get(uri.toString());
+  if (!tokens) {
+    return [];
+  }
   const token = binaryTokenSearch(tokens, offset);
   const payload = token?.payload;
   if (!payload) {

--- a/packages/language/src/language-server/document-symbol-request.ts
+++ b/packages/language/src/language-server/document-symbol-request.ts
@@ -30,7 +30,13 @@ export function documentSymbolRequest(
   // collect all related elements.
   const documentSymbols: DocumentSymbol[] = [];
   const tokensByElement = new Map<SyntaxNode, Token[]>();
-  const tokens = compilationUnit.tokens.fileTokens[textDocument.uri]
+  const fileTokens = compilationUnit.tokens.fileTokens.get(textDocument.uri);
+  if (!fileTokens) {
+    // No tokens found for ${textDocument.uri} in the current compilation unit.
+    return [];
+  }
+
+  const tokens = fileTokens
     .filter((token) => token.payload.element)
     .map((token) => {
       const element = token.payload.element!;

--- a/packages/language/src/language-server/hover-request.ts
+++ b/packages/language/src/language-server/hover-request.ts
@@ -116,7 +116,10 @@ export function hoverRequest(
   uri: URI,
   offset: number,
 ): HoverResponse | null {
-  const tokens = unit.tokens.fileTokens[uri.toString()] ?? [];
+  const tokens = unit.tokens.fileTokens.get(uri.toString());
+  if (!tokens) {
+    return null;
+  }
   const token = binaryTokenSearch(tokens, offset);
   const payload = token?.payload;
   if (!payload) {

--- a/packages/language/src/language-server/semantic-tokens.ts
+++ b/packages/language/src/language-server/semantic-tokens.ts
@@ -45,8 +45,11 @@ export function semanticTokens(
   compilationUnit: CompilationUnit,
   range?: Range,
 ): number[] {
+  const tokens = compilationUnit.tokens.fileTokens.get(textDocument.uri);
+  if (!tokens) {
+    return [];
+  }
   const semanticTokens = new SemanticTokensBuilder();
-  const tokens = compilationUnit.tokens.fileTokens[textDocument.uri] ?? [];
   for (const token of tokens) {
     const type = tokenType(token);
     if (type !== undefined) {

--- a/packages/language/src/language-server/skipped-code.ts
+++ b/packages/language/src/language-server/skipped-code.ts
@@ -61,7 +61,10 @@ export function skippedCodeRanges(
   compilationUnit: CompilationUnit,
   textDocument: TextDocument,
 ): Range[] {
-  const tokens = compilationUnit.tokens.fileTokens[textDocument.uri] ?? [];
+  const tokens = compilationUnit.tokens.fileTokens.get(textDocument.uri);
+  if (!tokens) {
+    return [];
+  }
   const result: Range[] = [];
 
   for (const token of tokens) {

--- a/packages/language/src/linking/resolver.ts
+++ b/packages/language/src/linking/resolver.ts
@@ -380,7 +380,7 @@ export function getReferenceLocations(
   offset: number,
 ): Location[] {
   const token = binaryTokenSearch(
-    unit.tokens.fileTokens[uri.toString()] ?? [],
+    unit.tokens.fileTokens.get(uri.toString()) ?? [],
     offset,
   );
   if (!token) {

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -197,7 +197,7 @@ export function runInstructions(
     },
     result: {
       all: [],
-      fileTokens: {},
+      fileTokens: new Map(),
     },
     options,
     counter: new Map(),
@@ -852,7 +852,7 @@ function runInclude(item: IncludeItem, context: InterpreterContext): void {
       uri,
     );
     const subProgram = context.options.parser.parse(subState);
-    context.result.fileTokens[uri.toString()] = subProgram.tokens;
+    context.result.fileTokens.set(uri.toString(), subProgram.tokens);
     context.errors.push(...subProgram.errors);
     const instruction = generateInstructions(subProgram.statements);
     const newContext: InterpreterContext = {

--- a/packages/language/src/preprocessor/pli-lexer.ts
+++ b/packages/language/src/preprocessor/pli-lexer.ts
@@ -37,7 +37,7 @@ export interface LexerResult {
   errors: LexingError[];
   compilerOptions: CompilerOptionsProcessorResult;
   statements: Statement[];
-  fileTokens: Record<string, Token[]>;
+  fileTokens: Map<string, Token[]>;
   evaluationResults: EvaluationResults;
   tokenReferences: Reference[];
 }
@@ -85,11 +85,11 @@ export class PliLexer {
       marginsProcessor: this.marginsProcessor,
       parser: this.preprocessorParser,
     });
-    output.fileTokens[uri.toString()] = fileTokens;
+    output.fileTokens.set(uri.toString(), fileTokens);
     if (compilerOptionsResult.result) {
-      output.fileTokens[uri.toString()].unshift(
-        ...compilerOptionsResult.result.tokens,
-      );
+      output.fileTokens
+        .get(uri.toString())
+        ?.unshift(...compilerOptionsResult.result.tokens);
     }
     errors.push(...output.errors);
     return {

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -66,7 +66,7 @@ export interface CompilationUnit {
 
 export interface CompilationUnitTokens {
   all: Token[];
-  fileTokens: Record<string, Token[]>;
+  fileTokens: Map<string, Token[]>;
 }
 
 export interface CompilationUnitDiagnostics {
@@ -144,7 +144,7 @@ export function createCompilationUnit(uri: URI): CompilationUnit {
       ifStatements: new Map(),
     },
     tokens: {
-      fileTokens: {},
+      fileTokens: new Map(),
       all: [],
     },
     referencesCache: new ReferencesCache(),

--- a/packages/language/src/workspace/lifecycle.ts
+++ b/packages/language/src/workspace/lifecycle.ts
@@ -46,7 +46,7 @@ export function tokenize(
   text: string,
 ): LexerResult {
   const result = lexer.tokenize(compilationUnit, text, compilationUnit.uri);
-  compilationUnit.files = Object.keys(result.fileTokens).map((e) =>
+  compilationUnit.files = [...result.fileTokens.keys()].map((e) =>
     URI.parse(e),
   );
   compilationUnit.tokens.all = result.all;


### PR DESCRIPTION
There are cases when document symbols are requested in which the text document is not included in the current compilation unit.  This occurred when changing an include in the code and than switching between different libraries in the lib folder, which should be investigated further. Nevertheless, the document symbol request should not try to access file tokens that are not present and fail.