### PR TITLE
Add diagnostic markers for text outside of margins

### DIFF
--- a/packages/language/src/preprocessor/compiler-options-processor.ts
+++ b/packages/language/src/preprocessor/compiler-options-processor.ts
@@ -44,13 +44,14 @@ export class CompilerOptionsProcessor {
     let sourceCompilerOptions: string[] = [];
     let newText = text;
     for (const range of ranges) {
-      // Magic number 8 is the length of the string "*PROCESS"
+      // newText should recognize the line break for the margins in the first line after the process directive.
       const offset =
         range.start + CompilerOptionsProcessor.PROCESS_TOKEN_LENGTH;
       sourceCompilerOptions.push(text.substring(offset, range.end));
       newText =
         newText.substring(0, range.start) +
-        " ".repeat(range.end - range.start) +
+        " ".repeat(range.end - range.start - 1) +
+        "\n" +
         newText.substring(range.end);
     }
 

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -19,7 +19,7 @@ import { CompilerOptionResult } from "./compiler-options/options";
 import { generateInstructions } from "./instruction-generator";
 import * as inst from "./instructions";
 import * as ast from "../syntax-tree/ast";
-import { LexingError } from "./pli-lexer";
+import { LexingIssue } from "./pli-lexer";
 import { MarginsProcessor } from "./pli-margins-processor";
 import { PreprocessorError } from "./pli-preprocessor-error";
 import { PliPreprocessorLexer } from "./pli-preprocessor-lexer";
@@ -158,7 +158,7 @@ interface InterpreterContext {
   entryUri?: URI;
   variables: Map<string, Variable>;
   result: CompilationUnitTokens;
-  errors: LexingError[];
+  errors: LexingIssue[];
   counter: Map<inst.InstructionNode, number>;
   references: ast.Reference[];
   evaluations: EvaluationResults;
@@ -169,7 +169,7 @@ interface InterpreterContext {
 
 export type InstructionInterpreterResult = CompilationUnitTokens & {
   evaluationResults: EvaluationResults;
-  errors: LexingError[];
+  errors: LexingIssue[];
   references: ast.Reference[];
 };
 
@@ -843,10 +843,13 @@ function runInclude(item: IncludeItem, context: InterpreterContext): void {
 
   try {
     const content = TextDocuments.get(uri)?.getText() ?? "";
-    const processedContent = context.options.marginsProcessor.processMargins({
-      result: context.options.compilerOptions,
-      text: content,
-    });
+    const processedContent = context.options.marginsProcessor.processMargins(
+      {
+        result: context.options.compilerOptions,
+        text: content,
+      },
+      uri,
+    );
     const subState = context.options.parser.initializeState(
       processedContent,
       uri,

--- a/packages/language/src/preprocessor/pli-lexer.ts
+++ b/packages/language/src/preprocessor/pli-lexer.ts
@@ -21,7 +21,7 @@ import {
 } from "./compiler-options-processor";
 import { CompilationUnit } from "../workspace/compilation-unit";
 import { Reference, Statement } from "../syntax-tree/ast";
-import { Range } from "../language-server/types";
+import { Range, Severity } from "../language-server/types";
 import { Token } from "../parser/tokens";
 import { recursivelySetContainer } from "../linking/symbol-table";
 import { generateInstructions } from "./instruction-generator";
@@ -33,15 +33,16 @@ import {
 } from "./compiler-options/options";
 import { CstNodeKind } from "../syntax-tree/cst";
 
-export interface LexingError {
+export interface LexingIssue {
   readonly message: string;
+  readonly severity: Severity;
   readonly range: Range | undefined;
   readonly uri: URI | undefined;
 }
 
 export interface LexerResult {
   all: Token[];
-  errors: LexingError[];
+  errors: LexingIssue[];
   compilerOptions: CompilerOptionsProcessorResult;
   statements: Statement[];
   fileTokens: Map<string, Token[]>;
@@ -74,6 +75,7 @@ export class PliLexer {
     );
     const textWithoutMargins = this.marginsProcessor.processMargins(
       compilerOptionsResult,
+      uri,
     );
     const state = this.preprocessorParser.initializeState(
       textWithoutMargins,
@@ -87,6 +89,7 @@ export class PliLexer {
     } = this.preprocessorParser.parse(state);
     unit.preprocessorAst.statements = statements;
     recursivelySetContainer(unit.preprocessorAst);
+    errors.push(...this.marginsProcessor.issues);
 
     let instructionNode = generateInstructions(statements);
     const incAfter = compilerOptionsResult.result?.options.incAfter;

--- a/packages/language/src/preprocessor/pli-margins-processor.ts
+++ b/packages/language/src/preprocessor/pli-margins-processor.ts
@@ -9,20 +9,51 @@
  *
  */
 
-import { Range } from "../language-server/types";
+import { Range, Severity } from "../language-server/types";
 import { CompilerOptionsProcessorResult } from "./compiler-options-processor";
+import { LexingIssue } from "./pli-lexer";
+import { URI } from "../utils/uri";
+import { Warning } from "../validation/messages/pli-codes";
+import { PluginConfigurationProviderInstance } from "../workspace/plugin-configuration-provider";
 
 const NEWLINE = "\n".charCodeAt(0);
+const SPACE = " ".charCodeAt(0);
+const PREFIX_PATTERN = /^[0-9\+\- ]+$/;
+const SEQUENCE_PATTERN = /^\s*[A-Z0-9]*\r?\n?$/;
 
 export interface MarginsProcessor {
-  processMargins(input: CompilerOptionsProcessorResult): string;
+  issues: LexingIssue[];
+  processMargins(input: CompilerOptionsProcessorResult, uri: URI): string;
 }
 
 /**
  * Helper class to replace text margins with space characters (characters 2-72 are normal program text)
  */
 export class PliMarginsProcessor implements MarginsProcessor {
-  processMargins(input: CompilerOptionsProcessorResult): string {
+  static readonly MARGIN_ERROR_MESSAGE_LEFT =
+    "PL/I statements must start from column 2 or as defined in MARGINS(M,N).";
+  static readonly MARGIN_ERROR_MESSAGE_RIGHT = Warning.IBM1084I.message;
+
+  issues: LexingIssue[] = [];
+
+  protected checkMargins: boolean = false;
+
+  processMargins(input: CompilerOptionsProcessorResult, uri: URI): string {
+    this.issues = [];
+
+    const programConfig =
+      PluginConfigurationProviderInstance.getProgramConfig(uri);
+    if (programConfig) {
+      const processGroup =
+        PluginConfigurationProviderInstance.getProcessGroupConfig(
+          programConfig.pgroup,
+        );
+      if (processGroup) {
+        this.checkMargins =
+          processGroup["lsp-options"]?.["check-margins"] ?? false;
+      }
+    }
+
     let margins: Range = {
       start: 2,
       end: 72,
@@ -37,19 +68,121 @@ export class PliMarginsProcessor implements MarginsProcessor {
         margins.end = end;
       }
     }
-    const lines = this.splitLines(input.text);
+
+    const lines = this.splitLines(input.text, margins, uri);
     const adjustedLines = lines.map((line) => this.adjustLine(line, margins));
     return adjustedLines.join("");
   }
 
-  private splitLines(text: string): string[] {
+  private splitLines(text: string, margins: Range, uri: URI): string[] {
     const lines: string[] = [];
+    const prefixLength = margins.start - 1;
+
+    const reportViolation = (
+      side: "left" | "right",
+      start: number,
+      end: number,
+    ) => {
+      this.issues.push({
+        message:
+          side === "left"
+            ? PliMarginsProcessor.MARGIN_ERROR_MESSAGE_LEFT
+            : PliMarginsProcessor.MARGIN_ERROR_MESSAGE_RIGHT,
+        severity: Severity.W,
+        range: { start, end },
+        uri,
+      });
+    };
+
+    let possibleViolationLeft = false;
+    let possibleViolationRight = false;
     for (let i = 0; i < text.length; i++) {
       const start = i;
-      while (i < text.length && text.charCodeAt(i) !== NEWLINE) {
-        i++;
+
+      if (this.checkMargins) {
+        // Basically, while scanning the text for the newline, the margins are checked via
+        // if ((i < leftMarginEnd || i > rightMarginStart) && code !== SPACE) {
+        //   possibleViolation = true;
+        // }
+        // Since the the majority of the line usually lives inbetween the margins,
+        // we check the margins in three dedicated loops,
+        // one for the left margin, one for the characters between the margins,
+        // and one for the right margin.
+        let code;
+        const leftMarginEnd = i + prefixLength;
+        const rightMarginStart = i + margins.end;
+        possibleViolationLeft = false;
+        possibleViolationRight = false;
+        const leftMarginSpace = Math.min(leftMarginEnd, text.length);
+        while (i < leftMarginSpace) {
+          code = text.charCodeAt(i);
+          if (code === NEWLINE) {
+            break;
+          }
+          i++;
+          if (code !== SPACE) {
+            possibleViolationLeft = true;
+            // We can stop here, the next loop will take care of the rest of the line.
+            break;
+          }
+        }
+        if (code !== NEWLINE) {
+          const rightMarginSpace = Math.min(rightMarginStart, text.length);
+          while (i < rightMarginSpace) {
+            code = text.charCodeAt(i);
+            if (code === NEWLINE) {
+              break;
+            }
+            i++;
+          }
+          if (code !== NEWLINE) {
+            while (i < text.length) {
+              code = text.charCodeAt(i);
+              if (code === NEWLINE) {
+                break;
+              }
+              if (code !== SPACE) {
+                possibleViolationRight = true;
+              }
+              i++;
+            }
+          }
+        }
+      } else {
+        // Margin check is disabled.
+        while (i < text.length && text.charCodeAt(i) !== NEWLINE) {
+          i++;
+        }
       }
-      lines.push(text.substring(start, i + 1));
+      const line = text.substring(start, i + 1);
+      lines.push(line);
+
+      // Check the left margin.
+      // TODO ssmifi: While COL1 should be reserved for %|*PROCESS, there are examples (ADVNTOPT)
+      // that use single digits, +, and -.
+      if (
+        possibleViolationLeft &&
+        !(
+          (line[0] === "%" || line[0] === "*") &&
+          line.substring(1, 8).toUpperCase().startsWith("PROCESS")
+        ) &&
+        !PREFIX_PATTERN.test(line.substring(0, prefixLength))
+      ) {
+        reportViolation("left", start, start + prefixLength);
+      }
+
+      // Check the right margin.
+      if (possibleViolationRight) {
+        const sequence = line.substring(margins.end).toUpperCase();
+        if (!SEQUENCE_PATTERN.test(sequence)) {
+          // Do not include the newline character.
+          reportViolation(
+            "right",
+            start + margins.end,
+            start + line.length - 1,
+          );
+        }
+      }
     }
     return lines;
   }

--- a/packages/language/src/preprocessor/pli-preprocessor-error.ts
+++ b/packages/language/src/preprocessor/pli-preprocessor-error.ts
@@ -9,15 +9,16 @@
  *
  */
 
-import type { LexingError } from "./pli-lexer";
-import { Range } from "../language-server/types";
+import type { LexingIssue } from "./pli-lexer";
+import { Range, Severity } from "../language-server/types";
 import { URI } from "../utils/uri";
 import { Token } from "../parser/tokens";
 
-export class PreprocessorError implements LexingError {
+export class PreprocessorError implements LexingIssue {
   private _uri: URI | undefined;
   private _range: Range | undefined;
   private _message: string;
+  private _severity: Severity;
 
   get uri(): URI | undefined {
     return this._uri;
@@ -31,12 +32,17 @@ export class PreprocessorError implements LexingError {
     return this._message;
   }
 
+  get severity(): Severity {
+    return this._severity;
+  }
+
   constructor(
     message: string,
     range: Range | Token | null | undefined,
     uri?: URI,
   ) {
     this._message = message;
+    this._severity = Severity.E;
     if (range) {
       if ("start" in range) {
         this._range = range;

--- a/packages/language/src/preprocessor/pli-preprocessor-parser.ts
+++ b/packages/language/src/preprocessor/pli-preprocessor-parser.ts
@@ -26,14 +26,14 @@ import {
   IntermediateBinaryExpression,
 } from "../parser/abstract-parser";
 import { CstNodeKind } from "../syntax-tree/cst";
-import { LexingError } from "./pli-lexer";
+import { LexingIssue } from "./pli-lexer";
 import { Token } from "../parser/tokens";
 import { performAssignmentLookahead } from "../parser/parser";
 import { tokenMatcher } from "chevrotain";
 
 export type PreprocessorParserResult = {
   statements: ast.Statement[];
-  errors: LexingError[];
+  errors: LexingIssue[];
   tokens: Token[];
 };
 
@@ -50,7 +50,7 @@ export class PliPreprocessorParser {
 
   parse(state: PreprocessorParserState): PreprocessorParserResult {
     const statements: ast.Statement[] = [];
-    const errors: LexingError[] = [];
+    const errors: LexingIssue[] = [];
     while (!state.eof) {
       try {
         if (state.canConsume(PreprocessorTokens.Percentage)) {

--- a/packages/language/src/validation/validator.ts
+++ b/packages/language/src/validation/validator.ts
@@ -22,7 +22,7 @@ import { isValidToken } from "../linking/tokens";
 import { SyntaxKind, SyntaxNode } from "../syntax-tree/ast";
 import { forEachNode } from "../syntax-tree/ast-iterator";
 import { registerPliValidationChecks } from "./pli-validator";
-import { LexingError } from "../preprocessor/pli-lexer";
+import { LexingIssue } from "../preprocessor/pli-lexer";
 import { isMainProcedure, labelPrefixPointsToPackage } from "./utils";
 import { ScopeCache, ScopeCacheGroups } from "../linking/scope";
 import { LinkerErrorReporter } from "../linking/error";
@@ -131,15 +131,15 @@ export function compilerOptionIssuesToDiagnostics(
   return diagnostics;
 }
 
-export function lexerErrorsToDiagnostics(
-  lexerErrors: LexingError[],
+export function lexerIssuesToDiagnostics(
+  lexerErrors: LexingIssue[],
 ): Diagnostic[] {
   const diagnostics: Diagnostic[] = [];
   for (const error of lexerErrors) {
     if (error.uri && error.range && !isNaN(error.range.start)) {
       diagnostics.push({
         uri: error.uri.toString(),
-        severity: Severity.E,
+        severity: error.severity,
         range: error.range,
         message: error.message,
         source: "lexer",

--- a/packages/language/src/workspace/lifecycle.ts
+++ b/packages/language/src/workspace/lifecycle.ts
@@ -17,7 +17,7 @@ import { PliProgram } from "../syntax-tree/ast";
 import {
   compilerOptionIssuesToDiagnostics,
   generateValidationDiagnostics,
-  lexerErrorsToDiagnostics,
+  lexerIssuesToDiagnostics,
   linkingErrorsToDiagnostics,
   parserErrorsToDiagnostics,
 } from "../validation/validator";
@@ -58,7 +58,7 @@ export function tokenize(
   compilationUnit.compilerOptions =
     result.compilerOptions.result?.options ?? getDefaultCompilerOptions();
   const uri = compilationUnit.uri.toString();
-  compilationUnit.diagnostics.lexer = lexerErrorsToDiagnostics(result.errors);
+  compilationUnit.diagnostics.lexer = lexerIssuesToDiagnostics(result.errors);
   compilationUnit.diagnostics.compilerOptions =
     compilerOptionIssuesToDiagnostics(
       result.compilerOptions.result?.issues,

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -58,6 +58,15 @@ export interface ProcessGroup {
   libs?: string[];
   "include-extensions"?: string[];
   "implicit-builtins"?: string[];
+  "lsp-options"?: {
+    "check-margins"?: boolean;
+  };
+
+  /**
+   * Number of issues found in the compiler options for this process group.
+   * Used to avoid duplicate issue reporting later on when running translation in a program context
+   */
+  issueCount?: number;
 }
 
 /**

--- a/packages/language/test/fourslash-harness/harness-interface.ts
+++ b/packages/language/test/fourslash-harness/harness-interface.ts
@@ -15,6 +15,7 @@ import { InternalCodes, PLICodes } from "../../src/validation/messages";
 import { ExpectedCompletion, TestBuilder } from "../test-builder";
 import { type Severity } from "../../src/language-server/types";
 import { SemanticTokenTypes } from "vscode-languageserver-types";
+import { PliMarginsProcessor } from "../../src/preprocessor/pli-margins-processor";
 
 type Label = string | number;
 type SemanticTokenTypesValues = `${SemanticTokenTypes}`;
@@ -166,6 +167,12 @@ export interface HarnessTesterInterface {
     Information: typeof PLICodes.Info;
     Error: typeof PLICodes.Error;
     Internal: typeof InternalCodes.Internal;
+    Lexer: {
+      Margins: {
+        ErrorLeft: typeof PliMarginsProcessor.MARGIN_ERROR_MESSAGE_LEFT;
+        ErrorRight: typeof PliMarginsProcessor.MARGIN_ERROR_MESSAGE_RIGHT;
+      };
+    };
   };
 
   constants: {

--- a/packages/language/test/fourslash-harness/harness-parser.ts
+++ b/packages/language/test/fourslash-harness/harness-parser.ts
@@ -28,7 +28,7 @@ const HarnessFileTag = {
 const HARNESS_TAG_PREFIX = "//";
 export const HARNESS_FILE_PREFIX = "////";
 const REFERENCE_PATH_PREFIX = "/// <reference path=";
-const HARNESS_TAG_PATTERN = /^\/\/\s*@(?<name>\w+)\s*:(?<value>.*)$/;
+const HARNESS_TAG_PATTERN = /^\/\/\s*@(?<name>\w+)\s*(?<value>:.*)?$/;
 
 type Context = {
   wrappers: Record<string, Wrapper>;
@@ -103,7 +103,11 @@ class HarnessTestParser {
         throw new Error(`Invalid tag: ${line}`);
       }
 
-      tags[match.groups!.name] = match.groups!.value.trim();
+      if (match.groups!.value) {
+        tags[match.groups!.name] = match.groups!.value.substring(1).trim(); // Remove the colon
+      } else {
+        tags[match.groups!.name] = "true";
+      }
     }
 
     return tags;
@@ -126,6 +130,7 @@ class HarnessTestParser {
     const wrap: string | undefined = tags[HarnessFileTag.Wrap];
 
     const lineOffsetPreWrap = this.lineOffset;
+    const eol = tags.crlf ? "\r\n" : "\n";
 
     while (true) {
       const line = this.peek();
@@ -140,7 +145,7 @@ class HarnessTestParser {
       lines.push(content);
     }
 
-    let content = lines.join("\n");
+    let content = lines.join(eol);
     const wrapper = wrap ? this.getWrapper(wrap) : undefined;
     if (wrapper) {
       content = wrapper.wrap(content);

--- a/packages/language/test/fourslash-harness/implementation/codes.ts
+++ b/packages/language/test/fourslash-harness/implementation/codes.ts
@@ -11,6 +11,7 @@
 
 import { PLICodes, InternalCodes } from "../../../src/validation/messages";
 import { HarnessTesterInterface } from "../harness-interface";
+import { PliMarginsProcessor } from "../../../src/preprocessor/pli-margins-processor";
 
 export const HarnessCodes: HarnessTesterInterface["code"] = {
   Severe: PLICodes.Severe,
@@ -18,4 +19,10 @@ export const HarnessCodes: HarnessTesterInterface["code"] = {
   Information: PLICodes.Info,
   Error: PLICodes.Error,
   Internal: InternalCodes.Internal,
+  Lexer: {
+    Margins: {
+      ErrorLeft: PliMarginsProcessor.MARGIN_ERROR_MESSAGE_LEFT,
+      ErrorRight: PliMarginsProcessor.MARGIN_ERROR_MESSAGE_RIGHT,
+    },
+  },
 };

--- a/packages/language/test/fourslash/lexer/margins-error-left-margin-default.ts
+++ b/packages/language/test/fourslash/lexer/margins-error-left-margin-default.ts
@@ -1,0 +1,40 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////         "name": "default",
+////         "lsp-options": {
+////             "check-margins": true
+////         }
+////         }
+////     ]
+//// }
+
+// @filename: main.pli
+//// /* *PROCESS MARGINS(2,) */
+//// RGT005: PACKAGE EXPORTS(RGT005);
+////   DCL SYSNULL BUILTIN;
+////   RGT005: PROCEDURE(Z) OPTIONS(MAIN);
+////<|1:x|>    DCL  Z      CHAR(32);
+////     DCL  X      CHAR(32);
+////     X = Z;
+////     PUT SKIP LIST(X);
+////   END RGT005;
+//// END RGT005;
+
+verify.expectExclusiveDiagnosticsAt(1, {
+  message: code.Lexer.Margins.ErrorLeft,
+});

--- a/packages/language/test/fourslash/lexer/margins-error-left-margin-directive.ts
+++ b/packages/language/test/fourslash/lexer/margins-error-left-margin-directive.ts
@@ -1,0 +1,43 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////         "name": "default",
+////         "lsp-options": {
+////             "check-margins": true
+////         }
+////         }
+////     ]
+//// }
+
+// @filename: main.pli
+////*PROCESS MARGINS(4,)
+////<|1: RG|>T005: PACKAGE EXPORTS(RGT005);
+////   DCL SYSNULL BUILTIN;
+////   RGT005: PROCEDURE(Z) OPTIONS(MAIN);
+////     DCL  Z      CHAR(32);
+////     DCL  X      CHAR(32);
+////     X = Z;
+////     PUT SKIP LIST(X);
+////   END RGT005;
+////<|2: EN|>D RGT005;
+
+verify.expectExclusiveDiagnosticsAt(1, {
+  message: code.Lexer.Margins.ErrorLeft,
+});
+verify.expectExclusiveDiagnosticsAt(2, {
+  message: code.Lexer.Margins.ErrorLeft,
+});

--- a/packages/language/test/fourslash/lexer/margins-error-right-margin-directive.ts
+++ b/packages/language/test/fourslash/lexer/margins-error-right-margin-directive.ts
@@ -1,0 +1,40 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////         "name": "default",
+////         "lsp-options": {
+////             "check-margins": true
+////         }
+////         }
+////     ]
+//// }
+
+// @filename: main.pli
+////*PROCESS MARGINS(2,40)
+//// RGT005: PACKAGE EXPORTS(RGT005);  /* Th<|1:is is being truncated */|>
+////   DCL SYSNULL BUILTIN;
+////   RGT005: PROCEDURE(Z) OPTIONS(MAIN);
+////     DCL  Z      CHAR(32);
+////     DCL  X      CHAR(32);
+////     X = Z;
+////     PUT SKIP LIST(X);
+////   END RGT005;
+//// END RGT005;
+
+verify.expectExclusiveDiagnosticsAt(1, {
+  message: code.Lexer.Margins.ErrorRight,
+});

--- a/packages/language/test/fourslash/lexer/margins-error-right-margin-sequencenumber-crlf.ts
+++ b/packages/language/test/fourslash/lexer/margins-error-right-margin-sequencenumber-crlf.ts
@@ -1,0 +1,39 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////         "name": "default",
+////         "lsp-options": {
+////             "check-margins": true
+////         }
+////         }
+////     ]
+//// }
+
+// @filename: main.pli
+// @crlf
+////*PROCESS MARGINS(2,38)
+//// RGT005: PACKAGE EXPORTS(RGT005);
+////   DCL SYSNULL BUILTIN;
+////   RGT005: PROCEDURE(Z) OPTIONS(MAIN); <|1:CAL00080|>
+////     DCL  Z      CHAR(32);
+////     DCL  X      CHAR(32);
+////     X = Z;
+////     PUT SKIP LIST(X);
+////   END RGT005;
+//// END RGT005;
+
+verify.noDiagnostics();

--- a/packages/language/test/fourslash/lexer/margins-error-right-margin-sequencenumber-invalid.ts
+++ b/packages/language/test/fourslash/lexer/margins-error-right-margin-sequencenumber-invalid.ts
@@ -1,0 +1,40 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////         "name": "default",
+////         "lsp-options": {
+////             "check-margins": true
+////         }
+////         }
+////     ]
+//// }
+
+// @filename: main.pli
+////*PROCESS MARGINS(2,38)
+//// RGT005: PACKAGE EXPORTS(RGT005);
+////   DCL SYSNULL BUILTIN;
+////   RGT005: PROCEDURE(Z) OPTIONS(MAIN);<|1: x CAL00080|>
+////     DCL  Z      CHAR(32);
+////     DCL  X      CHAR(32);
+////     X = Z;
+////     PUT SKIP LIST(X);
+////   END RGT005;
+//// END RGT005;
+
+verify.expectExclusiveDiagnosticsAt(1, {
+  message: code.Lexer.Margins.ErrorRight,
+});

--- a/packages/language/test/fourslash/lexer/margins-error-right-margin-sequencenumber.ts
+++ b/packages/language/test/fourslash/lexer/margins-error-right-margin-sequencenumber.ts
@@ -1,0 +1,38 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////         "name": "default",
+////         "lsp-options": {
+////             "check-margins": true
+////         }
+////         }
+////     ]
+//// }
+
+// @filename: main.pli
+////*PROCESS MARGINS(2,38)
+//// RGT005: PACKAGE EXPORTS(RGT005);
+////   DCL SYSNULL BUILTIN;
+////   RGT005: PROCEDURE(Z) OPTIONS(MAIN); <|1:CAL00080|>
+////     DCL  Z      CHAR(32);
+////     DCL  X      CHAR(32);
+////     X = Z;
+////     PUT SKIP LIST(X);
+////   END RGT005;
+//// END RGT005;
+
+verify.noDiagnostics(1);

--- a/packages/language/test/parsing.test.ts
+++ b/packages/language/test/parsing.test.ts
@@ -45,13 +45,13 @@ describe("PL/I Parsing tests", () => {
   });
 
   test("empty program w/ null statement", () => {
-    const doc = parseStmts(`;`);
+    const doc = parseStmts(` ;`);
     assertNoParseErrors(doc);
     generateAndAssertValidSymbolTable(doc);
   });
 
   test("empty program w/ null %statement", () => {
-    const doc = parseStmts(`%;`);
+    const doc = parseStmts(` %;`);
     assertNoParseErrors(doc);
     generateAndAssertValidSymbolTable(doc);
   });
@@ -280,7 +280,7 @@ describe("PL/I Parsing tests", () => {
   // tests fro declarations
   describe("Declaration tests", () => {
     test("simple char declarations", () => {
-      const doc = parseStmts(`
+      const doc = parseStmts(`*PROCESS MARGINS(2,200)
  declare UserA character (15); // 15 character var
  declare UserB character (15) varying; // varying
  declare UserC character (15) varyingz; // varying w/ null termination
@@ -293,7 +293,7 @@ describe("PL/I Parsing tests", () => {
     });
 
     test("char declaration w/ overflow assignment", () => {
-      const doc = parseStmts(`
+      const doc = parseStmts(`*PROCESS MARGINS(2,200)
  declare Subject char(10);
  Subject = 'Transformations'; // will truncate the last 5 chars, emitting a warning (but valid nonetheless)
 `);
@@ -408,7 +408,7 @@ describe("PL/I Parsing tests", () => {
     });
 
     test("multi-declaration", () => {
-      const doc = parseStmts(`
+      const doc = parseStmts(`*PROCESS MARGINS(2,200)
     declare Result bit(3),
         A fixed decimal(1),
         B fixed binary (15), // precison lower than 15 will trigger a compiler warning, less than storage allows

--- a/packages/language/test/utils.ts
+++ b/packages/language/test/utils.ts
@@ -133,8 +133,17 @@ export function parseStmts(
   text: string,
   options?: { validate: boolean },
 ): CompilationUnit {
+  // TODO ssmifi: Currently, process directives must start at the beginning of the file.
+  let prefix = "";
+  while (text.startsWith("*PROCESS") || text.startsWith("%PROCESS")) {
+    prefix += text.substring(0, text.indexOf("\n") + 1);
+    text = text.substring(text.indexOf("\n") + 1);
+  }
+  if (prefix) {
+    prefix += "\n";
+  }
   return parse(
-    ` STARTPR: PROCEDURE OPTIONS (MAIN);
+    `${prefix} STARTPR: PROCEDURE OPTIONS (MAIN);
 ${text}
  end STARTPR;`,
     options,

--- a/packages/vscode-extension/schemas/proc_grps.schema.json
+++ b/packages/vscode-extension/schemas/proc_grps.schema.json
@@ -45,6 +45,16 @@
             "items": {
               "type": "string"
             }
+          },
+          "lsp-options": {
+            "type": "object",
+            "description": "Options for the Language Server Protocol.",
+            "properties": {
+              "check-margins": {
+                "type": "boolean",
+                "description": "Whether to check for margins in the PL/I code."
+              }
+            }
           }
         },
         "required": ["name"],

--- a/packages/vscode-extension/src/extension/decorators.ts
+++ b/packages/vscode-extension/src/extension/decorators.ts
@@ -134,20 +134,20 @@ export namespace MarginIndicatorDecorator {
       return;
     }
 
+    // The left ruler should be left of the column number (-1), whereas
+    // the right ruler should be right of the column number.
     if (settings.marginIndicatorRulers === "automatic") {
       for (const margins of marginIndicatorRangesByUri.values()) {
-        if (!rulers.includes(margins.m)) {
-          rulers.push(margins.m);
+        if (!rulers.includes(margins.m - 1)) {
+          rulers.push(margins.m - 1);
         }
         if (!rulers.includes(margins.n)) {
           rulers.push(margins.n);
         }
       }
     } else {
-      rulers = [2, 72];
+      rulers = [1, 72];
     }
-
-    rulers = rulers.map((r) => r - 1);
 
     if (rulers.length === existingRulers.length) {
       // If the rulers are the same, no need to update

--- a/packages/vscode-extension/src/extension/main.ts
+++ b/packages/vscode-extension/src/extension/main.ts
@@ -98,6 +98,9 @@ function registerOnDidOpenTextDocListener() {
               libs: ["cpy", "inc"],
               "include-extensions": [".pli", ".pl1", ".inc"],
               "implicit-builtins": ["SUBSTR"],
+              "lsp-options": {
+                "check-margins": true,
+              },
             },
           ],
         },


### PR DESCRIPTION
Suggestion for https://github.com/zowe/zowe-pli-language-support/issues/186 (2)

I think we can check for violated boundaries without too much impact when checking each character in `splitLines` when processing the margins anyway. Please let me know if you agree. 

Also, allow tags without value in the test harness. 
Added `@crlf` tag to specifically test for \r\n in the harness to test lines that are processed manually.
(Could be reasonable to automatically test all harness test against both line endings in the future.)

Also, fixed display of the right margin ruler.