### PR TITLE
Improve document symbol LSP request

### DIFF
--- a/packages/language/src/language-server/connection-handler.ts
+++ b/packages/language/src/language-server/connection-handler.ts
@@ -20,7 +20,12 @@ import { definitionRequest } from "./definition-request";
 import { referencesRequest } from "./references-request";
 import { semanticTokenLegend, semanticTokens } from "./semantic-tokens";
 import { Location, TextEdit } from "vscode-languageserver-types";
-import { completionItemToLSP, hoverResponseToLSP, rangeToLSP } from "./types";
+import {
+  completionItemToLSP,
+  documentSymbolToLSP,
+  hoverResponseToLSP,
+  rangeToLSP,
+} from "./types";
 import { renameRequest } from "./rename-request";
 import { mapValues } from "../utils/common";
 import { getReferenceLocations } from "../linking/resolver";
@@ -238,7 +243,9 @@ export function startLanguageServer(connection: Connection): void {
     const unit = compilationUnitHandler.getCompilationUnit(parsedUri);
 
     if (textDocument && unit) {
-      return documentSymbolRequest(parsedUri, unit);
+      return documentSymbolRequest(parsedUri, unit).map((symbol) =>
+        documentSymbolToLSP(textDocument, symbol),
+      );
     }
     return [];
   });

--- a/packages/language/src/parser/tokens.ts
+++ b/packages/language/src/parser/tokens.ts
@@ -1443,7 +1443,7 @@ export const INTER = createToken({
 export const ENTRY = createToken({
   name: "ENTRY",
   pattern: /ENTRY/iy,
-  categories: [ID, DefaultAttribute],
+  categories: [ID],
   longer_alt: ID,
 });
 export const UCHAR = createToken({

--- a/packages/language/test/lsp/document-symbol-request.test.ts
+++ b/packages/language/test/lsp/document-symbol-request.test.ts
@@ -14,8 +14,9 @@ import { parse, replaceNamedIndices } from "../utils";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { URI } from "../../src/utils/uri";
 import { documentSymbolRequest } from "../../src/language-server/document-symbol-request";
-import { DocumentSymbol, SymbolKind } from "vscode-languageserver-types";
+import { SymbolKind } from "vscode-languageserver-types";
 import { EditorDocuments } from "../../src/language-server/text-documents";
+import { DocumentSymbol } from "../../src/language-server/types";
 
 type SymbolWithLevel = {
   symbol: DocumentSymbol;
@@ -71,10 +72,8 @@ function expectDocumentSymbols(annotatedCode: string): void {
         (s) =>
           documentSymbolKindString(s.symbol.kind) === symbolKind &&
           s.level === Number(hierarchyLevel) &&
-          s.symbol.selectionRange.start.line === startPosition.line &&
-          s.symbol.selectionRange.start.character === startPosition.character &&
-          s.symbol.selectionRange.end.line === endPosition.line &&
-          s.symbol.selectionRange.end.character === endPosition.character,
+          s.symbol.selectionRange.start === range[0] &&
+          s.symbol.selectionRange.end === range[1],
       );
       expect(
         matchingSymbol,


### PR DESCRIPTION
Improves the type safety of our document/workspace symbol requests. This prevents errors such as:

```
[Error - 11:33:19 AM] Request textDocument/documentSymbol failed.
Error: selectionRange must be contained in fullRange
```

By making sure that we correctly specify the `selectionRange` and `range` items and adjusting the `range` to make sure that all children are contained the range before returning the LSP response. Also ensures that all processed tokens are using valid ranges.

Also fixes a very minor parser ambiguity issue that I've noticed - `ENTRY` was never supposed to be a `DefaultAttribute`, it has it's own `EntryAttribute` type.