### PR TITLE
Add configure property and validation for implicit builtins

### DIFF
--- a/packages/language/src/linking/error.ts
+++ b/packages/language/src/linking/error.ts
@@ -19,7 +19,7 @@ import {
 import { Token } from "../parser/tokens";
 import { Reference, SyntaxKind, SyntaxNode } from "../syntax-tree/ast";
 import { PLICodes } from "../validation/messages";
-import { PliValidationAcceptor } from "../validation/validator";
+import { ValidationAcceptor } from "../validation/validator";
 import { CompilationUnit } from "../workspace/compilation-unit";
 import { QualifiedSyntaxNode } from "./qualified-syntax-node";
 
@@ -99,7 +99,7 @@ export class LinkerErrorReporter {
 
   constructor(
     private readonly unit: CompilationUnit,
-    protected readonly accept: PliValidationAcceptor,
+    protected readonly accept: ValidationAcceptor,
   ) {}
 
   /**

--- a/packages/language/src/linking/resolver.ts
+++ b/packages/language/src/linking/resolver.ts
@@ -27,7 +27,7 @@ import {
 } from "./tokens";
 import { URI } from "../utils/uri";
 import { CompilationUnit } from "../workspace/compilation-unit";
-import { PliValidationBuffer } from "../validation/validator";
+import { ValidationBuffer } from "../validation/validator";
 import { QualifiedSyntaxNode } from "./qualified-syntax-node";
 import { LinkerErrorReporter } from "./error";
 import { Scope } from "./scope";
@@ -330,7 +330,7 @@ function resolveReference(
 }
 
 export function resolveReferences(unit: CompilationUnit): Diagnostic[] {
-  const validationBuffer = new PliValidationBuffer();
+  const validationBuffer = new ValidationBuffer();
   const reporter = new LinkerErrorReporter(
     unit,
     validationBuffer.getAcceptor(),

--- a/packages/language/src/linking/symbol-table.ts
+++ b/packages/language/src/linking/symbol-table.ts
@@ -21,7 +21,7 @@ import {
 } from "../syntax-tree/ast";
 import { forEachNode } from "../syntax-tree/ast-iterator";
 import { groupBy } from "../utils/common";
-import { PliValidationBuffer } from "../validation/validator";
+import { ValidationBuffer } from "../validation/validator";
 import { CompilationUnit } from "../workspace/compilation-unit";
 import { ReferencesCache, StatementOrderCache } from "./resolver";
 import { getReference } from "./tokens";
@@ -281,7 +281,7 @@ export function iterateSymbols(unit: CompilationUnit): Diagnostic[] {
   // Set child containers for all nodes.
   recursivelySetContainer(unit.ast);
 
-  const validationBuffer = new PliValidationBuffer();
+  const validationBuffer = new ValidationBuffer();
   const reporter = new LinkerErrorReporter(
     unit,
     validationBuffer.getAcceptor(),

--- a/packages/language/src/validation/messages/IBM1295IE-sole-bound-specified.ts
+++ b/packages/language/src/validation/messages/IBM1295IE-sole-bound-specified.ts
@@ -11,12 +11,12 @@
 
 import { getSyntaxNodeRange, Severity } from "../../language-server/types";
 import { Bound, DimensionBound, SyntaxKind } from "../../syntax-tree/ast";
-import { PliValidationAcceptor } from "../validator";
+import { ValidationAcceptor } from "../validator";
 import { Error } from "./pli-codes";
 
 export function IBM1295IE_sole_bound_specified(
   bound: DimensionBound,
-  accept: PliValidationAcceptor,
+  accept: ValidationAcceptor,
 ): void {
   if (bound.lower !== undefined) {
     return;

--- a/packages/language/src/validation/messages/IBM1324IE-name-occurs-more-than-once-within-exports-clause.ts
+++ b/packages/language/src/validation/messages/IBM1324IE-name-occurs-more-than-once-within-exports-clause.ts
@@ -11,11 +11,11 @@
 
 import { getSyntaxNodeRange, Severity } from "../../language-server/types";
 import { Exports } from "../../syntax-tree/ast";
-import { PliValidationAcceptor } from "../validator";
+import { ValidationAcceptor } from "../validator";
 
 export function IBM1324IE_name_occurs_more_than_once_within_exports_clause(
   exports: Exports,
-  accept: PliValidationAcceptor,
+  accept: ValidationAcceptor,
 ): void {
   const set = new Set<string>();
   exports.procedures.forEach((procedure) => {

--- a/packages/language/src/validation/messages/IBM1388IE-NODESCRIPTOR-attribute-is-invalid-when-any-parameter-has-NONCONNECTED-attribute.ts
+++ b/packages/language/src/validation/messages/IBM1388IE-NODESCRIPTOR-attribute-is-invalid-when-any-parameter-has-NONCONNECTED-attribute.ts
@@ -17,11 +17,11 @@ import {
   SyntaxKind,
 } from "../../syntax-tree/ast";
 import { compareIdentifiers, normalizeIdentifier } from "../utils";
-import { PliValidationAcceptor } from "../validator";
+import { ValidationAcceptor } from "../validator";
 
 export function IBM1388IE_NODESCRIPTOR_attribute_is_invalid_when_any_parameter_has_NONCONNECTED_attribute(
   procedureStatement: ProcedureStatement,
-  accept: PliValidationAcceptor,
+  accept: ValidationAcceptor,
 ): void {
   const items = procedureStatement.options
     .filter((e) => e.kind === SyntaxKind.Options)

--- a/packages/language/src/workspace/builtins.ts
+++ b/packages/language/src/workspace/builtins.ts
@@ -637,8 +637,7 @@ export const Builtins = ` /* Arithmetic built-in functions */
  POINTERVALUE: PROC (value) RETURNS (); END;
  SIZE: PROC (value) RETURNS (); END;
  STORAGE: PROC (value) RETURNS (); END;
- /* Only available if declared explicitly */
- /* SYSNULL: PROC (value) RETURNS (); END; */
+ SYSNULL: PROC (value) RETURNS (); END; 
  TYPE: PROC (value) RETURNS (); END;
  UNALLOCATED: PROC (value) RETURNS (); END;
  VARGLIST: PROC (value) RETURNS (); END;

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -37,6 +37,7 @@ export interface ProcessGroup {
   libs?: string[];
   "include-extensions"?: string[];
   abstractOptions?: AbstractCompilerOptions;
+  "implicit-builtins"?: string[];
 
   /**
    * Number of issues found in the compiler options for this process group.
@@ -49,7 +50,11 @@ export interface ProcessGroup {
  * Plugin configuration provider for loading '.pliplugin/pgm_conf.json' and '.pliplugin/proc_grps.json' (when they exist),
  * processing their contents, and making those settings available to the language server.
  */
-class PluginConfigurationProvider {
+export class PluginConfigurationProvider {
+  public static readonly PROGRAM_CONFIG_FILE = ".pliplugin/pgm_conf.json";
+  public static readonly PROCESS_GROUP_CONFIG_FILE =
+    ".pliplugin/proc_grps.json";
+
   /**
    * Prebuilt list of glob patterns for library file matching.
    */
@@ -349,5 +354,12 @@ class PluginConfigurationProvider {
 /**
  * Singleton instance of the pli plugin configuration provider.
  */
-export const PluginConfigurationProviderInstance: PluginConfigurationProvider =
+export let PluginConfigurationProviderInstance: PluginConfigurationProvider =
   new PluginConfigurationProvider();
+
+export function setPluginConfigurationProvider(
+  provider: PluginConfigurationProvider | undefined = undefined,
+): void {
+  PluginConfigurationProviderInstance =
+    provider ?? new PluginConfigurationProvider();
+}

--- a/packages/language/test/fourslash-harness/execute.test.ts
+++ b/packages/language/test/fourslash-harness/execute.test.ts
@@ -25,7 +25,10 @@ import {
 } from "../test-builder";
 import { createTestBuilderHarnessImplementation } from "./implementation/test-builder";
 import { resetDocumentProviders } from "../../src/language-server/text-documents";
-import { PluginConfigurationProviderInstance } from "../../src/workspace/plugin-configuration-provider";
+import {
+  PluginConfigurationProviderInstance,
+  setPluginConfigurationProvider,
+} from "../../src/workspace/plugin-configuration-provider";
 
 const frameworkFileName = "framework.ts";
 const testsPath = "packages/language/test/fourslash";
@@ -51,7 +54,9 @@ beforeEach(() => {
   setFileSystemProvider(fs);
   resetDocumentProviders();
 
+  // Clear the plugin configuration provider and
   // ensure the 'cpy' directory is always resolvable for includes via config
+  setPluginConfigurationProvider();
   PluginConfigurationProviderInstance.setProgramConfigs("", [
     {
       program: "*.pli",

--- a/packages/language/test/fourslash/validate/builtins-explicit-declaration.ts
+++ b/packages/language/test/fourslash/validate/builtins-explicit-declaration.ts
@@ -1,0 +1,30 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @filename: main.pli
+//// RGT005: PACKAGE EXPORTS(RGT005);
+//// DCL SYSNULL BUILTIN;
+//// DCL SUBSTR BUILTIN;
+//// RGT005: PROCEDURE() OPTIONS(MAIN);
+////   DCL  P1     POINTER;
+////   P1 = <|1:SYSNULL|>;
+////   DCL (I,J) CHAR(32);
+////   I = 'This is a test string';
+////   J = <|2:SUBSTR|>(I,1,10);
+////   PUT SKIP LIST(I);
+////   PUT SKIP LIST(J);
+//// END RGT005;
+//// END RGT005;
+
+verify.noDiagnostics(1);
+verify.noDiagnostics(2);

--- a/packages/language/test/fourslash/validate/builtins-implicit-config-declaration.ts
+++ b/packages/language/test/fourslash/validate/builtins-implicit-config-declaration.ts
@@ -1,0 +1,49 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////         "name": "default",
+////         "compiler-options": [],
+////         "libs": [
+////             "lib"
+////         ],
+////         "include-extensions": [
+////             ".pli",
+////             ".cpy",
+////             ".inc"
+////         ],
+////         "implicit-builtins": [
+////             "SUBSTR"
+////         ]
+////         }
+////     ]
+//// }
+
+// @filename: main.pli
+//// RGT005: PACKAGE EXPORTS(RGT005);
+//// RGT005: PROCEDURE() OPTIONS(MAIN);
+////   DCL  P1     POINTER;
+////   P1 = <|1:SYSNULL|>;
+////   DCL (I,J) CHAR(32);
+////   I = 'This is a test string';
+////   J = <|2:SUBSTR|>(I,1,10);
+////   PUT SKIP LIST(I);
+////   PUT SKIP LIST(J);
+//// END RGT005;
+//// END RGT005;
+
+verify.expectExclusiveErrorCodesAt(1, code.Error.IBM1373I.fullCode);
+verify.noDiagnostics(2);

--- a/packages/language/test/fourslash/validate/builtins-implicit-declaration.ts
+++ b/packages/language/test/fourslash/validate/builtins-implicit-declaration.ts
@@ -1,0 +1,28 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @filename: main.pli
+//// RGT005: PACKAGE EXPORTS(RGT005);
+//// RGT005: PROCEDURE() OPTIONS(MAIN);
+////   DCL  P1     POINTER;
+////   P1 = <|1:SYSNULL|>;
+////   DCL (I,J) CHAR(32);
+////   I = 'This is a test string';
+////   J = <|2:SUBSTR|>(I,1,10);
+////   PUT SKIP LIST(I);
+////   PUT SKIP LIST(J);
+//// END RGT005;
+//// END RGT005;
+
+verify.expectExclusiveErrorCodesAt(1, code.Error.IBM1373I.fullCode);
+verify.expectExclusiveErrorCodesAt(2, code.Error.IBM1373I.fullCode);

--- a/packages/vscode-extension/schemas/proc_grps.schema.json
+++ b/packages/vscode-extension/schemas/proc_grps.schema.json
@@ -34,6 +34,13 @@
               "type": "string",
               "enum": [".pli", ".pl1", ".cpy", ".inc"]
             }
+          },
+          "implicit-builtins": {
+            "type": "array",
+            "description": "List of builtins to include implicitly.",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": ["name"],

--- a/packages/vscode-extension/src/extension/main.ts
+++ b/packages/vscode-extension/src/extension/main.ts
@@ -97,6 +97,7 @@ function registerOnDidOpenTextDocListener() {
               "compiler-options": [],
               libs: ["cpy", "inc"],
               "include-extensions": [".pli", ".pl1", ".inc"],
+              "implicit-builtins": ["SUBSTR"],
             },
           ],
         },


### PR DESCRIPTION
Concludes https://github.com/zowe/zowe-pli-language-support/issues/275 

In our tests only `SUBSTR` is implicitly available on the system we have access to, but this must not be the case in general. Therefore, developer can add additional implicit builtins in the process group config. 

(@montymxb:) Also added program configurations and process groups to the `TestBuilder` (which can be a starting point for a more sophisticated system in https://github.com/zowe/zowe-pli-language-support/issues/172 if needed.)

Cleaned up validation naming a bit: General stuff in `validator.ts` now usually omits the Pli prefix, whereas Pli specific code in `pli-validator.ts` includes it. Also, it would be beneficial for some checks to not evaluate instances, such process groups, every time, so I made the `PliValidator` persistent. However, in the current state, the functions must be explicitly bound if they require state, which is not optimal. We should improve the validator architecture in this regard in a new PR in the near future.