### PR TITLE
[Bugfix] Correct INCAFTER Test

### DIFF
--- a/code_samples/plugin-example/a.pli
+++ b/code_samples/plugin-example/a.pli
@@ -1,6 +1,6 @@
 *PROCESS MARGINS(2,120);
  %INCLUDE "b.pli";
- VARB = SYSPARM;
+ VARB = 2;
  %INCLUDE C;
  VARC = 3;
  %INCLUDE lib;

--- a/packages/language/src/preprocessor/compiler-options/translator.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator.ts
@@ -1354,7 +1354,6 @@ translator.rule(["INCAFTER"], (option, options) => {
   ensureArguments(option, 1, 1);
   const value = option.values[0];
   if (value.kind === SyntaxKind.CompilerOption) {
-    ensureType(value, "option");
     if (value.name.toUpperCase() !== "PROCESS") {
       throw new TranslationError(
         value.token,

--- a/packages/language/src/preprocessor/compiler-options/translator.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator.ts
@@ -1353,21 +1353,26 @@ translator.flag("goff", ["GOFF"], ["NOGOFF"]);
 translator.rule(["INCAFTER"], (option, options) => {
   ensureArguments(option, 1, 1);
   const value = option.values[0];
-  ensureType(value, "option");
-  if (value.name.toUpperCase() !== "PROCESS") {
-    throw new TranslationError(
-      value.token,
-      `Expected "PROCESS", but received '${value.name}'.`,
-      1,
-    );
+  if (value.kind === SyntaxKind.CompilerOption) {
+    ensureType(value, "option");
+    if (value.name.toUpperCase() !== "PROCESS") {
+      throw new TranslationError(
+        value.token,
+        `Expected "PROCESS", but received '${value.name}'.`,
+        1,
+      );
+    }
+    ensureArguments(value, 1, 1);
+    const processValue = value.values[0];
+    ensureType(processValue, "plain");
+    options.incAfter = {
+      process: processValue.value,
+      token: processValue.token,
+    };
+  } else {
+    ensureType(value, "plain");
+    options.incAfter = undefined;
   }
-  ensureArguments(value, 1, 1);
-  const processValue = value.values[0];
-  ensureType(processValue, "plain");
-  options.incAfter = {
-    process: processValue.value,
-    token: processValue.token,
-  };
 });
 /** {@link CompilerOptions.incDir} */
 /** {@link CompilerOptions.include} */

--- a/packages/language/test/fourslash/preprocessor/include/incafter-in-config.ts
+++ b/packages/language/test/fourslash/preprocessor/include/incafter-in-config.ts
@@ -33,9 +33,7 @@
 
 // @filename: main.pli
 ////*PROCESS;
-//// DCL TEST FIXED;
 
 preprocessor.expectTokens(`
   DECLARE LIB_VAR FIXED;
-  DCL TEST FIXED;
 `);


### PR DESCRIPTION
Follows up on #295 w/ a correction to an existing test. The prior case was correct, but misleading, as there was an extra `DCL` statement being checked that was unrelated to the incafter effect under test.

This also adds support for the additional `INCAFTER()` compiler option usage, which allows setting back to the default state, and in turn makes the test a bit cleaner in terms of its expectations.

Small correction in an example file as well.