### PR TITLE
Fix endless event loop in ruler settings

### DIFF
--- a/packages/vscode-extension/src/extension/decorators.ts
+++ b/packages/vscode-extension/src/extension/decorators.ts
@@ -123,10 +123,14 @@ export namespace MarginIndicatorDecorator {
     const config = vscode.workspace.getConfiguration("editor", {
       languageId: "pli",
     });
+    const existingRulers = config.get<number[]>("rulers") || [];
     let rulers: number[] = [];
 
     if (!settings.marginIndicatorRulersEnabled) {
-      config.update("rulers", rulers, vscode.ConfigurationTarget.Global, true);
+      if (existingRulers.length > 0) {
+        // Ensure that we clear the rulers ONLY if they were previously set
+        config.update("rulers", [], vscode.ConfigurationTarget.Global, true);
+      }
       return;
     }
 
@@ -144,6 +148,13 @@ export namespace MarginIndicatorDecorator {
     }
 
     rulers = rulers.map((r) => r - 1);
+
+    if (rulers.length === existingRulers.length) {
+      // If the rulers are the same, no need to update
+      if (rulers.every((r, i) => r === existingRulers[i])) {
+        return;
+      }
+    }
     config.update("rulers", rulers, vscode.ConfigurationTarget.Global, true);
   }
 }


### PR DESCRIPTION
Closes https://github.com/zowe/zowe-pli-language-support/issues/287

The code as it is currently results in the VSCode extension host calling our settings update routine all the time, as we update the settings in there, which results in VSCode calling ..., etc. you know the drill. This essentially results in the thread that hosts the VS Code extension host to endlessly call our code.

This change ensures that we don't actually change the setting in case nothing has changed.