### PR TITLE
Sets up PP INCLUDE Option Handling (Plus Others)

### DIFF
--- a/packages/language/src/parser/tokens.ts
+++ b/packages/language/src/parser/tokens.ts
@@ -192,13 +192,13 @@ export function escapeRegExp(value: string): string {
 export function setCompilerOptions(options: CompilerOptions): void {
   const orChars = escapeRegExp(options.or || "|");
   const notChars = escapeRegExp(options.not || "¬^");
-  let includeAlt: string | undefined = '++include';
+  let includeAlt: string | undefined = "++include";
   // take last option if multiple are present
   if (Array.isArray(options.pp)) {
     for (let x = options.pp.length - 1; x >= 0; x--) {
       const item = options.pp[x];
       const val = item.value;
-      if (item.name.toLowerCase() === 'include' && val) {
+      if (item.name.toLowerCase() === "include" && val) {
         // check for the ID(...) syntax, denoting a new include alternative
         const match = val.match(/ID\(([^\)]+)\)/);
         if (match) {

--- a/packages/language/src/parser/tokens.ts
+++ b/packages/language/src/parser/tokens.ts
@@ -192,7 +192,23 @@ export function escapeRegExp(value: string): string {
 export function setCompilerOptions(options: CompilerOptions): void {
   const orChars = escapeRegExp(options.or || "|");
   const notChars = escapeRegExp(options.not || "¬^");
-  const includeAlt = "++include";
+  let includeAlt: string | undefined = '++include';
+  // take last option if multiple are present
+  if (Array.isArray(options.pp)) {
+    for (let x = options.pp.length - 1; x >= 0; x--) {
+      const item = options.pp[x];
+      const val = item.value;
+      if (item.name.toLowerCase() === 'include' && val) {
+        // check for the ID(...) syntax, denoting a new include alternative
+        const match = val.match(/ID\(([^\)]+)\)/);
+        if (match) {
+          includeAlt = match[1].toLowerCase();
+          break;
+        }
+      }
+    }
+  }
+
   if (includeAlt) {
     includeAltRegex = new RegExp(escapeRegExp(includeAlt), "y");
   } else {

--- a/packages/language/src/parser/tokens.ts
+++ b/packages/language/src/parser/tokens.ts
@@ -192,7 +192,7 @@ export function escapeRegExp(value: string): string {
 export function setCompilerOptions(options: CompilerOptions): void {
   const orChars = escapeRegExp(options.or || "|");
   const notChars = escapeRegExp(options.not || "¬^");
-  let includeAlt: string | undefined = "++include";
+  let includeAlt: string | undefined = undefined;
   // take last option if multiple are present
   if (Array.isArray(options.pp)) {
     for (let x = options.pp.length - 1; x >= 0; x--) {

--- a/packages/language/src/parser/tokens.ts
+++ b/packages/language/src/parser/tokens.ts
@@ -200,9 +200,10 @@ export function setCompilerOptions(options: CompilerOptions): void {
       const val = item.value;
       if (item.name.toLowerCase() === "include" && val) {
         // check for the ID(...) syntax, denoting a new include alternative
-        const match = val.match(/ID\(([^\)]+)\)/);
-        if (match) {
-          includeAlt = match[1].toLowerCase();
+        const match = val.match(/ID\(([^\)]+)\)/g);
+        if (match && match.length > 0) {
+          // take the last match & trim off the ID(...) part
+          includeAlt = match[match.length - 1].slice(3, -1).toLowerCase();
           break;
         }
       }

--- a/packages/language/src/parser/tokens.ts
+++ b/packages/language/src/parser/tokens.ts
@@ -193,21 +193,9 @@ export function setCompilerOptions(options: CompilerOptions): void {
   const orChars = escapeRegExp(options.or || "|");
   const notChars = escapeRegExp(options.not || "¬^");
   let includeAlt: string | undefined = undefined;
-  // take last option if multiple are present
-  if (Array.isArray(options.pp)) {
-    for (let x = options.pp.length - 1; x >= 0; x--) {
-      const item = options.pp[x];
-      const val = item.value;
-      if (item.name.toLowerCase() === "include" && val) {
-        // check for the ID(...) syntax, denoting a new include alternative
-        const match = val.match(/ID\(([^\)]+)\)/g);
-        if (match && match.length > 0) {
-          // take the last match & trim off the ID(...) part
-          includeAlt = match[match.length - 1].slice(3, -1).toLowerCase();
-          break;
-        }
-      }
-    }
+
+  if (options.pp && options.pp.ppInclude) {
+    includeAlt = options.pp.ppInclude.value;
   }
 
   if (includeAlt) {

--- a/packages/language/src/preprocessor/compiler-options/options.ts
+++ b/packages/language/src/preprocessor/compiler-options/options.ts
@@ -828,7 +828,21 @@ export declare namespace CompilerOptions {
         doc?: boolean;
       }
     | false;
-  export type PP = PPItem[] | false;
+  export type PP =
+    | {
+        items: PPItem[];
+
+        /**
+         * Effective PPINCLUDE option value (alt. include keyword)
+         */
+        ppInclude?: PPInclude;
+      }
+    | false;
+
+  export interface PPInclude {
+    value: string;
+  }
+
   export interface PPItem {
     name: string;
     value?: string;

--- a/packages/language/src/preprocessor/compiler-options/options.ts
+++ b/packages/language/src/preprocessor/compiler-options/options.ts
@@ -828,16 +828,17 @@ export declare namespace CompilerOptions {
         doc?: boolean;
       }
     | false;
-  export type PP =
-    | {
-        items: PPItem[];
 
-        /**
-         * Effective PPINCLUDE option value (alt. include keyword)
-         */
-        ppInclude?: PPInclude;
-      }
-    | false;
+  export type PPOption = PP | false;
+
+  export type PP = {
+    items: PPItem[];
+
+    /**
+     * Effective PPINCLUDE option value (alt. include keyword)
+     */
+    ppInclude?: PPInclude;
+  };
 
   export interface PPInclude {
     value: string;

--- a/packages/language/src/preprocessor/compiler-options/translator.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator.ts
@@ -1456,12 +1456,112 @@ translator.rule(
 );
 
 /** {@link CompilerOptions.pp} */
+translator.rule(["PP"], (option, options) => {
+  // 1 or more pre-processor options to collect
+  ensureArguments(option, 1, Infinity);
+  const ppOptions = option.values.map((value) => {
+    ensureType(value, "option");
+
+    if (value.values.length !== 1) {
+      throw new TranslationError(
+        value.token,
+        `Expected exactly one value for the ${value.name} option, but received ${value.values.length}.`,
+        1,
+      );
+    }
+
+    ensureType(value.values[0], "string");
+
+    return {
+      name: value.name,
+      value: value.values[0].value,
+    };
+  });
+
+  if (!options.pp) {
+    options.pp = [];
+  }
+  options.pp.push(...ppOptions);
+});
+
 /** {@link CompilerOptions.ppCics} */
+translator.rule(["PPCICS"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "string");
+  options.ppCics = value.value;
+});
+
 /** {@link CompilerOptions.ppInclude} */
+translator.rule(
+  ["PPINCLUDE"],
+  (option, options) => {
+    ensureArguments(option, 1, 1);
+    const value = option.values[0];
+    ensureType(value, "string");
+    options.ppInclude = value.value;
+  },
+  ["NOPPINCLUDE"],
+  (_, options) => {
+    options.ppInclude = false;
+  },
+);
+
 /** {@link CompilerOptions.ppList} */
+translator.rule(
+  ["PPLIST"],
+  plainTranslate(
+    (options, value) => {
+      options.ppList = value.value as "KEEP" | "ERASE";
+    },
+    "KEEP",
+    "ERASE",
+  ),
+);
+
 /** {@link CompilerOptions.ppMacro} */
+translator.rule(
+  ["PPMACRO"],
+  (option, options) => {
+    ensureArguments(option, 1, 1);
+    const value = option.values[0];
+    ensureType(value, "string");
+    options.ppMacro = value.value;
+  },
+  ["NOPPMACRO"],
+  (_, options) => {
+    options.ppMacro = false;
+  },
+);
+
 /** {@link CompilerOptions.ppSql} */
+translator.rule(
+  ["PPSQL"],
+  (option, options) => {
+    ensureArguments(option, 1, 1);
+    const value = option.values[0];
+    ensureType(value, "string");
+    options.ppSql = value.value;
+  },
+  ["NOPPSQL"],
+  (_, options) => {
+    options.ppSql = false;
+  },
+);
+
 /** {@link CompilerOptions.ppTrace} */
+translator.rule(
+  ["PPTRACE"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.ppTrace = true;
+  },
+  ["NOPPTRACE"],
+  (_, options) => {
+    options.ppTrace = false;
+  },
+);
+
 /** {@link CompilerOptions.precType} */
 /** {@link CompilerOptions.prefix} */
 /** {@link CompilerOptions.proceed} */

--- a/packages/language/src/preprocessor/compiler-options/translator.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator.ts
@@ -1458,7 +1458,7 @@ translator.rule(
 /** {@link CompilerOptions.pp} */
 translator.rule(["PP"], (option, options) => {
   // 1 or more pre-processor options to collect
-  ensureArguments(option, 1, Infinity);
+  ensureArguments(option, 1);
   const ppOptions = option.values.map((value) => {
     ensureType(value, "option");
 
@@ -1466,6 +1466,17 @@ translator.rule(["PP"], (option, options) => {
       throw new TranslationError(
         value.token,
         `Expected exactly one value for the ${value.name} option, but received ${value.values.length}.`,
+        1,
+      );
+    }
+
+    // whitelist for PP systems we can invoke
+    if (
+      !["CISC", "INCLUDE", "MACRO", "SQL"].includes(value.name.toUpperCase())
+    ) {
+      throw new TranslationError(
+        value.token,
+        `Expected CISC, INCLUDE, MACRO, or SQL, but received '${value.name}'.`,
         1,
       );
     }
@@ -1485,12 +1496,20 @@ translator.rule(["PP"], (option, options) => {
 });
 
 /** {@link CompilerOptions.ppCics} */
-translator.rule(["PPCICS"], (option, options) => {
-  ensureArguments(option, 1, 1);
-  const value = option.values[0];
-  ensureType(value, "string");
-  options.ppCics = value.value;
-});
+translator.rule(
+  ["PPCICS"],
+  (option, options) => {
+    ensureArguments(option, 1, 1);
+    const value = option.values[0];
+    ensureType(value, "string");
+    options.ppCics = value.value;
+  },
+  ["NOPPCICS"],
+  (option, options) => {
+    options.ppCics = false;
+    ensureArguments(option, 0, 0);
+  },
+);
 
 /** {@link CompilerOptions.ppInclude} */
 translator.rule(
@@ -1502,8 +1521,9 @@ translator.rule(
     options.ppInclude = value.value;
   },
   ["NOPPINCLUDE"],
-  (_, options) => {
+  (option, options) => {
     options.ppInclude = false;
+    ensureArguments(option, 0, 0);
   },
 );
 
@@ -1529,8 +1549,9 @@ translator.rule(
     options.ppMacro = value.value;
   },
   ["NOPPMACRO"],
-  (_, options) => {
+  (option, options) => {
     options.ppMacro = false;
+    ensureArguments(option, 0, 0);
   },
 );
 
@@ -1544,8 +1565,9 @@ translator.rule(
     options.ppSql = value.value;
   },
   ["NOPPSQL"],
-  (_, options) => {
+  (option, options) => {
     options.ppSql = false;
+    ensureArguments(option, 0, 0);
   },
 );
 
@@ -1557,8 +1579,9 @@ translator.rule(
     options.ppTrace = true;
   },
   ["NOPPTRACE"],
-  (_, options) => {
+  (option, options) => {
     options.ppTrace = false;
+    ensureArguments(option, 0, 0);
   },
 );
 

--- a/packages/language/src/preprocessor/compiler-options/translator.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator.ts
@@ -1459,40 +1459,57 @@ translator.rule(
 translator.rule(["PP"], (option, options) => {
   // 1 or more pre-processor options to collect
   ensureArguments(option, 1);
-  const ppOptions = option.values.map((value) => {
-    ensureType(value, "option");
 
-    if (value.values.length !== 1) {
+  if (!options.pp) {
+    options.pp = {
+      items: [],
+    };
+  }
+
+  const ppOptions = option.values.map((ppEntry) => {
+    ensureType(ppEntry, "option");
+
+    if (ppEntry.values.length !== 1) {
       throw new TranslationError(
-        value.token,
-        `Expected exactly one value for the ${value.name} option, but received ${value.values.length}.`,
+        ppEntry.token,
+        `Expected exactly one value for the ${ppEntry.name} option, but received ${ppEntry.values.length}.`,
         1,
       );
     }
 
     // whitelist for PP systems we can invoke
     if (
-      !["CISC", "INCLUDE", "MACRO", "SQL"].includes(value.name.toUpperCase())
+      !["CISC", "INCLUDE", "MACRO", "SQL"].includes(ppEntry.name.toUpperCase())
     ) {
       throw new TranslationError(
-        value.token,
-        `Expected CISC, INCLUDE, MACRO, or SQL, but received '${value.name}'.`,
+        ppEntry.token,
+        `Expected CISC, INCLUDE, MACRO, or SQL, but received '${ppEntry.name}'.`,
         1,
       );
     }
 
-    ensureType(value.values[0], "string");
+    ensureType(ppEntry.values[0], "string");
+
+    const value = ppEntry.values[0].value;
+
+    if (ppEntry.name.toUpperCase() === "INCLUDE" && options.pp) {
+      // set this as the effective INCLUDE PP option value, overriding any previous INCLUDE options
+      const match = value.match(/ID\(([^\)]+)\)\s*$/);
+      if (match && match.length > 0) {
+        const ppInclude = match[0].slice(3, -1).toLowerCase();
+        options.pp.ppInclude = {
+          value: ppInclude,
+        };
+      }
+    }
 
     return {
-      name: value.name,
-      value: value.values[0].value,
+      name: ppEntry.name,
+      value,
     };
   });
 
-  if (!options.pp) {
-    options.pp = [];
-  }
-  options.pp.push(...ppOptions);
+  options.pp.items.push(...ppOptions);
 });
 
 /** {@link CompilerOptions.ppCics} */

--- a/packages/language/test/compiler/options-parser.test.ts
+++ b/packages/language/test/compiler/options-parser.test.ts
@@ -346,6 +346,21 @@ describe("CompilerOptions translator", () => {
     );
   });
 
+  test("Test PP validation", () => {
+    const options = parseAbstractCompilerOptions("PP(INCLUDE('ID(++INCLUDE)'))");
+    const result = translateCompilerOptions(options);
+    const issues = result.issues;
+    expect(issues).toHaveLength(0);
+
+    const ppItems = result.options.pp;
+    expect(ppItems).toBeDefined();
+    expect(ppItems).toHaveLength(1);
+    
+    const ppItem: CompilerOptions.PPItem = (ppItems as CompilerOptions.PPItem[])[0];
+    expect(ppItem.name).toBe("INCLUDE");
+    expect(ppItem.value).toBe("ID(++INCLUDE)");
+  });
+
   const testCasesSensitivity: {
     input: string;
     toTest: (options: CompilerOptions) => unknown;

--- a/packages/language/test/compiler/options-parser.test.ts
+++ b/packages/language/test/compiler/options-parser.test.ts
@@ -347,7 +347,9 @@ describe("CompilerOptions translator", () => {
   });
 
   test("Test PP validation", () => {
-    const options = parseAbstractCompilerOptions("PP(INCLUDE('ID(++INCLUDE)'))");
+    const options = parseAbstractCompilerOptions(
+      "PP(INCLUDE('ID(++INCLUDE)'))",
+    );
     const result = translateCompilerOptions(options);
     const issues = result.issues;
     expect(issues).toHaveLength(0);
@@ -355,8 +357,10 @@ describe("CompilerOptions translator", () => {
     const ppItems = result.options.pp;
     expect(ppItems).toBeDefined();
     expect(ppItems).toHaveLength(1);
-    
-    const ppItem: CompilerOptions.PPItem = (ppItems as CompilerOptions.PPItem[])[0];
+
+    const ppItem: CompilerOptions.PPItem = (
+      ppItems as CompilerOptions.PPItem[]
+    )[0];
     expect(ppItem.name).toBe("INCLUDE");
     expect(ppItem.value).toBe("ID(++INCLUDE)");
   });

--- a/packages/language/test/compiler/options-parser.test.ts
+++ b/packages/language/test/compiler/options-parser.test.ts
@@ -354,10 +354,9 @@ describe("CompilerOptions translator", () => {
     const issues = result.issues;
     expect(issues).toHaveLength(0);
 
-    const pp = result.options.pp;
+    const pp = result.options.pp as CompilerOptions.PP;
     expect(pp).toBeDefined();
-    expect(pp !== false).toBeTruthy();
-    const items = (pp as any).items as CompilerOptions.PPItem[];
+    const items = pp.items as CompilerOptions.PPItem[];
     expect(items).toBeDefined();
     expect(items).toHaveLength(1);
 
@@ -368,7 +367,7 @@ describe("CompilerOptions translator", () => {
     expect(ppItem.value).toBe("ID(++INCLUDE)");
 
     // expect ppInclude to be normalized & set
-    const ppInclude = (pp as any).ppInclude as CompilerOptions.PPInclude;
+    const ppInclude = pp.ppInclude as CompilerOptions.PPInclude;
     expect(ppInclude).toBeDefined();
     expect(ppInclude.value).toBe("++include");
   });

--- a/packages/language/test/compiler/options-parser.test.ts
+++ b/packages/language/test/compiler/options-parser.test.ts
@@ -354,15 +354,23 @@ describe("CompilerOptions translator", () => {
     const issues = result.issues;
     expect(issues).toHaveLength(0);
 
-    const ppItems = result.options.pp;
-    expect(ppItems).toBeDefined();
-    expect(ppItems).toHaveLength(1);
+    const pp = result.options.pp;
+    expect(pp).toBeDefined();
+    expect(pp !== false).toBeTruthy();
+    const items = (pp as any).items as CompilerOptions.PPItem[];
+    expect(items).toBeDefined();
+    expect(items).toHaveLength(1);
 
     const ppItem: CompilerOptions.PPItem = (
-      ppItems as CompilerOptions.PPItem[]
+      items as CompilerOptions.PPItem[]
     )[0];
     expect(ppItem.name).toBe("INCLUDE");
     expect(ppItem.value).toBe("ID(++INCLUDE)");
+
+    // expect ppInclude to be normalized & set
+    const ppInclude = (pp as any).ppInclude as CompilerOptions.PPInclude;
+    expect(ppInclude).toBeDefined();
+    expect(ppInclude.value).toBe("++include");
   });
 
   const testCasesSensitivity: {

--- a/packages/language/test/fourslash/preprocessor/include/using-ppinclude.ts
+++ b/packages/language/test/fourslash/preprocessor/include/using-ppinclude.ts
@@ -15,8 +15,9 @@
 //// DECLARE LIB_VAR FIXED;
 
 // @filename: main.pli
-////*PROCESS PP(INCLUDE('ID(++INCLUDE)'));
-//// ++include lib
+////*PROCESS PP(INCLUDE('ID(++INCLUDE) ID(-inc)'));
+//// // w/ multiple options to handle, last one wins
+//// -inc lib
 
 preprocessor.expectTokens(`
   DECLARE LIB_VAR FIXED;

--- a/packages/language/test/fourslash/preprocessor/include/using-ppinclude.ts
+++ b/packages/language/test/fourslash/preprocessor/include/using-ppinclude.ts
@@ -15,6 +15,7 @@
 //// DECLARE LIB_VAR FIXED;
 
 // @filename: main.pli
+////*PROCESS PP(INCLUDE('ID(++INCLUDE)'));
 //// ++include lib
 
 preprocessor.expectTokens(`

--- a/packages/language/test/fourslash/preprocessor/include/without-ppinclude.ts
+++ b/packages/language/test/fourslash/preprocessor/include/without-ppinclude.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: cpy/lib.pli
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: main.pli
+//// // expecting no special handling here
+//// ++include lib
+
+preprocessor.expectTokens(`
+  ++include lib
+`);


### PR DESCRIPTION
Closes #171 by adding remaining handling for the `PP(INCLUDE('ID(++INCLUDE)'))` option case. Other cases are now picked up as well so we have access to them, but they're not yet handled (i.e. PPINCLUDE, PPCISC, PPLIST, etc.). But the pattern is pretty clear on how to proceed with these. 