### PR TITLE
Fix builtin validation uri

### DIFF
--- a/packages/language/src/validation/pli-validator.ts
+++ b/packages/language/src/validation/pli-validator.ts
@@ -323,7 +323,7 @@ export class PliValidator implements Validator {
         {
           code: PLICodes.Error.IBM1373I.fullCode,
           range: getSyntaxNodeRange(node)!,
-          uri: tokenToUri(node.ref.node.nameToken) || "",
+          uri: tokenToUri(node.ref.token) || "",
         },
       );
     }


### PR DESCRIPTION
The validation should use the uri of the reference item.