### PR TITLE
Add schemas for plugin configs

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -63,6 +63,16 @@
         "path": "syntaxes/pli.merged.json"
       }
     ],
+    "jsonValidation": [
+      {
+        "fileMatch": "**/.pliplugin/pgm_conf.json",
+        "url": "./schemas/pgm_conf.schema.json"
+      },
+      {
+        "fileMatch": "**/.pliplugin/proc_grps.json",
+        "url": "./schemas/proc_grps.schema.json"
+      }
+    ],
     "configuration": {
       "title": "PL/I Language Support",
       "properties": {

--- a/packages/vscode-extension/schemas/pgm_conf.schema.json
+++ b/packages/vscode-extension/schemas/pgm_conf.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PL/I Plugin Program Configuration",
+  "type": "object",
+  "properties": {
+    "pgms": {
+      "type": "array",
+      "description": "List of programs and their associated program groups.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "program": {
+            "type": "string",
+            "description": "Filename of the PL/I source program (e.g., 'a.pli')."
+          },
+          "pgroup": {
+            "type": "string",
+            "description": "Program group label (e.g., 'default')."
+          }
+        },
+        "required": ["program", "pgroup"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["pgms"],
+  "additionalProperties": false
+}
+  

--- a/packages/vscode-extension/schemas/proc_grps.schema.json
+++ b/packages/vscode-extension/schemas/proc_grps.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PL/I Plugin Procedure Groups Configuration",
+  "type": "object",
+  "properties": {
+    "pgroups": {
+      "type": "array",
+      "description": "List of procedure groups with build configuration.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the procedure group (e.g., 'default')."
+          },
+          "compiler-options": {
+            "type": "array",
+            "description": "Compiler options for this group.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "libs": {
+            "type": "array",
+            "description": "List of libraries to include during compilation.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "include-extensions": {
+            "type": "array",
+            "description": "List of file extensions to treat as include files.",
+            "items": {
+              "type": "string",
+              "enum": [".pli", ".pl1", ".cpy", ".inc"]
+            }
+          }
+        },
+        "required": ["name"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["pgroups"],
+  "additionalProperties": false
+}
+  


### PR DESCRIPTION
Closes https://github.com/zowe/zowe-pli-language-support/issues/273
and is also recommended for configuring implicit builtins (https://github.com/zowe/zowe-pli-language-support/issues/275).