### PR TITLE
Restrict Unrecognized Extension Include Resolution

### DIFF
--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -796,8 +796,15 @@ function resolveIncludeFileUri(
         const patt = `${libFileUri.path}\\.*`;
         const matches = FileSystemProviderInstance.findFilesByGlobSync(patt);
         if (matches.length > 0) {
-          // Return the first match found
-          return URI.file(matches[0]);
+          // ensure this extension is allowed
+          const ext = matches[0].match(/\.\w+$/);
+          if (
+            ext &&
+            ext?.length &&
+            pgroup["include-extensions"]?.includes(ext[0].toLowerCase())
+          ) {
+            return URI.file(matches[0]);
+          }
         }
       }
     }

--- a/packages/language/test/fourslash/preprocessor/include/dont-include-unrecognized-files.ts
+++ b/packages/language/test/fourslash/preprocessor/include/dont-include-unrecognized-files.ts
@@ -1,0 +1,27 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: cpy/LIB.xyz
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: cpy/lib.abc
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: main.pli
+//// // check variants of includes that could pull in a bad file
+//// %INCLUDE LIB;
+//// %INCLUDE lib;
+//// %INCLUDE "LIB";
+//// %INCLUDE "lib";
+
+preprocessor.expectTokens(``);


### PR DESCRIPTION
Closes an observed issue where having a file like `cpy/File.xyzabc` would still be included by its extension-less reference, such as `%INCLUDE FILE`. This was due to a missing secondary check where we attempted to resolve a potential match for that include, which has now been added. Also put in a test case to try and sneak around this with a few different include approaches.