### PR TITLE
Extend compiler options and tests

### DIFF
--- a/packages/language/src/preprocessor/compiler-options/codes.ts
+++ b/packages/language/src/preprocessor/compiler-options/codes.ts
@@ -1,0 +1,85 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { Severity } from "../../language-server/types";
+import { ParametricPLICode } from "../../validation/messages/pli-codes";
+
+export const CompilerOptionsCodes = {
+  WrongParameterCount: {
+    code: "_COOP01",
+    severity: Severity.W,
+    message: (received: string, min: string, max?: string) => {
+      if (min === max) {
+        return `Expected ${min} arguments, but received ${received}.`;
+      } else if (max === "") {
+        return `Expected at least ${min} arguments, but received ${received}.`;
+      } else {
+        return `Expected between ${min} and ${max} arguments, but received ${received}.`;
+      }
+    },
+    fullCode: "_COOP01W",
+  } as ParametricPLICode,
+
+  DupeOptionIssue: {
+    code: "_COOP02",
+    severity: Severity.W,
+    message: (name: string) => `Duplicate compiler option ${name}`,
+    fullCode: "_COOP02W",
+  } as ParametricPLICode,
+
+  MutexOptionIssue: {
+    code: "_COOP03",
+    severity: Severity.W,
+    message: (name: string) =>
+      `Mutually exclusive compiler options found for ${name}, only the last one will take effect.`,
+    fullCode: "_COOP03W",
+  } as ParametricPLICode,
+
+  gonumber: {
+    WrongParameter: {
+      code: "_COGN01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "SEPARATE" or "NOSEPARATE", but received '${value}'.`,
+      fullCode: "_COGN01W",
+    } as ParametricPLICode,
+  },
+
+  header: {
+    WrongParameter: {
+      code: "_COHE01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "ALL", "FILE", "FIRST" or "SOURCE", but received '${value}'.`,
+      fullCode: "_COHE01W",
+    } as ParametricPLICode,
+  },
+
+  hgpr: {
+    WrongParameter: {
+      code: "_COHG01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "PRESERVE" or "NOPRESERVE", but received '${value}'.`,
+      fullCode: "_COHG01W",
+    } as ParametricPLICode,
+  },
+
+  ignore: {
+    WrongParameter: {
+      code: "_COIG01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "ASSERT", "DISPLAY" or "PUT", but received '${value}'.`,
+      fullCode: "_COIG01W",
+    } as ParametricPLICode,
+  },
+};

--- a/packages/language/src/preprocessor/compiler-options/translator.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator.ts
@@ -24,8 +24,12 @@ import {
   CompilerOptionValue,
   SyntaxKind,
 } from "../../syntax-tree/ast";
-import { Warning as PLIWarning } from "../../validation/messages/pli-codes";
+import {
+  ParametricPLICode,
+  Warning as PLIWarning,
+} from "../../validation/messages/pli-codes";
 import { Token } from "../../parser/tokens";
+import { CompilerOptionsCodes } from "./codes";
 
 interface TranslatorRule {
   positive?: string[];
@@ -44,7 +48,7 @@ enum Applied {
   NEGATIVE = -1,
 }
 
-const PLI_CHARACTER_SET = /[A-Za-z0-9 =+\-*/()\.,'"%;:&|<>_¬]/i;
+const PLI_CHARACTER_SET = /[A-Za-z0-9 =+\-*/()\.,'"%;:&|<>_¬]/;
 
 class Translator {
   options: CompilerOptions = getDefaultCompilerOptions();
@@ -173,8 +177,8 @@ class Translator {
   reportDupeOptIssue(option: CompilerOption, name: string): void {
     this.issues.push({
       range: tokenToRange(option.token),
-      message: `Duplicate compiler option ${name}`,
-      severity: Severity.W,
+      message: CompilerOptionsCodes.DupeOptionIssue.message(name),
+      severity: CompilerOptionsCodes.DupeOptionIssue.severity,
     });
   }
 
@@ -184,8 +188,8 @@ class Translator {
   reportMutexOptIssue(option: CompilerOption, name: string): void {
     this.issues.push({
       range: tokenToRange(option.token),
-      message: `Mutually exclusive compiler options found for ${name}, only the last one will take effect.`,
-      severity: Severity.W,
+      message: CompilerOptionsCodes.MutexOptionIssue.message(name),
+      severity: CompilerOptionsCodes.MutexOptionIssue.severity,
     });
   }
 }
@@ -200,6 +204,10 @@ class TranslationError {
     this.message = message;
     this.severity = severity;
   }
+
+  static fromCode(token: Token, code: ParametricPLICode, ...args: string[]) {
+    return new TranslationError(token, code.message(...args), code.severity);
+  }
 }
 
 function ensureArguments(option: CompilerOption, min: number, max?: number) {
@@ -207,15 +215,13 @@ function ensureArguments(option: CompilerOption, min: number, max?: number) {
     option.values.length < min ||
     (max !== undefined && option.values.length > max)
   ) {
-    let message: string;
-    if (min === max) {
-      message = `Expected ${min} arguments, but received ${option.values.length}.`;
-    } else if (max === undefined) {
-      message = `Expected at least ${min} arguments, but received ${option.values.length}.`;
-    } else {
-      message = `Expected between ${min} and ${max} arguments, but received ${option.values.length}.`;
-    }
-    throw new TranslationError(option.token, message, 1);
+    throw TranslationError.fromCode(
+      option.token,
+      CompilerOptionsCodes.WrongParameterCount,
+      option.values.length.toString(),
+      min.toString(),
+      max?.toString() ?? "",
+    );
   }
 }
 
@@ -1345,10 +1351,105 @@ translator.rule(
 translator.flag("goff", ["GOFF"], ["NOGOFF"]);
 
 /** {@link CompilerOptions.goNumber} */
+translator.rule(
+  ["GONUMBER", "GN"],
+  (option, options) => {
+    ensureArguments(option, 1, 1);
+    const value = option.values[0];
+    ensureType(value, "plain");
+    if (value.value === "SEPARATE") {
+      options.goNumber = {
+        separate: true,
+      };
+    } else if (value.value === "NOSEPARATE") {
+      options.goNumber = {
+        separate: false,
+      };
+    } else {
+      throw TranslationError.fromCode(
+        value.token,
+        CompilerOptionsCodes.gonumber.WrongParameter,
+        value.value,
+      );
+    }
+  },
+  ["NOGONUMBER", "NGN"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.goNumber = false;
+  },
+);
+
 /** {@link CompilerOptions.graphic} */
+translator.flag("graphic", ["GRAPHIC", "GR"], ["NOGRAPHIC", "NGR"]);
+
 /** {@link CompilerOptions.header} */
+translator.rule(["HEADER"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "plain");
+  const headValue = value.value.toUpperCase();
+  if (["ALL", "FILE", "FIRST", "SOURCE"].includes(headValue)) {
+    options.header = headValue as CompilerOptions.Header;
+  } else {
+    throw TranslationError.fromCode(
+      value.token,
+      CompilerOptionsCodes.header.WrongParameter,
+      value.value,
+    );
+  }
+});
+
 /** {@link CompilerOptions.hgpr} */
+translator.rule(["HGPR"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "plain");
+  const hgprValue = value.value.toUpperCase();
+  if (["PRESERVE", "NOPRESERVE"].includes(hgprValue)) {
+    options.hgpr = {
+      preserve: hgprValue === "PRESERVE",
+    };
+  } else {
+    throw TranslationError.fromCode(
+      value.token,
+      CompilerOptionsCodes.hgpr.WrongParameter,
+      value.value,
+    );
+  }
+});
+
 /** {@link CompilerOptions.ignore} */
+translator.rule(
+  ["IGNORE"],
+  (option, options) => {
+    ensureArguments(option, 1);
+    options.ignore = {
+      items: [],
+    };
+    for (const opt of option.values) {
+      ensureType(opt, "plain");
+      const ignoreValue = opt.value.toUpperCase();
+      if (["ASSERT", "DISPLAY", "PUT"].includes(ignoreValue)) {
+        options.ignore!.items!.push(
+          ignoreValue as "ASSERT" | "DISPLAY" | "PUT",
+        );
+      } else {
+        throw TranslationError.fromCode(
+          opt.token,
+          CompilerOptionsCodes.ignore.WrongParameter,
+          opt.value,
+        );
+      }
+    }
+  },
+  ["NOIGNORE"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.ignore = false;
+  },
+);
+
 /** {@link CompilerOptions.incAfter} */
 translator.rule(["INCAFTER"], (option, options) => {
   ensureArguments(option, 1, 1);
@@ -1369,6 +1470,7 @@ translator.rule(["INCAFTER"], (option, options) => {
     token: processValue.token,
   };
 });
+
 /** {@link CompilerOptions.incDir} */
 /** {@link CompilerOptions.include} */
 /** {@link CompilerOptions.incPds} */

--- a/packages/language/src/validation/messages/internal-codes.ts
+++ b/packages/language/src/validation/messages/internal-codes.ts
@@ -9,12 +9,13 @@
  *
  */
 
+import { Severity } from "../../language-server/types";
 import { ParametricPLICode } from "./pli-codes";
 
 export const Internal = {
   DiagnosticURIMismatch: {
     code: "_TB0001", // TestBuilder diagnostic code
-    severity: "E",
+    severity: Severity.E,
     message: (label: string, file: string, uri: string) =>
       `Expected diagnostic at label "${label}" to be in file "${file}" but received: ${uri}`,
     fullCode: "_TB0001E",

--- a/packages/language/src/validation/messages/pli-codes.ts
+++ b/packages/language/src/validation/messages/pli-codes.ts
@@ -15,8 +15,7 @@
  * from PL/I Messages & Codes 6.1 Documentation
  * Version 6 Release 1 (GC31-5717-00)
  **/
-
-export type Severity = "I" | "W" | "E" | "S" | "U";
+import { Severity } from "../../language-server/types";
 
 export type PLICode = SimplePLICode | ParametricPLICode;
 
@@ -78,7 +77,7 @@ export const Info = {
    */
   IBM1018I: {
     code: "IBM1018I",
-    severity: "I",
+    severity: Severity.I,
     message: (optionname: string) =>
       `${optionname} should be specified within OPTIONS, but is accepted as is.`,
     fullCode: "IBM1018II",
@@ -91,7 +90,7 @@ export const Info = {
    */
   IBM1035I: {
     code: "IBM1035I",
-    severity: "I",
+    severity: Severity.I,
     message: "The next statement was merged with this statement.",
     fullCode: "IBM1035II",
   } as SimplePLICode,
@@ -103,7 +102,7 @@ export const Info = {
    */
   IBM1036I: {
     code: "IBM1036I",
-    severity: "I",
+    severity: Severity.I,
     message: (statementcount: string) =>
       `The next ${statementcount} statements were merged with this statement.`,
     fullCode: "IBM1036II",
@@ -115,7 +114,7 @@ export const Info = {
    */
   IBM1038I: {
     code: "IBM1038I",
-    severity: "I",
+    severity: Severity.I,
     message: (note: string) => `${note}`,
     fullCode: "IBM1038II",
   } as ParametricPLICode,
@@ -127,7 +126,7 @@ export const Info = {
    */
   IBM1039I: {
     code: "IBM1039I",
-    severity: "I",
+    severity: Severity.I,
     message: (variablename: string) =>
       `Variable ${variablename} is implicitly declared.`,
     fullCode: "IBM1039II",
@@ -139,7 +138,7 @@ export const Info = {
    */
   IBM1040I: {
     code: "IBM1040I",
-    severity: "I",
+    severity: Severity.I,
     message: (note: string) => `${note}`,
     fullCode: "IBM1040II",
   } as ParametricPLICode,
@@ -151,7 +150,7 @@ export const Info = {
    */
   IBM1041I: {
     code: "IBM1041I",
-    severity: "I",
+    severity: Severity.I,
     message: (linecount: string) => `Comment spans ${linecount} lines.`,
     fullCode: "IBM1041II",
   } as ParametricPLICode,
@@ -163,7 +162,7 @@ export const Info = {
    */
   IBM1042I: {
     code: "IBM1042I",
-    severity: "I",
+    severity: Severity.I,
     message: (linecount: string) => `String spans ${linecount} lines.`,
     fullCode: "IBM1042II",
   } as ParametricPLICode,
@@ -176,7 +175,7 @@ export const Info = {
    */
   IBM1043I: {
     code: "IBM1043I",
-    severity: "I",
+    severity: Severity.I,
     message: (variablename: string, attribute: string) =>
       `${variablename} is contextually declared as ${attribute} .`,
     fullCode: "IBM1043II",
@@ -188,7 +187,7 @@ export const Info = {
    */
   IBM1044I: {
     code: "IBM1044I",
-    severity: "I",
+    severity: Severity.I,
     message: "FIXED BINARY with precision 7 or less is mapped to 1 byte.",
     fullCode: "IBM1044II",
   } as SimplePLICode,
@@ -200,7 +199,7 @@ export const Info = {
    */
   IBM1046I: {
     code: "IBM1046I",
-    severity: "I",
+    severity: Severity.I,
     message: "UNSPEC applied to an array is handled as a scalar reference.",
     fullCode: "IBM1046II",
   } as SimplePLICode,
@@ -213,7 +212,7 @@ export const Info = {
    */
   IBM1047I: {
     code: "IBM1047I",
-    severity: "I",
+    severity: Severity.I,
     message: "ORDER option may inhibit optimization.",
     fullCode: "IBM1047II",
   } as SimplePLICode,
@@ -226,7 +225,7 @@ export const Info = {
    */
   IBM1048I: {
     code: "IBM1048I",
-    severity: "I",
+    severity: Severity.I,
     message: "GET/PUT DATA without a data-list inhibits optimization.",
     fullCode: "IBM1048II",
   } as SimplePLICode,
@@ -239,7 +238,7 @@ export const Info = {
    */
   IBM1050I: {
     code: "IBM1050I",
-    severity: "I",
+    severity: Severity.I,
     message: "INITIAL attribute for RESERVED STATIC is ignored.",
     fullCode: "IBM1050II",
   } as SimplePLICode,
@@ -252,7 +251,7 @@ export const Info = {
    */
   IBM1051I: {
     code: "IBM1051I",
-    severity: "I",
+    severity: Severity.I,
     message: (BUILTINname: string) =>
       `Argument to ${BUILTINname} built-in function may not be byte aligned.`,
     fullCode: "IBM1051II",
@@ -271,7 +270,7 @@ export const Info = {
    */
   IBM1052I: {
     code: "IBM1052I",
-    severity: "I",
+    severity: Severity.I,
     message:
       "The NODESCRIPTOR attribute is accepted even though some arguments have * extents.",
     fullCode: "IBM1052II",
@@ -285,7 +284,7 @@ export const Info = {
    */
   IBM1053I: {
     code: "IBM1053I",
-    severity: "I",
+    severity: Severity.I,
     message: "Scaled FIXED operation evaluated as FIXED DECIMAL.",
     fullCode: "IBM1053II",
   } as SimplePLICode,
@@ -297,7 +296,7 @@ export const Info = {
    */
   IBM1058I: {
     code: "IBM1058I",
-    severity: "I",
+    severity: Severity.I,
     message: (sourcetype: string, targettype: string) =>
       `Conversion from ${sourcetype} to ${targettype} will be done by library call.`,
     fullCode: "IBM1058II",
@@ -309,7 +308,7 @@ export const Info = {
    */
   IBM1059I: {
     code: "IBM1059I",
-    severity: "I",
+    severity: Severity.I,
     message: "SELECT statement contains no OTHERWISE clause.",
     fullCode: "IBM1059II",
   } as SimplePLICode,
@@ -335,7 +334,7 @@ export const Info = {
    */
   IBM1060I: {
     code: "IBM1060I",
-    severity: "I",
+    severity: Severity.I,
     message: (identifier: string) =>
       `Name resolution for ${identifier} selected its declaration in a structure, rather than its non- member declaration in a parent block.`,
     fullCode: "IBM1060II",
@@ -349,7 +348,7 @@ export const Info = {
    */
   IBM1061I: {
     code: "IBM1061I",
-    severity: "I",
+    severity: Severity.I,
     message:
       "Probable DATE calculation should be examined for validity after the year 1999.",
     fullCode: "IBM1061II",
@@ -362,7 +361,7 @@ export const Info = {
    */
   IBM1062I: {
     code: "IBM1062I",
-    severity: "I",
+    severity: Severity.I,
     message: (variable: string) =>
       `${variable} inferred to contain a two- digit year.`,
     fullCode: "IBM1062II",
@@ -375,7 +374,7 @@ export const Info = {
    */
   IBM1064I: {
     code: "IBM1064I",
-    severity: "I",
+    severity: Severity.I,
     message: "Use of OPT(2) forces TEST(BLOCK).",
     fullCode: "IBM1064II",
   } as SimplePLICode,
@@ -389,7 +388,7 @@ export const Info = {
    */
   IBM1065I: {
     code: "IBM1065I",
-    severity: "I",
+    severity: Severity.I,
     message: (constant: string) =>
       `FLOAT constant ${constant} would be more precise if specified as a long FLOAT.`,
     fullCode: "IBM1065II",
@@ -408,7 +407,7 @@ export const Info = {
    */
   IBM1067I: {
     code: "IBM1067I",
-    severity: "I",
+    severity: Severity.I,
     message: "UNTIL clause ignored.",
     fullCode: "IBM1067II",
   } as SimplePLICode,
@@ -425,7 +424,7 @@ export const Info = {
    */
   IBM1068I: {
     code: "IBM1068I",
-    severity: "I",
+    severity: Severity.I,
     message:
       "PROCEDURE has no RETURNS attribute, but contains a RETURN statement. A RETURNS attribute will be assumed.",
     fullCode: "IBM1068II",
@@ -443,7 +442,7 @@ export const Info = {
    */
   IBM1069I: {
     code: "IBM1069I",
-    severity: "I",
+    severity: Severity.I,
     message:
       "The AUTOMATIC variables in a block should not be used in the prologue of that block.",
     fullCode: "IBM1069II",
@@ -457,7 +456,7 @@ export const Info = {
    */
   IBM2800I: {
     code: "IBM2800I",
-    severity: "I",
+    severity: Severity.I,
     message: (procname: string) =>
       `The PROCEDURE ${procname} is not referenced.`,
     fullCode: "IBM2800II",
@@ -471,7 +470,7 @@ export const Info = {
    */
   IBM2801I: {
     code: "IBM2801I",
-    severity: "I",
+    severity: Severity.I,
     message: (
       sourceprecision: string,
       sourcescale: string,
@@ -494,7 +493,7 @@ export const Info = {
    */
   IBM2802I: {
     code: "IBM2802I",
-    severity: "I",
+    severity: Severity.I,
     message: "Aggregate mapping will be done by library call.",
     fullCode: "IBM2802II",
   } as SimplePLICode,
@@ -506,7 +505,7 @@ export const Info = {
    */
   IBM2803I: {
     code: "IBM2803I",
-    severity: "I",
+    severity: Severity.I,
     message: (keyword: string) => `${keyword} STRING EDIT statement optimized.`,
     fullCode: "IBM2803II",
   } as ParametricPLICode,
@@ -518,7 +517,7 @@ export const Info = {
    */
   IBM2805I: {
     code: "IBM2805I",
-    severity: "I",
+    severity: Severity.I,
     message: (variablename: string, sourcetype: string, targettype: string) =>
       `For assignment to ${variablename} , conversion from ${sourcetype} to ${targettype} will be done by library call.`,
     fullCode: "IBM2805II",
@@ -531,7 +530,7 @@ export const Info = {
    */
   IBM2806I: {
     code: "IBM2806I",
-    severity: "I",
+    severity: Severity.I,
     message:
       "Passing a LABEL to another routine is poor coding practice and will cause the compiler to generate less than optimal code.",
     fullCode: "IBM2806II",
@@ -548,7 +547,7 @@ export const Info = {
    */
   IBM2809I: {
     code: "IBM2809I",
-    severity: "I",
+    severity: Severity.I,
     message: (
       sourceprecision: string,
       sourcescale: string,
@@ -566,7 +565,7 @@ export const Info = {
    */
   IBM2810I: {
     code: "IBM2810I",
-    severity: "I",
+    severity: Severity.I,
     message: (
       sourceprecision: string,
       sourcescale: string,
@@ -584,7 +583,7 @@ export const Info = {
    */
   IBM2812I: {
     code: "IBM2812I",
-    severity: "I",
+    severity: Severity.I,
     message: (argumentnumber: string, BUILTINname: string) =>
       `Argument number ${argumentnumber} to ${BUILTINname} built- in function would lead to much better code if declared with the VALUE attribute.`,
     fullCode: "IBM2812II",
@@ -599,7 +598,7 @@ export const Info = {
    */
   IBM2814I: {
     code: "IBM2814I",
-    severity: "I",
+    severity: Severity.I,
     message:
       "Aggregate mapping for storage allocation will be done by library call.",
     fullCode: "IBM2814II",
@@ -614,7 +613,7 @@ export const Info = {
    */
   IBM2815I: {
     code: "IBM2815I",
-    severity: "I",
+    severity: Severity.I,
     message: (argumentnumber: string, ENTRYname: string) =>
       `Argument number ${argumentnumber} in ENTRY reference ${ENTRYname} is not recommended to be passed BYVALUE.`,
     fullCode: "IBM2815II",
@@ -629,7 +628,7 @@ export const Info = {
    */
   IBM2816I: {
     code: "IBM2816I",
-    severity: "I",
+    severity: Severity.I,
     message:
       "BYVALUE parameters should ideally be ones that can reasonably be passed in registers.",
     fullCode: "IBM2816II",
@@ -644,7 +643,7 @@ export const Info = {
    */
   IBM2817I: {
     code: "IBM2817I",
-    severity: "I",
+    severity: Severity.I,
     message:
       "BYVALUE in RETURNS is recommended only for types that can reasonably be returned in registers.",
     fullCode: "IBM2817II",
@@ -658,7 +657,7 @@ export const Info = {
    */
   IBM2818I: {
     code: "IBM2818I",
-    severity: "I",
+    severity: Severity.I,
     message: (
       precision: string,
       scalefactor: string,
@@ -677,7 +676,7 @@ export const Info = {
    */
   IBM2819I: {
     code: "IBM2819I",
-    severity: "I",
+    severity: Severity.I,
     message: (
       precision: string,
       scalefactor: string,
@@ -696,7 +695,7 @@ export const Info = {
    */
   IBM2820I: {
     code: "IBM2820I",
-    severity: "I",
+    severity: Severity.I,
     message: (optionname: string) =>
       `The ${optionname} option is not supported on this platform.`,
     fullCode: "IBM2820II",
@@ -709,7 +708,7 @@ export const Info = {
    */
   IBM2825I: {
     code: "IBM2825I",
-    severity: "I",
+    severity: Severity.I,
     message: (sourcetype: string, targettype: string) =>
       `Conversion from ${sourcetype} to ${targettype} will be done by library call.`,
     fullCode: "IBM2825II",
@@ -722,7 +721,7 @@ export const Info = {
    */
   IBM2826I: {
     code: "IBM2826I",
-    severity: "I",
+    severity: Severity.I,
     message: (variablename: string, sourcetype: string, targettype: string) =>
       `For assignment to ${variablename} , conversion from ${sourcetype} to ${targettype} will be done by library call.`,
     fullCode: "IBM2826II",
@@ -738,7 +737,7 @@ export const Info = {
    */
   IBM2827I: {
     code: "IBM2827I",
-    severity: "I",
+    severity: Severity.I,
     message: (sourcetype: string, targettype: string) =>
       `Conversion from ${sourcetype} to ${targettype} can produce an inexact or incorrect result.`,
     fullCode: "IBM2827II",
@@ -769,7 +768,7 @@ export const Info = {
    */
   IBM2830I: {
     code: "IBM2830I",
-    severity: "I",
+    severity: Severity.I,
     message: (typename: string) =>
       `VALUE(: ${typename} :) will return an instance of the structure type that is only partially initialized.`,
     fullCode: "IBM2830II",
@@ -782,7 +781,7 @@ export const Info = {
    */
   IBM2831I: {
     code: "IBM2831I",
-    severity: "I",
+    severity: Severity.I,
     message: "ASSERT statement may never be executed.",
     fullCode: "IBM2831II",
   } as SimplePLICode,
@@ -793,7 +792,7 @@ export const Info = {
    */
   IBM2832I: {
     code: "IBM2832I",
-    severity: "I",
+    severity: Severity.I,
     message: (procedurename: string) =>
       `INLINE directive will be ignored for ${procedurename} and all other PROCEDUREs since the TEST option is on.`,
     fullCode: "IBM2832II",
@@ -805,7 +804,7 @@ export const Info = {
    */
   IBM2833I: {
     code: "IBM2833I",
-    severity: "I",
+    severity: Severity.I,
     message: (procedurename: string) =>
       `INLINE directive will be ignored for ${procedurename} since it contains ENTRY statements.`,
     fullCode: "IBM2833II",
@@ -818,7 +817,7 @@ export const Info = {
    */
   IBM2834I: {
     code: "IBM2834I",
-    severity: "I",
+    severity: Severity.I,
     message: (procedurename: string) =>
       `INLINE directive will be ignored for ${procedurename} since it contains nested PROCEDUREs and/or BEGIN blocks.`,
     fullCode: "IBM2834II",
@@ -831,7 +830,7 @@ export const Info = {
    */
   IBM2835I: {
     code: "IBM2835I",
-    severity: "I",
+    severity: Severity.I,
     message: (procedurename: string) =>
       `INLINE directive will be ignored for ${procedurename} since it has OPTIONS(NODESCRIPTOR), but has some parameters with nonconstant extents.`,
     fullCode: "IBM2835II",
@@ -844,7 +843,7 @@ export const Info = {
    */
   IBM2836I: {
     code: "IBM2836I",
-    severity: "I",
+    severity: Severity.I,
     message: (procedurename: string) =>
       `INLINE directive will be ignored for ${procedurename} since it contains labels that may be targets of out-of-block GOTOs.`,
     fullCode: "IBM2836II",
@@ -857,7 +856,7 @@ export const Info = {
    */
   IBM2837I: {
     code: "IBM2837I",
-    severity: "I",
+    severity: Severity.I,
     message: (procedurename: string) =>
       `INLINE directive will be ignored for ${procedurename} since it contains some DATA-directed I/O statements.`,
     fullCode: "IBM2837II",
@@ -870,7 +869,7 @@ export const Info = {
    */
   IBM2838I: {
     code: "IBM2838I",
-    severity: "I",
+    severity: Severity.I,
     message: (procedurename: string) =>
       `INLINE directive will be ignored for ${procedurename} since it has non-default condition enablement.`,
     fullCode: "IBM2838II",
@@ -882,7 +881,7 @@ export const Info = {
    */
   IBM2839I: {
     code: "IBM2839I",
-    severity: "I",
+    severity: Severity.I,
     message: (procedurename: string) =>
       `INLINE directive will be ignored for ${procedurename} since it contains ON-units.`,
     fullCode: "IBM2839II",
@@ -918,7 +917,7 @@ export const Info = {
    */
   IBM2840I: {
     code: "IBM2840I",
-    severity: "I",
+    severity: Severity.I,
     message:
       "If TRANSLATE is being used to reformat a date-time value, it would be better to use the REPATTERN or DATETIME built-in function instead.",
     fullCode: "IBM2840II",
@@ -930,7 +929,7 @@ export const Info = {
    */
   IBM2841I: {
     code: "IBM2841I",
-    severity: "I",
+    severity: Severity.I,
     message:
       "Changing MEMCONVERT(p,n,1200,q,m,1208 ) to MEMCU12(p,n,q,m) would be better for performance.",
     fullCode: "IBM2841II",
@@ -942,7 +941,7 @@ export const Info = {
    */
   IBM2842I: {
     code: "IBM2842I",
-    severity: "I",
+    severity: Severity.I,
     message:
       "Changing MEMCONVERT(p,n,1208,q,m,1200 ) to MEMCU21(p,n,q,m) would be better for performance.",
     fullCode: "IBM2842II",
@@ -955,7 +954,7 @@ export const Info = {
    */
   IBM2844I: {
     code: "IBM2844I",
-    severity: "I",
+    severity: Severity.I,
     message: (characters: string) =>
       `The characters ${characters} will be accepted as two separate characters. It would be better to separate these characters with a blank.`,
     fullCode: "IBM2844II",
@@ -968,7 +967,7 @@ export const Info = {
    */
   IBM2845I: {
     code: "IBM2845I",
-    severity: "I",
+    severity: Severity.I,
     message: (characters: string) =>
       `The characters ${characters} will be accepted as two separate characters. It would be better to separate these characters with a blank.`,
     fullCode: "IBM2845II",
@@ -981,7 +980,7 @@ export const Info = {
    */
   IBM2846I: {
     code: "IBM2846I",
-    severity: "I",
+    severity: Severity.I,
     message:
       "It would be better to convert nested PROCEDUREs in a PACKAGE into sister nonnested PROCEDUREs.",
     fullCode: "IBM2846II",
@@ -1003,7 +1002,7 @@ export const Info = {
    */
   IBM2847I: {
     code: "IBM2847I",
-    severity: "I",
+    severity: Severity.I,
     message: (returnlength: string, returnslength: string) =>
       `Source in RETURN statement has a MAXLENGTH of ${returnlength} which is greater than the length of ${returnslength} in the corresponding RETURNS attribute.`,
     fullCode: "IBM2847II",
@@ -1016,7 +1015,7 @@ export const Info = {
    */
   IBM2848I: {
     code: "IBM2848I",
-    severity: "I",
+    severity: Severity.I,
     message: (
       xprecision: string,
       xscale: string,
@@ -1040,7 +1039,7 @@ export const Info = {
    */
   IBM2851I: {
     code: "IBM2851I",
-    severity: "I",
+    severity: Severity.I,
     message:
       "CEIL will be evaluated by computing the integral quotient and if the quotient is nonnegative, rounding it up by one if the remainder is non-zero.",
     fullCode: "IBM2851II",
@@ -1057,7 +1056,7 @@ export const Info = {
    */
   IBM2852I: {
     code: "IBM2852I",
-    severity: "I",
+    severity: Severity.I,
     message:
       "FLOOR will be evaluated by computing the integral quotient and if the quotient is not positive, rounding it down by one if the remainder is non-zero.",
     fullCode: "IBM2852II",
@@ -1070,7 +1069,7 @@ export const Info = {
    */
   IBM3000I: {
     code: "IBM3000I",
-    severity: "I",
+    severity: Severity.I,
     message: (note: string) => `${note}`,
     fullCode: "IBM3000II",
   } as ParametricPLICode,
@@ -1083,7 +1082,7 @@ export const Info = {
    */
   IBM3019I: {
     code: "IBM3019I",
-    severity: "I",
+    severity: Severity.I,
     message: "Program contains no EXEC SQL statements requiring translation.",
     fullCode: "IBM3019II",
   } as SimplePLICode,
@@ -1095,7 +1094,7 @@ export const Info = {
    */
   IBM3020I: {
     code: "IBM3020I",
-    severity: "I",
+    severity: Severity.I,
     message: (linecount: string) => `Comment spans ${linecount} lines.`,
     fullCode: "IBM3020II",
   } as ParametricPLICode,
@@ -1107,7 +1106,7 @@ export const Info = {
    */
   IBM3021I: {
     code: "IBM3021I",
-    severity: "I",
+    severity: Severity.I,
     message: (linecount: string) => `String spans ${linecount} lines.`,
     fullCode: "IBM3021II",
   } as ParametricPLICode,
@@ -1118,7 +1117,7 @@ export const Info = {
    */
   IBM3024I: {
     code: "IBM3024I",
-    severity: "I",
+    severity: Severity.I,
     message: (note: string) => `${note}`,
     fullCode: "IBM3024II",
   } as ParametricPLICode,
@@ -1132,7 +1131,7 @@ export const Warning = {
    */
   IBM1078I: {
     code: "IBM1078I",
-    severity: "W",
+    severity: Severity.W,
     message: "Statement may never be executed.",
     fullCode: "IBM1078IW",
   } as SimplePLICode,
@@ -1144,7 +1143,7 @@ export const Warning = {
    */
   IBM1079I: {
     code: "IBM1079I",
-    severity: "W",
+    severity: Severity.W,
     message: (ENTRYname: string) =>
       `Too few arguments have been specified for the ENTRY ${ENTRYname} .`,
     fullCode: "IBM1079IW",
@@ -1165,7 +1164,7 @@ export const Warning = {
    */
   IBM1080I: {
     code: "IBM1080I",
-    severity: "W",
+    severity: Severity.W,
     message: (labelname: string) =>
       `The keyword ${labelname} , which could form a complete statement, is accepted as a label name, but a colon may have been used where a semicolon was meant.`,
     fullCode: "IBM1080IW",
@@ -1184,7 +1183,7 @@ export const Warning = {
    */
   IBM1081I: {
     code: "IBM1081I",
-    severity: "W",
+    severity: Severity.W,
     message: (keyword: string) =>
       `${keyword} expression should be scalar. Lower bounds assumed for any missing subscripts.`,
     fullCode: "IBM1081IW",
@@ -1204,7 +1203,7 @@ export const Warning = {
    */
   IBM1082I: {
     code: "IBM1082I",
-    severity: "W",
+    severity: Severity.W,
     message: (argumentnumber: string, entryname: string) =>
       `Argument number ${argumentnumber} in ENTRY reference ${entryname} is a scalar, but its declare specifies a structure.`,
     fullCode: "IBM1082IW",
@@ -1219,7 +1218,7 @@ export const Warning = {
    */
   IBM1083I: {
     code: "IBM1083I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "Source in label assignment is inside a DO-loop, and an illegal jump into the loop may be attempted. Optimization will also be very inhibited.",
     fullCode: "IBM1083IW",
@@ -1232,7 +1231,7 @@ export const Warning = {
    */
   IBM1084I: {
     code: "IBM1084I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "Nonblanks after right margin are not allowed under RULES(NOLAXMARGINS).",
     fullCode: "IBM1084IW",
@@ -1245,7 +1244,7 @@ export const Warning = {
    */
   IBM1085I: {
     code: "IBM1085I",
-    severity: "W",
+    severity: Severity.W,
     message: (variable: string) => `${variable} may be unset when used.`,
     fullCode: "IBM1085IW",
   } as ParametricPLICode,
@@ -1258,7 +1257,7 @@ export const Warning = {
    */
   IBM1086I: {
     code: "IBM1086I",
-    severity: "W",
+    severity: Severity.W,
     message: (builtinfunction: string) =>
       `${builtinfunction} will be evaluated using long rather than extended routines.`,
     fullCode: "IBM1086IW",
@@ -1272,7 +1271,7 @@ export const Warning = {
    */
   IBM1087I: {
     code: "IBM1087I",
-    severity: "W",
+    severity: Severity.W,
     message: (assumedvalue: string) =>
       `FLOAT source is too big for its target. An appropriate HUGE value of ${assumedvalue} is assumed.`,
     fullCode: "IBM1087IW",
@@ -1286,7 +1285,7 @@ export const Warning = {
    */
   IBM1088I: {
     code: "IBM1088I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "FLOAT literal is too big for its implicit precision. The E in the exponent will be replaced by a D.",
     fullCode: "IBM1088IW",
@@ -1312,7 +1311,7 @@ export const Warning = {
    */
   IBM1089I: {
     code: "IBM1089I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "Control variable in DO loop cannot exceed TO value, and loop may be infinite.",
     fullCode: "IBM1089IW",
@@ -1331,7 +1330,7 @@ export const Warning = {
    */
   IBM1090I: {
     code: "IBM1090I",
-    severity: "W",
+    severity: Severity.W,
     message: "Constant used as locator qualifier.",
     fullCode: "IBM1090IW",
   } as SimplePLICode,
@@ -1345,7 +1344,7 @@ export const Warning = {
    */
   IBM1091I: {
     code: "IBM1091I",
-    severity: "W",
+    severity: Severity.W,
     message: "FIXED BIN precision less than storage allows.",
     fullCode: "IBM1091IW",
   } as SimplePLICode,
@@ -1357,7 +1356,7 @@ export const Warning = {
    */
   IBM1092I: {
     code: "IBM1092I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "GOTO whose target is or may be in another block severely limits optimization.",
     fullCode: "IBM1092IW",
@@ -1370,7 +1369,7 @@ export const Warning = {
    */
   IBM1093I: {
     code: "IBM1093I",
-    severity: "W",
+    severity: Severity.W,
     message: (messagenumber: string) =>
       `PLIXOPT string is invalid. See related runtime message ${messagenumber} .`,
     fullCode: "IBM1093IW",
@@ -1383,7 +1382,7 @@ export const Warning = {
    */
   IBM1094I: {
     code: "IBM1094I",
-    severity: "W",
+    severity: Severity.W,
     message: (option: string, messagenumber: string) =>
       `Element ${option} in PLIXOPT is invalid. See related runtime message ${messagenumber} .`,
     fullCode: "IBM1094IW",
@@ -1396,7 +1395,7 @@ export const Warning = {
    */
   IBM1095I: {
     code: "IBM1095I",
-    severity: "W",
+    severity: Severity.W,
     message: (option: string, option2: string, messagenumber: string) =>
       `Element ${option} in PLIXOPT has been remapped to ${option2} . See related runtime message ${messagenumber} .`,
     fullCode: "IBM1095IW",
@@ -1411,7 +1410,7 @@ export const Warning = {
    */
   IBM1096I: {
     code: "IBM1096I",
-    severity: "W",
+    severity: Severity.W,
     message: (messagenumber: string) =>
       `STAE and SPIE in PLIXOPT is not supported. See related runtime message ${messagenumber} .`,
     fullCode: "IBM1096IW",
@@ -1429,7 +1428,7 @@ export const Warning = {
    */
   IBM1097I: {
     code: "IBM1097I",
-    severity: "W",
+    severity: Severity.W,
     message: (argumentnumber: string, ENTRYname: string) =>
       `Scalar accepted as argument number ${argumentnumber} in ENTRY reference ${ENTRYname} although parameter description specifies an array.`,
     fullCode: "IBM1097IW",
@@ -1446,7 +1445,7 @@ export const Warning = {
    */
   IBM1098I: {
     code: "IBM1098I",
-    severity: "W",
+    severity: Severity.W,
     message: "Extraneous comma at end of statement ignored.",
     fullCode: "IBM1098IW",
   } as SimplePLICode,
@@ -1475,7 +1474,7 @@ export const Warning = {
    */
   IBM1099I: {
     code: "IBM1099I",
-    severity: "W",
+    severity: Severity.W,
     message: (
       sourceprecision: string,
       sourcescale: string,
@@ -1496,7 +1495,7 @@ export const Warning = {
    */
   IBM1100I: {
     code: "IBM1100I",
-    severity: "W",
+    severity: Severity.W,
     message: (attributeoption: string) =>
       `The attribute ${attributeoption} is not valid on BEGIN blocks and is ignored.`,
     fullCode: "IBM1100IW",
@@ -1512,7 +1511,7 @@ export const Warning = {
    */
   IBM1101I: {
     code: "IBM1101I",
-    severity: "W",
+    severity: Severity.W,
     message: (optionname: string) =>
       `${optionname} is not a known PROCEDURE attribute and is ignored.`,
     fullCode: "IBM1101IW",
@@ -1528,7 +1527,7 @@ export const Warning = {
    */
   IBM1102I: {
     code: "IBM1102I",
-    severity: "W",
+    severity: Severity.W,
     message: (optionname: string) =>
       `${optionname} is not a known BEGIN attribute and is ignored.`,
     fullCode: "IBM1102IW",
@@ -1543,7 +1542,7 @@ export const Warning = {
    */
   IBM1103I: {
     code: "IBM1103I",
-    severity: "W",
+    severity: Severity.W,
     message: (optionname: string) =>
       `${optionname} is not a supported compiler option and is ignored.`,
     fullCode: "IBM1103IW",
@@ -1558,7 +1557,7 @@ export const Warning = {
    */
   IBM1104I: {
     code: "IBM1104I",
-    severity: "W",
+    severity: Severity.W,
     message: (optionname: string) =>
       `Suboptions of the compiler option ${optionname} are not supported and are ignored.`,
     fullCode: "IBM1104IW",
@@ -1574,7 +1573,7 @@ export const Warning = {
    */
   IBM1105I: {
     code: "IBM1105I",
-    severity: "W",
+    severity: Severity.W,
     message: (optionname: string, numberofletters: string) =>
       `A suboption of the compiler option ${optionname} is too long. It is shortened to length ${numberofletters} .`,
     fullCode: "IBM1105IW",
@@ -1590,7 +1589,7 @@ export const Warning = {
    */
   IBM1106I: {
     code: "IBM1106I",
-    severity: "W",
+    severity: Severity.W,
     message: (keyword: string) =>
       `Condition prefixes on ${keyword} statements are ignored.`,
     fullCode: "IBM1106IW",
@@ -1606,7 +1605,7 @@ export const Warning = {
    */
   IBM1107I: {
     code: "IBM1107I",
-    severity: "W",
+    severity: Severity.W,
     message: (optionname: string) =>
       `${optionname} is not a known ENTRY statement attribute and is ignored.`,
     fullCode: "IBM1107IW",
@@ -1623,7 +1622,7 @@ export const Warning = {
    */
   IBM1108I: {
     code: "IBM1108I",
-    severity: "W",
+    severity: Severity.W,
     message: (char: string, option: string) =>
       `The character ${char} specified in the ${option} option is already defined and may not be redefined. The redefinition will be ignored.`,
     fullCode: "IBM1108IW",
@@ -1639,7 +1638,7 @@ export const Warning = {
    */
   IBM1109I: {
     code: "IBM1109I",
-    severity: "W",
+    severity: Severity.W,
     message: "The second argument in the C- format item will be ignored.",
     fullCode: "IBM1109IW",
   } as SimplePLICode,
@@ -1653,7 +1652,7 @@ export const Warning = {
    */
   IBM1110I: {
     code: "IBM1110I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "The INCLUDE statement should be on a line by itself. The source on the line after the INCLUDE statement is ignored.",
     fullCode: "IBM1110IW",
@@ -1668,7 +1667,7 @@ export const Warning = {
    */
   IBM1111I: {
     code: "IBM1111I",
-    severity: "W",
+    severity: Severity.W,
     message: "CHECK prefix is not supported and is ignored.",
     fullCode: "IBM1111IW",
   } as SimplePLICode,
@@ -1682,7 +1681,7 @@ export const Warning = {
    */
   IBM1112I: {
     code: "IBM1112I",
-    severity: "W",
+    severity: Severity.W,
     message: (conditionname: string) =>
       `${conditionname} condition is not supported and is ignored.`,
     fullCode: "IBM1112IW",
@@ -1695,7 +1694,7 @@ export const Warning = {
    */
   IBM1113I: {
     code: "IBM1113I",
-    severity: "W",
+    severity: Severity.W,
     message: (verbname: string) =>
       `${verbname} statement is not supported and is ignored.`,
     fullCode: "IBM1113IW",
@@ -1709,7 +1708,7 @@ export const Warning = {
    */
   IBM1114I: {
     code: "IBM1114I",
-    severity: "W",
+    severity: Severity.W,
     message: "Comparands are both constant.",
     fullCode: "IBM1114IW",
   } as SimplePLICode,
@@ -1724,7 +1723,7 @@ export const Warning = {
    */
   IBM1115I: {
     code: "IBM1115I",
-    severity: "W",
+    severity: Severity.W,
     message: (count: string, variablename: string, arraysize: string) =>
       `INITIAL list contains ${count} items, but the array ${variablename} contains only ${arraysize} . Excess is ignored.`,
     fullCode: "IBM1115IW",
@@ -1737,7 +1736,7 @@ export const Warning = {
    */
   IBM1116I: {
     code: "IBM1116I",
-    severity: "W",
+    severity: Severity.W,
     message: "Comment spans more than one file.",
     fullCode: "IBM1116IW",
   } as SimplePLICode,
@@ -1749,7 +1748,7 @@ export const Warning = {
    */
   IBM1117I: {
     code: "IBM1117I",
-    severity: "W",
+    severity: Severity.W,
     message: "String spans more than one file.",
     fullCode: "IBM1117IW",
   } as SimplePLICode,
@@ -1764,7 +1763,7 @@ export const Warning = {
    */
   IBM1118I: {
     code: "IBM1118I",
-    severity: "W",
+    severity: Severity.W,
     message: (nondelimiter: string, nondelimiter2: string) =>
       `Delimiter missing between ${nondelimiter} and ${nondelimiter2} . A blank is assumed.`,
     fullCode: "IBM1118IW",
@@ -1777,7 +1776,7 @@ export const Warning = {
    */
   IBM1119I: {
     code: "IBM1119I",
-    severity: "W",
+    severity: Severity.W,
     message: (name: string) =>
       `Code generated for DO group would be more efficient if control variable ${name} were not an aggregate member.`,
     fullCode: "IBM1119IW",
@@ -1790,7 +1789,7 @@ export const Warning = {
    */
   IBM1120I: {
     code: "IBM1120I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "Multiple closure of groups. END statements will be inserted to close intervening groups.",
     fullCode: "IBM1120IW",
@@ -1804,7 +1803,7 @@ export const Warning = {
    */
   IBM1121I: {
     code: "IBM1121I",
-    severity: "W",
+    severity: Severity.W,
     message: (character: string) => `Missing ${character} assumed.`,
     fullCode: "IBM1121IW",
   } as ParametricPLICode,
@@ -1819,7 +1818,7 @@ export const Warning = {
    */
   IBM1122I: {
     code: "IBM1122I",
-    severity: "W",
+    severity: Severity.W,
     message: (character: string, character2: string) =>
       `Missing ${character} assumed before ${character2} .`,
     fullCode: "IBM1122IW",
@@ -1834,7 +1833,7 @@ export const Warning = {
    */
   IBM1123I: {
     code: "IBM1123I",
-    severity: "W",
+    severity: Severity.W,
     message: (optionname: string, optionname2: string) =>
       `The ENVIRONMENT option ${optionname} has been specified without a suboption. The option ${optionname2} is ignored.`,
     fullCode: "IBM1123IW",
@@ -1850,7 +1849,7 @@ export const Warning = {
    */
   IBM1124I: {
     code: "IBM1124I",
-    severity: "W",
+    severity: Severity.W,
     message: (optionname: string) =>
       `A suboption has been specified for the ENVIRONMENT option ${optionname} . The suboption will be ignored.`,
     fullCode: "IBM1124IW",
@@ -1865,7 +1864,7 @@ export const Warning = {
    */
   IBM1125I: {
     code: "IBM1125I",
-    severity: "W",
+    severity: Severity.W,
     message: (optionname: string) =>
       `The ENVIRONMENT option ${optionname} has been specified more than once.`,
     fullCode: "IBM1125IW",
@@ -1880,7 +1879,7 @@ export const Warning = {
    */
   IBM1126I: {
     code: "IBM1126I",
-    severity: "W",
+    severity: Severity.W,
     message: (optionname: string) =>
       `The ENVIRONMENT option ${optionname} has an invalid suboption. The option will be ignored.`,
     fullCode: "IBM1126IW",
@@ -1895,7 +1894,7 @@ export const Warning = {
    */
   IBM1127I: {
     code: "IBM1127I",
-    severity: "W",
+    severity: Severity.W,
     message: (optionname: string) =>
       `${optionname} is not a known ENVIRONMENT option. It will be ignored.`,
     fullCode: "IBM1127IW",
@@ -1910,7 +1909,7 @@ export const Warning = {
    */
   IBM1128I: {
     code: "IBM1128I",
-    severity: "W",
+    severity: Severity.W,
     message: (optionname: string) =>
       `The ENVIRONMENT option ${optionname} conflicts with the LANGLVL compiler option. The option will be ignored.`,
     fullCode: "IBM1128IW",
@@ -1926,7 +1925,7 @@ export const Warning = {
    */
   IBM1129I: {
     code: "IBM1129I",
-    severity: "W",
+    severity: Severity.W,
     message: (verbname: string, processorname: string) =>
       `${verbname} ${processorname} statement ignored up to closing semicolon.`,
     fullCode: "IBM1129IW",
@@ -1943,7 +1942,7 @@ export const Warning = {
    */
   IBM1130I: {
     code: "IBM1130I",
-    severity: "W",
+    severity: Severity.W,
     message: (identifier: string, identifier2: string) =>
       `The external name ${identifier} is too long. It will be shortened to ${identifier2} .`,
     fullCode: "IBM1130IW",
@@ -1960,7 +1959,7 @@ export const Warning = {
    */
   IBM1131I: {
     code: "IBM1131I",
-    severity: "W",
+    severity: Severity.W,
     message: (name: string) =>
       `An EXTERNAL name specification for ${name} has been specified on its PROCEDURE statement and in the EXPORTS clause of the PACKAGE statement. The EXPORTS specification will be used.`,
     fullCode: "IBM1131IW",
@@ -1977,7 +1976,7 @@ export const Warning = {
    */
   IBM1132I: {
     code: "IBM1132I",
-    severity: "W",
+    severity: Severity.W,
     message: (name: string) =>
       `An EXTERNAL name specification for ${name} has been specified in its declaration and in the RESERVES clause of the PACKAGE statement. The RESERVES specification will be used.`,
     fullCode: "IBM1132IW",
@@ -1994,7 +1993,7 @@ export const Warning = {
    */
   IBM1133I: {
     code: "IBM1133I",
-    severity: "W",
+    severity: Severity.W,
     message: (labelname: string) =>
       `The FORMAT CONSTANT array ${labelname} is not fully initialized.`,
     fullCode: "IBM1133IW",
@@ -2011,7 +2010,7 @@ export const Warning = {
    */
   IBM1134I: {
     code: "IBM1134I",
-    severity: "W",
+    severity: Severity.W,
     message: (labelreference: string) =>
       `The LABEL CONSTANT array ${labelreference} is not fully initialized.`,
     fullCode: "IBM1134IW",
@@ -2029,7 +2028,7 @@ export const Warning = {
    */
   IBM1135I: {
     code: "IBM1135I",
-    severity: "W",
+    severity: Severity.W,
     message: "Logical operand is constant.",
     fullCode: "IBM1135IW",
   } as SimplePLICode,
@@ -2043,7 +2042,7 @@ export const Warning = {
    */
   IBM1136I: {
     code: "IBM1136I",
-    severity: "W",
+    severity: Severity.W,
     message: "Function invoked as a subroutine.",
     fullCode: "IBM1136IW",
   } as SimplePLICode,
@@ -2058,7 +2057,7 @@ export const Warning = {
    */
   IBM1137I: {
     code: "IBM1137I",
-    severity: "W",
+    severity: Severity.W,
     message: (attribute: string) =>
       `The attribute ${attribute} is invalid in GENERIC descriptions and will be ignored.`,
     fullCode: "IBM1137IW",
@@ -2076,7 +2075,7 @@ export const Warning = {
    */
   IBM1138I: {
     code: "IBM1138I",
-    severity: "W",
+    severity: Severity.W,
     message: (count: string, variablename: string, arraysize: string) =>
       `Number of items in INITIAL list is ${count} for the array ${variablename} which contains ${arraysize} elements.`,
     fullCode: "IBM1138IW",
@@ -2089,7 +2088,7 @@ export const Warning = {
    */
   IBM1139I: {
     code: "IBM1139I",
-    severity: "W",
+    severity: Severity.W,
     message: "Syntax of the CONTROL statement is incorrect.",
     fullCode: "IBM1139IW",
   } as SimplePLICode,
@@ -2101,7 +2100,7 @@ export const Warning = {
    */
   IBM1140I: {
     code: "IBM1140I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "Syntax of the LANGLVL option in the OPTION statement is incorrect.",
     fullCode: "IBM1140IW",
@@ -2114,7 +2113,7 @@ export const Warning = {
    */
   IBM1141I: {
     code: "IBM1141I",
-    severity: "W",
+    severity: Severity.W,
     message: "Syntax of the NOPRINT statement is incorrect.",
     fullCode: "IBM1141IW",
   } as SimplePLICode,
@@ -2126,7 +2125,7 @@ export const Warning = {
    */
   IBM1142I: {
     code: "IBM1142I",
-    severity: "W",
+    severity: Severity.W,
     message: "Syntax of the PAGE statement is incorrect.",
     fullCode: "IBM1142IW",
   } as SimplePLICode,
@@ -2138,7 +2137,7 @@ export const Warning = {
    */
   IBM1143I: {
     code: "IBM1143I",
-    severity: "W",
+    severity: Severity.W,
     message: "Syntax of the PRINT statement is incorrect.",
     fullCode: "IBM1143IW",
   } as SimplePLICode,
@@ -2152,7 +2151,7 @@ export const Warning = {
    */
   IBM1144I: {
     code: "IBM1144I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "Number of lines specified with SKIP must be between 0 and 999 inclusive.",
     fullCode: "IBM1144IW",
@@ -2165,7 +2164,7 @@ export const Warning = {
    */
   IBM1145I: {
     code: "IBM1145I",
-    severity: "W",
+    severity: Severity.W,
     message: "Syntax of the SKIP statement is incorrect.",
     fullCode: "IBM1145IW",
   } as SimplePLICode,
@@ -2177,7 +2176,7 @@ export const Warning = {
    */
   IBM1146I: {
     code: "IBM1146I",
-    severity: "W",
+    severity: Severity.W,
     message: "Syntax of the TEST option in the OPTION statement is incorrect.",
     fullCode: "IBM1146IW",
   } as SimplePLICode,
@@ -2189,7 +2188,7 @@ export const Warning = {
    */
   IBM1147I: {
     code: "IBM1147I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "Syntax of the NOTEST option in the OPTION statement is incorrect.",
     fullCode: "IBM1147IW",
@@ -2202,7 +2201,7 @@ export const Warning = {
    */
   IBM1148I: {
     code: "IBM1148I",
-    severity: "W",
+    severity: Severity.W,
     message: "Syntax of the PUSH statement is incorrect.",
     fullCode: "IBM1148IW",
   } as SimplePLICode,
@@ -2214,7 +2213,7 @@ export const Warning = {
    */
   IBM1149I: {
     code: "IBM1149I",
-    severity: "W",
+    severity: Severity.W,
     message: "Syntax of the POP statement is incorrect.",
     fullCode: "IBM1149IW",
   } as SimplePLICode,
@@ -2226,7 +2225,7 @@ export const Warning = {
    */
   IBM1150I: {
     code: "IBM1150I",
-    severity: "W",
+    severity: Severity.W,
     message: "Syntax of the NOTE statement is incorrect.",
     fullCode: "IBM1150IW",
   } as SimplePLICode,
@@ -2237,7 +2236,7 @@ export const Warning = {
    */
   IBM1151I: {
     code: "IBM1151I",
-    severity: "W",
+    severity: Severity.W,
     message: (maximumvalue: string) =>
       `FIXED BINARY precision is reduced to ${maximumvalue} .`,
     fullCode: "IBM1151IW",
@@ -2249,7 +2248,7 @@ export const Warning = {
    */
   IBM1152I: {
     code: "IBM1152I",
-    severity: "W",
+    severity: Severity.W,
     message: (maximumvalue: string) =>
       `FIXED DECIMAL precision is reduced to ${maximumvalue} .`,
     fullCode: "IBM1152IW",
@@ -2261,7 +2260,7 @@ export const Warning = {
    */
   IBM1153I: {
     code: "IBM1153I",
-    severity: "W",
+    severity: Severity.W,
     message: (maximumvalue: string) =>
       `FLOAT BINARY precision is reduced to ${maximumvalue} .`,
     fullCode: "IBM1153IW",
@@ -2274,7 +2273,7 @@ export const Warning = {
    */
   IBM1154I: {
     code: "IBM1154I",
-    severity: "W",
+    severity: Severity.W,
     message: (maximumvalue: string) =>
       `FLOAT DECIMAL precision is reduced to ${maximumvalue} .`,
     fullCode: "IBM1154IW",
@@ -2294,7 +2293,7 @@ export const Warning = {
    */
   IBM1155I: {
     code: "IBM1155I",
-    severity: "W",
+    severity: Severity.W,
     message: (aggregatename: string) =>
       `The aggregate ${aggregatename} contains noncomputational values. Those values will be ignored.`,
     fullCode: "IBM1155IW",
@@ -2307,7 +2306,7 @@ export const Warning = {
    */
   IBM1156I: {
     code: "IBM1156I",
-    severity: "W",
+    severity: Severity.W,
     message: "Arguments to MAIN PROCEDURE are not all POINTER.",
     fullCode: "IBM1156IW",
   } as SimplePLICode,
@@ -2318,7 +2317,7 @@ export const Warning = {
    */
   IBM1157I: {
     code: "IBM1157I",
-    severity: "W",
+    severity: Severity.W,
     message: (note: string) => `${note}`,
     fullCode: "IBM1157IW",
   } as ParametricPLICode,
@@ -2330,7 +2329,7 @@ export const Warning = {
    */
   IBM1158I: {
     code: "IBM1158I",
-    severity: "W",
+    severity: Severity.W,
     message: (option: string, option2: string) =>
       `A ${option} is missing in the specification of the ${option2} option. One is assumed.`,
     fullCode: "IBM1158IW",
@@ -2342,7 +2341,7 @@ export const Warning = {
    */
   IBM1159I: {
     code: "IBM1159I",
-    severity: "W",
+    severity: Severity.W,
     message: (option: string) =>
       `The string ${option} is not recognized as a valid option keyword and is ignored.`,
     fullCode: "IBM1159IW",
@@ -2354,7 +2353,7 @@ export const Warning = {
    */
   IBM1160I: {
     code: "IBM1160I",
-    severity: "W",
+    severity: Severity.W,
     message: "The third argument to the MARGINS option is not supported.",
     fullCode: "IBM1160IW",
   } as SimplePLICode,
@@ -2369,7 +2368,7 @@ export const Warning = {
    */
   IBM1161I: {
     code: "IBM1161I",
-    severity: "W",
+    severity: Severity.W,
     message: (suboption: string, option: string) =>
       `The suboption ${suboption} is not valid for the ${option} compiler option.`,
     fullCode: "IBM1161IW",
@@ -2384,7 +2383,7 @@ export const Warning = {
    */
   IBM1162I: {
     code: "IBM1162I",
-    severity: "W",
+    severity: Severity.W,
     message: (suboption: string) =>
       `A required suboption is missing for the ${suboption} option.`,
     fullCode: "IBM1162IW",
@@ -2399,7 +2398,7 @@ export const Warning = {
    */
   IBM1163I: {
     code: "IBM1163I",
-    severity: "W",
+    severity: Severity.W,
     message: (option: string) =>
       `Required sub-fields are missing for the ${option} option. Default values are assumed.`,
     fullCode: "IBM1163IW",
@@ -2413,7 +2412,7 @@ export const Warning = {
    */
   IBM1164I: {
     code: "IBM1164I",
-    severity: "W",
+    severity: Severity.W,
     message: (optionname: string) =>
       `${optionname} should be specified within OPTIONS, but is accepted as is.`,
     fullCode: "IBM1164IW",
@@ -2425,7 +2424,7 @@ export const Warning = {
    */
   IBM1165I: {
     code: "IBM1165I",
-    severity: "W",
+    severity: Severity.W,
     message: (optionname: string) =>
       `The OPTIONS option ${optionname} has been specified more than once.`,
     fullCode: "IBM1165IW",
@@ -2438,7 +2437,7 @@ export const Warning = {
    */
   IBM1166I: {
     code: "IBM1166I",
-    severity: "W",
+    severity: Severity.W,
     message: (suboptionname: string, optionname: string, optionname2: string) =>
       `${suboptionname} is not a known ${optionname} suboption. The ${optionname2} option will be ignored.`,
     fullCode: "IBM1166IW",
@@ -2450,7 +2449,7 @@ export const Warning = {
    */
   IBM1167I: {
     code: "IBM1167I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "Maximum number of PUSH statements exceeded. The control statement is ignored.",
     fullCode: "IBM1167IW",
@@ -2462,7 +2461,7 @@ export const Warning = {
    */
   IBM1168I: {
     code: "IBM1168I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "No PUSH statements are in effect. The POP control statement is ignored.",
     fullCode: "IBM1168IW",
@@ -2477,7 +2476,7 @@ export const Warning = {
    */
   IBM1169I: {
     code: "IBM1169I",
-    severity: "W",
+    severity: Severity.W,
     message: (builtinname: string) =>
       `No precision was specified for the result of the ${builtinname} built- in function. The precision will be determined from the argument.`,
     fullCode: "IBM1169IW",
@@ -2492,7 +2491,7 @@ export const Warning = {
    */
   IBM1170I: {
     code: "IBM1170I",
-    severity: "W",
+    severity: Severity.W,
     message: (optionattribute: string) =>
       `The OPTIONS attribute ${optionattribute} is not supported and is ignored.`,
     fullCode: "IBM1170IW",
@@ -2505,7 +2504,7 @@ export const Warning = {
    */
   IBM1171I: {
     code: "IBM1171I",
-    severity: "W",
+    severity: Severity.W,
     message: "SELECT statement contains no WHEN or OTHERWISE clauses.",
     fullCode: "IBM1171IW",
   } as SimplePLICode,
@@ -2519,7 +2518,7 @@ export const Warning = {
    */
   IBM1172I: {
     code: "IBM1172I",
-    severity: "W",
+    severity: Severity.W,
     message: (optionname: string) =>
       `A zero length string has been entered for the ${optionname} option. The option is ignored.`,
     fullCode: "IBM1172IW",
@@ -2532,7 +2531,7 @@ export const Warning = {
    */
   IBM1173I: {
     code: "IBM1173I",
-    severity: "W",
+    severity: Severity.W,
     message: "SELECT statement contains no WHEN clauses.",
     fullCode: "IBM1173IW",
   } as SimplePLICode,
@@ -2544,7 +2543,7 @@ export const Warning = {
    */
   IBM1174I: {
     code: "IBM1174I",
-    severity: "W",
+    severity: Severity.W,
     message: (fromintoclause: string) =>
       `The reference in the ${fromintoclause} clause may not be byte- aligned.`,
     fullCode: "IBM1174IW",
@@ -2557,7 +2556,7 @@ export const Warning = {
    */
   IBM1175I: {
     code: "IBM1175I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "FIXED BINARY constant contains too many digits. Excess nonsignificant digits will be ignored.",
     fullCode: "IBM1175IW",
@@ -2570,7 +2569,7 @@ export const Warning = {
    */
   IBM1176I: {
     code: "IBM1176I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "FIXED DECIMAL constant contains too many digits. Excess nonsignificant digits will be ignored.",
     fullCode: "IBM1176IW",
@@ -2583,7 +2582,7 @@ export const Warning = {
    */
   IBM1177I: {
     code: "IBM1177I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "Mantissa in FLOAT BINARY constant contains more digits than the implementation maximum. Excess nonsignificant digits will be ignored.",
     fullCode: "IBM1177IW",
@@ -2596,7 +2595,7 @@ export const Warning = {
    */
   IBM1178I: {
     code: "IBM1178I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "Mantissa in FLOAT DECIMAL constant contains more digits than the implementation maximum. Excess nonsignificant digits will be ignored.",
     fullCode: "IBM1178IW",
@@ -2610,7 +2609,7 @@ export const Warning = {
    */
   IBM1179I: {
     code: "IBM1179I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "FLOAT literal is too big for its implicit precision. An appropriate HUGE value is assumed.",
     fullCode: "IBM1179IW",
@@ -2624,7 +2623,7 @@ export const Warning = {
    */
   IBM1180I: {
     code: "IBM1180I",
-    severity: "W",
+    severity: Severity.W,
     message: (BUILTINname: string) =>
       `Argument to ${BUILTINname} is not byte aligned.`,
     fullCode: "IBM1180IW",
@@ -2640,7 +2639,7 @@ export const Warning = {
    */
   IBM1181I: {
     code: "IBM1181I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "A WHILE or UNTIL option at the end of a series of DO specifications applies only to the last specification.",
     fullCode: "IBM1181IW",
@@ -2658,7 +2657,7 @@ export const Warning = {
    */
   IBM1182I: {
     code: "IBM1182I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "Invocation of a NONRECURSIVE PROCEDURE from within that PROCEDURE is invalid. RECURSIVE attribute is assumed.",
     fullCode: "IBM1182IW",
@@ -2674,7 +2673,7 @@ export const Warning = {
    */
   IBM1183I: {
     code: "IBM1183I",
-    severity: "W",
+    severity: Severity.W,
     message: (conditionname: string) =>
       `${conditionname} condition is disabled. Statement is ignored.`,
     fullCode: "IBM1183IW",
@@ -2690,7 +2689,7 @@ export const Warning = {
    */
   IBM1184I: {
     code: "IBM1184I",
-    severity: "W",
+    severity: Severity.W,
     message: (
       stringlength: string,
       variablename: string,
@@ -2712,7 +2711,7 @@ export const Warning = {
    */
   IBM1185I: {
     code: "IBM1185I",
-    severity: "W",
+    severity: Severity.W,
     message: (stringlength: string) =>
       `Source with length ${stringlength} in RETURN statement has length greater than that in the corresponding RETURNS attribute.`,
     fullCode: "IBM1185IW",
@@ -2729,7 +2728,7 @@ export const Warning = {
    */
   IBM1186I: {
     code: "IBM1186I",
-    severity: "W",
+    severity: Severity.W,
     message: (stringlength: string, stringlength2: string) =>
       `Source with length ${stringlength} in string assignment has length greater than the length ${stringlength2} of the target.`,
     fullCode: "IBM1186IW",
@@ -2746,7 +2745,7 @@ export const Warning = {
    */
   IBM1187I: {
     code: "IBM1187I",
-    severity: "W",
+    severity: Severity.W,
     message: (
       argumentnumber: string,
       entryname: string,
@@ -2763,7 +2762,7 @@ export const Warning = {
    */
   IBM1188I: {
     code: "IBM1188I",
-    severity: "W",
+    severity: Severity.W,
     message: "Result of concatenating two strings is too long.",
     fullCode: "IBM1188IW",
   } as SimplePLICode,
@@ -2776,7 +2775,7 @@ export const Warning = {
    */
   IBM1189I: {
     code: "IBM1189I",
-    severity: "W",
+    severity: Severity.W,
     message: (parametername: string) =>
       `NODESCRIPTOR attribute conflicts with the NONCONNECTED attribute for the parameter ${parametername} . CONNECTED is assumed.`,
     fullCode: "IBM1189IW",
@@ -2789,7 +2788,7 @@ export const Warning = {
    */
   IBM1190I: {
     code: "IBM1190I",
-    severity: "W",
+    severity: Severity.W,
     message: (optionname: string) =>
       `The OPTIONS option ${optionname} conflicts with the LANGLVL compiler option. The option will be applied.`,
     fullCode: "IBM1190IW",
@@ -2803,7 +2802,7 @@ export const Warning = {
    */
   IBM1191I: {
     code: "IBM1191I",
-    severity: "W",
+    severity: Severity.W,
     message: "Result of FIXED BIN divide will not be scaled.",
     fullCode: "IBM1191IW",
   } as SimplePLICode,
@@ -2817,7 +2816,7 @@ export const Warning = {
    */
   IBM1192I: {
     code: "IBM1192I",
-    severity: "W",
+    severity: Severity.W,
     message: "WHEN clauses contain duplicate values.",
     fullCode: "IBM1192IW",
   } as SimplePLICode,
@@ -2829,7 +2828,7 @@ export const Warning = {
    */
   IBM1193I: {
     code: "IBM1193I",
-    severity: "W",
+    severity: Severity.W,
     message: (statementcount: string, blockname: string) =>
       `${statementcount} statements in block ${blockname} .`,
     fullCode: "IBM1193IW",
@@ -2842,7 +2841,7 @@ export const Warning = {
    */
   IBM1194I: {
     code: "IBM1194I",
-    severity: "W",
+    severity: Severity.W,
     message: "More than one argument to MAIN PROCEDURE.",
     fullCode: "IBM1194IW",
   } as SimplePLICode,
@@ -2854,7 +2853,7 @@ export const Warning = {
    */
   IBM1195I: {
     code: "IBM1195I",
-    severity: "W",
+    severity: Severity.W,
     message: "Argument to MAIN PROCEDURE is not CHARACTER VARYING.",
     fullCode: "IBM1195IW",
   } as SimplePLICode,
@@ -2866,7 +2865,7 @@ export const Warning = {
    */
   IBM1196I: {
     code: "IBM1196I",
-    severity: "W",
+    severity: Severity.W,
     message: "AREA initialized with EMPTY - INITIAL attribute is ignored.",
     fullCode: "IBM1196IW",
   } as SimplePLICode,
@@ -2879,7 +2878,7 @@ export const Warning = {
    */
   IBM1197I: {
     code: "IBM1197I",
-    severity: "W",
+    severity: Severity.W,
     message: (filename: string) =>
       `${filename} assumed as file condition reference.`,
     fullCode: "IBM1197IW",
@@ -2899,7 +2898,7 @@ export const Warning = {
    */
   IBM1198I: {
     code: "IBM1198I",
-    severity: "W",
+    severity: Severity.W,
     message: (variablename: string) =>
       `A null argument list is assumed for ${variablename} .`,
     fullCode: "IBM1198IW",
@@ -2915,7 +2914,7 @@ export const Warning = {
    */
   IBM1199I: {
     code: "IBM1199I",
-    severity: "W",
+    severity: Severity.W,
     message: "Syntax of the LINE directive is incorrect.",
     fullCode: "IBM1199IW",
   } as SimplePLICode,
@@ -2927,7 +2926,7 @@ export const Warning = {
    */
   IBM1200I: {
     code: "IBM1200I",
-    severity: "W",
+    severity: Severity.W,
     message: "Use of DATE built-in function may cause problems.",
     fullCode: "IBM1200IW",
   } as SimplePLICode,
@@ -2942,7 +2941,7 @@ export const Warning = {
    */
   IBM1201I: {
     code: "IBM1201I",
-    severity: "W",
+    severity: Severity.W,
     message: (suboption: string, option: string) =>
       `${suboption} conflicts with a previously specified suboption for the ${option} compiler option.`,
     fullCode: "IBM1201IW",
@@ -2954,7 +2953,7 @@ export const Warning = {
    */
   IBM1202I: {
     code: "IBM1202I",
-    severity: "W",
+    severity: Severity.W,
     message: "Syntax of the OPTION statement is incorrect.",
     fullCode: "IBM1202IW",
   } as SimplePLICode,
@@ -2965,7 +2964,7 @@ export const Warning = {
    */
   IBM1203I: {
     code: "IBM1203I",
-    severity: "W",
+    severity: Severity.W,
     message: "Argument to PLITEST is ignored.",
     fullCode: "IBM1203IW",
   } as SimplePLICode,
@@ -2981,7 +2980,7 @@ export const Warning = {
    */
   IBM1204I: {
     code: "IBM1204I",
-    severity: "W",
+    severity: Severity.W,
     message: "INTERNAL CONSTANT assumed for initialized STATIC LABEL.",
     fullCode: "IBM1204IW",
   } as SimplePLICode,
@@ -2998,7 +2997,7 @@ export const Warning = {
    */
   IBM1205I: {
     code: "IBM1205I",
-    severity: "W",
+    severity: Severity.W,
     message: (option: string) =>
       `Arguments of the ${option} compiler option must be the same length.`,
     fullCode: "IBM1205IW",
@@ -3011,7 +3010,7 @@ export const Warning = {
    */
   IBM1206I: {
     code: "IBM1206I",
-    severity: "W",
+    severity: Severity.W,
     message: "BIT operators should be applied only to BIT operands.",
     fullCode: "IBM1206IW",
   } as SimplePLICode,
@@ -3024,7 +3023,7 @@ export const Warning = {
    */
   IBM1207I: {
     code: "IBM1207I",
-    severity: "W",
+    severity: Severity.W,
     message: "Operand to LENGTH built-in function should have string type.",
     fullCode: "IBM1207IW",
   } as SimplePLICode,
@@ -3044,7 +3043,7 @@ export const Warning = {
    */
   IBM1208I: {
     code: "IBM1208I",
-    severity: "W",
+    severity: Severity.W,
     message: (variablename: string) =>
       `INITIAL list for the array ${variablename} contains only one item.`,
     fullCode: "IBM1208IW",
@@ -3063,7 +3062,7 @@ export const Warning = {
    */
   IBM1209I: {
     code: "IBM1209I",
-    severity: "W",
+    severity: Severity.W,
     message: (filename: string) =>
       `INDEXED environment option for file ${filename} will be treated as ORGANIZATION(INDEXED).`,
     fullCode: "IBM1209IW",
@@ -3076,7 +3075,7 @@ export const Warning = {
    */
   IBM1210I: {
     code: "IBM1210I",
-    severity: "W",
+    severity: Severity.W,
     message: (keyword: string) =>
       `The field width specified in the ${keyword} -format item may be too small for complete output of the data item.`,
     fullCode: "IBM1210IW",
@@ -3093,7 +3092,7 @@ export const Warning = {
    */
   IBM1211I: {
     code: "IBM1211I",
-    severity: "W",
+    severity: Severity.W,
     message: (stringlength: string, stringlength2: string, variable: string) =>
       `Source with length ${stringlength} in string assignment has length greater than the length ${stringlength2} of the target ${variable} .`,
     fullCode: "IBM1211IW",
@@ -3108,7 +3107,7 @@ export const Warning = {
    */
   IBM1212I: {
     code: "IBM1212I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "The A format item requires an argument when used in GET statement. An L format item is assumed in its place.",
     fullCode: "IBM1212IW",
@@ -3122,7 +3121,7 @@ export const Warning = {
    */
   IBM1213I: {
     code: "IBM1213I",
-    severity: "W",
+    severity: Severity.W,
     message: (procname: string) =>
       `The PROCEDURE ${procname} is not referenced.`,
     fullCode: "IBM1213IW",
@@ -3144,7 +3143,7 @@ export const Warning = {
    */
   IBM1214I: {
     code: "IBM1214I",
-    severity: "W",
+    severity: Severity.W,
     message: (argumentnumber: string, entryname: string) =>
       `A dummy argument will be created for argument number ${argumentnumber} in ENTRY reference ${entryname} .`,
     fullCode: "IBM1214IW",
@@ -3160,7 +3159,7 @@ export const Warning = {
    */
   IBM1215I: {
     code: "IBM1215I",
-    severity: "W",
+    severity: Severity.W,
     message: (variablename: string) =>
       `The variable ${variablename} is declared without any data attributes.`,
     fullCode: "IBM1215IW",
@@ -3181,7 +3180,7 @@ export const Warning = {
    */
   IBM1216I: {
     code: "IBM1216I",
-    severity: "W",
+    severity: Severity.W,
     message: (variablename: string) =>
       `The structure member ${variablename} is declared without any data attributes. A level number may be incorrect.`,
     fullCode: "IBM1216IW",
@@ -3202,7 +3201,7 @@ export const Warning = {
    */
   IBM1217I: {
     code: "IBM1217I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "An unnamed structure member is declared without any data attributes. A level number may be incorrect.",
     fullCode: "IBM1217IW",
@@ -3219,7 +3218,7 @@ export const Warning = {
    */
   IBM1218I: {
     code: "IBM1218I",
-    severity: "W",
+    severity: Severity.W,
     message: (BUILTINname: string) =>
       `First argument to ${BUILTINname} built-in function should have string type.`,
     fullCode: "IBM1218IW",
@@ -3243,7 +3242,7 @@ export const Warning = {
    */
   IBM1219I: {
     code: "IBM1219I",
-    severity: "W",
+    severity: Severity.W,
     message: "LEAVE will exit noniterative DO- group.",
     fullCode: "IBM1219IW",
   } as SimplePLICode,
@@ -3262,7 +3261,7 @@ export const Warning = {
    */
   IBM1220I: {
     code: "IBM1220I",
-    severity: "W",
+    severity: Severity.W,
     message: "Result of comparison is always constant.",
     fullCode: "IBM1220IW",
   } as SimplePLICode,
@@ -3274,7 +3273,7 @@ export const Warning = {
    */
   IBM1221I: {
     code: "IBM1221I",
-    severity: "W",
+    severity: Severity.W,
     message: (count: string) =>
       `Statement uses ${count} bytes for temporaries.`,
     fullCode: "IBM1221IW",
@@ -3287,7 +3286,7 @@ export const Warning = {
    */
   IBM1222I: {
     code: "IBM1222I",
-    severity: "W",
+    severity: Severity.W,
     message: "Comparison involving 2-digit year is problematic.",
     fullCode: "IBM1222IW",
   } as SimplePLICode,
@@ -3306,7 +3305,7 @@ export const Warning = {
    */
   IBM1223I: {
     code: "IBM1223I",
-    severity: "W",
+    severity: Severity.W,
     message: "Literal in comparison interpreted with DATE attribute.",
     fullCode: "IBM1223IW",
   } as SimplePLICode,
@@ -3324,7 +3323,7 @@ export const Warning = {
    */
   IBM1224I: {
     code: "IBM1224I",
-    severity: "W",
+    severity: Severity.W,
     message: "DATE attribute ignored in comparison with non-date literal.",
     fullCode: "IBM1224IW",
   } as SimplePLICode,
@@ -3341,7 +3340,7 @@ export const Warning = {
    */
   IBM1225I: {
     code: "IBM1225I",
-    severity: "W",
+    severity: Severity.W,
     message: "DATE attribute ignored in conversion from literal.",
     fullCode: "IBM1225IW",
   } as SimplePLICode,
@@ -3352,7 +3351,7 @@ export const Warning = {
    */
   IBM2600I: {
     code: "IBM2600I",
-    severity: "W",
+    severity: Severity.W,
     message: "Compiler backend issued warning messages to STDOUT.",
     fullCode: "IBM2600IW",
   } as SimplePLICode,
@@ -3367,7 +3366,7 @@ export const Warning = {
    */
   IBM2601I: {
     code: "IBM2601I",
-    severity: "W",
+    severity: Severity.W,
     message: (character: string, character2: string) =>
       `Missing ${character} assumed before ${character2} . DECLARE and other nonexecutable statements should not have labels.`,
     fullCode: "IBM2601IW",
@@ -3388,7 +3387,7 @@ export const Warning = {
    */
   IBM2602I: {
     code: "IBM2602I",
-    severity: "W",
+    severity: Severity.W,
     message: (count: string, variablename: string, arraysize: string) =>
       `Number of items in INITIAL list is ${count} for the array ${variablename} which contains ${arraysize} elements.`,
     fullCode: "IBM2602IW",
@@ -3412,7 +3411,7 @@ export const Warning = {
    */
   IBM2603I: {
     code: "IBM2603I",
-    severity: "W",
+    severity: Severity.W,
     message: (variablename: string) =>
       `INITIAL list for the array ${variablename} contains only one item.`,
     fullCode: "IBM2603IW",
@@ -3433,7 +3432,7 @@ export const Warning = {
    */
   IBM2604I: {
     code: "IBM2604I",
-    severity: "W",
+    severity: Severity.W,
     message: (
       sourceprecision: string,
       sourcescale: string,
@@ -3451,7 +3450,7 @@ export const Warning = {
    */
   IBM2605I: {
     code: "IBM2605I",
-    severity: "W",
+    severity: Severity.W,
     message: "Invalid carriage control character. Blank assumed.",
     fullCode: "IBM2605IW",
   } as SimplePLICode,
@@ -3463,7 +3462,7 @@ export const Warning = {
    */
   IBM2606I: {
     code: "IBM2606I",
-    severity: "W",
+    severity: Severity.W,
     message: (referencename: string) =>
       `Code generated for the REFER object ${referencename} would be more efficient if the REFER object had the attributes REAL FIXED BIN(p,0).`,
     fullCode: "IBM2606IW",
@@ -3484,7 +3483,7 @@ export const Warning = {
    */
   IBM2607I: {
     code: "IBM2607I",
-    severity: "W",
+    severity: Severity.W,
     message: (
       sourceprecision: string,
       sourcescale: string,
@@ -3512,7 +3511,7 @@ export const Warning = {
    */
   IBM2608I: {
     code: "IBM2608I",
-    severity: "W",
+    severity: Severity.W,
     message: (
       sourceprecision: string,
       sourcescale: string,
@@ -3536,7 +3535,7 @@ export const Warning = {
    */
   IBM2609I: {
     code: "IBM2609I",
-    severity: "W",
+    severity: Severity.W,
     message: (linenumber: string, filenumber: string) =>
       `Comment contains a semicolon on line ${linenumber} . ${filenumber} .`,
     fullCode: "IBM2609IW",
@@ -3558,7 +3557,7 @@ export const Warning = {
    */
   IBM2610I: {
     code: "IBM2610I",
-    severity: "W",
+    severity: Severity.W,
     message: (BUILTINname: string) =>
       `One argument to ${BUILTINname} built-in function is FIXED DEC while the other is FIXED BIN. Compiler will not interpret precision as FIXED DEC.`,
     fullCode: "IBM2610IW",
@@ -3573,7 +3572,7 @@ export const Warning = {
    */
   IBM2611I: {
     code: "IBM2611I",
-    severity: "W",
+    severity: Severity.W,
     message: (binaryvalue: string) =>
       `The binary value ${binaryvalue} appears in more than one WHEN clause.`,
     fullCode: "IBM2611IW",
@@ -3588,7 +3587,7 @@ export const Warning = {
    */
   IBM2612I: {
     code: "IBM2612I",
-    severity: "W",
+    severity: Severity.W,
     message: (characterstring: string) =>
       `The character string ${characterstring} appears in more than one WHEN clause.`,
     fullCode: "IBM2612IW",
@@ -3602,7 +3601,7 @@ export const Warning = {
    */
   IBM2613I: {
     code: "IBM2613I",
-    severity: "W",
+    severity: Severity.W,
     message: (variable: string) =>
       `RULES(NOLAXINOUT) violation: ${variable} is being passed as an INOUT parameter, but may be unset.`,
     fullCode: "IBM2613IW",
@@ -3618,7 +3617,7 @@ export const Warning = {
    */
   IBM2614I: {
     code: "IBM2614I",
-    severity: "W",
+    severity: Severity.W,
     message: "Both comparands are Booleans.",
     fullCode: "IBM2614IW",
   } as SimplePLICode,
@@ -3637,7 +3636,7 @@ export const Warning = {
    */
   IBM2615I: {
     code: "IBM2615I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "DO-loop will always execute exactly once. A semicolon after the DO may be missing.",
     fullCode: "IBM2615IW",
@@ -3652,7 +3651,7 @@ export const Warning = {
    */
   IBM2616I: {
     code: "IBM2616I",
-    severity: "W",
+    severity: Severity.W,
     message: (variable: string) =>
       `Size of parameter ${variable} will return the currentsize value since no descriptor is available.`,
     fullCode: "IBM2616IW",
@@ -3668,7 +3667,7 @@ export const Warning = {
    */
   IBM2617I: {
     code: "IBM2617I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "Passing a LABEL to a non-PL/I routine is very poor coding practice and will cause the compiler to generate less than optimal code.",
     fullCode: "IBM2617IW",
@@ -3684,7 +3683,7 @@ export const Warning = {
    */
   IBM2618I: {
     code: "IBM2618I",
-    severity: "W",
+    severity: Severity.W,
     message: (suboption: string, option: string, option2: string) =>
       `The suboption ${suboption} is not valid for the suboption ${option} of the ${option2} compiler option.`,
     fullCode: "IBM2618IW",
@@ -3708,7 +3707,7 @@ export const Warning = {
    */
   IBM2620I: {
     code: "IBM2620I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "Target structure contains REFER objects. Results are undefined if the assignment changes any REFER object.",
     fullCode: "IBM2620IW",
@@ -3722,7 +3721,7 @@ export const Warning = {
    */
   IBM2621I: {
     code: "IBM2621I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "ON ERROR block does not start with ON ERROR SYSTEM. An error inside the block may lead to an infinite loop.",
     fullCode: "IBM2621IW",
@@ -3744,7 +3743,7 @@ export const Warning = {
    */
   IBM2622I: {
     code: "IBM2622I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "ENTRY used to set the initial value in a DO loop will be invoked after any TO or BY values are set.",
     fullCode: "IBM2622IW",
@@ -3765,7 +3764,7 @@ export const Warning = {
    */
   IBM2623I: {
     code: "IBM2623I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "Mixing FIXED BIN and FLOAT DEC produces a FLOAT BIN result. Under DFP, this will lead to poor performance.",
     fullCode: "IBM2623IW",
@@ -3786,7 +3785,7 @@ export const Warning = {
    */
   IBM2624I: {
     code: "IBM2624I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "Mixing BIT and FLOAT DEC produces a FLOAT BIN result. 27 Under DFP, this will lead to poor performance.",
     fullCode: "IBM2624IW",
@@ -3799,7 +3798,7 @@ export const Warning = {
    */
   IBM2625I: {
     code: "IBM2625I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "Mixing FLOAT BIN and FLOAT DEC produces a FLOAT BIN result. Under DFP, this will lead to poor performance.",
     fullCode: "IBM2625IW",
@@ -3812,7 +3811,7 @@ export const Warning = {
    */
   IBM2626I: {
     code: "IBM2626I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "Use of SUBSTR with a third argument equal to 0 is somewhat pointless since the result will always be a null string.",
     fullCode: "IBM2626IW",
@@ -3825,7 +3824,7 @@ export const Warning = {
    */
   IBM2627I: {
     code: "IBM2627I",
-    severity: "W",
+    severity: Severity.W,
     message: (identifier: string) =>
       `No metadata will be generated for the structure ${identifier} since its use of REFER is too complex.`,
     fullCode: "IBM2627IW",
@@ -3838,7 +3837,7 @@ export const Warning = {
    */
   IBM2628I: {
     code: "IBM2628I",
-    severity: "W",
+    severity: Severity.W,
     message: "BYVALUE parameters should ideally be no larger than 32 bytes.",
     fullCode: "IBM2628IW",
   } as SimplePLICode,
@@ -3850,7 +3849,7 @@ export const Warning = {
    */
   IBM2629I: {
     code: "IBM2629I",
-    severity: "W",
+    severity: Severity.W,
     message: (identifier: string) =>
       `No debug symbol information will be generated for ${identifier} .`,
     fullCode: "IBM2629IW",
@@ -3868,7 +3867,7 @@ export const Warning = {
    */
   IBM2630I: {
     code: "IBM2630I",
-    severity: "W",
+    severity: Severity.W,
     message: (
       operandattributes: string,
       operandattributes2: string,
@@ -3894,7 +3893,7 @@ export const Warning = {
    */
   IBM2631I: {
     code: "IBM2631I",
-    severity: "W",
+    severity: Severity.W,
     message: (BUILTINname: string) =>
       `One argument to ${BUILTINname} built-in function is FIXED DEC while the other is FLOAT BIN. Compiler will not interpret precision as FIXED DEC.`,
     fullCode: "IBM2631IW",
@@ -3916,7 +3915,7 @@ export const Warning = {
    */
   IBM2632I: {
     code: "IBM2632I",
-    severity: "W",
+    severity: Severity.W,
     message: (BUILTINname: string) =>
       `One argument to ${BUILTINname} built-in function is FIXED DEC while the other is FLOAT DEC. Compiler will not interpret precision as FIXED DEC.`,
     fullCode: "IBM2632IW",
@@ -3929,7 +3928,7 @@ export const Warning = {
    */
   IBM2633I: {
     code: "IBM2633I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "Given the support for addressing arithmetic, basing a POINTER or OFFSET on a FIXED BIN is unnecessary, and it will also fail to work properly if the size of a POINTER changes.",
     fullCode: "IBM2633IW",
@@ -3942,7 +3941,7 @@ export const Warning = {
    */
   IBM2634I: {
     code: "IBM2634I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "Given the support for addressing arithmetic, basing a FIXED BIN on a POINTER or OFFSET is unnecessary, and it will also fail to work properly if the size of a POINTER changes.",
     fullCode: "IBM2634IW",
@@ -3960,7 +3959,7 @@ export const Warning = {
    */
   IBM2635I: {
     code: "IBM2635I",
-    severity: "W",
+    severity: Severity.W,
     message: (
       operandattributes: string,
       operandattributes2: string,
@@ -3979,7 +3978,7 @@ export const Warning = {
    */
   IBM2636I: {
     code: "IBM2636I",
-    severity: "W",
+    severity: Severity.W,
     message: (ordinalname: string) =>
       `The ordinal ${ordinalname} appears in more than one WHEN clause.`,
     fullCode: "IBM2636IW",
@@ -4000,7 +3999,7 @@ export const Warning = {
    */
   IBM2637I: {
     code: "IBM2637I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "An ENTRY invoked as a function should have the RETURNS attribute.",
     fullCode: "IBM2637IW",
@@ -4014,7 +4013,7 @@ export const Warning = {
    */
   IBM2638I: {
     code: "IBM2638I",
-    severity: "W",
+    severity: Severity.W,
     message: (count: string) =>
       `Statement used ${count} intermediate language instructions.`,
     fullCode: "IBM2638IW",
@@ -4030,7 +4029,7 @@ export const Warning = {
    */
   IBM2639I: {
     code: "IBM2639I",
-    severity: "W",
+    severity: Severity.W,
     message: (count: string) =>
       `Previous statement used ${count} intermediate language instructions.`,
     fullCode: "IBM2639IW",
@@ -4055,7 +4054,7 @@ export const Warning = {
    */
   IBM2640I: {
     code: "IBM2640I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "Target is a REFER object. Results are undefined if an assignment changes a REFER object.",
     fullCode: "IBM2640IW",
@@ -4072,7 +4071,7 @@ export const Warning = {
    */
   IBM2641I: {
     code: "IBM2641I",
-    severity: "W",
+    severity: Severity.W,
     message: (option: string, option2: string) =>
       `The suboption ${option} of the ${option2} compiler option must be followed by a (possibly empty) parenthesized list.`,
     fullCode: "IBM2641IW",
@@ -4087,7 +4086,7 @@ export const Warning = {
    */
   IBM2642I: {
     code: "IBM2642I",
-    severity: "W",
+    severity: Severity.W,
     message: "OPTIONS(REENTRANT) is ignored.",
     fullCode: "IBM2642IW",
   } as SimplePLICode,
@@ -4099,7 +4098,7 @@ export const Warning = {
    */
   IBM2643I: {
     code: "IBM2643I",
-    severity: "W",
+    severity: Severity.W,
     message: (builtin: string) =>
       `The built-in function ${builtin} will be deprecated.`,
     fullCode: "IBM2643IW",
@@ -4112,7 +4111,7 @@ export const Warning = {
    */
   IBM2644I: {
     code: "IBM2644I",
-    severity: "W",
+    severity: Severity.W,
     message: (filename: string) =>
       `The INCLUDE file ${filename} will be deprecated.`,
     fullCode: "IBM2644IW",
@@ -4125,7 +4124,7 @@ export const Warning = {
    */
   IBM2645I: {
     code: "IBM2645I",
-    severity: "W",
+    severity: Severity.W,
     message: (entryname: string) =>
       `The ENTRY named ${entryname} will be deprecated.`,
     fullCode: "IBM2645IW",
@@ -4138,7 +4137,7 @@ export const Warning = {
    */
   IBM2646I: {
     code: "IBM2646I",
-    severity: "W",
+    severity: Severity.W,
     message: (variable: string) =>
       `The VARIABLE named ${variable} will be deprecated.`,
     fullCode: "IBM2646IW",
@@ -4151,7 +4150,7 @@ export const Warning = {
    */
   IBM2647I: {
     code: "IBM2647I",
-    severity: "W",
+    severity: Severity.W,
     message: (statementname: string) =>
       `The ${statementname} statement will be deprecated.`,
     fullCode: "IBM2647IW",
@@ -4164,7 +4163,7 @@ export const Warning = {
    */
   IBM2648I: {
     code: "IBM2648I",
-    severity: "W",
+    severity: Severity.W,
     message: (count: string) => `Declaration contains ${count} INITIAL items.`,
     fullCode: "IBM2648IW",
   } as ParametricPLICode,
@@ -4177,7 +4176,7 @@ export const Warning = {
    */
   IBM2649I: {
     code: "IBM2649I",
-    severity: "W",
+    severity: Severity.W,
     message: (binaryvalue: string) =>
       `The binary value ${binaryvalue} appears more than once in the INLIST argument set.`,
     fullCode: "IBM2649IW",
@@ -4191,7 +4190,7 @@ export const Warning = {
    */
   IBM2650I: {
     code: "IBM2650I",
-    severity: "W",
+    severity: Severity.W,
     message: (ordinalname: string) =>
       `The ordinal ${ordinalname} appears more than once in the INLIST argument set.`,
     fullCode: "IBM2650IW",
@@ -4204,7 +4203,7 @@ export const Warning = {
    */
   IBM2651I: {
     code: "IBM2651I",
-    severity: "W",
+    severity: Severity.W,
     message: (blockname: string, count: string) =>
       `Block ${blockname} contains ${count} branches.`,
     fullCode: "IBM2651IW",
@@ -4217,7 +4216,7 @@ export const Warning = {
    */
   IBM2652I: {
     code: "IBM2652I",
-    severity: "W",
+    severity: Severity.W,
     message: "REINIT reference contains no element with an INITIAL attribute.",
     fullCode: "IBM2652IW",
   } as SimplePLICode,
@@ -4229,7 +4228,7 @@ export const Warning = {
    */
   IBM2653I: {
     code: "IBM2653I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "The list of preprocessor options must be enclosed in quotation marks.",
     fullCode: "IBM2653IW",
@@ -4247,7 +4246,7 @@ export const Warning = {
    */
   IBM2654I: {
     code: "IBM2654I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "INITIAL attribute for BASED on ADDR has no effect on the base variable.",
     fullCode: "IBM2654IW",
@@ -4262,7 +4261,7 @@ export const Warning = {
    */
   IBM2655I: {
     code: "IBM2655I",
-    severity: "W",
+    severity: Severity.W,
     message: "Some options conflict with the non-overridable options.",
     fullCode: "IBM2655IW",
   } as SimplePLICode,
@@ -4279,7 +4278,7 @@ export const Warning = {
    */
   IBM2656I: {
     code: "IBM2656I",
-    severity: "W",
+    severity: Severity.W,
     message: (variablename: string) =>
       `Simple defining applies to ${variablename}. If string-overlay defining is intended, then add POS(1) to its declaration.`,
     fullCode: "IBM2656IW",
@@ -4291,7 +4290,7 @@ export const Warning = {
    */
   IBM2657I: {
     code: "IBM2657I",
-    severity: "W",
+    severity: Severity.W,
     message: "Both logical AND operands are identical.",
     fullCode: "IBM2657IW",
   } as SimplePLICode,
@@ -4302,7 +4301,7 @@ export const Warning = {
    */
   IBM2658I: {
     code: "IBM2658I",
-    severity: "W",
+    severity: Severity.W,
     message: "Both logical OR operands are identical.",
     fullCode: "IBM2658IW",
   } as SimplePLICode,
@@ -4317,7 +4316,7 @@ export const Warning = {
    */
   IBM2659I: {
     code: "IBM2659I",
-    severity: "W",
+    severity: Severity.W,
     message: (variablename: string) =>
       `Generated code would be better if all the INITIAL attributes in the declare for ${variablename} were changed to VALUE.`,
     fullCode: "IBM2659IW",
@@ -4342,7 +4341,7 @@ export const Warning = {
    */
   IBM2660I: {
     code: "IBM2660I",
-    severity: "W",
+    severity: Severity.W,
     message: (procedurename: string, procedurename2: string) =>
       `Program logic may lead to the END statement for ${procedurename} even though ${procedurename2} is a function that should return a value.`,
     fullCode: "IBM2660IW",
@@ -4356,7 +4355,7 @@ export const Warning = {
    */
   IBM2661I: {
     code: "IBM2661I",
-    severity: "W",
+    severity: Severity.W,
     message: (stringvalue: string) =>
       `The string ${stringvalue} appears more than once in the INLIST argument set.`,
     fullCode: "IBM2661IW",
@@ -4370,7 +4369,7 @@ export const Warning = {
    */
   IBM2662I: {
     code: "IBM2662I",
-    severity: "W",
+    severity: Severity.W,
     message: "INLIST argument set contains duplicate values.",
     fullCode: "IBM2662IW",
   } as SimplePLICode,
@@ -4384,7 +4383,7 @@ export const Warning = {
    */
   IBM2663I: {
     code: "IBM2663I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "WHEN clause contains an expression that matches the previous expression in the containing SELECT statement.",
     fullCode: "IBM2663IW",
@@ -4399,7 +4398,7 @@ export const Warning = {
    */
   IBM2664I: {
     code: "IBM2664I",
-    severity: "W",
+    severity: Severity.W,
     message: (count: string) =>
       `WHEN clause contains an expression that matches the expression ${count} previous in the containing SELECT statement.`,
     fullCode: "IBM2664IW",
@@ -4412,7 +4411,7 @@ export const Warning = {
    */
   IBM2665I: {
     code: "IBM2665I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "EXTERNAL PLIXOPT declare specifies run-time options only if the variable has the attribute CHARACTER VARYING INITIAL and is not an array.",
     fullCode: "IBM2665IW",
@@ -4425,7 +4424,7 @@ export const Warning = {
    */
   IBM2666I: {
     code: "IBM2666I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "RETURN expression holds the address of a variable in AUTOMATIC storage.",
     fullCode: "IBM2666IW",
@@ -4439,7 +4438,7 @@ export const Warning = {
    */
   IBM2667I: {
     code: "IBM2667I",
-    severity: "W",
+    severity: Severity.W,
     message: (first: string, second: string) =>
       `The string lengths in the declare for ${first} depend on the size of ${second} whose declare comes later in the block. Consider moving the first declare after the second.`,
     fullCode: "IBM2667IW",
@@ -4454,7 +4453,7 @@ export const Warning = {
    */
   IBM2668I: {
     code: "IBM2668I",
-    severity: "W",
+    severity: Severity.W,
     message: (type: string, count: string) =>
       `Using the VALUE function with the structure type ${type} adds ${count} bytes to the generated object.`,
     fullCode: "IBM2668IW",
@@ -4467,7 +4466,7 @@ export const Warning = {
    */
   IBM2669I: {
     code: "IBM2669I",
-    severity: "W",
+    severity: Severity.W,
     message: (attributekeyword: string) =>
       `The ${attributekeyword} attribute is ignored in an ALIAS definition.`,
     fullCode: "IBM2669IW",
@@ -4480,7 +4479,7 @@ export const Warning = {
    */
   IBM2670I: {
     code: "IBM2670I",
-    severity: "W",
+    severity: Severity.W,
     message: "The parameter to MAIN should be declared as CHAR(*) VARYING.",
     fullCode: "IBM2670IW",
   } as SimplePLICode,
@@ -4503,7 +4502,7 @@ export const Warning = {
    */
   IBM2671I: {
     code: "IBM2671I",
-    severity: "W",
+    severity: Severity.W,
     message: (X: string, n: string, E: string, A: string, D: string) =>
       `The variable ${X} is passed as argument number ${n} to entry ${E} . The corresponding parameter has the ${A} attribute, and hence the variable could be modified despite having the ${D} attribute.`,
     fullCode: "IBM2671IW",
@@ -4523,7 +4522,7 @@ export const Warning = {
    */
   IBM2672I: {
     code: "IBM2672I",
-    severity: "W",
+    severity: Severity.W,
     message: (extentvariable: string) =>
       `If ${extentvariable} is constant, then removing its STATIC attribute and changing its INITIAL attribute to the VALUE attribute would improve the performance of the generated code.`,
     fullCode: "IBM2672IW",
@@ -4544,7 +4543,7 @@ export const Warning = {
    */
   IBM2673I: {
     code: "IBM2673I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "Boolean is compared with something other than a BIT(1) restricted expression.",
     fullCode: "IBM2673IW",
@@ -4568,7 +4567,7 @@ export const Warning = {
    */
   IBM2674I: {
     code: "IBM2674I",
-    severity: "W",
+    severity: Severity.W,
     message: (structname: string, alignment: string, storagesize: string) =>
       `The defined structure ${structname} is ${alignment} byte aligned, but occupies only ${storagesize} bytes of storage. This may lead to addressing problems and data corruption.`,
     fullCode: "IBM2674IW",
@@ -4582,7 +4581,7 @@ export const Warning = {
    */
   IBM2675I: {
     code: "IBM2675I",
-    severity: "W",
+    severity: Severity.W,
     message: "Use of PICTURE as DO control variable is not recommended.",
     fullCode: "IBM2675IW",
   } as SimplePLICode,
@@ -4595,7 +4594,7 @@ export const Warning = {
    */
   IBM2676I: {
     code: "IBM2676I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "Code generated for DO group would be more efficient if control variable had type FIXED BIN with zero scale factor.",
     fullCode: "IBM2676IW",
@@ -4610,7 +4609,7 @@ export const Warning = {
    */
   IBM2677I: {
     code: "IBM2677I",
-    severity: "W",
+    severity: Severity.W,
     message: (variablename: string) =>
       `Generated code would be better if the declare for ${variablename} were changed from AUTOMATIC to STATIC NONASSIGNABLE.`,
     fullCode: "IBM2677IW",
@@ -4629,7 +4628,7 @@ export const Warning = {
    */
   IBM2678I: {
     code: "IBM2678I",
-    severity: "W",
+    severity: Severity.W,
     message: "Loop will never be run. TO value may be incorrect.",
     fullCode: "IBM2678IW",
   } as SimplePLICode,
@@ -4641,7 +4640,7 @@ export const Warning = {
    */
   IBM2679I: {
     code: "IBM2679I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "GONUMBER(SEPARATE) changed to GONUMBER(NOSEPARATE) since the SEPARATE suboption for the GONUMBER option should be specified only when the TEST option and its SEPARATE suboption are also specified.",
     fullCode: "IBM2679IW",
@@ -4654,7 +4653,7 @@ export const Warning = {
    */
   IBM2680I: {
     code: "IBM2680I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "Code generated for DO group would perform better if control variable was STATIC or AUTOMATIC.",
     fullCode: "IBM2680IW",
@@ -4667,7 +4666,7 @@ export const Warning = {
    */
   IBM2681I: {
     code: "IBM2681I",
-    severity: "W",
+    severity: Severity.W,
     message: (sourcelength: string, sourcepattern: string) =>
       `Source has length ${sourcelength} which is greater than the length of the source pattern ${sourcepattern} . Unless the source has enough leading blanks, invoking this REPATTERN will cause the ERROR condition to be raised. The required checking will also cause this REPATTERN not to be inlined.`,
     fullCode: "IBM2681IW",
@@ -4680,7 +4679,7 @@ export const Warning = {
    */
   IBM2682I: {
     code: "IBM2682I",
-    severity: "W",
+    severity: Severity.W,
     message: (name: string, count: string) =>
       `The variable ${name} needs ${count} storage bytes which exceeds the MAXSTATIC limit.`,
     fullCode: "IBM2682IW",
@@ -4693,7 +4692,7 @@ export const Warning = {
    */
   IBM3250I: {
     code: "IBM3250I",
-    severity: "W",
+    severity: Severity.W,
     message: (note: string) => `${note}`,
     fullCode: "IBM3250IW",
   } as ParametricPLICode,
@@ -4709,7 +4708,7 @@ export const Warning = {
    */
   IBM3251I: {
     code: "IBM3251I",
-    severity: "W",
+    severity: Severity.W,
     message: (identifier: string) =>
       `${identifier} is multiply defined, but with different attributes. The declaration is ignored.`,
     fullCode: "IBM3251IW",
@@ -4724,7 +4723,7 @@ export const Warning = {
    */
   IBM3252I: {
     code: "IBM3252I",
-    severity: "W",
+    severity: Severity.W,
     message: (attribute: string) =>
       `The attribute ${attribute} conflicts with previous attributes and is ignored.`,
     fullCode: "IBM3252IW",
@@ -4737,7 +4736,7 @@ export const Warning = {
    */
   IBM3253I: {
     code: "IBM3253I",
-    severity: "W",
+    severity: Severity.W,
     message: "Comment spans more than one file.",
     fullCode: "IBM3253IW",
   } as SimplePLICode,
@@ -4749,7 +4748,7 @@ export const Warning = {
    */
   IBM3254I: {
     code: "IBM3254I",
-    severity: "W",
+    severity: Severity.W,
     message: "String spans more than one file.",
     fullCode: "IBM3254IW",
   } as SimplePLICode,
@@ -4764,7 +4763,7 @@ export const Warning = {
    */
   IBM3255I: {
     code: "IBM3255I",
-    severity: "W",
+    severity: Severity.W,
     message: (nondelimiter: string, nondelimiter2: string) =>
       `Delimiter missing between ${nondelimiter} and ${nondelimiter2} . A blank is assumed.`,
     fullCode: "IBM3255IW",
@@ -4777,7 +4776,7 @@ export const Warning = {
    */
   IBM3256I: {
     code: "IBM3256I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "Multiple closure of groups. END statements will be inserted to close intervening groups.",
     fullCode: "IBM3256IW",
@@ -4791,7 +4790,7 @@ export const Warning = {
    */
   IBM3257I: {
     code: "IBM3257I",
-    severity: "W",
+    severity: Severity.W,
     message: (character: string) => `Missing ${character} assumed.`,
     fullCode: "IBM3257IW",
   } as ParametricPLICode,
@@ -4808,7 +4807,7 @@ export const Warning = {
    */
   IBM3258I: {
     code: "IBM3258I",
-    severity: "W",
+    severity: Severity.W,
     message: (character: string, character2: string) =>
       `Missing ${character} assumed before ${character2} .`,
     fullCode: "IBM3258IW",
@@ -4820,7 +4819,7 @@ export const Warning = {
    */
   IBM3259I: {
     code: "IBM3259I",
-    severity: "W",
+    severity: Severity.W,
     message: (note: string) => `${note}`,
     fullCode: "IBM3259IW",
   } as ParametricPLICode,
@@ -4832,7 +4831,7 @@ export const Warning = {
    */
   IBM3260I: {
     code: "IBM3260I",
-    severity: "W",
+    severity: Severity.W,
     message: "Syntax of the %CONTROL statement is incorrect.",
     fullCode: "IBM3260IW",
   } as SimplePLICode,
@@ -4847,7 +4846,7 @@ export const Warning = {
    */
   IBM3261I: {
     code: "IBM3261I",
-    severity: "W",
+    severity: Severity.W,
     message: (suboption: string, option: string, option2: string) =>
       `The suboption ${suboption} is not valid for the suboption ${option} of the ${option2} option.`,
     fullCode: "IBM3261IW",
@@ -4864,7 +4863,7 @@ export const Warning = {
    */
   IBM3262I: {
     code: "IBM3262I",
-    severity: "W",
+    severity: Severity.W,
     message: (option: string, option2: string) =>
       `The suboption ${option} of the ${option2} option must be followed by a (possibly empty) parenthesized list.`,
     fullCode: "IBM3262IW",
@@ -4879,7 +4878,7 @@ export const Warning = {
    */
   IBM3265I: {
     code: "IBM3265I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "Number of lines specified with %SKIP must be between 0 and 999 inclusive.",
     fullCode: "IBM3265IW",
@@ -4891,7 +4890,7 @@ export const Warning = {
    */
   IBM3270I: {
     code: "IBM3270I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "'EXEC CICS' encountered, but the CICS option is not in effect. Command ignored.",
     fullCode: "IBM3270IW",
@@ -4903,7 +4902,7 @@ export const Warning = {
    */
   IBM3271I: {
     code: "IBM3271I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "'EXEC CSPM' encountered, but the CSPM option is not in effect. Command ignored.",
     fullCode: "IBM3271IW",
@@ -4915,7 +4914,7 @@ export const Warning = {
    */
   IBM3272I: {
     code: "IBM3272I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "'EXEC DLI' encountered, but the DLI option is not in effect. Command ignored.",
     fullCode: "IBM3272IW",
@@ -4928,7 +4927,7 @@ export const Warning = {
    */
   IBM3281I: {
     code: "IBM3281I",
-    severity: "W",
+    severity: Severity.W,
     message: "SELECT statement contains no WHEN or OTHERWISE clauses.",
     fullCode: "IBM3281IW",
   } as SimplePLICode,
@@ -4940,7 +4939,7 @@ export const Warning = {
    */
   IBM3283I: {
     code: "IBM3283I",
-    severity: "W",
+    severity: Severity.W,
     message: "SELECT statement contains no WHEN clauses.",
     fullCode: "IBM3283IW",
   } as SimplePLICode,
@@ -4951,7 +4950,7 @@ export const Warning = {
    */
   IBM3285I: {
     code: "IBM3285I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "FIXED BINARY constant contains too many digits. Excess nonsignificant digits will be ignored.",
     fullCode: "IBM3285IW",
@@ -4964,7 +4963,7 @@ export const Warning = {
    */
   IBM3286I: {
     code: "IBM3286I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "FIXED DECIMAL constant contains too many digits. Excess nonsignificant digits will be ignored.",
     fullCode: "IBM3286IW",
@@ -4976,7 +4975,7 @@ export const Warning = {
    */
   IBM3287I: {
     code: "IBM3287I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "Mantissa in FLOAT BINARY constant contains more digits than the implementation maximum. Excess nonsignificant digits will be ignored.",
     fullCode: "IBM3287IW",
@@ -4988,7 +4987,7 @@ export const Warning = {
    */
   IBM3288I: {
     code: "IBM3288I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "Mantissa in FLOAT DECIMAL constant contains more digits than the implementation maximum. Excess nonsignificant digits will be ignored.",
     fullCode: "IBM3288IW",
@@ -5002,7 +5001,7 @@ export const Warning = {
    */
   IBM3289I: {
     code: "IBM3289I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "FLOAT literal is too big for its implicit precision. An appropriate HUGE value is assumed.",
     fullCode: "IBM3289IW",
@@ -5015,7 +5014,7 @@ export const Warning = {
    */
   IBM3291I: {
     code: "IBM3291I",
-    severity: "W",
+    severity: Severity.W,
     message: (optionname: string) =>
       `The OPTIONS option ${optionname} conflicts with the LANGLVL compiler option. The option will be applied.`,
     fullCode: "IBM3291IW",
@@ -5031,7 +5030,7 @@ export const Warning = {
    */
   IBM3292I: {
     code: "IBM3292I",
-    severity: "W",
+    severity: Severity.W,
     message: (suboption: string, option: string) =>
       `${suboption} is not a valid suboption for ${option} .`,
     fullCode: "IBM3292IW",
@@ -5046,7 +5045,7 @@ export const Warning = {
    */
   IBM3293I: {
     code: "IBM3293I",
-    severity: "W",
+    severity: Severity.W,
     message: (suboption: string) =>
       `A required suboption is missing for the ${suboption} option.`,
     fullCode: "IBM3293IW",
@@ -5061,7 +5060,7 @@ export const Warning = {
    */
   IBM3294I: {
     code: "IBM3294I",
-    severity: "W",
+    severity: Severity.W,
     message: (option: string) =>
       `A closing parenthesis is missing in the specification of the ${option} option. One is assumed.`,
     fullCode: "IBM3294IW",
@@ -5076,7 +5075,7 @@ export const Warning = {
    */
   IBM3295I: {
     code: "IBM3295I",
-    severity: "W",
+    severity: Severity.W,
     message: (option: string) => `${option} is not a supported option.`,
     fullCode: "IBM3295IW",
   } as ParametricPLICode,
@@ -5091,7 +5090,7 @@ export const Warning = {
    */
   IBM3299I: {
     code: "IBM3299I",
-    severity: "W",
+    severity: Severity.W,
     message: "Syntax of the %LINE directive is incorrect.",
     fullCode: "IBM3299IW",
   } as SimplePLICode,
@@ -5102,7 +5101,7 @@ export const Warning = {
    */
   IBM3300I: {
     code: "IBM3300I",
-    severity: "W",
+    severity: Severity.W,
     message: (identifier: string) =>
       `${identifier} has not been declared. CHARACTER attribute assumed.`,
     fullCode: "IBM3300IW",
@@ -5116,7 +5115,7 @@ export const Warning = {
    */
   IBM3309I: {
     code: "IBM3309I",
-    severity: "W",
+    severity: Severity.W,
     message: (BUILTINname: string) =>
       `Comparison of ${BUILTINname} to a value it could not return is odd.`,
     fullCode: "IBM3309IW",
@@ -5133,7 +5132,7 @@ export const Warning = {
    */
   IBM3310I: {
     code: "IBM3310I",
-    severity: "W",
+    severity: Severity.W,
     message: (BUILTINname: string) =>
       `First argument to ${BUILTINname} built-in should have string type.`,
     fullCode: "IBM3310IW",
@@ -5150,7 +5149,7 @@ export const Warning = {
    */
   IBM3311I: {
     code: "IBM3311I",
-    severity: "W",
+    severity: Severity.W,
     message: (number: string, BUILTINname: string) =>
       `Argument ${number} to the ${BUILTINname} built-in function is missing. A null value will be passed for the missing argument.`,
     fullCode: "IBM3311IW",
@@ -5174,7 +5173,7 @@ export const Warning = {
    */
   IBM3312I: {
     code: "IBM3312I",
-    severity: "W",
+    severity: Severity.W,
     message: "LEAVE will exit noniterative DO- group.",
     fullCode: "IBM3312IW",
   } as SimplePLICode,
@@ -5193,7 +5192,7 @@ export const Warning = {
    */
   IBM3313I: {
     code: "IBM3313I",
-    severity: "W",
+    severity: Severity.W,
     message: "Result of comparison is always constant.",
     fullCode: "IBM3313IW",
   } as SimplePLICode,
@@ -5207,7 +5206,7 @@ export const Warning = {
    */
   IBM3314I: {
     code: "IBM3314I",
-    severity: "W",
+    severity: Severity.W,
     message: (reference: string) =>
       `The reference ${reference} could refer to a parent or its child, but the child is assumed.`,
     fullCode: "IBM3314IW",
@@ -5220,7 +5219,7 @@ export const Warning = {
    */
   IBM3315I: {
     code: "IBM3315I",
-    severity: "W",
+    severity: Severity.W,
     message: (reference: string) =>
       `The reference ${reference} is an array of structures. Arrays of structures are not valid in SQL statements, but because this structure consists of only one element, the reference is treated as if it were a reference to its lone child.`,
     fullCode: "IBM3315IW",
@@ -5233,7 +5232,7 @@ export const Warning = {
    */
   IBM3316I: {
     code: "IBM3316I",
-    severity: "W",
+    severity: Severity.W,
     message: (reference: string) =>
       `The reference ${reference} is a structure containing an array. 152 Structures containing arrays are not valid in SQL statements, but because this structure consists of only one element, the reference is treated as if it were a reference to its lone child.`,
     fullCode: "IBM3316IW",
@@ -5245,7 +5244,7 @@ export const Warning = {
    */
   IBM3317I: {
     code: "IBM3317I",
-    severity: "W",
+    severity: Severity.W,
     message: (note: string) => `${note}`,
     fullCode: "IBM3317IW",
   } as ParametricPLICode,
@@ -5260,7 +5259,7 @@ export const Warning = {
    */
   IBM3320I: {
     code: "IBM3320I",
-    severity: "W",
+    severity: Severity.W,
     message: "RETURNS attribute in ENTRY declare ignored.",
     fullCode: "IBM3320IW",
   } as SimplePLICode,
@@ -5278,7 +5277,7 @@ export const Warning = {
    */
   IBM3321I: {
     code: "IBM3321I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "RETURNS option assumed to enclose attribute in PROCEDURE statement.",
     fullCode: "IBM3321IW",
@@ -5300,7 +5299,7 @@ export const Warning = {
    */
   IBM3322I: {
     code: "IBM3322I",
-    severity: "W",
+    severity: Severity.W,
     message: (identifier: string) =>
       `Argument list for PROCEDURE ${identifier} is missing. It will be invoked without any arguments.`,
     fullCode: "IBM3322IW",
@@ -5321,7 +5320,7 @@ export const Warning = {
    */
   IBM3323I: {
     code: "IBM3323I",
-    severity: "W",
+    severity: Severity.W,
     message: (identifier: string) =>
       `Too few arguments for PROCEDURE ${identifier} . Null values will be passed for the missing arguments.`,
     fullCode: "IBM3323IW",
@@ -5342,7 +5341,7 @@ export const Warning = {
    */
   IBM3324I: {
     code: "IBM3324I",
-    severity: "W",
+    severity: Severity.W,
     message: (identifier: string) =>
       `Too many arguments for PROCEDURE ${identifier} . Excess ignored.`,
     fullCode: "IBM3324IW",
@@ -5359,7 +5358,7 @@ export const Warning = {
    */
   IBM3325I: {
     code: "IBM3325I",
-    severity: "W",
+    severity: Severity.W,
     message: (identifier: string) =>
       `No data attributes specified in declare for ${identifier} .`,
     fullCode: "IBM3325IW",
@@ -5376,7 +5375,7 @@ export const Warning = {
    */
   IBM3326I: {
     code: "IBM3326I",
-    severity: "W",
+    severity: Severity.W,
     message: "The LIKE reference is neither a structure nor a union.",
     fullCode: "IBM3326IW",
   } as SimplePLICode,
@@ -5402,7 +5401,7 @@ export const Warning = {
    */
   IBM3327I: {
     code: "IBM3327I",
-    severity: "W",
+    severity: Severity.W,
     message: "The LIKE reference is ambiguous.",
     fullCode: "IBM3327IW",
   } as SimplePLICode,
@@ -5424,7 +5423,7 @@ export const Warning = {
    */
   IBM3328I: {
     code: "IBM3328I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "Neither the LIKE reference nor any of its substructures can be declared with the LIKE attribute.",
     fullCode: "IBM3328IW",
@@ -5447,7 +5446,7 @@ export const Warning = {
    */
   IBM3329I: {
     code: "IBM3329I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "The LIKE reference must not be a member of a structure or union declared with the LIKE attribute.",
     fullCode: "IBM3329IW",
@@ -5460,7 +5459,7 @@ export const Warning = {
    */
   IBM3330I: {
     code: "IBM3330I",
-    severity: "W",
+    severity: Severity.W,
     message: "The LIKE reference is unknown.",
     fullCode: "IBM3330IW",
   } as SimplePLICode,
@@ -5472,7 +5471,7 @@ export const Warning = {
    */
   IBM3331I: {
     code: "IBM3331I",
-    severity: "W",
+    severity: Severity.W,
     message: (filename: string) =>
       `The INCLUDE file ${filename} will be deprecated.`,
     fullCode: "IBM3331IW",
@@ -5486,7 +5485,7 @@ export const Warning = {
    */
   IBM3332I: {
     code: "IBM3332I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "The END statement has no matching BEGIN, DO, PACKAGE, PROC, or SELECT. This may indicate a problem with the syntax of a previous statement.",
     fullCode: "IBM3332IW",
@@ -5500,7 +5499,7 @@ export const Warning = {
    */
   IBM3333I: {
     code: "IBM3333I",
-    severity: "W",
+    severity: Severity.W,
     message:
       "One or more END statements are missing. This may indicate a problem with the syntax of a previous statement.",
     fullCode: "IBM3333IW",
@@ -5513,7 +5512,7 @@ export const Warning = {
    */
   IBM3334I: {
     code: "IBM3334I",
-    severity: "W",
+    severity: Severity.W,
     message: (variable: string) =>
       `The ENTRY named ${variable} will be deprecated.`,
     fullCode: "IBM3334IW",
@@ -5527,7 +5526,7 @@ export const Error = {
    */
   IBM1226I: {
     code: "IBM1226I",
-    severity: "E",
+    severity: Severity.E,
     message: (maximumvalue: string) =>
       `Area extent is reduced to ${maximumvalue} .`,
     fullCode: "IBM1226IE",
@@ -5542,7 +5541,7 @@ export const Error = {
    */
   IBM1227I: {
     code: "IBM1227I",
-    severity: "E",
+    severity: Severity.E,
     message: (keyword: string, keyword2: string) =>
       `${keyword} statement is not allowed where an executable statement is required. A null statement will be inserted before the ${keyword2} statement.`,
     fullCode: "IBM1227IE",
@@ -5557,7 +5556,7 @@ export const Error = {
    */
   IBM1228I: {
     code: "IBM1228I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "DEFAULT statement is not allowed where an executable statement is required. The DEFAULT statement will be enrolled in the current block, and a null statement will be inserted in its place.",
     fullCode: "IBM1228IE",
@@ -5572,7 +5571,7 @@ export const Error = {
    */
   IBM1229I: {
     code: "IBM1229I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "FORMAT statement is not allowed where an executable statement is required. The FORMAT statement will be enrolled in the current block, and a null statement will be inserted in its place.",
     fullCode: "IBM1229IE",
@@ -5588,7 +5587,7 @@ export const Error = {
    */
   IBM1230I: {
     code: "IBM1230I",
-    severity: "E",
+    severity: Severity.E,
     message: (variablename: string) =>
       `Arguments have been specified for the variable ${variablename}, but it is not an entry variable.`,
     fullCode: "IBM1230IE",
@@ -5604,7 +5603,7 @@ export const Error = {
    */
   IBM1231I: {
     code: "IBM1231I",
-    severity: "E",
+    severity: Severity.E,
     message: (variablename: string) =>
       `Arguments/subscripts have been specified for the variable ${variablename} , but it is neither an entry nor an array variable.`,
     fullCode: "IBM1231IE",
@@ -5622,7 +5621,7 @@ export const Error = {
    */
   IBM1232I: {
     code: "IBM1232I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "RULES(NOLAXPUNC) violation: extraneous comma at end of statement ignored.",
     fullCode: "IBM1232IE",
@@ -5637,7 +5636,7 @@ export const Error = {
    */
   IBM1233I: {
     code: "IBM1233I",
-    severity: "E",
+    severity: Severity.E,
     message: (character: string) =>
       `RULES(NOLAXPUNC) violation: missing ${character} assumed.`,
     fullCode: "IBM1233IE",
@@ -5654,7 +5653,7 @@ export const Error = {
    */
   IBM1234I: {
     code: "IBM1234I",
-    severity: "E",
+    severity: Severity.E,
     message: (character: string, character2: string) =>
       `RULES(NOLAXPUNC) violation: missing ${character} assumed before ${character2} .`,
     fullCode: "IBM1234IE",
@@ -5670,7 +5669,7 @@ export const Error = {
    */
   IBM1235I: {
     code: "IBM1235I",
-    severity: "E",
+    severity: Severity.E,
     message: "No data format item in format list.",
     fullCode: "IBM1235IE",
   } as SimplePLICode,
@@ -5682,7 +5681,7 @@ export const Error = {
    */
   IBM1236I: {
     code: "IBM1236I",
-    severity: "E",
+    severity: Severity.E,
     message: (keyword: string) =>
       `Subscripts on ${keyword} labels are ignored.`,
     fullCode: "IBM1236IE",
@@ -5695,7 +5694,7 @@ export const Error = {
    */
   IBM1237I: {
     code: "IBM1237I",
-    severity: "E",
+    severity: Severity.E,
     message: (variablename: string) =>
       `EXTERNAL ENTRY attribute is assumed for ${variablename} .`,
     fullCode: "IBM1237IE",
@@ -5711,7 +5710,7 @@ export const Error = {
    */
   IBM1238I: {
     code: "IBM1238I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string) =>
       `The second argument to the ${BUILTINname} built-in function is greater than the precision of the result.`,
     fullCode: "IBM1238IE",
@@ -5727,7 +5726,7 @@ export const Error = {
    */
   IBM1239I: {
     code: "IBM1239I",
-    severity: "E",
+    severity: Severity.E,
     message: (attribute: string) =>
       `The ${attribute} attribute is not supported and is ignored.`,
     fullCode: "IBM1239IE",
@@ -5742,7 +5741,7 @@ export const Error = {
    */
   IBM1240I: {
     code: "IBM1240I",
-    severity: "E",
+    severity: Severity.E,
     message: (attribute: string) =>
       `The ${attribute} attribute is invalid in a RETURNS descriptor.`,
     fullCode: "IBM1240IE",
@@ -5755,7 +5754,7 @@ export const Error = {
    */
   IBM1241I: {
     code: "IBM1241I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Equality and inequality are the only valid comparisons of COMPLEX numbers.",
     fullCode: "IBM1241IE",
@@ -5768,7 +5767,7 @@ export const Error = {
    */
   IBM1242I: {
     code: "IBM1242I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Equality and inequality are the only valid comparisons of program control data.",
     fullCode: "IBM1242IE",
@@ -5781,7 +5780,7 @@ export const Error = {
    */
   IBM1243I: {
     code: "IBM1243I",
-    severity: "E",
+    severity: Severity.E,
     message: (integerSpec2or3: string) =>
       `REGIONAL(${integerSpec2or3}) ENVIRONMENT option is not supported.`,
     fullCode: "IBM1243IE",
@@ -5793,7 +5792,7 @@ export const Error = {
    */
   IBM1244I: {
     code: "IBM1244I",
-    severity: "E",
+    severity: Severity.E,
     message: (option: string) =>
       `The variable specified as the ${option} value in an ENVIRONMENT option must be a STATIC scalar 36 with the attributes REAL FIXED BIN(31,0).`,
     fullCode: "IBM1244IE",
@@ -5805,7 +5804,7 @@ export const Error = {
    */
   IBM1245I: {
     code: "IBM1245I",
-    severity: "E",
+    severity: Severity.E,
     message: (option: string) =>
       `The variable specified as the ${option} value in an ENVIRONMENT option must be a STATIC scalar with the attribute CHARACTER.`,
     fullCode: "IBM1245IE",
@@ -5821,7 +5820,7 @@ export const Error = {
    */
   IBM1246I: {
     code: "IBM1246I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string) =>
       `Argument to ${BUILTINname} built-in function should be CONNECTED.`,
     fullCode: "IBM1246IE",
@@ -5838,7 +5837,7 @@ export const Error = {
    */
   IBM1247I: {
     code: "IBM1247I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "RULES(NOLAXCONV) violation: arithmetic operands should both be numeric.",
     fullCode: "IBM1247IE",
@@ -5852,7 +5851,7 @@ export const Error = {
    */
   IBM1248I: {
     code: "IBM1248I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string) =>
       `RULES(NOLAXCONV) violation: argument to ${BUILTINname} built- in function should have arithmetic type.`,
     fullCode: "IBM1248IE",
@@ -5866,7 +5865,7 @@ export const Error = {
    */
   IBM1249I: {
     code: "IBM1249I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string) =>
       `Argument to ${BUILTINname} built-in function should have CHARACTER type.`,
     fullCode: "IBM1249IE",
@@ -5883,7 +5882,7 @@ export const Error = {
    */
   IBM1252I: {
     code: "IBM1252I",
-    severity: "E",
+    severity: Severity.E,
     message: (argumentnumber: string, BUILTINname: string) =>
       `RULES(NOLAXCONV) violation: argument number ${argumentnumber} to ${BUILTINname} built-in function should have arithmetic type.`,
     fullCode: "IBM1252IE",
@@ -5900,7 +5899,7 @@ export const Error = {
    */
   IBM1254I: {
     code: "IBM1254I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "RULES(NOLAXCONV) violation: arithmetic prefix operand should be numeric.",
     fullCode: "IBM1254IE",
@@ -5916,7 +5915,7 @@ export const Error = {
    */
   IBM1272I: {
     code: "IBM1272I",
-    severity: "E",
+    severity: Severity.E,
     message: (argumentnumber: string, BUILTINname: string) =>
       `Argument number ${argumentnumber} to ${BUILTINname} built-in function is negative. It will be changed to 0.`,
     fullCode: "IBM1272IE",
@@ -5932,7 +5931,7 @@ export const Error = {
    */
   IBM1273I: {
     code: "IBM1273I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string) =>
       `Third argument to ${BUILTINname} built-in function is negative. It will be changed to 0.`,
     fullCode: "IBM1273IE",
@@ -5951,7 +5950,7 @@ export const Error = {
    */
   IBM1274I: {
     code: "IBM1274I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "RULES(NOLAXIF) violation: conditional expression does not have the attributes BIT(1).",
     fullCode: "IBM1274IE",
@@ -5963,7 +5962,7 @@ export const Error = {
    */
   IBM1281I: {
     code: "IBM1281I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "OPTIONS(RETCODE) on ATTACH reference is invalid and will be ignored.",
     fullCode: "IBM1281IE",
@@ -5976,7 +5975,7 @@ export const Error = {
    */
   IBM1287I: {
     code: "IBM1287I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "RULES(NOLAXCONV) violation: exponentiation operands should have numeric type.",
     fullCode: "IBM1287IE",
@@ -5989,7 +5988,7 @@ export const Error = {
    */
   IBM1293I: {
     code: "IBM1293I",
-    severity: "E",
+    severity: Severity.E,
     message: (maximumvalue: string) =>
       `WIDECHAR extent is reduced to ${maximumvalue} .`,
     fullCode: "IBM1293IE",
@@ -6002,7 +6001,7 @@ export const Error = {
    */
   IBM1294I: {
     code: "IBM1294I",
-    severity: "E",
+    severity: Severity.E,
     message: (maximumvalue: string) =>
       `BIT extent is reduced to ${maximumvalue} .`,
     fullCode: "IBM1294IE",
@@ -6018,7 +6017,7 @@ export const Error = {
    */
   IBM1295I: {
     code: "IBM1295I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Sole bound specified is less than 1. An upper bound of 1 is assumed.",
     fullCode: "IBM1295IE",
@@ -6036,7 +6035,7 @@ export const Error = {
    */
   IBM1296I: {
     code: "IBM1296I",
-    severity: "E",
+    severity: Severity.E,
     message: "The BYADDR option conflicts with the SYSTEM option.",
     fullCode: "IBM1296IE",
   } as SimplePLICode,
@@ -6053,7 +6052,7 @@ export const Error = {
    */
   IBM1297I: {
     code: "IBM1297I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Source and target in BY NAME assignment have no matching assignable base identifiers.",
     fullCode: "IBM1297IE",
@@ -6065,7 +6064,7 @@ export const Error = {
    */
   IBM1298I: {
     code: "IBM1298I",
-    severity: "E",
+    severity: Severity.E,
     message: "Characters in B3 literals must be 0-7.",
     fullCode: "IBM1298IE",
   } as SimplePLICode,
@@ -6077,7 +6076,7 @@ export const Error = {
    */
   IBM1299I: {
     code: "IBM1299I",
-    severity: "E",
+    severity: Severity.E,
     message: (maximumvalue: string) =>
       `CHARACTER extent is reduced to ${maximumvalue} .`,
     fullCode: "IBM1299IE",
@@ -6089,7 +6088,7 @@ export const Error = {
    */
   IBM1300I: {
     code: "IBM1300I",
-    severity: "E",
+    severity: Severity.E,
     message: (variablename: string, attribute: string) =>
       `RULES(NOLAXDCL) violation: ${variablename} is contextually declared as ${attribute} .`,
     fullCode: "IBM1300IE",
@@ -6102,7 +6101,7 @@ export const Error = {
    */
   IBM1301I: {
     code: "IBM1301I",
-    severity: "E",
+    severity: Severity.E,
     message: "A DECIMAL exponent is required.",
     fullCode: "IBM1301IE",
   } as SimplePLICode,
@@ -6113,7 +6112,7 @@ export const Error = {
    */
   IBM1302I: {
     code: "IBM1302I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "The limit on the number of DEFAULT predicates in a block has already been reached. This and subsequent DEFAULT predicates in this block will be ignored.",
     fullCode: "IBM1302IE",
@@ -6130,7 +6129,7 @@ export const Error = {
    */
   IBM1303I: {
     code: "IBM1303I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string) =>
       `A second argument to the ${BUILTINname} built-in function must be supplied for arrays with more than one dimension. A value of 1 is assumed.`,
     fullCode: "IBM1303IE",
@@ -6143,7 +6142,7 @@ export const Error = {
    */
   IBM1304I: {
     code: "IBM1304I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string) =>
       `Second argument to ${BUILTINname} built-in function is not positive. A value of 1 is assumed.`,
     fullCode: "IBM1304IE",
@@ -6160,7 +6159,7 @@ export const Error = {
    */
   IBM1305I: {
     code: "IBM1305I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string, dimensioncount: string) =>
       `Second argument to ${BUILTINname} built-in function is greater than the number of dimensions for the first argument. A value of ${dimensioncount} is assumed.`,
     fullCode: "IBM1305IE",
@@ -6175,7 +6174,7 @@ export const Error = {
    */
   IBM1306I: {
     code: "IBM1306I",
-    severity: "E",
+    severity: Severity.E,
     message: (identifier: string) =>
       `Repeated declaration of ${identifier} is invalid and will be ignored.`,
     fullCode: "IBM1306IE",
@@ -6190,7 +6189,7 @@ export const Error = {
    */
   IBM1307I: {
     code: "IBM1307I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Duplicate specification of arithmetic precision. Subsequent specification ignored.",
     fullCode: "IBM1307IE",
@@ -6208,7 +6207,7 @@ export const Error = {
    */
   IBM1308I: {
     code: "IBM1308I",
-    severity: "E",
+    severity: Severity.E,
     message: (identifier: string) =>
       `Repeated declaration of ${identifier} is invalid. The name will be replaced by an asterisk.`,
     fullCode: "IBM1308IE",
@@ -6224,7 +6223,7 @@ export const Error = {
    */
   IBM1309I: {
     code: "IBM1309I",
-    severity: "E",
+    severity: Severity.E,
     message: (attribute: string) =>
       `Duplicate specification of ${attribute} . Subsequent specification ignored.`,
     fullCode: "IBM1309IE",
@@ -6239,7 +6238,7 @@ export const Error = {
    */
   IBM1310I: {
     code: "IBM1310I",
-    severity: "E",
+    severity: Severity.E,
     message: (character: string) =>
       `The attribute ${character} conflicts with previous attributes and is ignored.`,
     fullCode: "IBM1310IE",
@@ -6254,7 +6253,7 @@ export const Error = {
    */
   IBM1311I: {
     code: "IBM1311I",
-    severity: "E",
+    severity: Severity.E,
     message: "EXTERNAL name contains no non- blank characters and is ignored.",
     fullCode: "IBM1311IE",
   } as SimplePLICode,
@@ -6269,7 +6268,7 @@ export const Error = {
    */
   IBM1312I: {
     code: "IBM1312I",
-    severity: "E",
+    severity: Severity.E,
     message: "WX literals should contain a multiple of 4 hex digits.",
     fullCode: "IBM1312IE",
   } as SimplePLICode,
@@ -6283,7 +6282,7 @@ export const Error = {
    */
   IBM1314I: {
     code: "IBM1314I",
-    severity: "E",
+    severity: Severity.E,
     message: "ELSE clause outside of an open IF- THEN statement is ignored.",
     fullCode: "IBM1314IE",
   } as SimplePLICode,
@@ -6300,7 +6299,7 @@ export const Error = {
    */
   IBM1315I: {
     code: "IBM1315I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "END label matches a label on an open group, but that group label is subscripted.",
     fullCode: "IBM1315IE",
@@ -6318,7 +6317,7 @@ export const Error = {
    */
   IBM1316I: {
     code: "IBM1316I",
-    severity: "E",
+    severity: Severity.E,
     message: "END label is not a label on any open group.",
     fullCode: "IBM1316IE",
   } as SimplePLICode,
@@ -6339,7 +6338,7 @@ export const Error = {
    */
   IBM1317I: {
     code: "IBM1317I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "An END statement may be missing after an OTHERWISE unit. One will be inserted.",
     fullCode: "IBM1317IE",
@@ -6353,7 +6352,7 @@ export const Error = {
    */
   IBM1318I: {
     code: "IBM1318I",
-    severity: "E",
+    severity: Severity.E,
     message: (optionname: string) =>
       `The ENVIRONMENT option ${optionname} conflicts with preceding ENVIRONMENT options. This option will be ignored.`,
     fullCode: "IBM1318IE",
@@ -6367,7 +6366,7 @@ export const Error = {
    */
   IBM1319I: {
     code: "IBM1319I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "STRINGSIZE condition raised while evaluating expression. Result is truncated.",
     fullCode: "IBM1319IE",
@@ -6385,7 +6384,7 @@ export const Error = {
    */
   IBM1320I: {
     code: "IBM1320I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "STRINGRANGE condition raised while evaluating expression. Arguments are adjusted to fit.",
     fullCode: "IBM1320IE",
@@ -6403,7 +6402,7 @@ export const Error = {
    */
   IBM1321I: {
     code: "IBM1321I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "LEAVE/ITERATE label matches a label on an open DO group, but that DO group label is subscripted.",
     fullCode: "IBM1321IE",
@@ -6421,7 +6420,7 @@ export const Error = {
    */
   IBM1322I: {
     code: "IBM1322I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "LEAVE/ITERATE label is not a label on any open DO group in its containing block.",
     fullCode: "IBM1322IE",
@@ -6440,7 +6439,7 @@ export const Error = {
    */
   IBM1323I: {
     code: "IBM1323I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "ITERATE/LEAVE statement is invalid outside an open DO statement. The statement will be ignored.",
     fullCode: "IBM1323IE",
@@ -6455,7 +6454,7 @@ export const Error = {
    */
   IBM1324I: {
     code: "IBM1324I",
-    severity: "E",
+    severity: Severity.E,
     message: (name: string) =>
       `The name ${name} occurs more than once in the EXPORTS clause.`,
     fullCode: "IBM1324IE",
@@ -6471,7 +6470,7 @@ export const Error = {
    */
   IBM1325I: {
     code: "IBM1325I",
-    severity: "E",
+    severity: Severity.E,
     message: (name: string) =>
       `The name ${name} occurs in the EXPORTS clause, but is not the name of any nonnested PROCEDURE.`,
     fullCode: "IBM1325IE",
@@ -6489,7 +6488,7 @@ export const Error = {
    */
   IBM1326I: {
     code: "IBM1326I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Variables declared without a name must be structure members or followed by a substructure list.",
     fullCode: "IBM1326IE",
@@ -6502,7 +6501,7 @@ export const Error = {
    */
   IBM1327I: {
     code: "IBM1327I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "The CHARACTER VARYING parameter to MAIN should be ASCII with the attribute NATIVE.",
     fullCode: "IBM1327IE",
@@ -6515,7 +6514,7 @@ export const Error = {
    */
   IBM1328I: {
     code: "IBM1328I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "The CHARACTER VARYING parameter to MAIN should be EBCDIC with the attribute BIGENDIAN.",
     fullCode: "IBM1328IE",
@@ -6528,7 +6527,7 @@ export const Error = {
    */
   IBM1329I: {
     code: "IBM1329I",
-    severity: "E",
+    severity: Severity.E,
     message: "ENTRY statements are not allowed under RULES(NOMULTIENTRY).",
     fullCode: "IBM1329IE",
   } as SimplePLICode,
@@ -6542,7 +6541,7 @@ export const Error = {
    */
   IBM1330I: {
     code: "IBM1330I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "The I in an iSUB token must be bigger than zero. A value of 1 is assumed.",
     fullCode: "IBM1330IE",
@@ -6557,7 +6556,7 @@ export const Error = {
    */
   IBM1331I: {
     code: "IBM1331I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "The I in an iSUB token must have no more than 2 digits. A value of 1 is assumed.",
     fullCode: "IBM1331IE",
@@ -6573,7 +6572,7 @@ export const Error = {
    */
   IBM1332I: {
     code: "IBM1332I",
-    severity: "E",
+    severity: Severity.E,
     message: (formatitem: string) =>
       `The ${formatitem} format item requires an argument when used in GET statement. A value of 1 is assumed.`,
     fullCode: "IBM1332IE",
@@ -6588,7 +6587,7 @@ export const Error = {
    */
   IBM1333I: {
     code: "IBM1333I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Non-asterisk array bounds are not permitted in GENERIC descriptions.",
     fullCode: "IBM1333IE",
@@ -6603,7 +6602,7 @@ export const Error = {
    */
   IBM1334I: {
     code: "IBM1334I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "String lengths and area sizes are not permitted in GENERIC descriptions.",
     fullCode: "IBM1334IE",
@@ -6619,7 +6618,7 @@ export const Error = {
    */
   IBM1335I: {
     code: "IBM1335I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Entry description lists are not permitted in GENERIC descriptions.",
     fullCode: "IBM1335IE",
@@ -6632,7 +6631,7 @@ export const Error = {
    */
   IBM1336I: {
     code: "IBM1336I",
-    severity: "E",
+    severity: Severity.E,
     message: (maximumvalue: string) =>
       `GRAPHIC extent is reduced to ${maximumvalue} .`,
     fullCode: "IBM1336IE",
@@ -6648,7 +6647,7 @@ export const Error = {
    */
   IBM1337I: {
     code: "IBM1337I",
-    severity: "E",
+    severity: Severity.E,
     message: "GX literals should contain a multiple of 4 hex digits.",
     fullCode: "IBM1337IE",
   } as SimplePLICode,
@@ -6661,7 +6660,7 @@ export const Error = {
    */
   IBM1338I: {
     code: "IBM1338I",
-    severity: "E",
+    severity: Severity.E,
     message: "Upper bound is less than lower bound. Bounds will be reversed.",
     fullCode: "IBM1338IE",
   } as SimplePLICode,
@@ -6673,7 +6672,7 @@ export const Error = {
    */
   IBM1339I: {
     code: "IBM1339I",
-    severity: "E",
+    severity: Severity.E,
     message: (identifier: string) =>
       `Identifier is too long. It will be collapsed to ${identifier} .`,
     fullCode: "IBM1339IE",
@@ -6691,7 +6690,7 @@ export const Error = {
    */
   IBM1340I: {
     code: "IBM1340I",
-    severity: "E",
+    severity: Severity.E,
     message: (argumentnumber: string, ENTRYname: string) =>
       `Argument number ${argumentnumber} in ENTRY reference ${ENTRYname} contains BIT data. NOMAP is assumed.`,
     fullCode: "IBM1340IE",
@@ -6710,7 +6709,7 @@ export const Error = {
    */
   IBM1341I: {
     code: "IBM1341I",
-    severity: "E",
+    severity: Severity.E,
     message: (argumentnumber: string, ENTRYname: string) =>
       `Argument number ${argumentnumber} in ENTRY reference ${ENTRYname} is or contains a UNION. NOMAP is assumed.`,
     fullCode: "IBM1341IE",
@@ -6729,7 +6728,7 @@ export const Error = {
    */
   IBM1342I: {
     code: "IBM1342I",
-    severity: "E",
+    severity: Severity.E,
     message: (argumentnumber: string, ENTRYname: string) =>
       `Argument number ${argumentnumber} in ENTRY reference ${ENTRYname} contains non-constant extents. NOMAP is assumed.`,
     fullCode: "IBM1342IE",
@@ -6746,7 +6745,7 @@ export const Error = {
    */
   IBM1343I: {
     code: "IBM1343I",
-    severity: "E",
+    severity: Severity.E,
     message: (nomapsuboption: string, option: string) =>
       `${nomapsuboption} is invalid as a suboption of ${option} .`,
     fullCode: "IBM1343IE",
@@ -6759,7 +6758,7 @@ export const Error = {
    */
   IBM1344I: {
     code: "IBM1344I",
-    severity: "E",
+    severity: Severity.E,
     message: "NOMAP specifications are valid only for ILC routines.",
     fullCode: "IBM1344IE",
   } as SimplePLICode,
@@ -6778,7 +6777,7 @@ export const Error = {
    */
   IBM1345I: {
     code: "IBM1345I",
-    severity: "E",
+    severity: Severity.E,
     message: "Initial level number in a structure is not 1.",
     fullCode: "IBM1345IE",
   } as SimplePLICode,
@@ -6794,7 +6793,7 @@ export const Error = {
    */
   IBM1346I: {
     code: "IBM1346I",
-    severity: "E",
+    severity: Severity.E,
     message: "INIT expression should be enclosed in parentheses.",
     fullCode: "IBM1346IE",
   } as SimplePLICode,
@@ -6808,7 +6807,7 @@ export const Error = {
    */
   IBM1347I: {
     code: "IBM1347I",
-    severity: "E",
+    severity: Severity.E,
     message: "B assumed to complete iSUB.",
     fullCode: "IBM1347IE",
   } as SimplePLICode,
@@ -6819,7 +6818,7 @@ export const Error = {
    */
   IBM1348I: {
     code: "IBM1348I",
-    severity: "E",
+    severity: Severity.E,
     message: "Digit in BINARY constant is not zero or one.",
     fullCode: "IBM1348IE",
   } as SimplePLICode,
@@ -6830,7 +6829,7 @@ export const Error = {
    */
   IBM1349I: {
     code: "IBM1349I",
-    severity: "E",
+    severity: Severity.E,
     message: "Characters in BIT literals must be 0 or 1.",
     fullCode: "IBM1349IE",
   } as SimplePLICode,
@@ -6844,7 +6843,7 @@ export const Error = {
    */
   IBM1350I: {
     code: "IBM1350I",
-    severity: "E",
+    severity: Severity.E,
     message: (n: string) =>
       `Character with decimal value ${n} does not belong to the PL/I character set. It will be ignored.`,
     fullCode: "IBM1350IE",
@@ -6856,7 +6855,7 @@ export const Error = {
    */
   IBM1351I: {
     code: "IBM1351I",
-    severity: "E",
+    severity: Severity.E,
     message: "Characters in hex literals must be 0-9 or A-F.",
     fullCode: "IBM1351IE",
   } as SimplePLICode,
@@ -6868,7 +6867,7 @@ export const Error = {
    */
   IBM1352I: {
     code: "IBM1352I",
-    severity: "E",
+    severity: Severity.E,
     message: (character: string) =>
       `The statement element ${character} is invalid. The statement will be ignored.`,
     fullCode: "IBM1352IE",
@@ -6883,7 +6882,7 @@ export const Error = {
    */
   IBM1353I: {
     code: "IBM1353I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Use of underscore as initial character in an identifier accepted although invalid under LANGLVL(SAA).",
     fullCode: "IBM1353IE",
@@ -6895,7 +6894,7 @@ export const Error = {
    */
   IBM1354I: {
     code: "IBM1354I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Multiple argument lists are valid only with the last identifier in a reference.",
     fullCode: "IBM1354IE",
@@ -6907,7 +6906,7 @@ export const Error = {
    */
   IBM1355I: {
     code: "IBM1355I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Empty argument lists are valid only with the last identifier in a reference.",
     fullCode: "IBM1355IE",
@@ -6923,7 +6922,7 @@ export const Error = {
    */
   IBM1356I: {
     code: "IBM1356I",
-    severity: "E",
+    severity: Severity.E,
     message: (n: string) =>
       `Character with decimal value ${n} does not belong to the PL/I character set. It is assumed to be an OR symbol.`,
     fullCode: "IBM1356IE",
@@ -6939,7 +6938,7 @@ export const Error = {
    */
   IBM1357I: {
     code: "IBM1357I",
-    severity: "E",
+    severity: Severity.E,
     message: (n: string) =>
       `Character with decimal value ${n} does not belong to the PL/I 44 character set. It is assumed to be a NOT symbol.`,
     fullCode: "IBM1357IE",
@@ -6956,7 +6955,7 @@ export const Error = {
    */
   IBM1358I: {
     code: "IBM1358I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string) =>
       `The scale factor specified in ${BUILTINname} built-in function with a floating-point argument must be positive. It will be changed to 1.`,
     fullCode: "IBM1358IE",
@@ -6971,7 +6970,7 @@ export const Error = {
    */
   IBM1359I: {
     code: "IBM1359I",
-    severity: "E",
+    severity: Severity.E,
     message: (identifier: string, identifier2: string) =>
       `Names in RANGE( ${identifier} : ${identifier2} ) are not in ascending order. Order is reversed.`,
     fullCode: "IBM1359IE",
@@ -6988,7 +6987,7 @@ export const Error = {
    */
   IBM1360I: {
     code: "IBM1360I",
-    severity: "E",
+    severity: Severity.E,
     message: (identifier: string) =>
       `The name ${identifier} has already been defined as a FORMAT constant.`,
     fullCode: "IBM1360IE",
@@ -7005,7 +7004,7 @@ export const Error = {
    */
   IBM1361I: {
     code: "IBM1361I",
-    severity: "E",
+    severity: Severity.E,
     message: (identifier: string) =>
       `The name ${identifier} has already been defined as a LABEL constant.`,
     fullCode: "IBM1361IE",
@@ -7022,7 +7021,7 @@ export const Error = {
    */
   IBM1362I: {
     code: "IBM1362I",
-    severity: "E",
+    severity: Severity.E,
     message: (labelname: string) =>
       `The label ${labelname} has already been declared. The explicit declaration of the label will not be accepted.`,
     fullCode: "IBM1362IE",
@@ -7040,7 +7039,7 @@ export const Error = {
    */
   IBM1363I: {
     code: "IBM1363I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Structure level greater than 255 specified. It will be replaced by 255.",
     fullCode: "IBM1363IE",
@@ -7058,7 +7057,7 @@ export const Error = {
    */
   IBM1364I: {
     code: "IBM1364I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Elements with level numbers greater than 1 follow an element without a level number. A level number of 1 is assumed.",
     fullCode: "IBM1364IE",
@@ -7076,7 +7075,7 @@ export const Error = {
    */
   IBM1365I: {
     code: "IBM1365I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Statement type resolution requires too many lexical units to 45 be examined. The statement will be ignored.",
     fullCode: "IBM1365IE",
@@ -7094,7 +7093,7 @@ export const Error = {
    */
   IBM1366I: {
     code: "IBM1366I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Level number following LIKE specification is greater than than the level number for the LIKE specification. LIKE attribute will be ignored.",
     fullCode: "IBM1366IE",
@@ -7112,7 +7111,7 @@ export const Error = {
    */
   IBM1367I: {
     code: "IBM1367I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Statements inside a SELECT must be preceded by a WHEN or an OTHERWISE clause. Statement is ignored.",
     fullCode: "IBM1367IE",
@@ -7132,7 +7131,7 @@ export const Error = {
    */
   IBM1368I: {
     code: "IBM1368I",
-    severity: "E",
+    severity: Severity.E,
     message: (character: string) =>
       `The attribute ${character} is invalid if it is not followed by an element with a greater logical level.`,
     fullCode: "IBM1368IE",
@@ -7145,7 +7144,7 @@ export const Error = {
    */
   IBM1369I: {
     code: "IBM1369I",
-    severity: "E",
+    severity: Severity.E,
     message: "MAIN has already been specified in the PACKAGE.",
     fullCode: "IBM1369IE",
   } as SimplePLICode,
@@ -7159,7 +7158,7 @@ export const Error = {
    */
   IBM1370I: {
     code: "IBM1370I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Extent expression is negative. It will be replaced by the constant 1.",
     fullCode: "IBM1370IE",
@@ -7172,7 +7171,7 @@ export const Error = {
    */
   IBM1371I: {
     code: "IBM1371I",
-    severity: "E",
+    severity: Severity.E,
     message: (identifier: string) =>
       `RULES(NOLAXQUAL) violation: structure element ${identifier} is not dot qualified.`,
     fullCode: "IBM1371IE",
@@ -7191,7 +7190,7 @@ export const Error = {
    */
   IBM1372I: {
     code: "IBM1372I",
-    severity: "E",
+    severity: Severity.E,
     message: "EXTERNAL specified on internal entry point.",
     fullCode: "IBM1372IE",
   } as SimplePLICode,
@@ -7203,7 +7202,7 @@ export const Error = {
    */
   IBM1373I: {
     code: "IBM1373I",
-    severity: "E",
+    severity: Severity.E,
     message: (variablename: string) =>
       `RULES(NOLAXDCL) violation: variable ${variablename} is implicitly declared.`,
     fullCode: "IBM1373IE",
@@ -7221,7 +7220,7 @@ export const Error = {
    */
   IBM1374I: {
     code: "IBM1374I",
-    severity: "E",
+    severity: Severity.E,
     message: (variablename: string) =>
       `Contextual attributes conflicting with PARAMETER will not be applied to ${variablename} .`,
     fullCode: "IBM1374IE",
@@ -7238,7 +7237,7 @@ export const Error = {
    */
   IBM1375I: {
     code: "IBM1375I",
-    severity: "E",
+    severity: Severity.E,
     message: (variablename: string) =>
       `The DEFINED variable ${variablename} does not fit into its base variable.`,
     fullCode: "IBM1375IE",
@@ -7253,7 +7252,7 @@ export const Error = {
    */
   IBM1376I: {
     code: "IBM1376I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Factoring of level numbers into declaration lists containing level numbers is invalid. The level numbers in the declaration list will be ignored.",
     fullCode: "IBM1376IE",
@@ -7268,7 +7267,7 @@ export const Error = {
    */
   IBM1377I: {
     code: "IBM1377I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string) =>
       `A scale factor has been specified as an argument to the ${BUILTINname} built-in function, but the result of that function has type FLOAT. The scale factor will be ignored.`,
     fullCode: "IBM1377IE",
@@ -7285,7 +7284,7 @@ export const Error = {
    */
   IBM1378I: {
     code: "IBM1378I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "An arguments list or subscripts list has been provided for a GENERIC ENTRY reference. It will be ignored.",
     fullCode: "IBM1378IE",
@@ -7301,7 +7300,7 @@ export const Error = {
    */
   IBM1379I: {
     code: "IBM1379I",
-    severity: "E",
+    severity: Severity.E,
     message: "Locator qualifier for GENERIC reference is ignored.",
     fullCode: "IBM1379IE",
   } as SimplePLICode,
@@ -7320,7 +7319,7 @@ export const Error = {
    */
   IBM1380I: {
     code: "IBM1380I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Target structure in assignment contains no elements with the ASSIGNABLE attribute. No assignments will be generated.",
     fullCode: "IBM1380IE",
@@ -7334,7 +7333,7 @@ export const Error = {
    */
   IBM1381I: {
     code: "IBM1381I",
-    severity: "E",
+    severity: Severity.E,
     message: "DEFINED base for a BIT structure should be aligned.",
     fullCode: "IBM1381IE",
   } as SimplePLICode,
@@ -7348,7 +7347,7 @@ export const Error = {
    */
   IBM1382I: {
     code: "IBM1382I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "INITIAL attribute is invalid for STATIC FORMAT variables. Storage class is changed to AUTOMATIC.",
     fullCode: "IBM1382IE",
@@ -7361,7 +7360,7 @@ export const Error = {
    */
   IBM1383I: {
     code: "IBM1383I",
-    severity: "E",
+    severity: Severity.E,
     message: (keyword: string) =>
       `Labels on ${keyword} statements are invalid and ignored.`,
     fullCode: "IBM1383IE",
@@ -7373,7 +7372,7 @@ export const Error = {
    */
   IBM1384I: {
     code: "IBM1384I",
-    severity: "E",
+    severity: Severity.E,
     message: (message: string) => `${message}`,
     fullCode: "IBM1384IE",
   } as ParametricPLICode,
@@ -7385,7 +7384,7 @@ export const Error = {
    */
   IBM1385I: {
     code: "IBM1385I",
-    severity: "E",
+    severity: Severity.E,
     message: "Invalid DEFINED - string overlay defining attempted.",
     fullCode: "IBM1385IE",
   } as SimplePLICode,
@@ -7401,7 +7400,7 @@ export const Error = {
    */
   IBM1386I: {
     code: "IBM1386I",
-    severity: "E",
+    severity: Severity.E,
     message: "DEFINED base for a BIT variable should not be subscripted.",
     fullCode: "IBM1386IE",
   } as SimplePLICode,
@@ -7418,7 +7417,7 @@ export const Error = {
    */
   IBM1387I: {
     code: "IBM1387I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "The NODESCRIPTOR attribute is invalid when any parameters have * extents. The NODESCRIPTOR attribute will be ignored.",
     fullCode: "IBM1387IE",
@@ -7435,7 +7434,7 @@ export const Error = {
    */
   IBM1388I: {
     code: "IBM1388I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "The NODESCRIPTOR attribute is invalid when any parameters have the NONCONNECTED attribute.",
     fullCode: "IBM1388IE",
@@ -7448,7 +7447,7 @@ export const Error = {
    */
   IBM1389I: {
     code: "IBM1389I",
-    severity: "E",
+    severity: Severity.E,
     message: (identifier: string) =>
       `The identifier ${identifier} is not the name of a built-in function. The BUILTIN attribute will be ignored.`,
     fullCode: "IBM1389IE",
@@ -7460,7 +7459,7 @@ export const Error = {
    */
   IBM1390I: {
     code: "IBM1390I",
-    severity: "E",
+    severity: Severity.E,
     message: (note: string) => `${note}`,
     fullCode: "IBM1390IE",
   } as ParametricPLICode,
@@ -7471,7 +7470,7 @@ export const Error = {
    */
   IBM1391I: {
     code: "IBM1391I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "End-of-source has been encountered after an unmatched comment marker.",
     fullCode: "IBM1391IE",
@@ -7483,7 +7482,7 @@ export const Error = {
    */
   IBM1392I: {
     code: "IBM1392I",
-    severity: "E",
+    severity: Severity.E,
     message: "End-of-source has been encountered after an unmatched quote.",
     fullCode: "IBM1392IE",
   } as SimplePLICode,
@@ -7497,7 +7496,7 @@ export const Error = {
    */
   IBM1393I: {
     code: "IBM1393I",
-    severity: "E",
+    severity: Severity.E,
     message: (optionname: string) =>
       `Item in OPTIONS list conflicts with other attributes in the declaration. ${optionname} is ignored.`,
     fullCode: "IBM1393IE",
@@ -7513,7 +7512,7 @@ export const Error = {
    */
   IBM1394I: {
     code: "IBM1394I",
-    severity: "E",
+    severity: Severity.E,
     message: (optionname: string) =>
       `Item in OPTIONS list is invalid for BEGIN blocks. ${optionname} is ignored.`,
     fullCode: "IBM1394IE",
@@ -7529,7 +7528,7 @@ export const Error = {
    */
   IBM1395I: {
     code: "IBM1395I",
-    severity: "E",
+    severity: Severity.E,
     message: (optionname: string) =>
       `Item in OPTIONS list is invalid for PACKAGEs. ${optionname} is ignored.`,
     fullCode: "IBM1395IE",
@@ -7545,7 +7544,7 @@ export const Error = {
    */
   IBM1396I: {
     code: "IBM1396I",
-    severity: "E",
+    severity: Severity.E,
     message: (optionname: string) =>
       `Item in OPTIONS list is invalid for PROCEDUREs. ${optionname} is ignored.`,
     fullCode: "IBM1396IE",
@@ -7562,7 +7561,7 @@ export const Error = {
    */
   IBM1397I: {
     code: "IBM1397I",
-    severity: "E",
+    severity: Severity.E,
     message: (optionname: string) =>
       `Item in OPTIONS list is invalid for nested PROCEDUREs. ${optionname} is ignored.`,
     fullCode: "IBM1397IE",
@@ -7578,7 +7577,7 @@ export const Error = {
    */
   IBM1398I: {
     code: "IBM1398I",
-    severity: "E",
+    severity: Severity.E,
     message: (optionname: string) =>
       `Invalid item in OPTIONS list. ${optionname} is ignored.`,
     fullCode: "IBM1398IE",
@@ -7594,7 +7593,7 @@ export const Error = {
    */
   IBM1399I: {
     code: "IBM1399I",
-    severity: "E",
+    severity: Severity.E,
     message: (optionname: string) =>
       `Item in OPTIONS list is invalid for ENTRY statements. ${optionname} is ignored.`,
     fullCode: "IBM1399IE",
@@ -7610,7 +7609,7 @@ export const Error = {
    */
   IBM1400I: {
     code: "IBM1400I",
-    severity: "E",
+    severity: Severity.E,
     message: (optionname: string) =>
       `Item in OPTIONS list conflicts with preceding items. ${optionname} is ignored.`,
     fullCode: "IBM1400IE",
@@ -7627,7 +7626,7 @@ export const Error = {
    */
   IBM1401I: {
     code: "IBM1401I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Parameter attributes have been specified for a variable that is not a parameter. The parameter attributes are ignored.",
     fullCode: "IBM1401IE",
@@ -7642,7 +7641,7 @@ export const Error = {
    */
   IBM1402I: {
     code: "IBM1402I",
-    severity: "E",
+    severity: Severity.E,
     message: "Constant in POSITION attribute is less than 1.",
     fullCode: "IBM1402IE",
   } as SimplePLICode,
@@ -7655,7 +7654,7 @@ export const Error = {
    */
   IBM1403I: {
     code: "IBM1403I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "The end of the source was reached before the logical end of the program. Null statements and END statements will be inserted as necessary to complete the program.",
     fullCode: "IBM1403IE",
@@ -7672,7 +7671,7 @@ export const Error = {
    */
   IBM1404I: {
     code: "IBM1404I",
-    severity: "E",
+    severity: Severity.E,
     message: (procname: string) =>
       `The PROCEDURE name ${procname} has already been declared. The explicit declaration of the PROCEDURE name will not be accepted.`,
     fullCode: "IBM1404IE",
@@ -7687,7 +7686,7 @@ export const Error = {
    */
   IBM1405I: {
     code: "IBM1405I",
-    severity: "E",
+    severity: Severity.E,
     message: "Only one description is allowed in a returns descriptor.",
     fullCode: "IBM1405IE",
   } as SimplePLICode,
@@ -7702,7 +7701,7 @@ export const Error = {
    */
   IBM1406I: {
     code: "IBM1406I",
-    severity: "E",
+    severity: Severity.E,
     message: (repetitionfactor: string, string: string) =>
       `The product of the repetition factor ${repetitionfactor} and the length of the constant ${string} to which it is applied is greater than the maximum length allowed for a constant. The repetition factor will be ignored.`,
     fullCode: "IBM1406IE",
@@ -7714,7 +7713,7 @@ export const Error = {
    */
   IBM1407I: {
     code: "IBM1407I",
-    severity: "E",
+    severity: Severity.E,
     message: "Scale factor is bigger than 127. It will be replaced by 127.",
     fullCode: "IBM1407IE",
   } as SimplePLICode,
@@ -7725,7 +7724,7 @@ export const Error = {
    */
   IBM1408I: {
     code: "IBM1408I",
-    severity: "E",
+    severity: Severity.E,
     message: "Scale factor is less than -128. It will be replaced by -128.",
     fullCode: "IBM1408IE",
   } as SimplePLICode,
@@ -7736,7 +7735,7 @@ export const Error = {
    */
   IBM1409I: {
     code: "IBM1409I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "A SELECT statement may be missing. A SELECT statement, without an expression, will be inserted.",
     fullCode: "IBM1409IE",
@@ -7756,7 +7755,7 @@ export const Error = {
    */
   IBM1410I: {
     code: "IBM1410I",
-    severity: "E",
+    severity: Severity.E,
     message: "Semicolon inserted after ELSE keyword.",
     fullCode: "IBM1410IE",
   } as SimplePLICode,
@@ -7774,7 +7773,7 @@ export const Error = {
    */
   IBM1411I: {
     code: "IBM1411I",
-    severity: "E",
+    severity: Severity.E,
     message: "Semicolon inserted after ON clause.",
     fullCode: "IBM1411IE",
   } as SimplePLICode,
@@ -7785,7 +7784,7 @@ export const Error = {
    */
   IBM1412I: {
     code: "IBM1412I",
-    severity: "E",
+    severity: Severity.E,
     message: "Semicolon inserted after OTHERWISE keyword.",
     fullCode: "IBM1412IE",
   } as SimplePLICode,
@@ -7796,7 +7795,7 @@ export const Error = {
    */
   IBM1413I: {
     code: "IBM1413I",
-    severity: "E",
+    severity: Severity.E,
     message: "Semicolon inserted after THEN keyword.",
     fullCode: "IBM1413IE",
   } as SimplePLICode,
@@ -7807,7 +7806,7 @@ export const Error = {
    */
   IBM1414I: {
     code: "IBM1414I",
-    severity: "E",
+    severity: Severity.E,
     message: "Semicolon inserted after WHEN clause.",
     fullCode: "IBM1414IE",
   } as SimplePLICode,
@@ -7820,7 +7819,7 @@ export const Error = {
    */
   IBM1415I: {
     code: "IBM1415I",
-    severity: "E",
+    severity: Severity.E,
     message: "Source file does not end with the logical end of the program.",
     fullCode: "IBM1415IE",
   } as SimplePLICode,
@@ -7831,7 +7830,7 @@ export const Error = {
    */
   IBM1416I: {
     code: "IBM1416I",
-    severity: "E",
+    severity: Severity.E,
     message: (variablename: string) =>
       `Subscripts have been specified for the variable ${variablename} , but it is not an array variable.`,
     fullCode: "IBM1416IE",
@@ -7843,7 +7842,7 @@ export const Error = {
    */
   IBM1417I: {
     code: "IBM1417I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string) =>
       `Second argument in ${BUILTINname} reference is less than 1. It will be replaced by 1.`,
     fullCode: "IBM1417IE",
@@ -7855,7 +7854,7 @@ export const Error = {
    */
   IBM1418I: {
     code: "IBM1418I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string) =>
       `Second argument in ${BUILTINname} reference is too big. It will be trimmed to fit.`,
     fullCode: "IBM1418IE",
@@ -7867,7 +7866,7 @@ export const Error = {
    */
   IBM1419I: {
     code: "IBM1419I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string) =>
       `Third argument in ${BUILTINname} reference is less than 0. It will be replaced by 0.`,
     fullCode: "IBM1419IE",
@@ -7879,7 +7878,7 @@ export const Error = {
    */
   IBM1420I: {
     code: "IBM1420I",
-    severity: "E",
+    severity: Severity.E,
     message: (kmConstant: string, maximumfactor: string) =>
       `The factor in ${kmConstant} is too large and is replaced by ${maximumfactor} .`,
     fullCode: "IBM1420IE",
@@ -7892,7 +7891,7 @@ export const Error = {
    */
   IBM1421I: {
     code: "IBM1421I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "More than 15 dimensions have been specified. Excess will be ignored.",
     fullCode: "IBM1421IE",
@@ -7905,7 +7904,7 @@ export const Error = {
    */
   IBM1422I: {
     code: "IBM1422I",
-    severity: "E",
+    severity: Severity.E,
     message: "Maximum of 500 LIKE attributes per block exceeded.",
     fullCode: "IBM1422IE",
   } as SimplePLICode,
@@ -7916,7 +7915,7 @@ export const Error = {
    */
   IBM1423I: {
     code: "IBM1423I",
-    severity: "E",
+    severity: Severity.E,
     message: "UNALIGNED attribute conflicts with AREA attribute.",
     fullCode: "IBM1423IE",
   } as SimplePLICode,
@@ -7927,7 +7926,7 @@ export const Error = {
    */
   IBM1424I: {
     code: "IBM1424I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "End of comment marker found when there are no open comments. Marker will be ignored.",
     fullCode: "IBM1424IE",
@@ -7939,7 +7938,7 @@ export const Error = {
    */
   IBM1425I: {
     code: "IBM1425I",
-    severity: "E",
+    severity: Severity.E,
     message: (directive: string) =>
       `There is no compiler directive ${directive} . Input up to the next semicolon will be ignored.`,
     fullCode: "IBM1425IE",
@@ -7951,7 +7950,7 @@ export const Error = {
    */
   IBM1426I: {
     code: "IBM1426I",
-    severity: "E",
+    severity: Severity.E,
     message: "Structure level of 0 replaced by 1.",
     fullCode: "IBM1426IE",
   } as SimplePLICode,
@@ -7962,7 +7961,7 @@ export const Error = {
    */
   IBM1427I: {
     code: "IBM1427I",
-    severity: "E",
+    severity: Severity.E,
     message: "Numeric precision of 0 replaced by 1.",
     fullCode: "IBM1427IE",
   } as SimplePLICode,
@@ -7973,7 +7972,7 @@ export const Error = {
    */
   IBM1428I: {
     code: "IBM1428I",
-    severity: "E",
+    severity: Severity.E,
     message: "X literals should contain a multiple of 2 hex digits.",
     fullCode: "IBM1428IE",
   } as SimplePLICode,
@@ -7985,7 +7984,7 @@ export const Error = {
    */
   IBM1429I: {
     code: "IBM1429I",
-    severity: "E",
+    severity: Severity.E,
     message: (variablename: string) =>
       `INITIAL attribute for REFER object ${variablename} is invalid.`,
     fullCode: "IBM1429IE",
@@ -7998,7 +7997,7 @@ export const Error = {
    */
   IBM1430I: {
     code: "IBM1430I",
-    severity: "E",
+    severity: Severity.E,
     message: (typetype: string, typename: string) =>
       `UNSIGNED attribute for ${typetype} type ${typename} conflicts with negative INITIAL values and is ignored.`,
     fullCode: "IBM1430IE",
@@ -8018,7 +8017,7 @@ export const Error = {
    */
   IBM1431I: {
     code: "IBM1431I",
-    severity: "E",
+    severity: Severity.E,
     message: (typetype: string, typename: string) =>
       `PRECISION specified for ${typetype} type ${typename} is too small to cover its INITIAL values and is adjusted to fit.`,
     fullCode: "IBM1431IE",
@@ -8030,7 +8029,7 @@ export const Error = {
    */
   IBM1432I: {
     code: "IBM1432I",
-    severity: "E",
+    severity: Severity.E,
     message: (typename: string) =>
       `The type ${typename} is already defined. The redefinition is ignored.`,
     fullCode: "IBM1432IE",
@@ -8045,7 +8044,7 @@ export const Error = {
    */
   IBM1433I: {
     code: "IBM1433I",
-    severity: "E",
+    severity: Severity.E,
     message: (name: string) =>
       `The name ${name} occurs more than once in the RESERVES clause.`,
     fullCode: "IBM1433IE",
@@ -8061,7 +8060,7 @@ export const Error = {
    */
   IBM1434I: {
     code: "IBM1434I",
-    severity: "E",
+    severity: Severity.E,
     message: (name: string) =>
       `The name ${name} occurs in the RESERVES clause, but is not the name of any level 1 STATIC EXTERNAL variable.`,
     fullCode: "IBM1434IE",
@@ -8076,7 +8075,7 @@ export const Error = {
    */
   IBM1435I: {
     code: "IBM1435I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string) =>
       `A precision value less than 1 has been specified as an argument to the ${BUILTINname} built-in function. It will be replaced by 15.`,
     fullCode: "IBM1435IE",
@@ -8091,7 +8090,7 @@ export const Error = {
    */
   IBM1436I: {
     code: "IBM1436I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string) =>
       `The scale factor specified as an argument to the ${BUILTINname} built-in function is out of the valid range. It will be replaced by the nearest valid value.`,
     fullCode: "IBM1436IE",
@@ -8107,7 +8106,7 @@ export const Error = {
    */
   IBM1437I: {
     code: "IBM1437I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string) =>
       `The second argument to the ${BUILTINname} built-in function is greater than the maximum FIXED BINARY precision. It will be replaced by the maximum value.`,
     fullCode: "IBM1437IE",
@@ -8124,7 +8123,7 @@ export const Error = {
    */
   IBM1438I: {
     code: "IBM1438I",
-    severity: "E",
+    severity: Severity.E,
     message: (ENTRYname: string) =>
       `Excess arguments for ENTRY ${ENTRYname} ignored.`,
     fullCode: "IBM1438IE",
@@ -8140,7 +8139,7 @@ export const Error = {
    */
   IBM1439I: {
     code: "IBM1439I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string) =>
       `Excess arguments for ${BUILTINname} built-in function ignored.`,
     fullCode: "IBM1439IE",
@@ -8157,7 +8156,7 @@ export const Error = {
    */
   IBM1441I: {
     code: "IBM1441I",
-    severity: "E",
+    severity: Severity.E,
     message: "ENTRY/RETURNS description lists for comparands do not match.",
     fullCode: "IBM1441IE",
   } as SimplePLICode,
@@ -8175,7 +8174,7 @@ export const Error = {
    */
   IBM1442I: {
     code: "IBM1442I",
-    severity: "E",
+    severity: Severity.E,
     message: (targetvariable: string) =>
       `The ENTRY/RETURNS description lists in the ENTRY to be assigned to ${targetvariable} do not match those of the target variable.`,
     fullCode: "IBM1442IE",
@@ -8193,7 +8192,7 @@ export const Error = {
    */
   IBM1443I: {
     code: "IBM1443I",
-    severity: "E",
+    severity: Severity.E,
     message: (targetvariable: string) =>
       `An ENTRY/RETURNS description list in an ENTRY in the INITIAL list for ${targetvariable} do not match those of the target variable.`,
     fullCode: "IBM1443IE",
@@ -8212,7 +8211,7 @@ export const Error = {
    */
   IBM1444I: {
     code: "IBM1444I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "The ENTRY/RETURNS description lists in the RETURN statement do not match those in the corresponding RETURNS attribute",
     fullCode: "IBM1444IE",
@@ -8229,7 +8228,7 @@ export const Error = {
    */
   IBM1445I: {
     code: "IBM1445I",
-    severity: "E",
+    severity: Severity.E,
     message: (argumentnumber: string, entryname: string) =>
       `The ENTRY/RETURNS description lists for argument number ${argumentnumber} in ENTRY reference ${entryname} do not match those in the corresponding parameter.`,
     fullCode: "IBM1445IE",
@@ -8241,7 +8240,7 @@ export const Error = {
    */
   IBM1446I: {
     code: "IBM1446I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string) =>
       `Third argument in ${BUILTINname} reference is too big. It will be trimmed to fit.`,
     fullCode: "IBM1446IE",
@@ -8253,7 +8252,7 @@ export const Error = {
    */
   IBM1447I: {
     code: "IBM1447I",
-    severity: "E",
+    severity: Severity.E,
     message: "Literals with an X prefix are valid only in EXEC SQL statements.",
     fullCode: "IBM1447IE",
   } as SimplePLICode,
@@ -8268,7 +8267,7 @@ export const Error = {
    */
   IBM1448I: {
     code: "IBM1448I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Use of nonconstant extents in BASED variables without REFER accepted although invalid under LANGLVL(SAA).",
     fullCode: "IBM1448IE",
@@ -8280,7 +8279,7 @@ export const Error = {
    */
   IBM1449I: {
     code: "IBM1449I",
-    severity: "E",
+    severity: Severity.E,
     message: (typefunction: string) =>
       `Use of ${typefunction} accepted although invalid under LANGLVL(SAA).`,
     fullCode: "IBM1449IE",
@@ -8296,7 +8295,7 @@ export const Error = {
    */
   IBM1450I: {
     code: "IBM1450I",
-    severity: "E",
+    severity: Severity.E,
     message: (keyword: string) =>
       `${keyword} keyword accepted although invalid under LANGLVL(SAA).`,
     fullCode: "IBM1450IE",
@@ -8309,7 +8308,7 @@ export const Error = {
    */
   IBM1451I: {
     code: "IBM1451I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Use of S, D and Q constants accepted although invalid under LANGLVL(SAA).",
     fullCode: "IBM1451IE",
@@ -8322,7 +8321,7 @@ export const Error = {
    */
   IBM1452I: {
     code: "IBM1452I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Use of underscores in constants accepted although invalid under LANGLVL(SAA).",
     fullCode: "IBM1452IE",
@@ -8335,7 +8334,7 @@ export const Error = {
    */
   IBM1453I: {
     code: "IBM1453I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Use of asterisks for names in declares accepted although invalid under LANGLVL(SAA).",
     fullCode: "IBM1453IE",
@@ -8347,7 +8346,7 @@ export const Error = {
    */
   IBM1454I: {
     code: "IBM1454I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Use of XN and XU constants accepted although invalid under LANGLVL(SAA).",
     fullCode: "IBM1454IE",
@@ -8362,7 +8361,7 @@ export const Error = {
    */
   IBM1455I: {
     code: "IBM1455I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string) =>
       `Use of arguments with ${BUILTINname} built-in function accepted although invalid under LANGLVL(SAA).`,
     fullCode: "IBM1455IE",
@@ -8378,7 +8377,7 @@ export const Error = {
    */
   IBM1456I: {
     code: "IBM1456I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string) =>
       `Use of 3 arguments with ${BUILTINname} built-in function accepted although invalid under LANGLVL(SAA).`,
     fullCode: "IBM1456IE",
@@ -8394,7 +8393,7 @@ export const Error = {
    */
   IBM1457I: {
     code: "IBM1457I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string) =>
       `Use of 1 argument with ${BUILTINname} built-in function accepted although invalid under LANGLVL(SAA).`,
     fullCode: "IBM1457IE",
@@ -8407,7 +8406,7 @@ export const Error = {
    */
   IBM1458I: {
     code: "IBM1458I",
-    severity: "E",
+    severity: Severity.E,
     message: "GOTO is not allowed under RULES(NOGOTO).",
     fullCode: "IBM1458IE",
   } as SimplePLICode,
@@ -8424,7 +8423,7 @@ export const Error = {
    */
   IBM1459I: {
     code: "IBM1459I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Uninitialized AUTOMATIC variables in a block should not be used in the prologue of that block.",
     fullCode: "IBM1459IE",
@@ -8441,7 +8440,7 @@ export const Error = {
    */
   IBM1460I: {
     code: "IBM1460I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Under RULES(ANS), nonzero scale factors are not permitted in declarations of FIXED BIN. Declared scale factor will be ignored.",
     fullCode: "IBM1460IE",
@@ -8459,7 +8458,7 @@ export const Error = {
    */
   IBM1461I: {
     code: "IBM1461I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string, precision: string, scalefactor: string) =>
       `Tne result of the ${BUILTINname} built-in would have the attributes FIXED BIN( ${precision} , ${scalefactor} ), but under RULES(ANS), FIXED BIN scale factors must be zero. The scale factor will be set to zero.`,
     fullCode: "IBM1461IE",
@@ -8474,7 +8473,7 @@ export const Error = {
    */
   IBM1462I: {
     code: "IBM1462I",
-    severity: "E",
+    severity: Severity.E,
     message: "Expression in comparison interpreted with DATE attribute.",
     fullCode: "IBM1462IE",
   } as SimplePLICode,
@@ -8492,7 +8491,7 @@ export const Error = {
    */
   IBM1463I: {
     code: "IBM1463I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Operand with DATE attribute is invalid except in compare or 55 assign. DATE attribute will be ignored.",
     fullCode: "IBM1463IE",
@@ -8506,7 +8505,7 @@ export const Error = {
    */
   IBM1464I: {
     code: "IBM1464I",
-    severity: "E",
+    severity: Severity.E,
     message: "DATE attribute ignored in comparison with non-date expression.",
     fullCode: "IBM1464IE",
   } as SimplePLICode,
@@ -8522,7 +8521,7 @@ export const Error = {
    */
   IBM1465I: {
     code: "IBM1465I",
-    severity: "E",
+    severity: Severity.E,
     message: (variable: string) =>
       `Source in assignment has the DATE attribute, but target ${variable} does not. The DATE attribute will be ignored.`,
     fullCode: "IBM1465IE",
@@ -8534,7 +8533,7 @@ export const Error = {
    */
   IBM1466I: {
     code: "IBM1466I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Source in assignment has the DATE attribute, but target does not. The DATE attribute will be ignored.",
     fullCode: "IBM1466IE",
@@ -8546,7 +8545,7 @@ export const Error = {
    */
   IBM1467I: {
     code: "IBM1467I",
-    severity: "E",
+    severity: Severity.E,
     message: (variablename: string) =>
       `Source in INITIAL clause for ${variablename} has the DATE attribute but the target does not. The DATE attribute will be ignored.`,
     fullCode: "IBM1467IE",
@@ -8562,7 +8561,7 @@ export const Error = {
    */
   IBM1468I: {
     code: "IBM1468I",
-    severity: "E",
+    severity: Severity.E,
     message: (argumentnumber: string, entryname: string) =>
       `Argument number ${argumentnumber} in ENTRY reference ${entryname} has the DATE attribute but the corresponding parameter does not. The DATE attribute will be ignored.`,
     fullCode: "IBM1468IE",
@@ -8580,7 +8579,7 @@ export const Error = {
    */
   IBM1469I: {
     code: "IBM1469I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Source in RETURN statement has the DATE attribute, but the corresponding RETURNS option does not. The DATE attribute will be ignored.",
     fullCode: "IBM1469IE",
@@ -8592,7 +8591,7 @@ export const Error = {
    */
   IBM1470I: {
     code: "IBM1470I",
-    severity: "E",
+    severity: Severity.E,
     message: "An ID option must be specified for the INCLUDE preprocessor.",
     fullCode: "IBM1470IE",
   } as SimplePLICode,
@@ -8604,7 +8603,7 @@ export const Error = {
    */
   IBM1471I: {
     code: "IBM1471I",
-    severity: "E",
+    severity: Severity.E,
     message: "The ID option specified for the INCLUDE preprocessor is invalid.",
     fullCode: "IBM1471IE",
   } as SimplePLICode,
@@ -8616,7 +8615,7 @@ export const Error = {
    */
   IBM1472I: {
     code: "IBM1472I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "A closing right parenthesis is missing from the ID option specified for the INCLUDE preprocessor.",
     fullCode: "IBM1472IE",
@@ -8630,7 +8629,7 @@ export const Error = {
    */
   IBM1473I: {
     code: "IBM1473I",
-    severity: "E",
+    severity: Severity.E,
     message: "The syntax of the preprocessor INCLUDE directive is incorrect.",
     fullCode: "IBM1473IE",
   } as SimplePLICode,
@@ -8646,7 +8645,7 @@ export const Error = {
    */
   IBM1474I: {
     code: "IBM1474I",
-    severity: "E",
+    severity: Severity.E,
     message: (variable: string) =>
       `Source in assignment does not have the DATE attribute, but target ${variable} does. The DATE attribute will be ignored.`,
     fullCode: "IBM1474IE",
@@ -8658,7 +8657,7 @@ export const Error = {
    */
   IBM1475I: {
     code: "IBM1475I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Target in assignment has the DATE attribute, but source does not. The DATE attribute will be ignored.",
     fullCode: "IBM1475IE",
@@ -8670,7 +8669,7 @@ export const Error = {
    */
   IBM1476I: {
     code: "IBM1476I",
-    severity: "E",
+    severity: Severity.E,
     message: (variablename: string) =>
       `Source in INITIAL clause for ${variablename} does not have the DATE attribute but the target does. The DATE attribute will be ignored.`,
     fullCode: "IBM1476IE",
@@ -8686,7 +8685,7 @@ export const Error = {
    */
   IBM1477I: {
     code: "IBM1477I",
-    severity: "E",
+    severity: Severity.E,
     message: (argumentnumber: string, entryname: string) =>
       `Argument number ${argumentnumber} in ENTRY reference ${entryname} does not have the DATE attribute but the corresponding parameter does. The DATE attribute will be ignored.`,
     fullCode: "IBM1477IE",
@@ -8704,7 +8703,7 @@ export const Error = {
    */
   IBM1478I: {
     code: "IBM1478I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Source in RETURN statement does not have the DATE attribute, but the corresponding RETURNS option does. The DATE attribute will be ignored.",
     fullCode: "IBM1478IE",
@@ -8717,7 +8716,7 @@ export const Error = {
    */
   IBM1479I: {
     code: "IBM1479I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Multiple RETURN statements are not allowed under RULES(NOMULTIEXIT).",
     fullCode: "IBM1479IE",
@@ -8730,7 +8729,7 @@ export const Error = {
    */
   IBM1480I: {
     code: "IBM1480I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Multiple closure of groups is not allowed under RULES(NOMULTICLOSE).",
     fullCode: "IBM1480IE",
@@ -8743,7 +8742,7 @@ export const Error = {
    */
   IBM1481I: {
     code: "IBM1481I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "BYNAME assignment statements are not allowed under RULES(NOBYNAME).",
     fullCode: "IBM1481IE",
@@ -8760,7 +8759,7 @@ export const Error = {
    */
   IBM1482I: {
     code: "IBM1482I",
-    severity: "E",
+    severity: Severity.E,
     message: (variablename: string) =>
       `RULES(NOLAXDCL) violation: the variable ${variablename} is declared without any data attributes.`,
     fullCode: "IBM1482IE",
@@ -8781,7 +8780,7 @@ export const Error = {
    */
   IBM1483I: {
     code: "IBM1483I",
-    severity: "E",
+    severity: Severity.E,
     message: (variablename: string) =>
       `RULES(NOLAXDCL) violation: the structure member ${variablename} is declared without any data attributes. A level number may be incorrect.`,
     fullCode: "IBM1483IE",
@@ -8802,7 +8801,7 @@ export const Error = {
    */
   IBM1484I: {
     code: "IBM1484I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "RULES(NOLAXDCL) violation: an unnamed structure member is declared without any data attributes. A level number may be incorrect.",
     fullCode: "IBM1484IE",
@@ -8816,7 +8815,7 @@ export const Error = {
    */
   IBM1485I: {
     code: "IBM1485I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "A WHEN or OTHERWISE clause has been found inside of an open DO group contained in an open SELECT group. An END statement may be missing and will be inserted in an attempt to fix the problem.",
     fullCode: "IBM1485IE",
@@ -8828,7 +8827,7 @@ export const Error = {
    */
   IBM1486I: {
     code: "IBM1486I",
-    severity: "E",
+    severity: Severity.E,
     message: "Statement contains a mismatching number of ( and ).",
     fullCode: "IBM1486IE",
   } as SimplePLICode,
@@ -8839,7 +8838,7 @@ export const Error = {
    */
   IBM1487I: {
     code: "IBM1487I",
-    severity: "E",
+    severity: Severity.E,
     message: "Statement contains a mismatching number of (: and :).",
     fullCode: "IBM1487IE",
   } as SimplePLICode,
@@ -8850,7 +8849,7 @@ export const Error = {
    */
   IBM1488I: {
     code: "IBM1488I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Specification of an alternate DD for SYSIN after the source has been opened will be ignored.",
     fullCode: "IBM1488IE",
@@ -8862,7 +8861,7 @@ export const Error = {
    */
   IBM2400I: {
     code: "IBM2400I",
-    severity: "E",
+    severity: Severity.E,
     message: "Compiler backend issued error messages to STDOUT.",
     fullCode: "IBM2400IE",
   } as SimplePLICode,
@@ -8878,7 +8877,7 @@ export const Error = {
    */
   IBM2401I: {
     code: "IBM2401I",
-    severity: "E",
+    severity: Severity.E,
     message: (character: string, character2: string) =>
       `RULES(NOLAXPUNC) violation: missing ${character} assumed before ${character2} . DECLARE and other nonexecutable statements should not have labels.`,
     fullCode: "IBM2401IE",
@@ -8895,7 +8894,7 @@ export const Error = {
    */
   IBM2402I: {
     code: "IBM2402I",
-    severity: "E",
+    severity: Severity.E,
     message: (
       variablename: string,
       variablename2: string,
@@ -8913,7 +8912,7 @@ export const Error = {
    */
   IBM2403I: {
     code: "IBM2403I",
-    severity: "E",
+    severity: Severity.E,
     message: "PROCESS statements are not permitted under the NOPROCESS option.",
     fullCode: "IBM2403IE",
   } as SimplePLICode,
@@ -8929,7 +8928,7 @@ export const Error = {
    */
   IBM2404I: {
     code: "IBM2404I",
-    severity: "E",
+    severity: Severity.E,
     message: (
       variablename: string,
       variablename2: string,
@@ -8951,7 +8950,7 @@ export const Error = {
    */
   IBM2405I: {
     code: "IBM2405I",
-    severity: "E",
+    severity: Severity.E,
     message: "Even decimal precisions are not allowed under RULES(NOEVENDEC).",
     fullCode: "IBM2405IE",
   } as SimplePLICode,
@@ -8966,7 +8965,7 @@ export const Error = {
    */
   IBM2406I: {
     code: "IBM2406I",
-    severity: "E",
+    severity: Severity.E,
     message: "Precision outside VALUE clause will be ignored.",
     fullCode: "IBM2406IE",
   } as SimplePLICode,
@@ -8981,7 +8980,7 @@ export const Error = {
    */
   IBM2407I: {
     code: "IBM2407I",
-    severity: "E",
+    severity: Severity.E,
     message: "Length outside VALUE clause will be ignored.",
     fullCode: "IBM2407IE",
   } as SimplePLICode,
@@ -8996,7 +8995,7 @@ export const Error = {
    */
   IBM2408I: {
     code: "IBM2408I",
-    severity: "E",
+    severity: Severity.E,
     message: "AREA size outside VALUE clause will be ignored.",
     fullCode: "IBM2408IE",
   } as SimplePLICode,
@@ -9011,7 +9010,7 @@ export const Error = {
    */
   IBM2409I: {
     code: "IBM2409I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "RETURN statement without an expression is invalid inside a nested PROCEDURE that specified the RETURNS attribute.",
     fullCode: "IBM2409IE",
@@ -9023,7 +9022,7 @@ export const Error = {
    */
   IBM2410I: {
     code: "IBM2410I",
-    severity: "E",
+    severity: Severity.E,
     message: (functionname: string) =>
       `Function ${functionname} contains no valid RETURN statement.`,
     fullCode: "IBM2410IE",
@@ -9037,7 +9036,7 @@ export const Error = {
    */
   IBM2411I: {
     code: "IBM2411I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "STRINGOFGRAPHIC( CHARACTER ) option is ignored because argument to STRING built-in 59 function is possibly not contiguous.",
     fullCode: "IBM2411IE",
@@ -9055,7 +9054,7 @@ export const Error = {
    */
   IBM2412I: {
     code: "IBM2412I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "PROCEDURE has no RETURNS attribute, but contains a RETURN statement. A RETURNS attribute will be assumed.",
     fullCode: "IBM2412IE",
@@ -9070,7 +9069,7 @@ export const Error = {
    */
   IBM2413I: {
     code: "IBM2413I",
-    severity: "E",
+    severity: Severity.E,
     message: (attribute: string) =>
       `The attribute ${attribute} should be specified only on parameters and descriptors.`,
     fullCode: "IBM2413IE",
@@ -9086,7 +9085,7 @@ export const Error = {
    */
   IBM2414I: {
     code: "IBM2414I",
-    severity: "E",
+    severity: Severity.E,
     message: (option: string, option2: string, option3: string) =>
       `The ${option} option conflicts with the ${option2} option. The ${option3} option will be used instead.`,
     fullCode: "IBM2414IE",
@@ -9098,7 +9097,7 @@ export const Error = {
    */
   IBM2415I: {
     code: "IBM2415I",
-    severity: "E",
+    severity: Severity.E,
     message: (number: string) =>
       `Without APAR ${number} , compiler would generate incorrect code for this statement.`,
     fullCode: "IBM2415IE",
@@ -9111,7 +9110,7 @@ export const Error = {
    */
   IBM2416I: {
     code: "IBM2416I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "The SEPARATE suboption of TEST is not supported when the LINEDIR option is in effect.",
     fullCode: "IBM2416IE",
@@ -9123,7 +9122,7 @@ export const Error = {
    */
   IBM2417I: {
     code: "IBM2417I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "In FETCHABLE code compiled with NORENT NOWRITABLE(PRV), it is invalid to ALLOCATE or FREE a CONTROLLED variable unless it is a PARAMETER.",
     fullCode: "IBM2417IE",
@@ -9137,7 +9136,7 @@ export const Error = {
    */
   IBM2418I: {
     code: "IBM2418I",
-    severity: "E",
+    severity: Severity.E,
     message: (variable: string) => `Variable ${variable} is unreferenced.`,
     fullCode: "IBM2418IE",
   } as ParametricPLICode,
@@ -9149,7 +9148,7 @@ export const Error = {
    */
   IBM2419I: {
     code: "IBM2419I",
-    severity: "E",
+    severity: Severity.E,
     message: (option: string, level: string) =>
       `${option} is invalid and ignored unless the ARCH option is ${level} or greater.`,
     fullCode: "IBM2419IE",
@@ -9162,7 +9161,7 @@ export const Error = {
    */
   IBM2420I: {
     code: "IBM2420I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "DFP is invalid and ignored unless the ARCH option is 7 or greater.",
     fullCode: "IBM2420IE",
@@ -9175,7 +9174,7 @@ export const Error = {
    */
   IBM2421I: {
     code: "IBM2421I",
-    severity: "E",
+    severity: Severity.E,
     message: "A file should not be closed in its ENDFILE block.",
     fullCode: "IBM2421IE",
   } as SimplePLICode,
@@ -9187,7 +9186,7 @@ export const Error = {
    */
   IBM2422I: {
     code: "IBM2422I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Under the DFP option, the HEXADEC attribute is not supported for FLOAT DEC.",
     fullCode: "IBM2422IE",
@@ -9200,7 +9199,7 @@ export const Error = {
    */
   IBM2423I: {
     code: "IBM2423I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Under the DFP option, the IEEE attribute is not supported for FLOAT DEC.",
     fullCode: "IBM2423IE",
@@ -9218,7 +9217,7 @@ export const Error = {
    */
   IBM2424I: {
     code: "IBM2424I",
-    severity: "E",
+    severity: Severity.E,
     message: "Scale factors are not allowed in FLOAT declarations.",
     fullCode: "IBM2424IE",
   } as SimplePLICode,
@@ -9230,7 +9229,7 @@ export const Error = {
    */
   IBM2425I: {
     code: "IBM2425I",
-    severity: "E",
+    severity: Severity.E,
     message: "Statement with ELSE IF should be rewritten using SELECT.",
     fullCode: "IBM2425IE",
   } as SimplePLICode,
@@ -9242,7 +9241,7 @@ export const Error = {
    */
   IBM2426I: {
     code: "IBM2426I",
-    severity: "E",
+    severity: Severity.E,
     message: "Maximum nesting of DO statements has been exceeded.",
     fullCode: "IBM2426IE",
   } as SimplePLICode,
@@ -9254,7 +9253,7 @@ export const Error = {
    */
   IBM2427I: {
     code: "IBM2427I",
-    severity: "E",
+    severity: Severity.E,
     message: "Maximum nesting of IF statements has been exceeded.",
     fullCode: "IBM2427IE",
   } as SimplePLICode,
@@ -9266,7 +9265,7 @@ export const Error = {
    */
   IBM2428I: {
     code: "IBM2428I",
-    severity: "E",
+    severity: Severity.E,
     message: "Maximum nesting of PROC and BEGIN statements has been exceeded.",
     fullCode: "IBM2428IE",
   } as SimplePLICode,
@@ -9281,7 +9280,7 @@ export const Error = {
    */
   IBM2429I: {
     code: "IBM2429I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "CMPAT(V3) requires that 8-byte integers be allowed. The second value in the FIXEDBIN suboption of the LIMITS option will be set to 63.",
     fullCode: "IBM2429IE",
@@ -9297,7 +9296,7 @@ export const Error = {
    */
   IBM2430I: {
     code: "IBM2430I",
-    severity: "E",
+    severity: Severity.E,
     message: (filename: string) =>
       `The LINESIZE value specified in the OPEN of file ${filename} is not compatible with the RECSIZE specified in its declare.`,
     fullCode: "IBM2430IE",
@@ -9311,7 +9310,7 @@ export const Error = {
    */
   IBM2431I: {
     code: "IBM2431I",
-    severity: "E",
+    severity: Severity.E,
     message: (option: string) =>
       `The ${option} option conflicts with the GOFF option. NOGOFF will be used instead.`,
     fullCode: "IBM2431IE",
@@ -9327,7 +9326,7 @@ export const Error = {
    */
   IBM2432I: {
     code: "IBM2432I",
-    severity: "E",
+    severity: Severity.E,
     message: (character: string) =>
       `The attribute ${character} is invalid with parameters and is ignored.`,
     fullCode: "IBM2432IE",
@@ -9343,7 +9342,7 @@ export const Error = {
    */
   IBM2433I: {
     code: "IBM2433I",
-    severity: "E",
+    severity: Severity.E,
     message: (attribute: string) =>
       `The attribute ${attribute} is invalid with DEFINED and is ignored.`,
     fullCode: "IBM2433IE",
@@ -9357,7 +9356,7 @@ export const Error = {
    */
   IBM2434I: {
     code: "IBM2434I",
-    severity: "E",
+    severity: Severity.E,
     message: (name: string) =>
       `RULES(NOLAXENTRY) violation: ${name} does not specify a parameter list.`,
     fullCode: "IBM2434IE",
@@ -9373,7 +9372,7 @@ export const Error = {
    */
   IBM2435I: {
     code: "IBM2435I",
-    severity: "E",
+    severity: Severity.E,
     message: "RULES(NOLAXSCALE) violation: scale factor is less than 0.",
     fullCode: "IBM2435IE",
   } as SimplePLICode,
@@ -9387,7 +9386,7 @@ export const Error = {
    */
   IBM2436I: {
     code: "IBM2436I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "RULES(NOLAXSCALE) violation: scale factor is larger than the precision.",
     fullCode: "IBM2436IE",
@@ -9402,7 +9401,7 @@ export const Error = {
    */
   IBM2437I: {
     code: "IBM2437I",
-    severity: "E",
+    severity: Severity.E,
     message: "SQL preprocessor invoked more than once without INCONLY.",
     fullCode: "IBM2437IE",
   } as SimplePLICode,
@@ -9414,7 +9413,7 @@ export const Error = {
    */
   IBM2438I: {
     code: "IBM2438I",
-    severity: "E",
+    severity: Severity.E,
     message: "STOP and EXIT statements are not allowed.",
     fullCode: "IBM2438IE",
   } as SimplePLICode,
@@ -9427,7 +9426,7 @@ export const Error = {
    */
   IBM2439I: {
     code: "IBM2439I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "RULES(NOPROCENDONLY) violation: END statement for a PROCEDURE must include the name of the PROCEDURE.",
     fullCode: "IBM2439IE",
@@ -9440,7 +9439,7 @@ export const Error = {
    */
   IBM2440I: {
     code: "IBM2440I",
-    severity: "E",
+    severity: Severity.E,
     message: (identifier: string) =>
       `RULES(NOLAXQUAL) violation: structure element ${identifier} is not qualified with the name of its containing level 1 structure.`,
     fullCode: "IBM2440IE",
@@ -9454,7 +9453,7 @@ export const Error = {
    */
   IBM2441I: {
     code: "IBM2441I",
-    severity: "E",
+    severity: Severity.E,
     message: "RULES(NOGOTO) violation: GOTO exits the current block.",
     fullCode: "IBM2441IE",
   } as SimplePLICode,
@@ -9465,7 +9464,7 @@ export const Error = {
    */
   IBM2442I: {
     code: "IBM2442I",
-    severity: "E",
+    severity: Severity.E,
     message: (identifier: string) =>
       `RULES(NOPADDING) violation: structure ${identifier} contains padding.`,
     fullCode: "IBM2442IE",
@@ -9478,7 +9477,7 @@ export const Error = {
    */
   IBM2443I: {
     code: "IBM2443I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "RULES(NOGLOBALDO) violation: control variable in DO statement belongs to a parent block.",
     fullCode: "IBM2443IE",
@@ -9491,7 +9490,7 @@ export const Error = {
    */
   IBM2444I: {
     code: "IBM2444I",
-    severity: "E",
+    severity: Severity.E,
     message: (builtin: string) =>
       `The built-in function ${builtin} has been deprecated.`,
     fullCode: "IBM2444IE",
@@ -9504,7 +9503,7 @@ export const Error = {
    */
   IBM2445I: {
     code: "IBM2445I",
-    severity: "E",
+    severity: Severity.E,
     message: (filename: string) =>
       `The INCLUDE file ${filename} has been deprecated.`,
     fullCode: "IBM2445IE",
@@ -9517,7 +9516,7 @@ export const Error = {
    */
   IBM2446I: {
     code: "IBM2446I",
-    severity: "E",
+    severity: Severity.E,
     message: (variable: string) =>
       `The ENTRY named ${variable} has been deprecated.`,
     fullCode: "IBM2446IE",
@@ -9530,7 +9529,7 @@ export const Error = {
    */
   IBM2447I: {
     code: "IBM2447I",
-    severity: "E",
+    severity: Severity.E,
     message: (variable: string) =>
       `The VARIABLE named ${variable} has been deprecated.`,
     fullCode: "IBM2447IE",
@@ -9545,7 +9544,7 @@ export const Error = {
    */
   IBM2448I: {
     code: "IBM2448I",
-    severity: "E",
+    severity: Severity.E,
     message: "CICS preprocessor invoked more than once.",
     fullCode: "IBM2448IE",
   } as SimplePLICode,
@@ -9557,7 +9556,7 @@ export const Error = {
    */
   IBM2449I: {
     code: "IBM2449I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "RULES(NOSELFASSIGN) violation: source and target in assignment are identical.",
     fullCode: "IBM2449IE",
@@ -9572,7 +9571,7 @@ export const Error = {
    */
   IBM2450I: {
     code: "IBM2450I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string, length: string) =>
       `First argument to ${BUILTINname} built-in function should have length greater than or equal to ${length} .`,
     fullCode: "IBM2450IE",
@@ -9592,7 +9591,7 @@ export const Error = {
    */
   IBM2451I: {
     code: "IBM2451I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "RULES(NOLAXIF) violation: source in the assignment is a Boolean, but the target is not BIT(1).",
     fullCode: "IBM2451IE",
@@ -9610,7 +9609,7 @@ export const Error = {
    */
   IBM2452I: {
     code: "IBM2452I",
-    severity: "E",
+    severity: Severity.E,
     message: "RULES(NOLAXSCALE) violation: scale factor is less than 0.",
     fullCode: "IBM2452IE",
   } as SimplePLICode,
@@ -9623,7 +9622,7 @@ export const Error = {
    */
   IBM2453I: {
     code: "IBM2453I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "RULES(NOLAXNESTED) violation: code should come in one group of statements with no intervening procedures or BEGIN blocks.",
     fullCode: "IBM2453IE",
@@ -9636,7 +9635,7 @@ export const Error = {
    */
   IBM2454I: {
     code: "IBM2454I",
-    severity: "E",
+    severity: Severity.E,
     message: (builtin: string) =>
       `The ${builtin} statement has been deprecated.`,
     fullCode: "IBM2454IE",
@@ -9649,7 +9648,7 @@ export const Error = {
    */
   IBM2455I: {
     code: "IBM2455I",
-    severity: "E",
+    severity: Severity.E,
     message: (builtin: string) =>
       `The ${builtin} keyword does not conform to the CASERULES option.`,
     fullCode: "IBM2455IE",
@@ -9662,7 +9661,7 @@ export const Error = {
    */
   IBM2456I: {
     code: "IBM2456I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "RULES(NORECURSIVE) violation: RECURSIVE PROCEDUREs are not allowed under RULES(NORECURSIVE).",
     fullCode: "IBM2456IE",
@@ -9675,7 +9674,7 @@ export const Error = {
    */
   IBM2457I: {
     code: "IBM2457I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "RULES(NORECURSIVE) conflicts with DFT(RECURSIVE). The compiler will apply RULES(RECURSIVE) instead.",
     fullCode: "IBM2457IE",
@@ -9687,7 +9686,7 @@ export const Error = {
    */
   IBM2458I: {
     code: "IBM2458I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "The CONTROLLED attribute is not allowed under RULES(NOCONTROLLED).",
     fullCode: "IBM2458IE",
@@ -9700,7 +9699,7 @@ export const Error = {
    */
   IBM2459I: {
     code: "IBM2459I",
-    severity: "E",
+    severity: Severity.E,
     message: (option: string) =>
       `The characters specified in the ${option} option must all have hexadecimal values less than 80.`,
     fullCode: "IBM2459IE",
@@ -9713,7 +9712,7 @@ export const Error = {
    */
   IBM2460I: {
     code: "IBM2460I",
-    severity: "E",
+    severity: Severity.E,
     message: (option: string) =>
       `The ${option} option conflicts with the ENCODING(UTF8) option. ENCODING(ASCII) will be assumed.`,
     fullCode: "IBM2460IE",
@@ -9726,7 +9725,7 @@ export const Error = {
    */
   IBM2461I: {
     code: "IBM2461I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "The MARGINI option must specify a valid UTF-8 string consisting of one UTF-8 character.",
     fullCode: "IBM2461IE",
@@ -9741,7 +9740,7 @@ export const Error = {
    */
   IBM2462I: {
     code: "IBM2462I",
-    severity: "E",
+    severity: Severity.E,
     message: (character: string, character2: string) =>
       `The attribute ${character} conflicts with the attribute ${character2} and is ignored.`,
     fullCode: "IBM2462IE",
@@ -9753,7 +9752,7 @@ export const Error = {
    */
   IBM2463I: {
     code: "IBM2463I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "LINKAGE(SYSTEM) is not supported for PL/I PROCEDUREs, and LINKAGE(OPTLINK) will be assumed instead.",
     fullCode: "IBM2463IE",
@@ -9765,7 +9764,7 @@ export const Error = {
    */
   IBM2464I: {
     code: "IBM2464I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "RULES(NOLAXSTMT) violation: line contains more than one statement.",
     fullCode: "IBM2464IE",
@@ -9777,7 +9776,7 @@ export const Error = {
    */
   IBM2465I: {
     code: "IBM2465I",
-    severity: "E",
+    severity: Severity.E,
     message: "Assignment of a null string to a pointer is invalid.",
     fullCode: "IBM2465IE",
   } as SimplePLICode,
@@ -9788,7 +9787,7 @@ export const Error = {
    */
   IBM2466I: {
     code: "IBM2466I",
-    severity: "E",
+    severity: Severity.E,
     message: "Comparison of a null string to a pointer is invalid.",
     fullCode: "IBM2466IE",
   } as SimplePLICode,
@@ -9799,7 +9798,7 @@ export const Error = {
    */
   IBM2467I: {
     code: "IBM2467I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "RULES(NOYY) conflicts with use of a date pattern with a 2-digit year.",
     fullCode: "IBM2467IE",
@@ -9811,7 +9810,7 @@ export const Error = {
    */
   IBM2468I: {
     code: "IBM2468I",
-    severity: "E",
+    severity: Severity.E,
     message: "RULES(NOYY) conflicts with use of a date pattern with a ZY.",
     fullCode: "IBM2468IE",
   } as SimplePLICode,
@@ -9823,7 +9822,7 @@ export const Error = {
    */
   IBM2469I: {
     code: "IBM2469I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "RULES(NOYY) conflicts with use of the DATE attribute without a pattern.",
     fullCode: "IBM2469IE",
@@ -9835,7 +9834,7 @@ export const Error = {
    */
   IBM2470I: {
     code: "IBM2470I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string) =>
       `RULES(NOYY) conflicts with use of the ${BUILTINname} built-in function.`,
     fullCode: "IBM2470IE",
@@ -9848,7 +9847,7 @@ export const Error = {
    */
   IBM2471I: {
     code: "IBM2471I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string) =>
       `RULES(NOYY) conflicts with use of the ${BUILTINname} built-in function with a window argument.`,
     fullCode: "IBM2471IE",
@@ -9861,7 +9860,7 @@ export const Error = {
    */
   IBM2472I: {
     code: "IBM2472I",
-    severity: "E",
+    severity: Severity.E,
     message: "RULES(NOYY) conflicts with use of the DATE built-in function.",
     fullCode: "IBM2472IE",
   } as SimplePLICode,
@@ -9873,7 +9872,7 @@ export const Error = {
    */
   IBM2473I: {
     code: "IBM2473I",
-    severity: "E",
+    severity: Severity.E,
     message: (procname: string) =>
       `RULES(NOLAXINTERFACE) violation: ${procname} has not been explicitly declared.`,
     fullCode: "IBM2473IE",
@@ -9887,7 +9886,7 @@ export const Error = {
    */
   IBM2474I: {
     code: "IBM2474I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "RULES(NOGOTO) violation: GOTO jumps to a previous line in the current block.",
     fullCode: "IBM2474IE",
@@ -9899,7 +9898,7 @@ export const Error = {
    */
   IBM2475I: {
     code: "IBM2475I",
-    severity: "E",
+    severity: Severity.E,
     message: "RULES(NOMULTISEMI) violation: line contains too many semicolons.",
     fullCode: "IBM2475IE",
   } as SimplePLICode,
@@ -9914,7 +9913,7 @@ export const Error = {
    */
   IBM2476I: {
     code: "IBM2476I",
-    severity: "E",
+    severity: Severity.E,
     message: (optionname: string) =>
       `Item in OPTIONS list is invalid for ON-unit BEGIN blocks. ${optionname} is ignored.`,
     fullCode: "IBM2476IE",
@@ -9927,7 +9926,7 @@ export const Error = {
    */
   IBM2478I: {
     code: "IBM2478I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Under RULES(NOCOMPLEX), the COMPLEX attribute, the COMPLEX built-in function, and constants ending with the I suffix are not allowed.",
     fullCode: "IBM2478IE",
@@ -9940,7 +9939,7 @@ export const Error = {
    */
   IBM2479I: {
     code: "IBM2479I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "RULES(NOLAXPACKAGE) violation: compilation unit does not contain a PACKAGE statement.",
     fullCode: "IBM2479IE",
@@ -9953,7 +9952,7 @@ export const Error = {
    */
   IBM2480I: {
     code: "IBM2480I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "RULES(NOLAXEXPORTS) violation: package contains PROCEDUREs but no EXPORTS clause naming specifically which PROCEDUREs are exported.",
     fullCode: "IBM2480IE",
@@ -9971,7 +9970,7 @@ export const Error = {
    */
   IBM2481I: {
     code: "IBM2481I",
-    severity: "E",
+    severity: Severity.E,
     message: "RULES(NOLAXSCALE) violation: scale factor is greater than 0.",
     fullCode: "IBM2481IE",
   } as SimplePLICode,
@@ -9984,7 +9983,7 @@ export const Error = {
    */
   IBM2482I: {
     code: "IBM2482I",
-    severity: "E",
+    severity: Severity.E,
     message: (variable: string) =>
       `RULES(NOLAXPARMS) violation: Parameter ${variable} is declared without INONLY, OUTONLY, or INOUT.`,
     fullCode: "IBM2482IE",
@@ -9996,7 +9995,7 @@ export const Error = {
    */
   IBM2483I: {
     code: "IBM2483I",
-    severity: "E",
+    severity: Severity.E,
     message: (identifier: string, count: string, count2: string) =>
       `RULES(NOPADDING) violation: the structure ${identifier} is ${count} -byte aligned, but does not have a multiple of ${count2} bytes before its first element with that alignment.`,
     fullCode: "IBM2483IE",
@@ -10008,7 +10007,7 @@ export const Error = {
    */
   IBM2484I: {
     code: "IBM2484I",
-    severity: "E",
+    severity: Severity.E,
     message: (identifier: string) =>
       `RULES(NOPADDING) violation: the structure ${identifier} does not have a multiple of 8 bits before its first element with byte (or greater) alignment.`,
     fullCode: "IBM2484IE",
@@ -10020,7 +10019,7 @@ export const Error = {
    */
   IBM2485I: {
     code: "IBM2485I",
-    severity: "E",
+    severity: Severity.E,
     message: (identifier: string) =>
       `RULES(NOPADDING) violation: the size of the structure ${identifier} is not a multiple of its alignment.`,
     fullCode: "IBM2485IE",
@@ -10032,7 +10031,7 @@ export const Error = {
    */
   IBM2486I: {
     code: "IBM2486I",
-    severity: "E",
+    severity: Severity.E,
     message: (identifier: string) =>
       `RULES(NOPADDING) violation: the structure ${identifier} does not have a multiple of 8 bits after its last element with byte (or greater) alignment.`,
     fullCode: "IBM2486IE",
@@ -10044,7 +10043,7 @@ export const Error = {
    */
   IBM2487I: {
     code: "IBM2487I",
-    severity: "E",
+    severity: Severity.E,
     message: (identifier: string) =>
       `RULES(NOPADDING) violation: the structure ${identifier} does not contain a multiple of 8 bits.`,
     fullCode: "IBM2487IE",
@@ -10059,7 +10058,7 @@ export const Error = {
    */
   IBM2489I: {
     code: "IBM2489I",
-    severity: "E",
+    severity: Severity.E,
     message: (
       sourceprecision: string,
       sourcescale: string,
@@ -10079,7 +10078,7 @@ export const Error = {
    */
   IBM2490I: {
     code: "IBM2490I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Source in assignment does not fit in the the VALUERANGE of the target.",
     fullCode: "IBM2490IE",
@@ -10092,7 +10091,7 @@ export const Error = {
    */
   IBM2491I: {
     code: "IBM2491I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Source in assignment does not occur in the the VALUELIST of the target.",
     fullCode: "IBM2491IE",
@@ -10106,7 +10105,7 @@ export const Error = {
    */
   IBM2492I: {
     code: "IBM2492I",
-    severity: "E",
+    severity: Severity.E,
     message: (variable: string) =>
       `RULES(NOGLOBAL) violation: Variable ${variable} is used inside a nested PROCEDURE.`,
     fullCode: "IBM2492IE",
@@ -10120,7 +10119,7 @@ export const Error = {
    */
   IBM2493I: {
     code: "IBM2493I",
-    severity: "E",
+    severity: Severity.E,
     message: (variable: string, BUILTINname: string) =>
       `RULES(NOLAXOPTIONAL) violation: Variable ${variable} is used as an argument to the ${BUILTINname} function, but does not have the OPTIONAL attribute.`,
     fullCode: "IBM2493IE",
@@ -10133,7 +10132,7 @@ export const Error = {
    */
   IBM2494I: {
     code: "IBM2494I",
-    severity: "E",
+    severity: Severity.E,
     message: (identifier: string) =>
       `RULES(NOLAXQUAL) violation: Structure element ${identifier} is not fully qualified.`,
     fullCode: "IBM2494IE",
@@ -10146,7 +10145,7 @@ export const Error = {
    */
   IBM2495I: {
     code: "IBM2495I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string) =>
       `Third argument in ${BUILTINname} reference is too small. It will be replaced by the value of the second argument minus 1.`,
     fullCode: "IBM2495IE",
@@ -10160,7 +10159,7 @@ export const Error = {
    */
   IBM2499I: {
     code: "IBM2499I",
-    severity: "E",
+    severity: Severity.E,
     message: (count: string) =>
       `MAXRUNONIF limit exceeded: IF statement tests an expression that consists of ${count} comparisons of the same reference against a series of constant values. The expression could be replaced by one INLIST reference.`,
     fullCode: "IBM2499IE",
@@ -10174,7 +10173,7 @@ export const Error = {
    */
   IBM2500I: {
     code: "IBM2500I",
-    severity: "E",
+    severity: Severity.E,
     message: (count: string) =>
       `MAXRUNONIF limit exceeded: IF statement tests an expression that consists of ${count} comparisons of the same reference against a series of constant values. The statement could be replaced by a SELECT statement containing one large WHEN statement.`,
     fullCode: "IBM2500IE",
@@ -10189,7 +10188,7 @@ export const Error = {
    */
   IBM2501I: {
     code: "IBM2501I",
-    severity: "E",
+    severity: Severity.E,
     message: "Alignment value is invalid and will be ignored.",
     fullCode: "IBM2501IE",
   } as SimplePLICode,
@@ -10201,7 +10200,7 @@ export const Error = {
    */
   IBM2502I: {
     code: "IBM2502I",
-    severity: "E",
+    severity: Severity.E,
     message: (optionvalue: string, suboptionvalue: string) =>
       `The compiler option CMPAT specifies V ${optionvalue} but the CMPAT suboption in the OPTIONS attribute specifies V ${suboptionvalue} . These values should match.`,
     fullCode: "IBM2502IE",
@@ -10215,7 +10214,7 @@ export const Error = {
    */
   IBM2503I: {
     code: "IBM2503I",
-    severity: "E",
+    severity: Severity.E,
     message: (name: string) =>
       `RULES(NOLAXENTRY) violation: ${name} has a parameter with the ENTRY attribute but which does not specify a parameter list.`,
     fullCode: "IBM2503IE",
@@ -10228,7 +10227,7 @@ export const Error = {
    */
   IBM2504I: {
     code: "IBM2504I",
-    severity: "E",
+    severity: Severity.E,
     message: "PROCINC syntax is invalid.",
     fullCode: "IBM2504IE",
   } as SimplePLICode,
@@ -10239,7 +10238,7 @@ export const Error = {
    */
   IBM2505I: {
     code: "IBM2505I",
-    severity: "E",
+    severity: Severity.E,
     message: "PROCINC files must include only PROCESS and PROCINC statements.",
     fullCode: "IBM2505IE",
   } as SimplePLICode,
@@ -10250,7 +10249,7 @@ export const Error = {
    */
   IBM2506I: {
     code: "IBM2506I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Only LIMITED ENTRY may be passed BYVALUE. All other ENTRY must be passed BYADDR.",
     fullCode: "IBM2506IE",
@@ -10268,7 +10267,7 @@ export const Error = {
    */
   IBM2507I: {
     code: "IBM2507I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string, precision: string, scalefactor: string) =>
       `Tne result of the ${BUILTINname} built-in would have the attributes FIXED BIN( ${precision} , ${scalefactor} ), but FIXED BIN scale factors must be between zero and the specified precision. The scale factor will be adjusted to fit.`,
     fullCode: "IBM2507IE",
@@ -10281,7 +10280,7 @@ export const Error = {
    */
   IBM2508I: {
     code: "IBM2508I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "In FIXED BIN(p,q) declares q must be between 0 and p (inclusive).",
     fullCode: "IBM2508IE",
@@ -10294,7 +10293,7 @@ export const Error = {
    */
   IBM2509I: {
     code: "IBM2509I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Support for ROUND of fixed binary expressions is deprecated and will be withdrawn in the next release.",
     fullCode: "IBM2509IE",
@@ -10308,7 +10307,7 @@ export const Error = {
    */
   IBM2510I: {
     code: "IBM2510I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string) =>
       `In ${BUILTINname} of FIXED BIN(p,q), q should be greater than 0.`,
     fullCode: "IBM2510IE",
@@ -10324,7 +10323,7 @@ export const Error = {
    */
   IBM2511I: {
     code: "IBM2511I",
-    severity: "E",
+    severity: Severity.E,
     message: (
       operandattributes: string,
       operandattributes2: string,
@@ -10345,7 +10344,7 @@ export const Error = {
    */
   IBM2512I: {
     code: "IBM2512I",
-    severity: "E",
+    severity: Severity.E,
     message: (
       operandattributes: string,
       operandattributes2: string,
@@ -10362,7 +10361,7 @@ export const Error = {
    */
   IBM3500I: {
     code: "IBM3500I",
-    severity: "E",
+    severity: Severity.E,
     message: (note: string) => `${note}`,
     fullCode: "IBM3500IE",
   } as ParametricPLICode,
@@ -10373,7 +10372,7 @@ export const Error = {
    */
   IBM3501I: {
     code: "IBM3501I",
-    severity: "E",
+    severity: Severity.E,
     message: (note: string) => `${note}`,
     fullCode: "IBM3501IE",
   } as ParametricPLICode,
@@ -10385,7 +10384,7 @@ export const Error = {
    */
   IBM3502I: {
     code: "IBM3502I",
-    severity: "E",
+    severity: Severity.E,
     message: "An integer with a K suffix must have no more than 7 digits.",
     fullCode: "IBM3502IE",
   } as SimplePLICode,
@@ -10397,7 +10396,7 @@ export const Error = {
    */
   IBM3503I: {
     code: "IBM3503I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "In an integer with a K suffix the digits must specify a value less than or equal to 2097152.",
     fullCode: "IBM3503IE",
@@ -10410,7 +10409,7 @@ export const Error = {
    */
   IBM3504I: {
     code: "IBM3504I",
-    severity: "E",
+    severity: Severity.E,
     message: "An integer with an M suffix must have no more than 4 digits.",
     fullCode: "IBM3504IE",
   } as SimplePLICode,
@@ -10422,7 +10421,7 @@ export const Error = {
    */
   IBM3505I: {
     code: "IBM3505I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "In an integer with an M suffix the digits must specify a value less than or equal to 2048.",
     fullCode: "IBM3505IE",
@@ -10435,7 +10434,7 @@ export const Error = {
    */
   IBM3506I: {
     code: "IBM3506I",
-    severity: "E",
+    severity: Severity.E,
     message: "An integer with a G suffix must have only 1 digit.",
     fullCode: "IBM3506IE",
   } as SimplePLICode,
@@ -10447,7 +10446,7 @@ export const Error = {
    */
   IBM3507I: {
     code: "IBM3507I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "In an integer with an G suffix the digits must specify a value less than or equal to 2.",
     fullCode: "IBM3507IE",
@@ -10459,7 +10458,7 @@ export const Error = {
    */
   IBM3508I: {
     code: "IBM3508I",
-    severity: "E",
+    severity: Severity.E,
     message: "Numeric precision of 0 replaced by 1.",
     fullCode: "IBM3508IE",
   } as SimplePLICode,
@@ -10470,7 +10469,7 @@ export const Error = {
    */
   IBM3509I: {
     code: "IBM3509I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "DECLARE statement has invalid syntax. No variables in it may be used in EXEC SQL statements.",
     fullCode: "IBM3509IE",
@@ -10485,7 +10484,7 @@ export const Error = {
    */
   IBM3510I: {
     code: "IBM3510I",
-    severity: "E",
+    severity: Severity.E,
     message: (keyword: string, keyword2: string) =>
       `${keyword} statement is not allowed where an executable statement is required. A null statement will be inserted before the ${keyword2} statement.`,
     fullCode: "IBM3510IE",
@@ -10497,7 +10496,7 @@ export const Error = {
    */
   IBM3511I: {
     code: "IBM3511I",
-    severity: "E",
+    severity: Severity.E,
     message: "COUNTER value would exceed 99999. It will be reset to 0.",
     fullCode: "IBM3511IE",
   } as SimplePLICode,
@@ -10509,7 +10508,7 @@ export const Error = {
    */
   IBM3512I: {
     code: "IBM3512I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Multiple closure of groups is not allowed under RULES(NOMULTICLOSE).",
     fullCode: "IBM3512IE",
@@ -10525,7 +10524,7 @@ export const Error = {
    */
   IBM3514I: {
     code: "IBM3514I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string) =>
       `Second argument to ${BUILTINname} built-in is negative. It will be changed to 0.`,
     fullCode: "IBM3514IE",
@@ -10537,7 +10536,7 @@ export const Error = {
    */
   IBM3515I: {
     code: "IBM3515I",
-    severity: "E",
+    severity: Severity.E,
     message: "Scale factor is bigger than 127. It is replaced by 127.",
     fullCode: "IBM3515IE",
   } as SimplePLICode,
@@ -10548,7 +10547,7 @@ export const Error = {
    */
   IBM3516I: {
     code: "IBM3516I",
-    severity: "E",
+    severity: Severity.E,
     message: "Scale factor is less than -128. It is replaced by -128.",
     fullCode: "IBM3516IE",
   } as SimplePLICode,
@@ -10563,7 +10562,7 @@ export const Error = {
    */
   IBM3517I: {
     code: "IBM3517I",
-    severity: "E",
+    severity: Severity.E,
     message: (dimensionnumber: string, variablename: string) =>
       `Sole bound specified for dimension ${dimensionnumber} of array ${variablename} is less than 1. An upper bound of 1 is assumed.`,
     fullCode: "IBM3517IE",
@@ -10576,7 +10575,7 @@ export const Error = {
    */
   IBM3518I: {
     code: "IBM3518I",
-    severity: "E",
+    severity: Severity.E,
     message: (identifier: string) =>
       `${identifier} does not conform to the NAMEPREFIX option.`,
     fullCode: "IBM3518IE",
@@ -10588,7 +10587,7 @@ export const Error = {
    */
   IBM3519I: {
     code: "IBM3519I",
-    severity: "E",
+    severity: Severity.E,
     message: "Characters in B3 literals must be 0-7.",
     fullCode: "IBM3519IE",
   } as SimplePLICode,
@@ -10599,7 +10598,7 @@ export const Error = {
    */
   IBM3520I: {
     code: "IBM3520I",
-    severity: "E",
+    severity: Severity.E,
     message: "Structure level of 0 replaced by 1.",
     fullCode: "IBM3520IE",
   } as SimplePLICode,
@@ -10616,7 +10615,7 @@ export const Error = {
    */
   IBM3521I: {
     code: "IBM3521I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Structure level greater than 255 specified. It is replaced by 255.",
     fullCode: "IBM3521IE",
@@ -10629,7 +10628,7 @@ export const Error = {
    */
   IBM3522I: {
     code: "IBM3522I",
-    severity: "E",
+    severity: Severity.E,
     message: "A DECIMAL exponent is required.",
     fullCode: "IBM3522IE",
   } as SimplePLICode,
@@ -10645,7 +10644,7 @@ export const Error = {
    */
   IBM3523I: {
     code: "IBM3523I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string) =>
       `A second argument to the ${BUILTINname} built-in must be supplied for arrays with more than one dimension. A value of 1 is assumed.`,
     fullCode: "IBM3523IE",
@@ -10658,7 +10657,7 @@ export const Error = {
    */
   IBM3524I: {
     code: "IBM3524I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string) =>
       `Second argument to ${BUILTINname} built-in is not positive. A value of 1 is assumed.`,
     fullCode: "IBM3524IE",
@@ -10675,7 +10674,7 @@ export const Error = {
    */
   IBM3525I: {
     code: "IBM3525I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string, dimensioncount: string) =>
       `Second argument to ${BUILTINname} built-in is greater than the number of dimensions for the first argument. A value of ${dimensioncount} is assumed.`,
     fullCode: "IBM3525IE",
@@ -10690,7 +10689,7 @@ export const Error = {
    */
   IBM3526I: {
     code: "IBM3526I",
-    severity: "E",
+    severity: Severity.E,
     message: (identifier: string) =>
       `Repeated declaration of ${identifier} is invalid and will be ignored.`,
     fullCode: "IBM3526IE",
@@ -10702,7 +10701,7 @@ export const Error = {
    */
   IBM3527I: {
     code: "IBM3527I",
-    severity: "E",
+    severity: Severity.E,
     message: "Missing THEN assumed.",
     fullCode: "IBM3527IE",
   } as SimplePLICode,
@@ -10716,7 +10715,7 @@ export const Error = {
    */
   IBM3528I: {
     code: "IBM3528I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Duplicate specification of arithmetic precision. Subsequent specification ignored.",
     fullCode: "IBM3528IE",
@@ -10735,7 +10734,7 @@ export const Error = {
    */
   IBM3529I: {
     code: "IBM3529I",
-    severity: "E",
+    severity: Severity.E,
     message: "Scale factors are not allowed in FLOAT declarations.",
     fullCode: "IBM3529IE",
   } as SimplePLICode,
@@ -10746,7 +10745,7 @@ export const Error = {
    */
   IBM3530I: {
     code: "IBM3530I",
-    severity: "E",
+    severity: Severity.E,
     message: (identifier: string) =>
       `${identifier} is an array. ACTIVATE and DEACTIVATE are invalid for arrays.`,
     fullCode: "IBM3530IE",
@@ -10758,7 +10757,7 @@ export const Error = {
    */
   IBM3531I: {
     code: "IBM3531I",
-    severity: "E",
+    severity: Severity.E,
     message: (identifier: string) =>
       `${identifier} is a statement label. ACTIVATE and DEACTIVATE are invalid for labels.`,
     fullCode: "IBM3531IE",
@@ -10773,7 +10772,7 @@ export const Error = {
    */
   IBM3533I: {
     code: "IBM3533I",
-    severity: "E",
+    severity: Severity.E,
     message: "THEN clause outside of an open IF statement is ignored.",
     fullCode: "IBM3533IE",
   } as SimplePLICode,
@@ -10787,7 +10786,7 @@ export const Error = {
    */
   IBM3534I: {
     code: "IBM3534I",
-    severity: "E",
+    severity: Severity.E,
     message: "ELSE clause outside of an open IF- THEN statement is ignored.",
     fullCode: "IBM3534IE",
   } as SimplePLICode,
@@ -10804,7 +10803,7 @@ export const Error = {
    */
   IBM3536I: {
     code: "IBM3536I",
-    severity: "E",
+    severity: Severity.E,
     message: "END label is not a label on any open group.",
     fullCode: "IBM3536IE",
   } as SimplePLICode,
@@ -10827,7 +10826,7 @@ export const Error = {
    */
   IBM3537I: {
     code: "IBM3537I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "An END statement may be missing after an OTHERWISE unit. One will be inserted.",
     fullCode: "IBM3537IE",
@@ -10840,7 +10839,7 @@ export const Error = {
    */
   IBM3538I: {
     code: "IBM3538I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "%END statement found without any open %PROCEDURE, %DO or %SELECT statements. It will be ignored.",
     fullCode: "IBM3538IE",
@@ -10854,7 +10853,7 @@ export const Error = {
    */
   IBM3539I: {
     code: "IBM3539I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "STRINGSIZE condition raised while evaluating expression. Result is truncated.",
     fullCode: "IBM3539IE",
@@ -10872,7 +10871,7 @@ export const Error = {
    */
   IBM3540I: {
     code: "IBM3540I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "STRINGRANGE condition raised while evaluating expression. Arguments are adjusted to fit.",
     fullCode: "IBM3540IE",
@@ -10889,7 +10888,7 @@ export const Error = {
    */
   IBM3542I: {
     code: "IBM3542I",
-    severity: "E",
+    severity: Severity.E,
     message: "LEAVE/ITERATE label is not a label on any open DO group.",
     fullCode: "IBM3542IE",
   } as SimplePLICode,
@@ -10905,7 +10904,7 @@ export const Error = {
    */
   IBM3543I: {
     code: "IBM3543I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "ITERATE/LEAVE statement is invalid outside an open DO statement. The statement will be ignored.",
     fullCode: "IBM3543IE",
@@ -10921,7 +10920,7 @@ export const Error = {
    */
   IBM3544I: {
     code: "IBM3544I",
-    severity: "E",
+    severity: Severity.E,
     message: "GX literals should contain a multiple of 4 hex digits.",
     fullCode: "IBM3544IE",
   } as SimplePLICode,
@@ -10934,7 +10933,7 @@ export const Error = {
    */
   IBM3545I: {
     code: "IBM3545I",
-    severity: "E",
+    severity: Severity.E,
     message: (dimensionnumber: string, variablename: string) =>
       `Upper bound for dimension ${dimensionnumber} of array ${variablename} is less than lower bound. Bounds will be reversed.`,
     fullCode: "IBM3545IE",
@@ -10947,7 +10946,7 @@ export const Error = {
    */
   IBM3546I: {
     code: "IBM3546I",
-    severity: "E",
+    severity: Severity.E,
     message: (identifier: string) =>
       `Identifier is too long. It will be collapsed to ${identifier} .`,
     fullCode: "IBM3546IE",
@@ -10962,7 +10961,7 @@ export const Error = {
    */
   IBM3547I: {
     code: "IBM3547I",
-    severity: "E",
+    severity: Severity.E,
     message: "B assumed to complete iSUB.",
     fullCode: "IBM3547IE",
   } as SimplePLICode,
@@ -10973,7 +10972,7 @@ export const Error = {
    */
   IBM3548I: {
     code: "IBM3548I",
-    severity: "E",
+    severity: Severity.E,
     message: "Digit in BINARY constant is not zero or one.",
     fullCode: "IBM3548IE",
   } as SimplePLICode,
@@ -10984,7 +10983,7 @@ export const Error = {
    */
   IBM3549I: {
     code: "IBM3549I",
-    severity: "E",
+    severity: Severity.E,
     message: "Characters in BIT literals must be 0 or 1.",
     fullCode: "IBM3549IE",
   } as SimplePLICode,
@@ -10998,7 +10997,7 @@ export const Error = {
    */
   IBM3550I: {
     code: "IBM3550I",
-    severity: "E",
+    severity: Severity.E,
     message: (n: string) =>
       `Character with decimal value ${n} does not belong to the PL/I character set. It will be ignored.`,
     fullCode: "IBM3550IE",
@@ -11010,7 +11009,7 @@ export const Error = {
    */
   IBM3551I: {
     code: "IBM3551I",
-    severity: "E",
+    severity: Severity.E,
     message: "Characters in hex literals must be 0-9 or A-F.",
     fullCode: "IBM3551IE",
   } as SimplePLICode,
@@ -11022,7 +11021,7 @@ export const Error = {
    */
   IBM3552I: {
     code: "IBM3552I",
-    severity: "E",
+    severity: Severity.E,
     message: (character: string) =>
       `The statement element ${character} is invalid. The statement will be ignored.`,
     fullCode: "IBM3552IE",
@@ -11037,7 +11036,7 @@ export const Error = {
    */
   IBM3553I: {
     code: "IBM3553I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Use of underscore as initial character in an identifier accepted although invalid under LANGLVL(SAA).",
     fullCode: "IBM3553IE",
@@ -11053,7 +11052,7 @@ export const Error = {
    */
   IBM3556I: {
     code: "IBM3556I",
-    severity: "E",
+    severity: Severity.E,
     message: (n: string) =>
       `Character with decimal value ${n} does not belong to the PL/I character set. It is assumed to be an OR symbol.`,
     fullCode: "IBM3556IE",
@@ -11069,7 +11068,7 @@ export const Error = {
    */
   IBM3557I: {
     code: "IBM3557I",
-    severity: "E",
+    severity: Severity.E,
     message: (n: string) =>
       `Character with decimal value ${n} does not belong to the PL/I character set. It is assumed to be a NOT symbol.`,
     fullCode: "IBM3557IE",
@@ -11085,7 +11084,7 @@ export const Error = {
    */
   IBM3558I: {
     code: "IBM3558I",
-    severity: "E",
+    severity: Severity.E,
     message: "WX literals should contain a multiple of 4 hex digits.",
     fullCode: "IBM3558IE",
   } as SimplePLICode,
@@ -11097,7 +11096,7 @@ export const Error = {
    */
   IBM3559I: {
     code: "IBM3559I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "RULES(NOGOTO) violation: the use of EXEC SQL WHENEVER statements violates RULES(NOGOTO).",
     fullCode: "IBM3559IE",
@@ -11110,7 +11109,7 @@ export const Error = {
    */
   IBM3560I: {
     code: "IBM3560I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "RULES(NOGOTO) violation: the use of EXEC CICS HANDLE CONDITION statements violates RULES(NOGOTO).",
     fullCode: "IBM3560IE",
@@ -11128,7 +11127,7 @@ export const Error = {
    */
   IBM3565I: {
     code: "IBM3565I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Statement type resolution requires too many lexical units to 159 be examined. The statement will be ignored.",
     fullCode: "IBM3565IE",
@@ -11146,7 +11145,7 @@ export const Error = {
    */
   IBM3567I: {
     code: "IBM3567I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Statements inside a SELECT must be preceded by a WHEN or an OTHERWISE clause.",
     fullCode: "IBM3567IE",
@@ -11159,7 +11158,7 @@ export const Error = {
    */
   IBM3568I: {
     code: "IBM3568I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Under RULES(NOLAXFIELDS), EXEC SQL SELECT statements must specify a list of field names.",
     fullCode: "IBM3568IE",
@@ -11172,7 +11171,7 @@ export const Error = {
    */
   IBM3569I: {
     code: "IBM3569I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Under RULES(NOLAXFIELDS), EXEC SQL INSERT INTO statements must specify a list of field names.",
     fullCode: "IBM3569IE",
@@ -11187,7 +11186,7 @@ export const Error = {
    */
   IBM3570I: {
     code: "IBM3570I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Extent expression is negative. It will be replaced by the constant 1.",
     fullCode: "IBM3570IE",
@@ -11200,7 +11199,7 @@ export const Error = {
    */
   IBM3571I: {
     code: "IBM3571I",
-    severity: "E",
+    severity: Severity.E,
     message: "The SQL and PL/I float options are inconsistent.",
     fullCode: "IBM3571IE",
   } as SimplePLICode,
@@ -11217,7 +11216,7 @@ export const Error = {
    */
   IBM3572I: {
     code: "IBM3572I",
-    severity: "E",
+    severity: Severity.E,
     message: "Initial level number in a structure is not 1.",
     fullCode: "IBM3572IE",
   } as SimplePLICode,
@@ -11234,7 +11233,7 @@ export const Error = {
    */
   IBM3573I: {
     code: "IBM3573I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Elements with level numbers greater than 1 follow an element without a level number. A level number of 1 is assumed.",
     fullCode: "IBM3573IE",
@@ -11252,7 +11251,7 @@ export const Error = {
    */
   IBM3574I: {
     code: "IBM3574I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Variables declared without a name must be structure members or followed by a substructure list.",
     fullCode: "IBM3574IE",
@@ -11268,7 +11267,7 @@ export const Error = {
    */
   IBM3575I: {
     code: "IBM3575I",
-    severity: "E",
+    severity: Severity.E,
     message: (attribute: string) =>
       `Duplicate specification of ${attribute} . Subsequent specification ignored.`,
     fullCode: "IBM3575IE",
@@ -11280,7 +11279,7 @@ export const Error = {
    */
   IBM3576I: {
     code: "IBM3576I",
-    severity: "E",
+    severity: Severity.E,
     message: "The SQL statement is empty and is ignored.",
     fullCode: "IBM3576IE",
   } as SimplePLICode,
@@ -11291,7 +11290,7 @@ export const Error = {
    */
   IBM3577I: {
     code: "IBM3577I",
-    severity: "E",
+    severity: Severity.E,
     message: "INCONLY option is ignored because preceded by other options.",
     fullCode: "IBM3577IE",
   } as SimplePLICode,
@@ -11313,7 +11312,7 @@ export const Error = {
    */
   IBM3580I: {
     code: "IBM3580I",
-    severity: "E",
+    severity: Severity.E,
     message: (keyword: string) =>
       `Parameter ${keyword} may not be set more than once. First setting is assumed.`,
     fullCode: "IBM3580IE",
@@ -11334,7 +11333,7 @@ export const Error = {
    */
   IBM3581I: {
     code: "IBM3581I",
-    severity: "E",
+    severity: Severity.E,
     message: (keyword: string) =>
       `Unknown keyword in statement- form procedure invocation. ${keyword} and any argument are ignored.`,
     fullCode: "IBM3581IE",
@@ -11351,7 +11350,7 @@ export const Error = {
    */
   IBM3582I: {
     code: "IBM3582I",
-    severity: "E",
+    severity: Severity.E,
     message: (identifier: string) => `Parameter ${identifier} is not declared.`,
     fullCode: "IBM3582IE",
   } as ParametricPLICode,
@@ -11362,7 +11361,7 @@ export const Error = {
    */
   IBM3583I: {
     code: "IBM3583I",
-    severity: "E",
+    severity: Severity.E,
     message: (keyword: string) =>
       `Labels on ${keyword} statements are invalid and ignored.`,
     fullCode: "IBM3583IE",
@@ -11375,7 +11374,7 @@ export const Error = {
    */
   IBM3589I: {
     code: "IBM3589I",
-    severity: "E",
+    severity: Severity.E,
     message: (identifier: string) =>
       `The identifier ${identifier} is not the name of a built-in function. The BUILTIN attribute will be ignored.`,
     fullCode: "IBM3589IE",
@@ -11390,7 +11389,7 @@ export const Error = {
    */
   IBM3590I: {
     code: "IBM3590I",
-    severity: "E",
+    severity: Severity.E,
     message: (keyword: string) =>
       `The attribute ${keyword} is not supported and will be ignored.`,
     fullCode: "IBM3590IE",
@@ -11406,7 +11405,7 @@ export const Error = {
    */
   IBM3591I: {
     code: "IBM3591I",
-    severity: "E",
+    severity: Severity.E,
     message: "Right parenthesis will be assumed at end of argument list.",
     fullCode: "IBM3591IE",
   } as SimplePLICode,
@@ -11418,7 +11417,7 @@ export const Error = {
    */
   IBM3603I: {
     code: "IBM3603I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "The end of the source was reached before the logical end of the program. Null statements and END statements will be inserted as necessary to complete the program.",
     fullCode: "IBM3603IE",
@@ -11435,7 +11434,7 @@ export const Error = {
    */
   IBM3604I: {
     code: "IBM3604I",
-    severity: "E",
+    severity: Severity.E,
     message: (procname: string) =>
       `The procedure name ${procname} has already been declared. The explicit declaration of the procedure name will not be accepted.`,
     fullCode: "IBM3604IE",
@@ -11447,7 +11446,7 @@ export const Error = {
    */
   IBM3605I: {
     code: "IBM3605I",
-    severity: "E",
+    severity: Severity.E,
     message: (typetype: string, typename: string) =>
       `The ${typetype} type ${typename} is already defined. The redefinition is ignored.`,
     fullCode: "IBM3605IE",
@@ -11463,7 +11462,7 @@ export const Error = {
    */
   IBM3606I: {
     code: "IBM3606I",
-    severity: "E",
+    severity: Severity.E,
     message: (identifier: string) =>
       `Repeated declaration of ${identifier} is invalid. The name will be replaced by an asterisk.`,
     fullCode: "IBM3606IE",
@@ -11476,7 +11475,7 @@ export const Error = {
    */
   IBM3607I: {
     code: "IBM3607I",
-    severity: "E",
+    severity: Severity.E,
     message: (typetype: string, typename: string) =>
       `UNSIGNED attribute for ${typetype} type ${typename} conflicts with negative INITIAL values and is ignored.`,
     fullCode: "IBM3607IE",
@@ -11496,7 +11495,7 @@ export const Error = {
    */
   IBM3608I: {
     code: "IBM3608I",
-    severity: "E",
+    severity: Severity.E,
     message: (typetype: string, typename: string) =>
       `PRECISION specified for ${typetype} type ${typename} is too small to cover its INITIAL values and is adjusted to fit.`,
     fullCode: "IBM3608IE",
@@ -11508,7 +11507,7 @@ export const Error = {
    */
   IBM3609I: {
     code: "IBM3609I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "A SELECT statement may be missing. A SELECT statement, without an expression, will be inserted.",
     fullCode: "IBM3609IE",
@@ -11528,7 +11527,7 @@ export const Error = {
    */
   IBM3610I: {
     code: "IBM3610I",
-    severity: "E",
+    severity: Severity.E,
     message: "Semicolon inserted after ELSE keyword.",
     fullCode: "IBM3610IE",
   } as SimplePLICode,
@@ -11539,7 +11538,7 @@ export const Error = {
    */
   IBM3612I: {
     code: "IBM3612I",
-    severity: "E",
+    severity: Severity.E,
     message: "Semicolon inserted after OTHERWISE keyword.",
     fullCode: "IBM3612IE",
   } as SimplePLICode,
@@ -11550,7 +11549,7 @@ export const Error = {
    */
   IBM3613I: {
     code: "IBM3613I",
-    severity: "E",
+    severity: Severity.E,
     message: "Semicolon inserted after THEN keyword.",
     fullCode: "IBM3613IE",
   } as SimplePLICode,
@@ -11561,7 +11560,7 @@ export const Error = {
    */
   IBM3614I: {
     code: "IBM3614I",
-    severity: "E",
+    severity: Severity.E,
     message: "Semicolon inserted after WHEN clause.",
     fullCode: "IBM3614IE",
   } as SimplePLICode,
@@ -11574,7 +11573,7 @@ export const Error = {
    */
   IBM3615I: {
     code: "IBM3615I",
-    severity: "E",
+    severity: Severity.E,
     message: "Source file does not end with the logical end of the program.",
     fullCode: "IBM3615IE",
   } as SimplePLICode,
@@ -11585,7 +11584,7 @@ export const Error = {
    */
   IBM3616I: {
     code: "IBM3616I",
-    severity: "E",
+    severity: Severity.E,
     message: (variablename: string) =>
       `Subscripts have been specified for the variable ${variablename} , but it is not an array variable.`,
     fullCode: "IBM3616IE",
@@ -11597,7 +11596,7 @@ export const Error = {
    */
   IBM3617I: {
     code: "IBM3617I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Second argument in SUBSTR reference is less than 1. It will be replaced by 1.",
     fullCode: "IBM3617IE",
@@ -11609,7 +11608,7 @@ export const Error = {
    */
   IBM3618I: {
     code: "IBM3618I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Second argument in SUBSTR reference is too big. It will be trimmed to fit.",
     fullCode: "IBM3618IE",
@@ -11621,7 +11620,7 @@ export const Error = {
    */
   IBM3619I: {
     code: "IBM3619I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Third argument in SUBSTR reference is less than 0. It will be replaced by 0.",
     fullCode: "IBM3619IE",
@@ -11633,7 +11632,7 @@ export const Error = {
    */
   IBM3620I: {
     code: "IBM3620I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Third argument in SUBSTR reference is too big. It will be trimmed to fit.",
     fullCode: "IBM3620IE",
@@ -11646,7 +11645,7 @@ export const Error = {
    */
   IBM3621I: {
     code: "IBM3621I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "More than 15 dimensions have been specified. Excess will be ignored.",
     fullCode: "IBM3621IE",
@@ -11658,7 +11657,7 @@ export const Error = {
    */
   IBM3624I: {
     code: "IBM3624I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "End-of-comment marker found when there are no open comments. Marker will be ignored.",
     fullCode: "IBM3624IE",
@@ -11670,7 +11669,7 @@ export const Error = {
    */
   IBM3625I: {
     code: "IBM3625I",
-    severity: "E",
+    severity: Severity.E,
     message: (directive: string) =>
       `There is no compiler directive ${directive} . Input up to the next semicolon will be ignored.`,
     fullCode: "IBM3625IE",
@@ -11688,7 +11687,7 @@ export const Error = {
    */
   IBM3626I: {
     code: "IBM3626I",
-    severity: "E",
+    severity: Severity.E,
     message: "Listing control statement must start with a percent symbol.",
     fullCode: "IBM3626IE",
   } as SimplePLICode,
@@ -11699,7 +11698,7 @@ export const Error = {
    */
   IBM3628I: {
     code: "IBM3628I",
-    severity: "E",
+    severity: Severity.E,
     message: "X literals should contain a multiple of 2 hex digits.",
     fullCode: "IBM3628IE",
   } as SimplePLICode,
@@ -11715,7 +11714,7 @@ export const Error = {
    */
   IBM3638I: {
     code: "IBM3638I",
-    severity: "E",
+    severity: Severity.E,
     message: (ENTRYname: string) =>
       `Excess arguments for ENTRY ${ENTRYname} ignored.`,
     fullCode: "IBM3638IE",
@@ -11731,7 +11730,7 @@ export const Error = {
    */
   IBM3639I: {
     code: "IBM3639I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string) =>
       `Excess arguments for ${BUILTINname} built-in ignored.`,
     fullCode: "IBM3639IE",
@@ -11751,7 +11750,7 @@ export const Error = {
    */
   IBM3640I: {
     code: "IBM3640I",
-    severity: "E",
+    severity: Severity.E,
     message: (attribute: string) =>
       `The attribute ${attribute} is invalid if it is not followed by an element with a greater logical level.`,
     fullCode: "IBM3640IE",
@@ -11769,7 +11768,7 @@ export const Error = {
    */
   IBM3641I: {
     code: "IBM3641I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Level number following LIKE specification is greater than the level number for the LIKE specification. LIKE attribute is ignored.",
     fullCode: "IBM3641IE",
@@ -11785,7 +11784,7 @@ export const Error = {
    */
   IBM3650I: {
     code: "IBM3650I",
-    severity: "E",
+    severity: Severity.E,
     message: (keyword: string) =>
       `${keyword} keyword accepted although invalid under LANGLVL(SAA).`,
     fullCode: "IBM3650IE",
@@ -11798,7 +11797,7 @@ export const Error = {
    */
   IBM3651I: {
     code: "IBM3651I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Use of S, D and Q constants accepted although invalid under LANGLVL(SAA).",
     fullCode: "IBM3651IE",
@@ -11811,7 +11810,7 @@ export const Error = {
    */
   IBM3652I: {
     code: "IBM3652I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Use of underscores in constants accepted although invalid under LANGLVL(SAA).",
     fullCode: "IBM3652IE",
@@ -11824,7 +11823,7 @@ export const Error = {
    */
   IBM3653I: {
     code: "IBM3653I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Use of asterisks for names in declares accepted although invalid under LANGLVL(SAA).",
     fullCode: "IBM3653IE",
@@ -11836,7 +11835,7 @@ export const Error = {
    */
   IBM3654I: {
     code: "IBM3654I",
-    severity: "E",
+    severity: Severity.E,
     message:
       "Use of XN constants accepted although invalid under LANGLVL(SAA).",
     fullCode: "IBM3654IE",
@@ -11852,7 +11851,7 @@ export const Error = {
    */
   IBM3656I: {
     code: "IBM3656I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string) =>
       `Use of 3 arguments with ${BUILTINname} built-in accepted although invalid under LANGLVL(SAA).`,
     fullCode: "IBM3656IE",
@@ -11868,7 +11867,7 @@ export const Error = {
    */
   IBM3657I: {
     code: "IBM3657I",
-    severity: "E",
+    severity: Severity.E,
     message: (BUILTINname: string) =>
       `Use of 1 argument with ${BUILTINname} built-in accepted although invalid under LANGLVL(SAA).`,
     fullCode: "IBM3657IE",
@@ -11881,7 +11880,7 @@ export const Error = {
    */
   IBM3658I: {
     code: "IBM3658I",
-    severity: "E",
+    severity: Severity.E,
     message: (filename: string) =>
       `The INCLUDE file ${filename} has been deprecated.`,
     fullCode: "IBM3658IE",
@@ -11894,7 +11893,7 @@ export const Error = {
    */
   IBM3659I: {
     code: "IBM3659I",
-    severity: "E",
+    severity: Severity.E,
     message: (statement: string) =>
       `The EXEC SQL ${statement} statement has been deprecated.`,
     fullCode: "IBM3659IE",
@@ -11907,7 +11906,7 @@ export const Error = {
    */
   IBM3660I: {
     code: "IBM3660I",
-    severity: "E",
+    severity: Severity.E,
     message: (variable: string) =>
       `The ENTRY named ${variable} has been deprecated.`,
     fullCode: "IBM3660IE",
@@ -11920,7 +11919,7 @@ export const Error = {
    */
   IBM3661I: {
     code: "IBM3661I",
-    severity: "E",
+    severity: Severity.E,
     message: "Invalid use of question mark.",
     fullCode: "IBM3661IE",
   } as SimplePLICode,
@@ -11934,7 +11933,7 @@ export const Severe = {
    */
   IBM1500I: {
     code: "IBM1500I",
-    severity: "S",
+    severity: Severity.S,
     message: (
       argumentnumber: string,
       ENTRYname: string,
@@ -11952,7 +11951,7 @@ export const Severe = {
    */
   IBM1501I: {
     code: "IBM1501I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, ENTRYname: string) =>
       `Argument number ${argumentnumber} in ENTRY reference ${ENTRYname} has a different strong type than the corresponding parameter.`,
     fullCode: "IBM1501IS",
@@ -11965,7 +11964,7 @@ export const Severe = {
    */
   IBM1502I: {
     code: "IBM1502I",
-    severity: "S",
+    severity: Severity.S,
     message: (
       argumentnumber: string,
       ENTRYname: string,
@@ -11984,7 +11983,7 @@ export const Severe = {
    */
   IBM1503I: {
     code: "IBM1503I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, ENTRYname: string, sourcetype: string) =>
       `Argument number ${argumentnumber} in ENTRY reference ${ENTRYname} has type ${sourcetype} , which is invalid for a parameter with type LIMITED ENTRY.`,
     fullCode: "IBM1503IS",
@@ -11997,7 +11996,7 @@ export const Severe = {
    */
   IBM1504I: {
     code: "IBM1504I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, ENTRYname: string) =>
       `Argument number ${argumentnumber} in ENTRY reference ${ENTRYname} has type POINTER, which is invalid for an OFFSET parameter without an AREA qualifier.`,
     fullCode: "IBM1504IS",
@@ -12010,7 +12009,7 @@ export const Severe = {
    */
   IBM1505I: {
     code: "IBM1505I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, ENTRYname: string) =>
       `Argument number ${argumentnumber} in ENTRY reference ${ENTRYname} has type POINTER, which is invalid for a POINTER parameter since the OFFSET argument is not an OFFSET variable declared with an AREA qualifier.`,
     fullCode: "IBM1505IS",
@@ -12022,7 +12021,7 @@ export const Severe = {
    */
   IBM1506I: {
     code: "IBM1506I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, ENTRYname: string) =>
       `Argument number ${argumentnumber} in ENTRY reference ${ENTRYname} has a different ORDINAL type than the corresponding parameter.`,
     fullCode: "IBM1506IS",
@@ -12040,7 +12039,7 @@ export const Severe = {
    */
   IBM1507I: {
     code: "IBM1507I",
-    severity: "S",
+    severity: Severity.S,
     message: "Arrays of label constants may not be passed as arguments.",
     fullCode: "IBM1507IS",
   } as SimplePLICode,
@@ -12052,7 +12051,7 @@ export const Severe = {
    */
   IBM1508I: {
     code: "IBM1508I",
-    severity: "S",
+    severity: Severity.S,
     message: (ENTRYname: string) =>
       `Too few arguments have been specified for the ENTRY ${ENTRYname} .`,
     fullCode: "IBM1508IS",
@@ -12070,7 +12069,7 @@ export const Severe = {
    */
   IBM1509I: {
     code: "IBM1509I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `Argument to ${variablename} pseudovariable must be ASSIGNABLE.`,
     fullCode: "IBM1509IS",
@@ -12088,7 +12087,7 @@ export const Severe = {
    */
   IBM1510I: {
     code: "IBM1510I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `First argument to ${variablename} pseudovariable must be ASSIGNABLE.`,
     fullCode: "IBM1510IS",
@@ -12104,7 +12103,7 @@ export const Severe = {
    */
   IBM1511I: {
     code: "IBM1511I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, ENTRYname: string) =>
       `Argument number ${argumentnumber} in ENTRY reference ${ENTRYname} is an aggregate, but the parameter description specifies a scalar.`,
     fullCode: "IBM1511IS",
@@ -12123,7 +12122,7 @@ export const Severe = {
    */
   IBM1512I: {
     code: "IBM1512I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, ENTRYname: string) =>
       `Argument number ${argumentnumber} in ENTRY reference ${ENTRYname} is a scalar, but the parameter description specifies an aggregate to which it cannot be passed.`,
     fullCode: "IBM1512IS",
@@ -12137,7 +12136,7 @@ export const Severe = {
    */
   IBM1513I: {
     code: "IBM1513I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, ENTRYname: string) =>
       `Argument number ${argumentnumber} in ENTRY reference ${ENTRYname} is an aggregate that does not exactly match the corresponding parameter description.`,
     fullCode: "IBM1513IS",
@@ -12151,7 +12150,7 @@ export const Severe = {
    */
   IBM1514I: {
     code: "IBM1514I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, ENTRYname: string) =>
       `Argument number ${argumentnumber} in ENTRY reference ${ENTRYname} is an aggregate with more members than its corresponding parameter description.`,
     fullCode: "IBM1514IS",
@@ -12165,7 +12164,7 @@ export const Severe = {
    */
   IBM1515I: {
     code: "IBM1515I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, ENTRYname: string) =>
       `Argument number ${argumentnumber} in ENTRY reference ${ENTRYname} is an aggregate with fewer members than its corresponding parameter description.`,
     fullCode: "IBM1515IS",
@@ -12179,7 +12178,7 @@ export const Severe = {
    */
   IBM1516I: {
     code: "IBM1516I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, ENTRYname: string) =>
       `The number of dimensions in the subelements of argument number ${argumentnumber} in ENTRY reference ${ENTRYname} and in its corresponding parameter description do not match.`,
     fullCode: "IBM1516IS",
@@ -12193,7 +12192,7 @@ export const Severe = {
    */
   IBM1517I: {
     code: "IBM1517I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, ENTRYname: string) =>
       `The upper and lower bounds in the subelements of argument number ${argumentnumber} in 72 ENTRY reference ${ENTRYname} and in its corresponding parameter description do not match.`,
     fullCode: "IBM1517IS",
@@ -12210,7 +12209,7 @@ export const Severe = {
    */
   IBM1518I: {
     code: "IBM1518I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, ENTRYname: string) =>
       `The number of dimensions for argument number ${argumentnumber} in ENTRY reference ${ENTRYname} and in its corresponding parameter description do not match.`,
     fullCode: "IBM1518IS",
@@ -12227,7 +12226,7 @@ export const Severe = {
    */
   IBM1519I: {
     code: "IBM1519I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, ENTRYname: string) =>
       `The upper and lower bounds for argument number ${argumentnumber} in ENTRY reference ${ENTRYname} and in its corresponding parameter description do not match.`,
     fullCode: "IBM1519IS",
@@ -12240,7 +12239,7 @@ export const Severe = {
    */
   IBM1520I: {
     code: "IBM1520I",
-    severity: "S",
+    severity: Severity.S,
     message: "Charset 48 is not supported.",
     fullCode: "IBM1520IS",
   } as SimplePLICode,
@@ -12253,7 +12252,7 @@ export const Severe = {
    */
   IBM1521I: {
     code: "IBM1521I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Not enough virtual memory is available to continue the compilation.",
     fullCode: "IBM1521IS",
@@ -12266,7 +12265,7 @@ export const Severe = {
    */
   IBM1522I: {
     code: "IBM1522I",
-    severity: "S",
+    severity: Severity.S,
     message: (variable: string) =>
       `${variable} cannot be SET unless an IN clause is specified.`,
     fullCode: "IBM1522IS",
@@ -12278,7 +12277,7 @@ export const Severe = {
    */
   IBM1523I: {
     code: "IBM1523I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Argument to ${BUILTINname} built- in function must be an AREA reference.`,
     fullCode: "IBM1523IS",
@@ -12291,7 +12290,7 @@ export const Severe = {
    */
   IBM1524I: {
     code: "IBM1524I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `${BUILTINname} (x) is undefined if ABS(x) > 1.`,
     fullCode: "IBM1524IS",
@@ -12304,7 +12303,7 @@ export const Severe = {
    */
   IBM1525I: {
     code: "IBM1525I",
-    severity: "S",
+    severity: Severity.S,
     message: "ATANH(x) is undefined if x is REAL and ABS(x) >= 1.",
     fullCode: "IBM1525IS",
   } as SimplePLICode,
@@ -12316,7 +12315,7 @@ export const Severe = {
    */
   IBM1526I: {
     code: "IBM1526I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Argument to ${BUILTINname} must have derived mode REAL.`,
     fullCode: "IBM1526IS",
@@ -12329,7 +12328,7 @@ export const Severe = {
    */
   IBM1527I: {
     code: "IBM1527I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `First argument to ${BUILTINname} built-in function must have locator type.`,
     fullCode: "IBM1527IS",
@@ -12343,7 +12342,7 @@ export const Severe = {
    */
   IBM1528I: {
     code: "IBM1528I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `First argument to ${BUILTINname} built-in function must have derived mode REAL.`,
     fullCode: "IBM1528IS",
@@ -12357,7 +12356,7 @@ export const Severe = {
    */
   IBM1530I: {
     code: "IBM1530I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Second argument to ${BUILTINname} built-in function must have derived mode REAL.`,
     fullCode: "IBM1530IS",
@@ -12370,7 +12369,7 @@ export const Severe = {
    */
   IBM1531I: {
     code: "IBM1531I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `${BUILTINname} argument has invalid type.`,
     fullCode: "IBM1531IS",
@@ -12382,7 +12381,7 @@ export const Severe = {
    */
   IBM1532I: {
     code: "IBM1532I",
-    severity: "S",
+    severity: Severity.S,
     message: "E35 sort exit routines must use a 32-bit linkage.",
     fullCode: "IBM1532IS",
   } as SimplePLICode,
@@ -12394,7 +12393,7 @@ export const Severe = {
    */
   IBM1533I: {
     code: "IBM1533I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `${BUILTINname} argument must have computational type.`,
     fullCode: "IBM1533IS",
@@ -12407,7 +12406,7 @@ export const Severe = {
    */
   IBM1534I: {
     code: "IBM1534I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `${BUILTINname} result would be too long.`,
     fullCode: "IBM1534IS",
@@ -12422,7 +12421,7 @@ export const Severe = {
    */
   IBM1535I: {
     code: "IBM1535I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `${BUILTINname} argument must have type REAL FLOAT.`,
     fullCode: "IBM1535IS",
@@ -12435,7 +12434,7 @@ export const Severe = {
    */
   IBM1536I: {
     code: "IBM1536I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `${BUILTINname} argument must be a reference.`,
     fullCode: "IBM1536IS",
@@ -12449,7 +12448,7 @@ export const Severe = {
    */
   IBM1537I: {
     code: "IBM1537I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `${BUILTINname} argument must be an array expression.`,
     fullCode: "IBM1537IS",
@@ -12463,7 +12462,7 @@ export const Severe = {
    */
   IBM1538I: {
     code: "IBM1538I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `${BUILTINname} argument must be a FILE reference.`,
     fullCode: "IBM1538IS",
@@ -12480,7 +12479,7 @@ export const Severe = {
    */
   IBM1539I: {
     code: "IBM1539I",
-    severity: "S",
+    severity: Severity.S,
     message: "* is invalid as a built-in function argument.",
     fullCode: "IBM1539IS",
   } as SimplePLICode,
@@ -12492,7 +12491,7 @@ export const Severe = {
    */
   IBM1540I: {
     code: "IBM1540I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, BUILTINname: string) =>
       `Argument number ${argumentnumber} to ${BUILTINname} built-in function must have derived mode REAL.`,
     fullCode: "IBM1540IS",
@@ -12506,7 +12505,7 @@ export const Severe = {
    */
   IBM1541I: {
     code: "IBM1541I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, BUILTINname: string) =>
       `Argument number ${argumentnumber} to ${BUILTINname} built-in function must have computational type.`,
     fullCode: "IBM1541IS",
@@ -12519,7 +12518,7 @@ export const Severe = {
    */
   IBM1542I: {
     code: "IBM1542I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `First argument to ${BUILTINname} built-in function must have computational type.`,
     fullCode: "IBM1542IS",
@@ -12531,7 +12530,7 @@ export const Severe = {
    */
   IBM1543I: {
     code: "IBM1543I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Argument to ${BUILTINname} built- in function must have type CHARACTER(1) NONVARYING.`,
     fullCode: "IBM1543IS",
@@ -12545,7 +12544,7 @@ export const Severe = {
    */
   IBM1545I: {
     code: "IBM1545I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `First argument to ${BUILTINname} built-in function must be an array.`,
     fullCode: "IBM1545IS",
@@ -12557,7 +12556,7 @@ export const Severe = {
    */
   IBM1546I: {
     code: "IBM1546I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Second argument to ${BUILTINname} built-in function must have type CHARACTER(1) NONVARYING.`,
     fullCode: "IBM1546IS",
@@ -12570,7 +12569,7 @@ export const Severe = {
    */
   IBM1547I: {
     code: "IBM1547I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Second argument to ${BUILTINname} built-in function must have computational type.`,
     fullCode: "IBM1547IS",
@@ -12582,7 +12581,7 @@ export const Severe = {
    */
   IBM1548I: {
     code: "IBM1548I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINfunction: string) =>
       `${BUILTINfunction} may not be used inside a BEGIN block.`,
     fullCode: "IBM1548IS",
@@ -12595,7 +12594,7 @@ export const Severe = {
    */
   IBM1549I: {
     code: "IBM1549I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINfunction: string) =>
       `${BUILTINfunction} may be used only in PROCEDUREs with LINKAGE(SYSTEM).`,
     fullCode: "IBM1549IS",
@@ -12607,7 +12606,7 @@ export const Severe = {
    */
   IBM1550I: {
     code: "IBM1550I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Argument to the ${BUILTINname} pseudovariable must be an EVENT variable.`,
     fullCode: "IBM1550IS",
@@ -12619,7 +12618,7 @@ export const Severe = {
    */
   IBM1551I: {
     code: "IBM1551I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Argument to the ${BUILTINname} pseudovariable must be a TASK variable.`,
     fullCode: "IBM1551IS",
@@ -12633,7 +12632,7 @@ export const Severe = {
    */
   IBM1552I: {
     code: "IBM1552I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Third argument to ${BUILTINname} built-in function must have computational type.`,
     fullCode: "IBM1552IS",
@@ -12659,7 +12658,7 @@ export const Severe = {
    */
   IBM1554I: {
     code: "IBM1554I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Argument to ${BUILTINname} built- in function must be either a NONVARYING BIT array reference or else an array expression with known length.`,
     fullCode: "IBM1554IS",
@@ -12672,7 +12671,7 @@ export const Severe = {
    */
   IBM1555I: {
     code: "IBM1555I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Second argument to ${BUILTINname} built-in function must have computational type.`,
     fullCode: "IBM1555IS",
@@ -12687,7 +12686,7 @@ export const Severe = {
    */
   IBM1556I: {
     code: "IBM1556I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, BUILTINname: string) =>
       `Argument number ${argumentnumber} to ${BUILTINname} built-in function would force STRINGRANGE.`,
     fullCode: "IBM1556IS",
@@ -12700,7 +12699,7 @@ export const Severe = {
    */
   IBM1557I: {
     code: "IBM1557I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Second argument to ${BUILTINname} built-in function must be positive.`,
     fullCode: "IBM1557IS",
@@ -12713,7 +12712,7 @@ export const Severe = {
    */
   IBM1558I: {
     code: "IBM1558I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Argument to VALID built-in function must have the attributes FIXED DECIMAL or PICTURE.",
     fullCode: "IBM1558IS",
@@ -12726,7 +12725,7 @@ export const Severe = {
    */
   IBM1559I: {
     code: "IBM1559I",
-    severity: "S",
+    severity: Severity.S,
     message: "SQRT(x) is undefined if x is REAL and negative.",
     fullCode: "IBM1559IS",
   } as SimplePLICode,
@@ -12739,7 +12738,7 @@ export const Severe = {
    */
   IBM1560I: {
     code: "IBM1560I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINfunction: string) =>
       `${BUILTINfunction} (x) is undefined if x is REAL and not positive.`,
     fullCode: "IBM1560IS",
@@ -12752,7 +12751,7 @@ export const Severe = {
    */
   IBM1562I: {
     code: "IBM1562I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Argument to ${BUILTINname} built-in function has invalid type.`,
     fullCode: "IBM1562IS",
@@ -12765,7 +12764,7 @@ export const Severe = {
    */
   IBM1563I: {
     code: "IBM1563I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Second argument to ${BUILTINname} built-in function must be nonnegative.`,
     fullCode: "IBM1563IS",
@@ -12777,7 +12776,7 @@ export const Severe = {
    */
   IBM1564I: {
     code: "IBM1564I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Too few arguments have been specified for the ${BUILTINname} built-in function.`,
     fullCode: "IBM1564IS",
@@ -12790,7 +12789,7 @@ export const Severe = {
    */
   IBM1566I: {
     code: "IBM1566I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `${BUILTINname} (x) is undefined for x outside the supported domain.`,
     fullCode: "IBM1566IS",
@@ -12803,7 +12802,7 @@ export const Severe = {
    */
   IBM1568I: {
     code: "IBM1568I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINfunction: string) =>
       `${BUILTINfunction} (x,y) is undefined if x and y are both zero.`,
     fullCode: "IBM1568IS",
@@ -12816,7 +12815,7 @@ export const Severe = {
    */
   IBM1569I: {
     code: "IBM1569I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `${BUILTINname} argument must be a CONNECTED reference.`,
     fullCode: "IBM1569IS",
@@ -12829,7 +12828,7 @@ export const Severe = {
    */
   IBM1570I: {
     code: "IBM1570I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `${BUILTINname} argument must be a reference to a level 1 CONTROLLED variable.`,
     fullCode: "IBM1570IS",
@@ -12842,7 +12841,7 @@ export const Severe = {
    */
   IBM1571I: {
     code: "IBM1571I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `${BUILTINname} argument must be a reference to a level 1 BYADDR parameter.`,
     fullCode: "IBM1571IS",
@@ -12855,7 +12854,7 @@ export const Severe = {
    */
   IBM1573I: {
     code: "IBM1573I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The use of * as an argument is permitted only for parameters declared with the OPTIONAL attribute.",
     fullCode: "IBM1573IS",
@@ -12868,7 +12867,7 @@ export const Severe = {
    */
   IBM1575I: {
     code: "IBM1575I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, BUILTINname: string) =>
       `Argument number ${argumentnumber} to ${BUILTINname} built-in function must have type POINTER or OFFSET.`,
     fullCode: "IBM1575IS",
@@ -12880,7 +12879,7 @@ export const Severe = {
    */
   IBM1576I: {
     code: "IBM1576I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, BUILTINname: string) =>
       `Argument number ${argumentnumber} to ${BUILTINname} built- in function must have type CHARACTER(1) NONVARYING.`,
     fullCode: "IBM1576IS",
@@ -12892,7 +12891,7 @@ export const Severe = {
    */
   IBM1577I: {
     code: "IBM1577I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `First argument to ${BUILTINname} built-in function must have type POINTER.`,
     fullCode: "IBM1577IS",
@@ -12904,7 +12903,7 @@ export const Severe = {
    */
   IBM1578I: {
     code: "IBM1578I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `First argument to ${BUILTINname} built-in function must have type OFFSET.`,
     fullCode: "IBM1578IS",
@@ -12916,7 +12915,7 @@ export const Severe = {
    */
   IBM1579I: {
     code: "IBM1579I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Second argument to ${BUILTINname} built-in function must have type AREA.`,
     fullCode: "IBM1579IS",
@@ -12929,7 +12928,7 @@ export const Severe = {
    */
   IBM1580I: {
     code: "IBM1580I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `First argument to ${BUILTINname} built-in function is an OFFSET value.`,
     fullCode: "IBM1580IS",
@@ -12943,7 +12942,7 @@ export const Severe = {
    */
   IBM1581I: {
     code: "IBM1581I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `First argument to ${BUILTINname} built-in function is an OFFSET variable declared without an AREA qualifier.`,
     fullCode: "IBM1581IS",
@@ -12956,7 +12955,7 @@ export const Severe = {
    */
   IBM1582I: {
     code: "IBM1582I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, BUILTINname: string) =>
       `Argument number ${argumentnumber} to ${BUILTINname} built-in function is an OFFSET value.`,
     fullCode: "IBM1582IS",
@@ -12970,7 +12969,7 @@ export const Severe = {
    */
   IBM1583I: {
     code: "IBM1583I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, BUILTINname: string) =>
       `Argument number ${argumentnumber} to ${BUILTINname} built- in function is an OFFSET variable declared without an AREA qualifier.`,
     fullCode: "IBM1583IS",
@@ -12982,7 +12981,7 @@ export const Severe = {
    */
   IBM1584I: {
     code: "IBM1584I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Second argument to ${BUILTINname} built-in function must have type OFFSET.`,
     fullCode: "IBM1584IS",
@@ -12994,7 +12993,7 @@ export const Severe = {
    */
   IBM1585I: {
     code: "IBM1585I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Second argument to ${BUILTINname} built-in function must have type POINTER.`,
     fullCode: "IBM1585IS",
@@ -13008,7 +13007,7 @@ export const Severe = {
    */
   IBM1586I: {
     code: "IBM1586I",
-    severity: "S",
+    severity: Severity.S,
     message: "Argument to the STRING built-in function must be CONNECTED.",
     fullCode: "IBM1586IS",
   } as SimplePLICode,
@@ -13020,7 +13019,7 @@ export const Severe = {
    */
   IBM1587I: {
     code: "IBM1587I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, BUILTINname: string) =>
       `Argument number ${argumentnumber} to ${BUILTINname} built-in function must have the ENTRY attribute.`,
     fullCode: "IBM1587IS",
@@ -13038,7 +13037,7 @@ export const Severe = {
    */
   IBM1588I: {
     code: "IBM1588I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `First argument to ${BUILTINname} built-in function must have type GRAPHIC.`,
     fullCode: "IBM1588IS",
@@ -13051,7 +13050,7 @@ export const Severe = {
    */
   IBM1589I: {
     code: "IBM1589I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `${BUILTINname} argument must not have any subscripts.`,
     fullCode: "IBM1589IS",
@@ -13064,7 +13063,7 @@ export const Severe = {
    */
   IBM1590I: {
     code: "IBM1590I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Argument to the STRING built-in function must not be a UNION and must not contain a UNION.",
     fullCode: "IBM1590IS",
@@ -13077,7 +13076,7 @@ export const Severe = {
    */
   IBM1591I: {
     code: "IBM1591I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "All members of an argument to the STRING built-in function must have the UNALIGNED attribute.",
     fullCode: "IBM1591IS",
@@ -13090,7 +13089,7 @@ export const Severe = {
    */
   IBM1592I: {
     code: "IBM1592I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "All members of an argument to the STRING built-in function must have the NONVARYING attribute.",
     fullCode: "IBM1592IS",
@@ -13104,7 +13103,7 @@ export const Severe = {
    */
   IBM1593I: {
     code: "IBM1593I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "All members of an argument to the STRING built-in function must have string type.",
     fullCode: "IBM1593IS",
@@ -13118,7 +13117,7 @@ export const Severe = {
    */
   IBM1594I: {
     code: "IBM1594I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "All members of an argument to the STRING built-in function must have the same string type.",
     fullCode: "IBM1594IS",
@@ -13131,7 +13130,7 @@ export const Severe = {
    */
   IBM1595I: {
     code: "IBM1595I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `First argument to ${BUILTINname} built-in function must have type REAL FLOAT.`,
     fullCode: "IBM1595IS",
@@ -13143,7 +13142,7 @@ export const Severe = {
    */
   IBM1596I: {
     code: "IBM1596I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Second argument to ${BUILTINname} built-in function must have type CHARACTER.`,
     fullCode: "IBM1596IS",
@@ -13155,7 +13154,7 @@ export const Severe = {
    */
   IBM1597I: {
     code: "IBM1597I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `${BUILTINname} argument must have type TASK.`,
     fullCode: "IBM1597IS",
@@ -13167,7 +13166,7 @@ export const Severe = {
    */
   IBM1598I: {
     code: "IBM1598I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `${BUILTINname} argument must have type EVENT.`,
     fullCode: "IBM1598IS",
@@ -13179,7 +13178,7 @@ export const Severe = {
    */
   IBM1599I: {
     code: "IBM1599I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The built-in function ${variablename} may not be used as a pseudovariable.`,
     fullCode: "IBM1599IS",
@@ -13192,7 +13191,7 @@ export const Severe = {
    */
   IBM1600I: {
     code: "IBM1600I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Source to ${BUILTINname} pseudovariable must be scalar.`,
     fullCode: "IBM1600IS",
@@ -13205,7 +13204,7 @@ export const Severe = {
    */
   IBM1601I: {
     code: "IBM1601I",
-    severity: "S",
+    severity: Severity.S,
     message: (identifier: string) =>
       `The identifier ${identifier} is not the name of a built-in function. Any use of it is unsupported.`,
     fullCode: "IBM1601IS",
@@ -13225,7 +13224,7 @@ export const Severe = {
    */
   IBM1602I: {
     code: "IBM1602I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Fourth argument to ${BUILTINname} built-in function must have the attributes REAL FIXED BIN(31,0).`,
     fullCode: "IBM1602IS",
@@ -13238,7 +13237,7 @@ export const Severe = {
    */
   IBM1603I: {
     code: "IBM1603I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `${BUILTINname} argument must not have the CONSTANT attribute.`,
     fullCode: "IBM1603IS",
@@ -13250,7 +13249,7 @@ export const Severe = {
    */
   IBM1604I: {
     code: "IBM1604I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINfunction: string) =>
       `${BUILTINfunction} argument must be nonnegative.`,
     fullCode: "IBM1604IS",
@@ -13263,7 +13262,7 @@ export const Severe = {
    */
   IBM1605I: {
     code: "IBM1605I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Argument to ENTRYADDR built- in function must be an ENTRY variable or an EXTERNAL ENTRY constant.",
     fullCode: "IBM1605IS",
@@ -13278,7 +13277,7 @@ export const Severe = {
    */
   IBM1606I: {
     code: "IBM1606I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `Argument to ${variablename} pseudovariable must be a reference.`,
     fullCode: "IBM1606IS",
@@ -13293,7 +13292,7 @@ export const Severe = {
    */
   IBM1607I: {
     code: "IBM1607I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `First argument to ${variablename} pseudovariable must be a reference.`,
     fullCode: "IBM1607IS",
@@ -13306,7 +13305,7 @@ export const Severe = {
    */
   IBM1608I: {
     code: "IBM1608I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `Argument to ${variablename} pseudovariable must be a scalar.`,
     fullCode: "IBM1608IS",
@@ -13319,7 +13318,7 @@ export const Severe = {
    */
   IBM1609I: {
     code: "IBM1609I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `First argument to ${variablename} pseudovariable must be a scalar.`,
     fullCode: "IBM1609IS",
@@ -13332,7 +13331,7 @@ export const Severe = {
    */
   IBM1610I: {
     code: "IBM1610I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `Argument to ${variablename} pseudovariable must be COMPLEX.`,
     fullCode: "IBM1610IS",
@@ -13345,7 +13344,7 @@ export const Severe = {
    */
   IBM1611I: {
     code: "IBM1611I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `First argument to ${BUILTINname} pseudovariable must have string type.`,
     fullCode: "IBM1611IS",
@@ -13357,7 +13356,7 @@ export const Severe = {
    */
   IBM1612I: {
     code: "IBM1612I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Argument to the ENTRYADDR pseudovariable must be an ENTRY variable.",
     fullCode: "IBM1612IS",
@@ -13370,7 +13369,7 @@ export const Severe = {
    */
   IBM1613I: {
     code: "IBM1613I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string, fileattribute: string) =>
       `Argument to ${BUILTINname} built- in function has attributes that conflict with ${fileattribute} .`,
     fullCode: "IBM1613IS",
@@ -13382,7 +13381,7 @@ export const Severe = {
    */
   IBM1614I: {
     code: "IBM1614I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Argument to ${BUILTINname} built- in function has attributes that conflict with STREAM.`,
     fullCode: "IBM1614IS",
@@ -13394,7 +13393,7 @@ export const Severe = {
    */
   IBM1615I: {
     code: "IBM1615I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Argument to ${BUILTINname} built- in function has attributes that conflict with PRINT.`,
     fullCode: "IBM1615IS",
@@ -13411,7 +13410,7 @@ export const Severe = {
    */
   IBM1616I: {
     code: "IBM1616I",
-    severity: "S",
+    severity: Severity.S,
     message: (filename: string) =>
       `Attributes and ENVIRONMENT options for file ${filename} conflict.`,
     fullCode: "IBM1616IS",
@@ -13427,7 +13426,7 @@ export const Severe = {
    */
   IBM1617I: {
     code: "IBM1617I",
-    severity: "S",
+    severity: Severity.S,
     message: (filename: string) =>
       `DIRECT attribute for file ${filename} needs ENVIRONMENT option specification of INDEXED, REGIONAL, RELATIVE, or VSAM.`,
     fullCode: "IBM1617IS",
@@ -13440,7 +13439,7 @@ export const Severe = {
    */
   IBM1618I: {
     code: "IBM1618I",
-    severity: "S",
+    severity: Severity.S,
     message: "Syntax of the INCLUDE statement is incorrect.",
     fullCode: "IBM1618IS",
   } as SimplePLICode,
@@ -13451,7 +13450,7 @@ export const Severe = {
    */
   IBM1619I: {
     code: "IBM1619I",
-    severity: "S",
+    severity: Severity.S,
     message: "File specification after INCLUDE is too long.",
     fullCode: "IBM1619IS",
   } as SimplePLICode,
@@ -13462,7 +13461,7 @@ export const Severe = {
    */
   IBM1620I: {
     code: "IBM1620I",
-    severity: "S",
+    severity: Severity.S,
     message: "File specification missing after INCLUDE.",
     fullCode: "IBM1620IS",
   } as SimplePLICode,
@@ -13475,7 +13474,7 @@ export const Severe = {
    */
   IBM1621I: {
     code: "IBM1621I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "NODESCRIPTOR attribute is invalid if any parameters have bit alignment.",
     fullCode: "IBM1621IS",
@@ -13488,7 +13487,7 @@ export const Severe = {
    */
   IBM1622I: {
     code: "IBM1622I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The number of elements and dimension specifications in an aggregate must not exceed 131071.",
     fullCode: "IBM1622IS",
@@ -13501,7 +13500,7 @@ export const Severe = {
    */
   IBM1623I: {
     code: "IBM1623I",
-    severity: "S",
+    severity: Severity.S,
     message: (referencename: string) =>
       `The dot-qualified reference ${referencename} is unknown.`,
     fullCode: "IBM1623IS",
@@ -13514,7 +13513,7 @@ export const Severe = {
    */
   IBM1625I: {
     code: "IBM1625I",
-    severity: "S",
+    severity: Severity.S,
     message: "Extent must be a scalar.",
     fullCode: "IBM1625IS",
   } as SimplePLICode,
@@ -13526,7 +13525,7 @@ export const Severe = {
    */
   IBM1626I: {
     code: "IBM1626I",
-    severity: "S",
+    severity: Severity.S,
     message: "Extent must have computational type.",
     fullCode: "IBM1626IS",
   } as SimplePLICode,
@@ -13538,7 +13537,7 @@ export const Severe = {
    */
   IBM1627I: {
     code: "IBM1627I",
-    severity: "S",
+    severity: Severity.S,
     message: "Subscript expressions must be scalars.",
     fullCode: "IBM1627IS",
   } as SimplePLICode,
@@ -13549,7 +13548,7 @@ export const Severe = {
    */
   IBM1628I: {
     code: "IBM1628I",
-    severity: "S",
+    severity: Severity.S,
     message: (indexnumber: string, variablename: string) =>
       `Index number ${indexnumber} into the array ${variablename} must have computational type.`,
     fullCode: "IBM1628IS",
@@ -13562,7 +13561,7 @@ export const Severe = {
    */
   IBM1629I: {
     code: "IBM1629I",
-    severity: "S",
+    severity: Severity.S,
     message: "Extents for STATIC variable are not constant.",
     fullCode: "IBM1629IS",
   } as SimplePLICode,
@@ -13574,7 +13573,7 @@ export const Severe = {
    */
   IBM1630I: {
     code: "IBM1630I",
-    severity: "S",
+    severity: Severity.S,
     message: "Number of dimensions in arrays do not match.",
     fullCode: "IBM1630IS",
   } as SimplePLICode,
@@ -13586,7 +13585,7 @@ export const Severe = {
    */
   IBM1631I: {
     code: "IBM1631I",
-    severity: "S",
+    severity: Severity.S,
     message: "Upper and lower bounds in arrays do not match.",
     fullCode: "IBM1631IS",
   } as SimplePLICode,
@@ -13601,7 +13600,7 @@ export const Severe = {
    */
   IBM1632I: {
     code: "IBM1632I",
-    severity: "S",
+    severity: Severity.S,
     message: (indexnumber: string, variablename: string) =>
       `Index number ${indexnumber} into the variable ${variablename} is less than the lower bound for that dimension.`,
     fullCode: "IBM1632IS",
@@ -13617,7 +13616,7 @@ export const Severe = {
    */
   IBM1633I: {
     code: "IBM1633I",
-    severity: "S",
+    severity: Severity.S,
     message: (indexnumber: string, variablename: string) =>
       `Index number ${indexnumber} into the variable ${variablename} is greater than the upper bound for that dimension.`,
     fullCode: "IBM1633IS",
@@ -13641,7 +13640,7 @@ export const Severe = {
    */
   IBM1634I: {
     code: "IBM1634I",
-    severity: "S",
+    severity: Severity.S,
     message: "Number of dimensions in subelements of structures do not match.",
     fullCode: "IBM1634IS",
   } as SimplePLICode,
@@ -13664,7 +13663,7 @@ export const Severe = {
    */
   IBM1635I: {
     code: "IBM1635I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Upper and lower bounds in subelements of structures do not match.",
     fullCode: "IBM1635IS",
@@ -13678,7 +13677,7 @@ export const Severe = {
    */
   IBM1636I: {
     code: "IBM1636I",
-    severity: "S",
+    severity: Severity.S,
     message: "Substructuring in subelements of structures do not match.",
     fullCode: "IBM1636IS",
   } as SimplePLICode,
@@ -13690,7 +13689,7 @@ export const Severe = {
    */
   IBM1637I: {
     code: "IBM1637I",
-    severity: "S",
+    severity: Severity.S,
     message: "Number of subelements in structures do not match.",
     fullCode: "IBM1637IS",
   } as SimplePLICode,
@@ -13701,7 +13700,7 @@ export const Severe = {
    */
   IBM1638I: {
     code: "IBM1638I",
-    severity: "S",
+    severity: Severity.S,
     message: "Structures and unions are not permitted in GENERIC descriptions.",
     fullCode: "IBM1638IS",
   } as SimplePLICode,
@@ -13713,7 +13712,7 @@ export const Severe = {
    */
   IBM1639I: {
     code: "IBM1639I",
-    severity: "S",
+    severity: Severity.S,
     message: (aggregatename: string) =>
       `The aggregate ${aggregatename} contains only noncomputational values. The aggregate will be ignored.`,
     fullCode: "IBM1639IS",
@@ -13726,7 +13725,7 @@ export const Severe = {
    */
   IBM1640I: {
     code: "IBM1640I",
-    severity: "S",
+    severity: Severity.S,
     message: (aggregatename: string) =>
       `The aggregate ${aggregatename} contains one or more unions and cannot be used in stream I/O.`,
     fullCode: "IBM1640IS",
@@ -13745,7 +13744,7 @@ export const Severe = {
    */
   IBM1641I: {
     code: "IBM1641I",
-    severity: "S",
+    severity: Severity.S,
     message: (structurename: string) =>
       `References to slices of the array of structures ${structurename} are not permitted.`,
     fullCode: "IBM1641IS",
@@ -13764,7 +13763,7 @@ export const Severe = {
    */
   IBM1642I: {
     code: "IBM1642I",
-    severity: "S",
+    severity: Severity.S,
     message: (unionname: string) =>
       `References to slices of the array of unions ${unionname} are not permitted.`,
     fullCode: "IBM1642IS",
@@ -13777,7 +13776,7 @@ export const Severe = {
    */
   IBM1643I: {
     code: "IBM1643I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Each dimension of an array must contain no more than 2147483647 elements.",
     fullCode: "IBM1643IS",
@@ -13789,7 +13788,7 @@ export const Severe = {
    */
   IBM1644I: {
     code: "IBM1644I",
-    severity: "S",
+    severity: Severity.S,
     message: "Aggregate contains more than 15 logical levels.",
     fullCode: "IBM1644IS",
   } as SimplePLICode,
@@ -13801,7 +13800,7 @@ export const Severe = {
    */
   IBM1645I: {
     code: "IBM1645I",
-    severity: "S",
+    severity: Severity.S,
     message: "Data aggregate exceeds the maximum length.",
     fullCode: "IBM1645IS",
   } as SimplePLICode,
@@ -13826,7 +13825,7 @@ export const Severe = {
    */
   IBM1646I: {
     code: "IBM1646I",
-    severity: "S",
+    severity: Severity.S,
     message: "SIZE would be raised in assigning TO value to control variable.",
     fullCode: "IBM1646IS",
   } as SimplePLICode,
@@ -13838,7 +13837,7 @@ export const Severe = {
    */
   IBM1647I: {
     code: "IBM1647I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `Too few subscripts specified for the variable ${variablename} .`,
     fullCode: "IBM1647IS",
@@ -13851,7 +13850,7 @@ export const Severe = {
    */
   IBM1648I: {
     code: "IBM1648I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `Too many subscripts specified for the variable ${variablename} .`,
     fullCode: "IBM1648IS",
@@ -13873,7 +13872,7 @@ export const Severe = {
    */
   IBM1649I: {
     code: "IBM1649I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The number of inherited dimensions plus the number of member dimensions exceeds 15.",
     fullCode: "IBM1649IS",
@@ -13890,7 +13889,7 @@ export const Severe = {
    */
   IBM1650I: {
     code: "IBM1650I",
-    severity: "S",
+    severity: Severity.S,
     message: "The LIKE reference is neither a structure nor a union.",
     fullCode: "IBM1650IS",
   } as SimplePLICode,
@@ -13917,7 +13916,7 @@ export const Severe = {
    */
   IBM1651I: {
     code: "IBM1651I",
-    severity: "S",
+    severity: Severity.S,
     message: (keywordname: string) =>
       `The ${keywordname} reference is ambiguous.`,
     fullCode: "IBM1651IS",
@@ -13940,7 +13939,7 @@ export const Severe = {
    */
   IBM1652I: {
     code: "IBM1652I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Neither the LIKE reference nor any of its substructures can be declared with the LIKE attribute.",
     fullCode: "IBM1652IS",
@@ -13960,7 +13959,7 @@ export const Severe = {
    */
   IBM1653I: {
     code: "IBM1653I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "A LIKE reference in an ENTRY declaration must not be a member of a structure or union containing that ENTRY declaration.",
     fullCode: "IBM1653IS",
@@ -13973,7 +13972,7 @@ export const Severe = {
    */
   IBM1654I: {
     code: "IBM1654I",
-    severity: "S",
+    severity: Severity.S,
     message: (keywordname: string) =>
       `The ${keywordname} reference is unknown.`,
     fullCode: "IBM1654IS",
@@ -13992,7 +13991,7 @@ export const Severe = {
    */
   IBM1655I: {
     code: "IBM1655I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Only CONTROLLED variables can be passed to CONTROLLED parameters.",
     fullCode: "IBM1655IS",
@@ -14013,7 +14012,7 @@ export const Severe = {
    */
   IBM1656I: {
     code: "IBM1656I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "A CONTROLLED variable passed to a CONTROLLED parameter must have the same attributes as that parameter.",
     fullCode: "IBM1656IS",
@@ -14025,7 +14024,7 @@ export const Severe = {
    */
   IBM1657I: {
     code: "IBM1657I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `A subscript has been specified for the non-array variable ${variablename} .`,
     fullCode: "IBM1657IS",
@@ -14041,7 +14040,7 @@ export const Severe = {
    */
   IBM1658I: {
     code: "IBM1658I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, ENTRYname: string) =>
       `Argument number ${argumentnumber} in ENTRY reference ${ENTRYname} is an array expression requiring a temporary array with strings of unknown length.`,
     fullCode: "IBM1658IS",
@@ -14053,7 +14052,7 @@ export const Severe = {
    */
   IBM1659I: {
     code: "IBM1659I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "After LIKE expansion, aggregate would contain more than 15 logical levels.",
     fullCode: "IBM1659IS",
@@ -14072,7 +14071,7 @@ export const Severe = {
    */
   IBM1660I: {
     code: "IBM1660I",
-    severity: "S",
+    severity: Severity.S,
     message: (recordsize: string, recsize: string) =>
       `The size ( ${recordsize} ) of the record conflicts with the RECSIZE ( ${recsize} ) specified in the ENVIRONMENT attribute.`,
     fullCode: "IBM1660IS",
@@ -14084,7 +14083,7 @@ export const Severe = {
    */
   IBM1661I: {
     code: "IBM1661I",
-    severity: "S",
+    severity: Severity.S,
     message: "Aggregates cannot be assigned to scalars.",
     fullCode: "IBM1661IS",
   } as SimplePLICode,
@@ -14096,7 +14095,7 @@ export const Severe = {
    */
   IBM1662I: {
     code: "IBM1662I",
-    severity: "S",
+    severity: Severity.S,
     message: "Unsupported use of union or structure containing a union.",
     fullCode: "IBM1662IS",
   } as SimplePLICode,
@@ -14107,7 +14106,7 @@ export const Severe = {
    */
   IBM1663I: {
     code: "IBM1663I",
-    severity: "S",
+    severity: Severity.S,
     message: "Unsupported or invalid use of structure expression.",
     fullCode: "IBM1663IS",
   } as SimplePLICode,
@@ -14118,7 +14117,7 @@ export const Severe = {
    */
   IBM1664I: {
     code: "IBM1664I",
-    severity: "S",
+    severity: Severity.S,
     message: "Array expressions cannot be assigned to non-arrays.",
     fullCode: "IBM1664IS",
   } as SimplePLICode,
@@ -14130,7 +14129,7 @@ export const Severe = {
    */
   IBM1665I: {
     code: "IBM1665I",
-    severity: "S",
+    severity: Severity.S,
     message: "E15 sort exit routines must have the RETURNS attribute.",
     fullCode: "IBM1665IS",
   } as SimplePLICode,
@@ -14142,7 +14141,7 @@ export const Severe = {
    */
   IBM1666I: {
     code: "IBM1666I",
-    severity: "S",
+    severity: Severity.S,
     message: "E15 sort exit routines must return a CHARACTER string.",
     fullCode: "IBM1666IS",
   } as SimplePLICode,
@@ -14153,7 +14152,7 @@ export const Severe = {
    */
   IBM1667I: {
     code: "IBM1667I",
-    severity: "S",
+    severity: Severity.S,
     message: "Target in assignment is NONASSIGNABLE.",
     fullCode: "IBM1667IS",
   } as SimplePLICode,
@@ -14165,7 +14164,7 @@ export const Severe = {
    */
   IBM1668I: {
     code: "IBM1668I",
-    severity: "S",
+    severity: Severity.S,
     message: "Target in assignment is a function reference.",
     fullCode: "IBM1668IS",
   } as SimplePLICode,
@@ -14179,7 +14178,7 @@ export const Severe = {
    */
   IBM1669I: {
     code: "IBM1669I",
-    severity: "S",
+    severity: Severity.S,
     message: "Unsupported assignment to a target containing a UNION.",
     fullCode: "IBM1669IS",
   } as SimplePLICode,
@@ -14202,7 +14201,7 @@ export const Severe = {
    */
   IBM1670I: {
     code: "IBM1670I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "A PROCEDURE containing ENTRY statements with differing RETURNS attributes must return values BYADDR.",
     fullCode: "IBM1670IS",
@@ -14215,7 +14214,7 @@ export const Severe = {
    */
   IBM1671I: {
     code: "IBM1671I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The source in a structure assignment must be a scalar expression or a matching structure.",
     fullCode: "IBM1671IS",
@@ -14233,7 +14232,7 @@ export const Severe = {
    */
   IBM1672I: {
     code: "IBM1672I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "In multiple BY NAME assignments, if one target is an array of structures, then all must be.",
     fullCode: "IBM1672IS",
@@ -14246,7 +14245,7 @@ export const Severe = {
    */
   IBM1673I: {
     code: "IBM1673I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The target in a compound concatenate and assign must be a VARYING or VARYINGZ string.",
     fullCode: "IBM1673IS",
@@ -14258,7 +14257,7 @@ export const Severe = {
    */
   IBM1674I: {
     code: "IBM1674I",
-    severity: "S",
+    severity: Severity.S,
     message: "Target in assignment contains UNIONs.",
     fullCode: "IBM1674IS",
   } as SimplePLICode,
@@ -14269,7 +14268,7 @@ export const Severe = {
    */
   IBM1675I: {
     code: "IBM1675I",
-    severity: "S",
+    severity: Severity.S,
     message: "FROMALIEN option cannot be used with MAIN.",
     fullCode: "IBM1675IS",
   } as SimplePLICode,
@@ -14282,7 +14281,7 @@ export const Severe = {
    */
   IBM1676I: {
     code: "IBM1676I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Source in assignment to LIMITED ENTRY must be either a non- nested ENTRY constant or another LIMITED ENTRY.",
     fullCode: "IBM1676IS",
@@ -14295,7 +14294,7 @@ export const Severe = {
    */
   IBM1677I: {
     code: "IBM1677I",
-    severity: "S",
+    severity: Severity.S,
     message: (targettype: string) =>
       `Assignment of ENTRY to ${targettype} is invalid. If the ENTRY should be invoked, an argument list must be provided.`,
     fullCode: "IBM1677IS",
@@ -14307,7 +14306,7 @@ export const Severe = {
    */
   IBM1678I: {
     code: "IBM1678I",
-    severity: "S",
+    severity: Severity.S,
     message: (sourcetype: string, targettype: string) =>
       `Assignment of ${sourcetype} to ${targettype} is invalid.`,
     fullCode: "IBM1678IS",
@@ -14320,7 +14319,7 @@ export const Severe = {
    */
   IBM1679I: {
     code: "IBM1679I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Assignment of POINTER to OFFSET is invalid unless the OFFSET is declared with an AREA qualifier.",
     fullCode: "IBM1679IS",
@@ -14333,7 +14332,7 @@ export const Severe = {
    */
   IBM1680I: {
     code: "IBM1680I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Assignment of OFFSET to POINTER is invalid unless the OFFSET is declared with an AREA qualifier.",
     fullCode: "IBM1680IS",
@@ -14346,7 +14345,7 @@ export const Severe = {
    */
   IBM1681I: {
     code: "IBM1681I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The number of preprocessor invocations specified exceeds the maximum number (25) allowed.",
     fullCode: "IBM1681IS",
@@ -14358,7 +14357,7 @@ export const Severe = {
    */
   IBM1682I: {
     code: "IBM1682I",
-    severity: "S",
+    severity: Severity.S,
     message: "The target in a BY NAME assignment must be a structure.",
     fullCode: "IBM1682IS",
   } as SimplePLICode,
@@ -14371,7 +14370,7 @@ export const Severe = {
    */
   IBM1683I: {
     code: "IBM1683I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Set of matching names in the expansion of BY NAME assignment must contain either all structures or no structures.",
     fullCode: "IBM1683IS",
@@ -14395,7 +14394,7 @@ export const Severe = {
    */
   IBM1684I: {
     code: "IBM1684I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string, variablename2: string) =>
       `Number of dimensions in the BY NAME corresponding elements ${variablename} and ${variablename2} do not match.`,
     fullCode: "IBM1684IS",
@@ -14419,7 +14418,7 @@ export const Severe = {
    */
   IBM1685I: {
     code: "IBM1685I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string, variablename2: string) =>
       `Upper and lower bounds in BY NAME corresponding elements ${variablename} and ${variablename2} do not match.`,
     fullCode: "IBM1685IS",
@@ -14433,7 +14432,7 @@ export const Severe = {
    */
   IBM1686I: {
     code: "IBM1686I",
-    severity: "S",
+    severity: Severity.S,
     message: "BY NAME assignment contains UNIONs.",
     fullCode: "IBM1686IS",
   } as SimplePLICode,
@@ -14445,7 +14444,7 @@ export const Severe = {
    */
   IBM1687I: {
     code: "IBM1687I",
-    severity: "S",
+    severity: Severity.S,
     message: (reservedname: string) =>
       `${reservedname} cannot be declared with OPTIONS other than ASM.`,
     fullCode: "IBM1687IS",
@@ -14458,7 +14457,7 @@ export const Severe = {
    */
   IBM1688I: {
     code: "IBM1688I",
-    severity: "S",
+    severity: Severity.S,
     message: (reservedname: string) =>
       `${reservedname} cannot be declared with an entry description list.`,
     fullCode: "IBM1688IS",
@@ -14471,7 +14470,7 @@ export const Severe = {
    */
   IBM1689I: {
     code: "IBM1689I",
-    severity: "S",
+    severity: Severity.S,
     message: (reservedname: string) =>
       `${reservedname} cannot be declared as a function.`,
     fullCode: "IBM1689IS",
@@ -14484,7 +14483,7 @@ export const Severe = {
    */
   IBM1690I: {
     code: "IBM1690I",
-    severity: "S",
+    severity: Severity.S,
     message: (languagename: string) =>
       `OPTIONS( ${languagename} ) is not supported for functions.`,
     fullCode: "IBM1690IS",
@@ -14498,7 +14497,7 @@ export const Severe = {
    */
   IBM1691I: {
     code: "IBM1691I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Extents in ENTRY descriptors must be asterisks or restricted expressions with computational type.",
     fullCode: "IBM1691IS",
@@ -14514,7 +14513,7 @@ export const Severe = {
    */
   IBM1692I: {
     code: "IBM1692I",
-    severity: "S",
+    severity: Severity.S,
     message: "An ENTRY invoked as a function must have the RETURNS attribute.",
     fullCode: "IBM1692IS",
   } as SimplePLICode,
@@ -14526,7 +14525,7 @@ export const Severe = {
    */
   IBM1693I: {
     code: "IBM1693I",
-    severity: "S",
+    severity: Severity.S,
     message: (calloption: string) =>
       `${calloption} option repeated in CALL statement.`,
     fullCode: "IBM1693IS",
@@ -14540,7 +14539,7 @@ export const Severe = {
    */
   IBM1694I: {
     code: "IBM1694I",
-    severity: "S",
+    severity: Severity.S,
     message: "Reference in CALL statement must not be a built-in function.",
     fullCode: "IBM1694IS",
   } as SimplePLICode,
@@ -14552,7 +14551,7 @@ export const Severe = {
    */
   IBM1695I: {
     code: "IBM1695I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Reference in CALL statement must either be a built-in subroutine or have type ENTRY.",
     fullCode: "IBM1695IS",
@@ -14568,7 +14567,7 @@ export const Severe = {
    */
   IBM1696I: {
     code: "IBM1696I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "RETURN statement without an expression is invalid inside a nested PROCEDURE that specified the RETURNS attribute.",
     fullCode: "IBM1696IS",
@@ -14581,7 +14580,7 @@ export const Severe = {
    */
   IBM1697I: {
     code: "IBM1697I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "RETURN statement is invalid inside a PROCEDURE that did not specify the RETURNS attribute.",
     fullCode: "IBM1697IS",
@@ -14595,7 +14594,7 @@ export const Severe = {
    */
   IBM1698I: {
     code: "IBM1698I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "RETURN statement with an expression is invalid inside a BEGIN in a PROCEDURE that does not have the RETURNS(BYADDR) attribute.",
     fullCode: "IBM1698IS",
@@ -14607,7 +14606,7 @@ export const Severe = {
    */
   IBM1699I: {
     code: "IBM1699I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, ENTRYname: string) =>
       `Argument number ${argumentnumber} in ENTRY reference ${ENTRYname} is an aggregate. This conflicts with the BYVALUE option.`,
     fullCode: "IBM1699IS",
@@ -14619,7 +14618,7 @@ export const Severe = {
    */
   IBM1700I: {
     code: "IBM1700I",
-    severity: "S",
+    severity: Severity.S,
     message: (attribute: string) => `${attribute} must be passed BYADDR.`,
     fullCode: "IBM1700IS",
   } as ParametricPLICode,
@@ -14630,7 +14629,7 @@ export const Severe = {
    */
   IBM1701I: {
     code: "IBM1701I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, ENTRYname: string) =>
       `Argument number ${argumentnumber} in ENTRY reference ${ENTRYname} is a string with unknown size. This conflicts with the BYVALUE option.`,
     fullCode: "IBM1701IS",
@@ -14645,7 +14644,7 @@ export const Severe = {
    */
   IBM1702I: {
     code: "IBM1702I",
-    severity: "S",
+    severity: Severity.S,
     message: (attributekeyword: string) =>
       `The ${attributekeyword} attribute is invalid as a RETURNS subattribute.`,
     fullCode: "IBM1702IS",
@@ -14661,7 +14660,7 @@ export const Severe = {
    */
   IBM1703I: {
     code: "IBM1703I",
-    severity: "S",
+    severity: Severity.S,
     message: "Reference in CALL statement must not be an aggregate reference.",
     fullCode: "IBM1703IS",
   } as SimplePLICode,
@@ -14674,7 +14673,7 @@ export const Severe = {
    */
   IBM1704I: {
     code: "IBM1704I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `Too many argument lists have been specified for the variable ${variablename} .`,
     fullCode: "IBM1704IS",
@@ -14692,7 +14691,7 @@ export const Severe = {
    */
   IBM1705I: {
     code: "IBM1705I",
-    severity: "S",
+    severity: Severity.S,
     message: (sourcetype: string, targettype: string) =>
       `RETURN expression with attribute ${sourcetype} is invalid for RETURNS options specifying the attribute ${targettype} .`,
     fullCode: "IBM1705IS",
@@ -14711,7 +14710,7 @@ export const Severe = {
    */
   IBM1706I: {
     code: "IBM1706I",
-    severity: "S",
+    severity: Severity.S,
     message: (sourcetype: string, targettype: string) =>
       `RETURN expression with attribute ${sourcetype} is invalid for RETURNS options specifying the attribute ${targettype} . If the ENTRY should be invoked, an argument list must be provided.`,
     fullCode: "IBM1706IS",
@@ -14725,7 +14724,7 @@ export const Severe = {
    */
   IBM1707I: {
     code: "IBM1707I",
-    severity: "S",
+    severity: Severity.S,
     message: (sourcetype: string) =>
       `RETURN expression with attribute ${sourcetype} is invalid for RETURNS options specifying the attribute LIMITED ENTRY.`,
     fullCode: "IBM1707IS",
@@ -14738,7 +14737,7 @@ export const Severe = {
    */
   IBM1708I: {
     code: "IBM1708I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "RETURN expression with attribute POINTER is invalid for RETURNS options specifying the attribute OFFSET since the OFFSET attribute is not declared with an AREA qualifier.",
     fullCode: "IBM1708IS",
@@ -14751,7 +14750,7 @@ export const Severe = {
    */
   IBM1709I: {
     code: "IBM1709I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "RETURN expression with attribute OFFSET is invalid for RETURNS options specifying the attribute POINTER since the OFFSET expression is not an OFFSET variable declared with an AREA qualifier.",
     fullCode: "IBM1709IS",
@@ -14770,7 +14769,7 @@ export const Severe = {
    */
   IBM1710I: {
     code: "IBM1710I",
-    severity: "S",
+    severity: Severity.S,
     message: "ORDINAL type in RETURN expression and RETURNS option must match.",
     fullCode: "IBM1710IS",
   } as SimplePLICode,
@@ -14782,7 +14781,7 @@ export const Severe = {
    */
   IBM1711I: {
     code: "IBM1711I",
-    severity: "S",
+    severity: Severity.S,
     message: "Expression in RETURN statement must be scalar.",
     fullCode: "IBM1711IS",
   } as SimplePLICode,
@@ -14793,7 +14792,7 @@ export const Severe = {
    */
   IBM1712I: {
     code: "IBM1712I",
-    severity: "S",
+    severity: Severity.S,
     message: "External name specification must be a non-null string.",
     fullCode: "IBM1712IS",
   } as SimplePLICode,
@@ -14804,7 +14803,7 @@ export const Severe = {
    */
   IBM1713I: {
     code: "IBM1713I",
-    severity: "S",
+    severity: Severity.S,
     message: (functionname: string) =>
       `Function ${functionname} contains no RETURN statement.`,
     fullCode: "IBM1713IS",
@@ -14818,7 +14817,7 @@ export const Severe = {
    */
   IBM1714I: {
     code: "IBM1714I",
-    severity: "S",
+    severity: Severity.S,
     message: "Extents in RETURNS descriptors must be constants.",
     fullCode: "IBM1714IS",
   } as SimplePLICode,
@@ -14831,7 +14830,7 @@ export const Severe = {
    */
   IBM1715I: {
     code: "IBM1715I",
-    severity: "S",
+    severity: Severity.S,
     message: "Exit from an ON-unit via RETURN is invalid.",
     fullCode: "IBM1715IS",
   } as SimplePLICode,
@@ -14843,7 +14842,7 @@ export const Severe = {
    */
   IBM1716I: {
     code: "IBM1716I",
-    severity: "S",
+    severity: Severity.S,
     message: "FORMAT expression must be a scalar value.",
     fullCode: "IBM1716IS",
   } as SimplePLICode,
@@ -14855,7 +14854,7 @@ export const Severe = {
    */
   IBM1717I: {
     code: "IBM1717I",
-    severity: "S",
+    severity: Severity.S,
     message: "FORMAT expression must have computational type.",
     fullCode: "IBM1717IS",
   } as SimplePLICode,
@@ -14867,7 +14866,7 @@ export const Severe = {
    */
   IBM1718I: {
     code: "IBM1718I",
-    severity: "S",
+    severity: Severity.S,
     message: (sourcetype: string) =>
       `${sourcetype} is invalid as a Boolean expression.`,
     fullCode: "IBM1718IS",
@@ -14882,7 +14881,7 @@ export const Severe = {
    */
   IBM1719I: {
     code: "IBM1719I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "ENTRY is invalid as a Boolean expression. If an ENTRY should be invoked, an argument list must be provided.",
     fullCode: "IBM1719IS",
@@ -14896,7 +14895,7 @@ export const Severe = {
    */
   IBM1720I: {
     code: "IBM1720I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Expression for calculating size of variable with adjustable extents is 90 too complicated. Variable may be defined in terms of itself.",
     fullCode: "IBM1720IS",
@@ -14909,7 +14908,7 @@ export const Severe = {
    */
   IBM1721I: {
     code: "IBM1721I",
-    severity: "S",
+    severity: Severity.S,
     message: "Expression contains too many nested subexpressions.",
     fullCode: "IBM1721IS",
   } as SimplePLICode,
@@ -14921,7 +14920,7 @@ export const Severe = {
    */
   IBM1722I: {
     code: "IBM1722I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The number of error messages allowed by the MAXMSG option has been exceeded.",
     fullCode: "IBM1722IS",
@@ -14935,7 +14934,7 @@ export const Severe = {
    */
   IBM1723I: {
     code: "IBM1723I",
-    severity: "S",
+    severity: Severity.S,
     message: "Result of concatenating two literals is too long.",
     fullCode: "IBM1723IS",
   } as SimplePLICode,
@@ -14947,7 +14946,7 @@ export const Severe = {
    */
   IBM1724I: {
     code: "IBM1724I",
-    severity: "S",
+    severity: Severity.S,
     message: (sourcetype: string, targettype: string) =>
       `Addition of ${sourcetype} and ${targettype} is invalid.`,
     fullCode: "IBM1724IS",
@@ -14961,7 +14960,7 @@ export const Severe = {
    */
   IBM1725I: {
     code: "IBM1725I",
-    severity: "S",
+    severity: Severity.S,
     message: (sourcetype: string, targettype: string) =>
       `Addition of ${sourcetype} and ${targettype} is invalid. If an ENTRY should be invoked, an argument list must be provided.`,
     fullCode: "IBM1725IS",
@@ -14975,7 +14974,7 @@ export const Severe = {
    */
   IBM1726I: {
     code: "IBM1726I",
-    severity: "S",
+    severity: Severity.S,
     message: (targettype: string, sourcetype: string) =>
       `Subtraction of ${targettype} from ${sourcetype} is invalid.`,
     fullCode: "IBM1726IS",
@@ -14989,7 +14988,7 @@ export const Severe = {
    */
   IBM1727I: {
     code: "IBM1727I",
-    severity: "S",
+    severity: Severity.S,
     message: (targettype: string, sourcetype: string) =>
       `Subtraction of ${targettype} from ${sourcetype} is invalid. If an ENTRY should be invoked, an argument list must be provided.`,
     fullCode: "IBM1727IS",
@@ -15001,7 +15000,7 @@ export const Severe = {
    */
   IBM1728I: {
     code: "IBM1728I",
-    severity: "S",
+    severity: Severity.S,
     message: (sourcetype: string, targettype: string) =>
       `Multiplication of ${sourcetype} by ${targettype} is invalid.`,
     fullCode: "IBM1728IS",
@@ -15015,7 +15014,7 @@ export const Severe = {
    */
   IBM1729I: {
     code: "IBM1729I",
-    severity: "S",
+    severity: Severity.S,
     message: (sourcetype: string, targettype: string) =>
       `Multiplication of ${sourcetype} by ${targettype} is invalid. If an ENTRY should be invoked, an argument list must be provided.`,
     fullCode: "IBM1729IS",
@@ -15027,7 +15026,7 @@ export const Severe = {
    */
   IBM1730I: {
     code: "IBM1730I",
-    severity: "S",
+    severity: Severity.S,
     message: (sourcetype: string, targettype: string) =>
       `Division of ${sourcetype} by ${targettype} is invalid.`,
     fullCode: "IBM1730IS",
@@ -15041,7 +15040,7 @@ export const Severe = {
    */
   IBM1731I: {
     code: "IBM1731I",
-    severity: "S",
+    severity: Severity.S,
     message: (sourcetype: string, targettype: string) =>
       `Division of ${sourcetype} by ${targettype} is invalid. If an ENTRY should be invoked, an argument list must be provided.`,
     fullCode: "IBM1731IS",
@@ -15055,7 +15054,7 @@ export const Severe = {
    */
   IBM1732I: {
     code: "IBM1732I",
-    severity: "S",
+    severity: Severity.S,
     message: "Unsupported use of aggregate expression.",
     fullCode: "IBM1732IS",
   } as SimplePLICode,
@@ -15066,7 +15065,7 @@ export const Severe = {
    */
   IBM1733I: {
     code: "IBM1733I",
-    severity: "S",
+    severity: Severity.S,
     message: "Concatenate operands must have computational type.",
     fullCode: "IBM1733IS",
   } as SimplePLICode,
@@ -15078,7 +15077,7 @@ export const Severe = {
    */
   IBM1734I: {
     code: "IBM1734I",
-    severity: "S",
+    severity: Severity.S,
     message: "Operand in a prefix expression is not computational.",
     fullCode: "IBM1734IS",
   } as SimplePLICode,
@@ -15089,7 +15088,7 @@ export const Severe = {
    */
   IBM1735I: {
     code: "IBM1735I",
-    severity: "S",
+    severity: Severity.S,
     message: "AREA variables may not be compared.",
     fullCode: "IBM1735IS",
   } as SimplePLICode,
@@ -15101,7 +15100,7 @@ export const Severe = {
    */
   IBM1736I: {
     code: "IBM1736I",
-    severity: "S",
+    severity: Severity.S,
     message: (sourcetype: string, targettype: string) =>
       `Comparison of ${sourcetype} to ${targettype} is invalid.`,
     fullCode: "IBM1736IS",
@@ -15115,7 +15114,7 @@ export const Severe = {
    */
   IBM1737I: {
     code: "IBM1737I",
-    severity: "S",
+    severity: Severity.S,
     message: (targettype: string) =>
       `Comparison of ENTRY to ${targettype} is invalid. If the ENTRY should be invoked, an argument list must be provided.`,
     fullCode: "IBM1737IS",
@@ -15129,7 +15128,7 @@ export const Severe = {
    */
   IBM1738I: {
     code: "IBM1738I",
-    severity: "S",
+    severity: Severity.S,
     message: (sourcetype: string) =>
       `Comparison of ${sourcetype} to ENTRY is invalid. If the ENTRY should be invoked, an argument list must be provided.`,
     fullCode: "IBM1738IS",
@@ -15141,7 +15140,7 @@ export const Severe = {
    */
   IBM1739I: {
     code: "IBM1739I",
-    severity: "S",
+    severity: Severity.S,
     message: "TASK variables may not be compared.",
     fullCode: "IBM1739IS",
   } as SimplePLICode,
@@ -15153,7 +15152,7 @@ export const Severe = {
    */
   IBM1740I: {
     code: "IBM1740I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Comparison of an OFFSET to a POINTER is invalid since the OFFSET comparand is not an OFFSET variable declared with an AREA qualifier.",
     fullCode: "IBM1740IS",
@@ -15172,7 +15171,7 @@ export const Severe = {
    */
   IBM1741I: {
     code: "IBM1741I",
-    severity: "S",
+    severity: Severity.S,
     message: "Operands in comparison have differing strong types.",
     fullCode: "IBM1741IS",
   } as SimplePLICode,
@@ -15183,7 +15182,7 @@ export const Severe = {
    */
   IBM1742I: {
     code: "IBM1742I",
-    severity: "S",
+    severity: Severity.S,
     message: "Compared ORDINALs must have the same ORDINAL type.",
     fullCode: "IBM1742IS",
   } as SimplePLICode,
@@ -15195,7 +15194,7 @@ export const Severe = {
    */
   IBM1743I: {
     code: "IBM1743I",
-    severity: "S",
+    severity: Severity.S,
     message: "Source and target in assignment have differing strong types.",
     fullCode: "IBM1743IS",
   } as SimplePLICode,
@@ -15206,7 +15205,7 @@ export const Severe = {
    */
   IBM1744I: {
     code: "IBM1744I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Conversion of ORDINALs is invalid unless both have the same ORDINAL type.",
     fullCode: "IBM1744IS",
@@ -15219,7 +15218,7 @@ export const Severe = {
    */
   IBM1745I: {
     code: "IBM1745I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "In a function that returns a strong type, the type in any RETURN expression must be the same as that returned by the function.",
     fullCode: "IBM1745IS",
@@ -15237,7 +15236,7 @@ export const Severe = {
    */
   IBM1746I: {
     code: "IBM1746I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "VALUE, VALUELIST, VALUERANGE, and STATIC INITIAL expressions must be constant.",
     fullCode: "IBM1746IS",
@@ -15255,7 +15254,7 @@ export const Severe = {
    */
   IBM1747I: {
     code: "IBM1747I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Function cannot be used before the function's descriptor list has been scanned.",
     fullCode: "IBM1747IS",
@@ -15272,7 +15271,7 @@ export const Severe = {
    */
   IBM1748I: {
     code: "IBM1748I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Extents of automatic variables must not depend on the extents of automatic variables declared later in the same block.",
     fullCode: "IBM1748IS",
@@ -15284,7 +15283,7 @@ export const Severe = {
    */
   IBM1749I: {
     code: "IBM1749I",
-    severity: "S",
+    severity: Severity.S,
     message: "VALUE and INITIAL expressions must be scalars.",
     fullCode: "IBM1749IS",
   } as SimplePLICode,
@@ -15296,7 +15295,7 @@ export const Severe = {
    */
   IBM1750I: {
     code: "IBM1750I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `INITIAL attribute is invalid for the STATIC LABEL variable ${variablename} since it has the MEMBER attribute.`,
     fullCode: "IBM1750IS",
@@ -15309,7 +15308,7 @@ export const Severe = {
    */
   IBM1751I: {
     code: "IBM1751I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `INITIAL attribute is valid for the STATIC ENTRY variable ${variablename} only if it has the LIMITED attribute.`,
     fullCode: "IBM1751IS",
@@ -15323,7 +15322,7 @@ export const Severe = {
    */
   IBM1753I: {
     code: "IBM1753I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `INITIAL attribute is invalid for the STATIC FORMAT variable ${variablename} .`,
     fullCode: "IBM1753IS",
@@ -15340,7 +15339,7 @@ export const Severe = {
    */
   IBM1754I: {
     code: "IBM1754I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `An asterisk iteration factor can be applied only to the last expression in the INITIAL item list for ${variablename} .`,
     fullCode: "IBM1754IS",
@@ -15357,7 +15356,7 @@ export const Severe = {
    */
   IBM1755I: {
     code: "IBM1755I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `An asterisk iteration factor cannot be used in the nested INITIAL item list for ${variablename} .`,
     fullCode: "IBM1755IS",
@@ -15372,7 +15371,7 @@ export const Severe = {
    */
   IBM1756I: {
     code: "IBM1756I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The scalar variable ${variablename} has an INITIAL list with more than one item.`,
     fullCode: "IBM1756IS",
@@ -15390,7 +15389,7 @@ export const Severe = {
    */
   IBM1757I: {
     code: "IBM1757I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `LABEL constant in STATIC INITIAL for the variable ${variablename} must be in the same block as the LABEL being initialized.`,
     fullCode: "IBM1757IS",
@@ -15409,7 +15408,7 @@ export const Severe = {
    */
   IBM1758I: {
     code: "IBM1758I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `Only one element in the STATIC UNION ${variablename} may have the INITIAL attribute.`,
     fullCode: "IBM1758IS",
@@ -15428,7 +15427,7 @@ export const Severe = {
    */
   IBM1759I: {
     code: "IBM1759I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `Non-null INITIAL values are not supported for the STATIC NONCONNECTED array ${variablename} since it has the attributes UNALIGNED BIT.`,
     fullCode: "IBM1759IS",
@@ -15447,7 +15446,7 @@ export const Severe = {
    */
   IBM1760I: {
     code: "IBM1760I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `LABEL constant in the STATIC INITIAL list for ${variablename} must not be an element of a LABEL CONSTANT array.`,
     fullCode: "IBM1760IS",
@@ -15461,7 +15460,7 @@ export const Severe = {
    */
   IBM1761I: {
     code: "IBM1761I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `ENTRY reference in INITIAL clause for the STATIC ENTRY variable ${variablename} must not be FETCHABLE.`,
     fullCode: "IBM1761IS",
@@ -15473,7 +15472,7 @@ export const Severe = {
    */
   IBM1762I: {
     code: "IBM1762I",
-    severity: "S",
+    severity: Severity.S,
     message: "INITIAL iteration factor must have computational type.",
     fullCode: "IBM1762IS",
   } as SimplePLICode,
@@ -15485,7 +15484,7 @@ export const Severe = {
    */
   IBM1763I: {
     code: "IBM1763I",
-    severity: "S",
+    severity: Severity.S,
     message: "INITIAL iteration factor must be a scalar.",
     fullCode: "IBM1763IS",
   } as SimplePLICode,
@@ -15500,7 +15499,7 @@ export const Severe = {
    */
   IBM1764I: {
     code: "IBM1764I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The BYVALUE attribute is invalid for strings of nonconstant length.",
     fullCode: "IBM1764IS",
@@ -15517,7 +15516,7 @@ export const Severe = {
    */
   IBM1765I: {
     code: "IBM1765I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Length of string with the VALUE attribute must be a constant or an asterisk.",
     fullCode: "IBM1765IS",
@@ -15534,7 +15533,7 @@ export const Severe = {
    */
   IBM1766I: {
     code: "IBM1766I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `VALUE for ${variablename} must be evaluated before its first use.`,
     fullCode: "IBM1766IS",
@@ -15550,7 +15549,7 @@ export const Severe = {
    */
   IBM1767I: {
     code: "IBM1767I",
-    severity: "S",
+    severity: Severity.S,
     message: "Control variable in DO statement must not be a named constant.",
     fullCode: "IBM1767IS",
   } as SimplePLICode,
@@ -15565,7 +15564,7 @@ export const Severe = {
    */
   IBM1768I: {
     code: "IBM1768I",
-    severity: "S",
+    severity: Severity.S,
     message: "Control variable in DO statement must have VARIABLE attribute.",
     fullCode: "IBM1768IS",
   } as SimplePLICode,
@@ -15578,7 +15577,7 @@ export const Severe = {
    */
   IBM1769I: {
     code: "IBM1769I",
-    severity: "S",
+    severity: Severity.S,
     message: "Control variable has type POINTER, but TO expression does not.",
     fullCode: "IBM1769IS",
   } as SimplePLICode,
@@ -15591,7 +15590,7 @@ export const Severe = {
    */
   IBM1770I: {
     code: "IBM1770I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Control variable in loop with TO clause must have computational or locator type.",
     fullCode: "IBM1770IS",
@@ -15604,7 +15603,7 @@ export const Severe = {
    */
   IBM1771I: {
     code: "IBM1771I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The ${variablename} built-in function may be used as a pseudovariable in a DO-loop only if the length of the pseudovariable reference is known at compile time.`,
     fullCode: "IBM1771IS",
@@ -15616,7 +15615,7 @@ export const Severe = {
    */
   IBM1772I: {
     code: "IBM1772I",
-    severity: "S",
+    severity: Severity.S,
     message: "Source in DO loop initialization must be scalar.",
     fullCode: "IBM1772IS",
   } as SimplePLICode,
@@ -15627,7 +15626,7 @@ export const Severe = {
    */
   IBM1773I: {
     code: "IBM1773I",
-    severity: "S",
+    severity: Severity.S,
     message: "Control variable in DO statement must be a scalar.",
     fullCode: "IBM1773IS",
   } as SimplePLICode,
@@ -15639,7 +15638,7 @@ export const Severe = {
    */
   IBM1774I: {
     code: "IBM1774I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Compiler restriction: control variable in DO statement must not be a BASED or CONTROLLED string or area that has non-constant extent.",
     fullCode: "IBM1774IS",
@@ -15652,7 +15651,7 @@ export const Severe = {
    */
   IBM1775I: {
     code: "IBM1775I",
-    severity: "S",
+    severity: Severity.S,
     message: "BY expression must have computational type.",
     fullCode: "IBM1775IS",
   } as SimplePLICode,
@@ -15667,7 +15666,7 @@ export const Severe = {
    */
   IBM1776I: {
     code: "IBM1776I",
-    severity: "S",
+    severity: Severity.S,
     message: "BY expression must not be COMPLEX.",
     fullCode: "IBM1776IS",
   } as SimplePLICode,
@@ -15682,7 +15681,7 @@ export const Severe = {
    */
   IBM1777I: {
     code: "IBM1777I",
-    severity: "S",
+    severity: Severity.S,
     message: "TO expression must not be COMPLEX.",
     fullCode: "IBM1777IS",
   } as SimplePLICode,
@@ -15695,7 +15694,7 @@ export const Severe = {
    */
   IBM1778I: {
     code: "IBM1778I",
-    severity: "S",
+    severity: Severity.S,
     message: "Control variable in loop with TO clause must not be COMPLEX.",
     fullCode: "IBM1778IS",
   } as SimplePLICode,
@@ -15706,7 +15705,7 @@ export const Severe = {
    */
   IBM1779I: {
     code: "IBM1779I",
-    severity: "S",
+    severity: Severity.S,
     message: "TO expression must have computational type.",
     fullCode: "IBM1779IS",
   } as SimplePLICode,
@@ -15718,7 +15717,7 @@ export const Severe = {
    */
   IBM1780I: {
     code: "IBM1780I",
-    severity: "S",
+    severity: Severity.S,
     message: "SIGNAL ANYCONDITION is invalid.",
     fullCode: "IBM1780IS",
   } as SimplePLICode,
@@ -15729,7 +15728,7 @@ export const Severe = {
    */
   IBM1781I: {
     code: "IBM1781I",
-    severity: "S",
+    severity: Severity.S,
     message: (sourcetype: string, targettype: string) =>
       `And, or and exclusive-or of ${sourcetype} and ${targettype} is invalid.`,
     fullCode: "IBM1781IS",
@@ -15743,7 +15742,7 @@ export const Severe = {
    */
   IBM1782I: {
     code: "IBM1782I",
-    severity: "S",
+    severity: Severity.S,
     message: (sourcetype: string, targettype: string) =>
       `And, or and exclusive-or of ${sourcetype} and ${targettype} is invalid. If an ENTRY should be invoked, an argument list must be provided.`,
     fullCode: "IBM1782IS",
@@ -15757,7 +15756,7 @@ export const Severe = {
    */
   IBM1783I: {
     code: "IBM1783I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "BASED variable without an implicit qualifier must be explicitly qualified.",
     fullCode: "IBM1783IS",
@@ -15770,7 +15769,7 @@ export const Severe = {
    */
   IBM1784I: {
     code: "IBM1784I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The ENTRY ${variablename} may not be used as a locator qualifier since it does not have the RETURNS attribute.`,
     fullCode: "IBM1784IS",
@@ -15782,7 +15781,7 @@ export const Severe = {
    */
   IBM1785I: {
     code: "IBM1785I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The variable ${variablename} is used as a locator qualifier, but it is not a scalar.`,
     fullCode: "IBM1785IS",
@@ -15795,7 +15794,7 @@ export const Severe = {
    */
   IBM1786I: {
     code: "IBM1786I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `${BUILTINname} built-in function may not be used as a locator qualifier.`,
     fullCode: "IBM1786IS",
@@ -15808,7 +15807,7 @@ export const Severe = {
    */
   IBM1787I: {
     code: "IBM1787I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The ENTRY ${variablename} may not be used as a locator qualifier.`,
     fullCode: "IBM1787IS",
@@ -15821,7 +15820,7 @@ export const Severe = {
    */
   IBM1789I: {
     code: "IBM1789I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The qualifier ${variablename} does not have locator type.`,
     fullCode: "IBM1789IS",
@@ -15833,7 +15832,7 @@ export const Severe = {
    */
   IBM1790I: {
     code: "IBM1790I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `Locator qualification is invalid for ${variablename} .`,
     fullCode: "IBM1790IS",
@@ -15845,7 +15844,7 @@ export const Severe = {
    */
   IBM1791I: {
     code: "IBM1791I",
-    severity: "S",
+    severity: Severity.S,
     message: (referencename: string) =>
       `The locator qualified reference ${referencename} is ambiguous.`,
     fullCode: "IBM1791IS",
@@ -15858,7 +15857,7 @@ export const Severe = {
    */
   IBM1792I: {
     code: "IBM1792I",
-    severity: "S",
+    severity: Severity.S,
     message: (referencename: string) =>
       `The locator qualified reference ${referencename} is unknown.`,
     fullCode: "IBM1792IS",
@@ -15870,7 +15869,7 @@ export const Severe = {
    */
   IBM1793I: {
     code: "IBM1793I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The ${variablename} built-in function may not be used as a pseudovariable in a DO-loop.`,
     fullCode: "IBM1793IS",
@@ -15889,7 +15888,7 @@ export const Severe = {
    */
   IBM1794I: {
     code: "IBM1794I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Too many implicit locators are needed to resolve the qualification for a variable. Variable may be based on itself.",
     fullCode: "IBM1794IS",
@@ -15903,7 +15902,7 @@ export const Severe = {
    */
   IBM1795I: {
     code: "IBM1795I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The OFFSET variable ${variablename} may not be used as a locator qualifier since it was not declared with an AREA specification.`,
     fullCode: "IBM1795IS",
@@ -15915,7 +15914,7 @@ export const Severe = {
    */
   IBM1796I: {
     code: "IBM1796I",
-    severity: "S",
+    severity: Severity.S,
     message: "Qualifier must be a scalar.",
     fullCode: "IBM1796IS",
   } as SimplePLICode,
@@ -15927,7 +15926,7 @@ export const Severe = {
    */
   IBM1797I: {
     code: "IBM1797I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "BASED variables may not contain extents with nonconstant values if other extents use the REFER option.",
     fullCode: "IBM1797IS",
@@ -15941,7 +15940,7 @@ export const Severe = {
    */
   IBM1798I: {
     code: "IBM1798I",
-    severity: "S",
+    severity: Severity.S,
     message: "Invalid scale factor in PICTURE specification.",
     fullCode: "IBM1798IS",
   } as SimplePLICode,
@@ -15954,7 +15953,7 @@ export const Severe = {
    */
   IBM1799I: {
     code: "IBM1799I",
-    severity: "S",
+    severity: Severity.S,
     message: "Invalid characters in PICTURE specification.",
     fullCode: "IBM1799IS",
   } as SimplePLICode,
@@ -15967,7 +15966,7 @@ export const Severe = {
    */
   IBM1800I: {
     code: "IBM1800I",
-    severity: "S",
+    severity: Severity.S,
     message: "Invalid characters in the F scaling factor.",
     fullCode: "IBM1800IS",
   } as SimplePLICode,
@@ -15979,7 +15978,7 @@ export const Severe = {
    */
   IBM1801I: {
     code: "IBM1801I",
-    severity: "S",
+    severity: Severity.S,
     message: "A character PICTURE string may have only A, X, or 9.",
     fullCode: "IBM1801IS",
   } as SimplePLICode,
@@ -15991,7 +15990,7 @@ export const Severe = {
    */
   IBM1802I: {
     code: "IBM1802I",
-    severity: "S",
+    severity: Severity.S,
     message: "Invalid precision in PICTURE fixed decimal precision.",
     fullCode: "IBM1802IS",
   } as SimplePLICode,
@@ -16005,7 +16004,7 @@ export const Severe = {
    */
   IBM1803I: {
     code: "IBM1803I",
-    severity: "S",
+    severity: Severity.S,
     message: "Too many T, I, or R appear in the PICTURE specification.",
     fullCode: "IBM1803IS",
   } as SimplePLICode,
@@ -16016,7 +16015,7 @@ export const Severe = {
    */
   IBM1804I: {
     code: "IBM1804I",
-    severity: "S",
+    severity: Severity.S,
     message: "PICTURE specifications in C- format items must be arithmetic.",
     fullCode: "IBM1804IS",
   } as SimplePLICode,
@@ -16028,7 +16027,7 @@ export const Severe = {
    */
   IBM1805I: {
     code: "IBM1805I",
-    severity: "S",
+    severity: Severity.S,
     message: "Precision in numeric PICTURE must NOT be less than 1.",
     fullCode: "IBM1805IS",
   } as SimplePLICode,
@@ -16040,7 +16039,7 @@ export const Severe = {
    */
   IBM1806I: {
     code: "IBM1806I",
-    severity: "S",
+    severity: Severity.S,
     message: "The precision in FIXED DECIMAL PICTURE is too big.",
     fullCode: "IBM1806IS",
   } as SimplePLICode,
@@ -16052,7 +16051,7 @@ export const Severe = {
    */
   IBM1807I: {
     code: "IBM1807I",
-    severity: "S",
+    severity: Severity.S,
     message: "Precision in FLOAT DECIMAL PICTURE is too big.",
     fullCode: "IBM1807IS",
   } as SimplePLICode,
@@ -16063,7 +16062,7 @@ export const Severe = {
    */
   IBM1808I: {
     code: "IBM1808I",
-    severity: "S",
+    severity: Severity.S,
     message: "PICTURE string is empty.",
     fullCode: "IBM1808IS",
   } as SimplePLICode,
@@ -16075,7 +16074,7 @@ export const Severe = {
    */
   IBM1809I: {
     code: "IBM1809I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Exponent in FLOAT PICTURE is too long. Exponent will be truncated to fit.",
     fullCode: "IBM1809IS",
@@ -16088,7 +16087,7 @@ export const Severe = {
    */
   IBM1810I: {
     code: "IBM1810I",
-    severity: "S",
+    severity: Severity.S,
     message: "Exponent in FLOAT PICTURE has no digits.",
     fullCode: "IBM1810IS",
   } as SimplePLICode,
@@ -16100,7 +16099,7 @@ export const Severe = {
    */
   IBM1811I: {
     code: "IBM1811I",
-    severity: "S",
+    severity: Severity.S,
     message: "Exponent in PICTURE specification cannot contain V.",
     fullCode: "IBM1811IS",
   } as SimplePLICode,
@@ -16112,7 +16111,7 @@ export const Severe = {
    */
   IBM1812I: {
     code: "IBM1812I",
-    severity: "S",
+    severity: Severity.S,
     message: "FLOAT PICTURE cannot contain CR, DB or F.",
     fullCode: "IBM1812IS",
   } as SimplePLICode,
@@ -16128,7 +16127,7 @@ export const Severe = {
    */
   IBM1813I: {
     code: "IBM1813I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "PICTURE specification is too long. Excess characters are truncated on the right.",
     fullCode: "IBM1813IS",
@@ -16145,7 +16144,7 @@ export const Severe = {
    */
   IBM1814I: {
     code: "IBM1814I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "PICTURE string has an invalid floating insertion character string.",
     fullCode: "IBM1814IS",
@@ -16162,7 +16161,7 @@ export const Severe = {
    */
   IBM1815I: {
     code: "IBM1815I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `${BUILTINname} is a built-in subroutine. It should be used only in CALL statements and not as a function.`,
     fullCode: "IBM1815IS",
@@ -16178,7 +16177,7 @@ export const Severe = {
    */
   IBM1816I: {
     code: "IBM1816I",
-    severity: "S",
+    severity: Severity.S,
     message: (keyword: string, variablename: string) =>
       `${keyword} item ${variablename} is not computational.`,
     fullCode: "IBM1816IS",
@@ -16191,7 +16190,7 @@ export const Severe = {
    */
   IBM1817I: {
     code: "IBM1817I",
-    severity: "S",
+    severity: Severity.S,
     message: "The KEYTO reference must be of type CHARACTER or GRAPHIC.",
     fullCode: "IBM1817IS",
   } as SimplePLICode,
@@ -16206,7 +16205,7 @@ export const Severe = {
    */
   IBM1818I: {
     code: "IBM1818I",
-    severity: "S",
+    severity: Severity.S,
     message: (ioOption: string, ioStmt: string) =>
       `${ioOption} conflicts with previous options on the ${ioStmt} statement.`,
     fullCode: "IBM1818IS",
@@ -16221,7 +16220,7 @@ export const Severe = {
    */
   IBM1819I: {
     code: "IBM1819I",
-    severity: "S",
+    severity: Severity.S,
     message: (ioOption: string, ioStmt: string) =>
       `The ${ioOption} option is multiply specified on the ${ioStmt} statement.`,
     fullCode: "IBM1819IS",
@@ -16237,7 +16236,7 @@ export const Severe = {
    */
   IBM1820I: {
     code: "IBM1820I",
-    severity: "S",
+    severity: Severity.S,
     message: (ioOption: string, ioStmt: string) =>
       `Mandatory ${ioOption} option not specified on the ${ioStmt} statement.`,
     fullCode: "IBM1820IS",
@@ -16255,7 +16254,7 @@ export const Severe = {
    */
   IBM1821I: {
     code: "IBM1821I",
-    severity: "S",
+    severity: Severity.S,
     message: (fromintooption: string) =>
       `Reference for ${fromintooption} is an invalid element or aggregate type.`,
     fullCode: "IBM1821IS",
@@ -16268,7 +16267,7 @@ export const Severe = {
    */
   IBM1822I: {
     code: "IBM1822I",
-    severity: "S",
+    severity: Severity.S,
     message: (keywordtype: string) =>
       `The ${keywordtype} expression must be computational.`,
     fullCode: "IBM1822IS",
@@ -16281,7 +16280,7 @@ export const Severe = {
    */
   IBM1823I: {
     code: "IBM1823I",
-    severity: "S",
+    severity: Severity.S,
     message: "SET reference must have locator type.",
     fullCode: "IBM1823IS",
   } as SimplePLICode,
@@ -16299,7 +16298,7 @@ export const Severe = {
    */
   IBM1824I: {
     code: "IBM1824I",
-    severity: "S",
+    severity: Severity.S,
     message: (keyword: string) => `${keyword} expression must be scalar.`,
     fullCode: "IBM1824IS",
   } as ParametricPLICode,
@@ -16316,7 +16315,7 @@ export const Severe = {
    */
   IBM1825I: {
     code: "IBM1825I",
-    severity: "S",
+    severity: Severity.S,
     message: (keyword: string) =>
       `The reference in the ${keyword} clause cannot be a built-in function reference.`,
     fullCode: "IBM1825IS",
@@ -16329,7 +16328,7 @@ export const Severe = {
    */
   IBM1826I: {
     code: "IBM1826I",
-    severity: "S",
+    severity: Severity.S,
     message: (keyword: string) =>
       `The reference in the ${keyword} clause cannot be a function invocation.`,
     fullCode: "IBM1826IS",
@@ -16346,7 +16345,7 @@ export const Severe = {
    */
   IBM1827I: {
     code: "IBM1827I",
-    severity: "S",
+    severity: Severity.S,
     message: (keyword: string) =>
       `The reference in the ${keyword} clause must have CHARACTER type.`,
     fullCode: "IBM1827IS",
@@ -16363,7 +16362,7 @@ export const Severe = {
    */
   IBM1828I: {
     code: "IBM1828I",
-    severity: "S",
+    severity: Severity.S,
     message: (keyword: string) =>
       `The reference in the ${keyword} clause must be a scalar variable.`,
     fullCode: "IBM1828IS",
@@ -16379,7 +16378,7 @@ export const Severe = {
    */
   IBM1829I: {
     code: "IBM1829I",
-    severity: "S",
+    severity: Severity.S,
     message: (clause: string) =>
       `The attributes of the argument in the ${clause} clause conflict with its usage.`,
     fullCode: "IBM1829IS",
@@ -16395,7 +16394,7 @@ export const Severe = {
    */
   IBM1830I: {
     code: "IBM1830I",
-    severity: "S",
+    severity: Severity.S,
     message: (keyword: string) => `${keyword} expression is not computational.`,
     fullCode: "IBM1830IS",
   } as ParametricPLICode,
@@ -16413,7 +16412,7 @@ export const Severe = {
    */
   IBM1831I: {
     code: "IBM1831I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The LOCATE reference ${variablename} is not implicitly qualified and is invalid without a SET clause.`,
     fullCode: "IBM1831IS",
@@ -16426,7 +16425,7 @@ export const Severe = {
    */
   IBM1832I: {
     code: "IBM1832I",
-    severity: "S",
+    severity: Severity.S,
     message: "SET reference must have POINTER type.",
     fullCode: "IBM1832IS",
   } as SimplePLICode,
@@ -16445,7 +16444,7 @@ export const Severe = {
    */
   IBM1833I: {
     code: "IBM1833I",
-    severity: "S",
+    severity: Severity.S,
     message: (fromintoclause: string) =>
       `The aggregate reference in the ${fromintoclause} clause must be CONNECTED.`,
     fullCode: "IBM1833IS",
@@ -16462,7 +16461,7 @@ export const Severe = {
    */
   IBM1834I: {
     code: "IBM1834I",
-    severity: "S",
+    severity: Severity.S,
     message: "The expression in IGNORE must be computational.",
     fullCode: "IBM1834IS",
   } as SimplePLICode,
@@ -16474,7 +16473,7 @@ export const Severe = {
    */
   IBM1835I: {
     code: "IBM1835I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The LOCATE reference ${variablename} is not a level 1 BASED variable.`,
     fullCode: "IBM1835IS",
@@ -16486,7 +16485,7 @@ export const Severe = {
    */
   IBM1836I: {
     code: "IBM1836I",
-    severity: "S",
+    severity: Severity.S,
     message: "INITIAL attribute is invalid for structures.",
     fullCode: "IBM1836IS",
   } as SimplePLICode,
@@ -16504,7 +16503,7 @@ export const Severe = {
    */
   IBM1837I: {
     code: "IBM1837I",
-    severity: "S",
+    severity: Severity.S,
     message: (keyword: string) =>
       `The reference in the ${keyword} clause cannot be a named constant.`,
     fullCode: "IBM1837IS",
@@ -16521,7 +16520,7 @@ export const Severe = {
    */
   IBM1838I: {
     code: "IBM1838I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string) =>
       `The attributes of ${argumentnumber} conflict with its usage in data directed I/O.`,
     fullCode: "IBM1838IS",
@@ -16533,7 +16532,7 @@ export const Severe = {
    */
   IBM1839I: {
     code: "IBM1839I",
-    severity: "S",
+    severity: Severity.S,
     message: "DATA-directed I/O does not support references with locators.",
     fullCode: "IBM1839IS",
   } as SimplePLICode,
@@ -16544,7 +16543,7 @@ export const Severe = {
    */
   IBM1840I: {
     code: "IBM1840I",
-    severity: "S",
+    severity: Severity.S,
     message: "Subscripted references are not allowed in GET DATA.",
     fullCode: "IBM1840IS",
   } as SimplePLICode,
@@ -16558,7 +16557,7 @@ export const Severe = {
    */
   IBM1841I: {
     code: "IBM1841I",
-    severity: "S",
+    severity: Severity.S,
     message: (keyword: string) =>
       `The first argument in the ${keyword} - format item is invalid.`,
     fullCode: "IBM1841IS",
@@ -16573,7 +16572,7 @@ export const Severe = {
    */
   IBM1842I: {
     code: "IBM1842I",
-    severity: "S",
+    severity: Severity.S,
     message: (keyword: string) =>
       `The field width specified in the ${keyword} -format item is too small for complete input or output of the data item.`,
     fullCode: "IBM1842IS",
@@ -16586,7 +16585,7 @@ export const Severe = {
    */
   IBM1843I: {
     code: "IBM1843I",
-    severity: "S",
+    severity: Severity.S,
     message: (keyword: string) =>
       `The fractional digits specified in the ${keyword} -format item is invalid.`,
     fullCode: "IBM1843IS",
@@ -16599,7 +16598,7 @@ export const Severe = {
    */
   IBM1844I: {
     code: "IBM1844I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The argument in the R-format item is not a format constant or format variable.",
     fullCode: "IBM1844IS",
@@ -16612,7 +16611,7 @@ export const Severe = {
    */
   IBM1845I: {
     code: "IBM1845I",
-    severity: "S",
+    severity: Severity.S,
     message: "The significant digits specified in E-format item is invalid.",
     fullCode: "IBM1845IS",
   } as SimplePLICode,
@@ -16624,7 +16623,7 @@ export const Severe = {
    */
   IBM1846I: {
     code: "IBM1846I",
-    severity: "S",
+    severity: Severity.S,
     message: (formatitem: string) =>
       `The ${formatitem} format item is invalid with GET/PUT STRING.`,
     fullCode: "IBM1846IS",
@@ -16637,7 +16636,7 @@ export const Severe = {
    */
   IBM1847I: {
     code: "IBM1847I",
-    severity: "S",
+    severity: Severity.S,
     message: "GOTO target is inside a (different) DO loop.",
     fullCode: "IBM1847IS",
   } as SimplePLICode,
@@ -16648,7 +16647,7 @@ export const Severe = {
    */
   IBM1848I: {
     code: "IBM1848I",
-    severity: "S",
+    severity: Severity.S,
     message: (includestmtarg: string) =>
       `The INCLUDE file for ${includestmtarg} could not be found.`,
     fullCode: "IBM1848IS",
@@ -16661,7 +16660,7 @@ export const Severe = {
    */
   IBM1849I: {
     code: "IBM1849I",
-    severity: "S",
+    severity: Severity.S,
     message: "Under CMPAT(V1), bounds must not be greater than 32767.",
     fullCode: "IBM1849IS",
   } as SimplePLICode,
@@ -16673,7 +16672,7 @@ export const Severe = {
    */
   IBM1850I: {
     code: "IBM1850I",
-    severity: "S",
+    severity: Severity.S,
     message: "Under CMPAT(V1), bounds must not be less than -32768.",
     fullCode: "IBM1850IS",
   } as SimplePLICode,
@@ -16684,7 +16683,7 @@ export const Severe = {
    */
   IBM1851I: {
     code: "IBM1851I",
-    severity: "S",
+    severity: Severity.S,
     message: (includefilename: string) =>
       `The INCLUDE file ${includefilename} could not be opened.`,
     fullCode: "IBM1851IS",
@@ -16696,7 +16695,7 @@ export const Severe = {
    */
   IBM1852I: {
     code: "IBM1852I",
-    severity: "S",
+    severity: Severity.S,
     message: (preprocessor: string) =>
       `The preprocessor ${preprocessor} is not known to the compiler.`,
     fullCode: "IBM1852IS",
@@ -16709,7 +16708,7 @@ export const Severe = {
    */
   IBM1853I: {
     code: "IBM1853I",
-    severity: "S",
+    severity: Severity.S,
     message: (statement: string) =>
       `Variable in ${statement} statement must be a FETCHABLE entry constant.`,
     fullCode: "IBM1853IS",
@@ -16721,7 +16720,7 @@ export const Severe = {
    */
   IBM1854I: {
     code: "IBM1854I",
-    severity: "S",
+    severity: Severity.S,
     message: (PPname: string, oncode: string) =>
       `Fetch of the ${PPname} preprocessor failed with ONCODE= ${oncode} .`,
     fullCode: "IBM1854IS",
@@ -16733,7 +16732,7 @@ export const Severe = {
    */
   IBM1855I: {
     code: "IBM1855I",
-    severity: "S",
+    severity: Severity.S,
     message: (PPname: string, oncodevalue: string) =>
       `Preprocessor ${PPname} terminated abnormally with ONCODE= ${oncodevalue} .`,
     fullCode: "IBM1855IS",
@@ -16745,7 +16744,7 @@ export const Severe = {
    */
   IBM1856I: {
     code: "IBM1856I",
-    severity: "S",
+    severity: Severity.S,
     message: (oncode: string) =>
       `Fetch of the user exit initialization routine failed with ONCODE= ${oncode} .`,
     fullCode: "IBM1856IS",
@@ -16757,7 +16756,7 @@ export const Severe = {
    */
   IBM1857I: {
     code: "IBM1857I",
-    severity: "S",
+    severity: Severity.S,
     message: (oncodevalue: string) =>
       `User exit routine terminated abnormally with ONCODE= ${oncodevalue} .`,
     fullCode: "IBM1857IS",
@@ -16769,7 +16768,7 @@ export const Severe = {
    */
   IBM1858I: {
     code: "IBM1858I",
-    severity: "S",
+    severity: Severity.S,
     message: "Compilation aborted by user exit.",
     fullCode: "IBM1858IS",
   } as SimplePLICode,
@@ -16780,7 +16779,7 @@ export const Severe = {
    */
   IBM1859I: {
     code: "IBM1859I",
-    severity: "S",
+    severity: Severity.S,
     message: "The first statement must be a PROCEDURE or PACKAGE statement.",
     fullCode: "IBM1859IS",
   } as SimplePLICode,
@@ -16791,7 +16790,7 @@ export const Severe = {
    */
   IBM1860I: {
     code: "IBM1860I",
-    severity: "S",
+    severity: Severity.S,
     message: "PACKAGE statement must be the first statement in the program.",
     fullCode: "IBM1860IS",
   } as SimplePLICode,
@@ -16803,7 +16802,7 @@ export const Severe = {
    */
   IBM1861I: {
     code: "IBM1861I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "All statements other than DECLARE, DEFAULT and PROCEDURE statements must be contained inside a PROCEDURE.",
     fullCode: "IBM1861IS",
@@ -16816,7 +16815,7 @@ export const Severe = {
    */
   IBM1862I: {
     code: "IBM1862I",
-    severity: "S",
+    severity: Severity.S,
     message: "Statements are nested too deep.",
     fullCode: "IBM1862IS",
   } as SimplePLICode,
@@ -16828,7 +16827,7 @@ export const Severe = {
    */
   IBM1863I: {
     code: "IBM1863I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Variables declared in a PACKAGE outside of any PROCEDURE must have the storage class STATIC, BASED or CONTROLLED or must be DEFINED on STATIC.",
     fullCode: "IBM1863IS",
@@ -16840,7 +16839,7 @@ export const Severe = {
    */
   IBM1864I: {
     code: "IBM1864I",
-    severity: "S",
+    severity: Severity.S,
     message: (functionname: string) =>
       `The ${functionname} built-in function is not supported.`,
     fullCode: "IBM1864IS",
@@ -16854,7 +16853,7 @@ export const Severe = {
    */
   IBM1865I: {
     code: "IBM1865I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The only BASED variables supported in data-directed i/o are those that have constant extents and that are implicitly qualified by simple variables.",
     fullCode: "IBM1865IS",
@@ -16866,7 +16865,7 @@ export const Severe = {
    */
   IBM1866I: {
     code: "IBM1866I",
-    severity: "S",
+    severity: Severity.S,
     message: (keyword: string) => `The ${keyword} statement is not supported.`,
     fullCode: "IBM1866IS",
   } as ParametricPLICode,
@@ -16877,7 +16876,7 @@ export const Severe = {
    */
   IBM1867I: {
     code: "IBM1867I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The pseudovariable ${variablename} is not supported.`,
     fullCode: "IBM1867IS",
@@ -16889,7 +16888,7 @@ export const Severe = {
    */
   IBM1868I: {
     code: "IBM1868I",
-    severity: "S",
+    severity: Severity.S,
     message: "Invalid use of iSUB.",
     fullCode: "IBM1868IS",
   } as SimplePLICode,
@@ -16904,7 +16903,7 @@ export const Severe = {
    */
   IBM1869I: {
     code: "IBM1869I",
-    severity: "S",
+    severity: Severity.S,
     message: "ALLOCATE with attribute lists is not supported.",
     fullCode: "IBM1869IS",
   } as SimplePLICode,
@@ -16919,7 +16918,7 @@ export const Severe = {
    */
   IBM1870I: {
     code: "IBM1870I",
-    severity: "S",
+    severity: Severity.S,
     message: "ON statement cannot specify both SYSTEM and an ON-unit.",
     fullCode: "IBM1870IS",
   } as SimplePLICode,
@@ -16930,7 +16929,7 @@ export const Severe = {
    */
   IBM1871I: {
     code: "IBM1871I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The reference in the CONDITION condition must have type CONDITION.",
     fullCode: "IBM1871IS",
@@ -16942,7 +16941,7 @@ export const Severe = {
    */
   IBM1872I: {
     code: "IBM1872I",
-    severity: "S",
+    severity: Severity.S,
     message: (conditionname: string) =>
       `The reference in the ${conditionname} condition must have type FILE.`,
     fullCode: "IBM1872IS",
@@ -16954,7 +16953,7 @@ export const Severe = {
    */
   IBM1873I: {
     code: "IBM1873I",
-    severity: "S",
+    severity: Severity.S,
     message: "Nesting of DO statements exceeds the maximum.",
     fullCode: "IBM1873IS",
   } as SimplePLICode,
@@ -16965,7 +16964,7 @@ export const Severe = {
    */
   IBM1874I: {
     code: "IBM1874I",
-    severity: "S",
+    severity: Severity.S,
     message: "Nesting of IF statements exceeds the maximum.",
     fullCode: "IBM1874IS",
   } as SimplePLICode,
@@ -16976,7 +16975,7 @@ export const Severe = {
    */
   IBM1875I: {
     code: "IBM1875I",
-    severity: "S",
+    severity: Severity.S,
     message: "Nesting of SELECT statements exceeds the maximum.",
     fullCode: "IBM1875IS",
   } as SimplePLICode,
@@ -16987,7 +16986,7 @@ export const Severe = {
    */
   IBM1876I: {
     code: "IBM1876I",
-    severity: "S",
+    severity: Severity.S,
     message: "Nesting of blocks exceeds the maximum.",
     fullCode: "IBM1876IS",
   } as SimplePLICode,
@@ -16998,7 +16997,7 @@ export const Severe = {
    */
   IBM1878I: {
     code: "IBM1878I",
-    severity: "S",
+    severity: Severity.S,
     message: "The reference in the EVENT clause must have type EVENT.",
     fullCode: "IBM1878IS",
   } as SimplePLICode,
@@ -17009,7 +17008,7 @@ export const Severe = {
    */
   IBM1879I: {
     code: "IBM1879I",
-    severity: "S",
+    severity: Severity.S,
     message: "The reference in the TASK clause must have type TASK.",
     fullCode: "IBM1879IS",
   } as SimplePLICode,
@@ -17024,7 +17023,7 @@ export const Severe = {
    */
   IBM1880I: {
     code: "IBM1880I",
-    severity: "S",
+    severity: Severity.S,
     message: "Reference must have FILE type.",
     fullCode: "IBM1880IS",
   } as SimplePLICode,
@@ -17035,7 +17034,7 @@ export const Severe = {
    */
   IBM1881I: {
     code: "IBM1881I",
-    severity: "S",
+    severity: Severity.S,
     message: (referencename: string) =>
       `The reference ${referencename} is ambiguous.`,
     fullCode: "IBM1881IS",
@@ -17048,7 +17047,7 @@ export const Severe = {
    */
   IBM1882I: {
     code: "IBM1882I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The ALLOCATE reference ${variablename} is not a level 1 BASED or CONTROLLED variable.`,
     fullCode: "IBM1882IS",
@@ -17064,7 +17063,7 @@ export const Severe = {
    */
   IBM1883I: {
     code: "IBM1883I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The ALLOCATE reference ${variablename} is not implicitly qualified and is invalid without a SET clause.`,
     fullCode: "IBM1883IS",
@@ -17076,7 +17075,7 @@ export const Severe = {
    */
   IBM1884I: {
     code: "IBM1884I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The reference ${variablename} in the GENERIC attribute list is not a scalar ENTRY reference.`,
     fullCode: "IBM1884IS",
@@ -17088,7 +17087,7 @@ export const Severe = {
    */
   IBM1885I: {
     code: "IBM1885I",
-    severity: "S",
+    severity: Severity.S,
     message: "IN option reference must have AREA type.",
     fullCode: "IBM1885IS",
   } as SimplePLICode,
@@ -17110,7 +17109,7 @@ export const Severe = {
    */
   IBM1886I: {
     code: "IBM1886I",
-    severity: "S",
+    severity: Severity.S,
     message: (referencename: string) =>
       `The REFER object name ${referencename} is ambiguous.`,
     fullCode: "IBM1886IS",
@@ -17123,7 +17122,7 @@ export const Severe = {
    */
   IBM1887I: {
     code: "IBM1887I",
-    severity: "S",
+    severity: Severity.S,
     message: (referencename: string) =>
       `The REFER object ${referencename} must be an element of the same structure where it is used, and must precede its first usage in that structure.`,
     fullCode: "IBM1887IS",
@@ -17144,7 +17143,7 @@ export const Severe = {
    */
   IBM1888I: {
     code: "IBM1888I",
-    severity: "S",
+    severity: Severity.S,
     message: (referencename: string) =>
       `The REFER object ${referencename} must have computational type.`,
     fullCode: "IBM1888IS",
@@ -17165,7 +17164,7 @@ export const Severe = {
    */
   IBM1889I: {
     code: "IBM1889I",
-    severity: "S",
+    severity: Severity.S,
     message: (referencename: string) =>
       `The REFER object ${referencename} must be a scalar.`,
     fullCode: "IBM1889IS",
@@ -17186,7 +17185,7 @@ export const Severe = {
    */
   IBM1890I: {
     code: "IBM1890I",
-    severity: "S",
+    severity: Severity.S,
     message: (referencename: string) =>
       `The REFER object ${referencename} must precede the first level-2 element containing a REFER.`,
     fullCode: "IBM1890IS",
@@ -17198,7 +17197,7 @@ export const Severe = {
    */
   IBM1891I: {
     code: "IBM1891I",
-    severity: "S",
+    severity: Severity.S,
     message: "REFER is not allowed on non- BASED variables.",
     fullCode: "IBM1891IS",
   } as SimplePLICode,
@@ -17209,7 +17208,7 @@ export const Severe = {
    */
   IBM1892I: {
     code: "IBM1892I",
-    severity: "S",
+    severity: Severity.S,
     message: (referencename: string) =>
       `The REFER object ${referencename} must have constant length.`,
     fullCode: "IBM1892IS",
@@ -17221,7 +17220,7 @@ export const Severe = {
    */
   IBM1893I: {
     code: "IBM1893I",
-    severity: "S",
+    severity: Severity.S,
     message: "REFER is allowed only on members of structures and unions.",
     fullCode: "IBM1893IS",
   } as SimplePLICode,
@@ -17232,7 +17231,7 @@ export const Severe = {
    */
   IBM1894I: {
     code: "IBM1894I",
-    severity: "S",
+    severity: Severity.S,
     message: "REINIT references must not be subscripted.",
     fullCode: "IBM1894IS",
   } as SimplePLICode,
@@ -17246,7 +17245,7 @@ export const Severe = {
    */
   IBM1895I: {
     code: "IBM1895I",
-    severity: "S",
+    severity: Severity.S,
     message: (languagename: string) =>
       `Operations involving OPTIONS( ${languagename} ) routines are not supported if the DIRECTED option applies.`,
     fullCode: "IBM1895IS",
@@ -17260,7 +17259,7 @@ export const Severe = {
    */
   IBM1896I: {
     code: "IBM1896I",
-    severity: "S",
+    severity: Severity.S,
     message: (languagename: string) =>
       `OPTIONS( ${languagename} ) is not supported for ENTRY VARIABLEs if the DIRECTED option applies.`,
     fullCode: "IBM1896IS",
@@ -17273,7 +17272,7 @@ export const Severe = {
    */
   IBM1897I: {
     code: "IBM1897I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Simple defining is supported only for scalars, for structures with constant extents matching those in the base variable, and for arrays of such scalars and structures as long as the array is not based on a controlled variable.",
     fullCode: "IBM1897IS",
@@ -17285,7 +17284,7 @@ export const Severe = {
    */
   IBM1898I: {
     code: "IBM1898I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The base reference in the DEFINED attribute cannot be a built-in or type function.",
     fullCode: "IBM1898IS",
@@ -17297,7 +17296,7 @@ export const Severe = {
    */
   IBM1899I: {
     code: "IBM1899I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The base variable in the DEFINED attribute cannot be BASED, DEFINED or CONSTANT.",
     fullCode: "IBM1899IS",
@@ -17310,7 +17309,7 @@ export const Severe = {
    */
   IBM1900I: {
     code: "IBM1900I",
-    severity: "S",
+    severity: Severity.S,
     message: "Extents for DEFINED bit structures must be constant.",
     fullCode: "IBM1900IS",
   } as SimplePLICode,
@@ -17321,7 +17320,7 @@ export const Severe = {
    */
   IBM1901I: {
     code: "IBM1901I",
-    severity: "S",
+    severity: Severity.S,
     message: "POSITION attribute is invalid without the DEFINED attribute.",
     fullCode: "IBM1901IS",
   } as SimplePLICode,
@@ -17332,7 +17331,7 @@ export const Severe = {
    */
   IBM1902I: {
     code: "IBM1902I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The expression in the POSITION attribute must have computational type.",
     fullCode: "IBM1902IS",
@@ -17345,7 +17344,7 @@ export const Severe = {
    */
   IBM1903I: {
     code: "IBM1903I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The expression in the POSITION attribute for bit string-overlay defining must be an integer constant.",
     fullCode: "IBM1903IS",
@@ -17358,7 +17357,7 @@ export const Severe = {
    */
   IBM1904I: {
     code: "IBM1904I",
-    severity: "S",
+    severity: Severity.S,
     message: (freeclause: string) =>
       `Variable following the ${freeclause} clause must be level 1 and either BASED or CONTROLLED.`,
     fullCode: "IBM1904IS",
@@ -17371,7 +17370,7 @@ export const Severe = {
    */
   IBM1905I: {
     code: "IBM1905I",
-    severity: "S",
+    severity: Severity.S,
     message: (INorSEToption: string, ALLOCATEorFREEclause: string) =>
       `${INorSEToption} option invalid after the CONTROLLED variable in the ${ALLOCATEorFREEclause} clause.`,
     fullCode: "IBM1905IS",
@@ -17388,7 +17387,7 @@ export const Severe = {
    */
   IBM1906I: {
     code: "IBM1906I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The reference qualifying an OFFSET attribute must be a scalar AREA reference.",
     fullCode: "IBM1906IS",
@@ -17404,7 +17403,7 @@ export const Severe = {
    */
   IBM1907I: {
     code: "IBM1907I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Extents for CONTROLLED variables cannot be specified using asterisks or REFER.",
     fullCode: "IBM1907IS",
@@ -17416,7 +17415,7 @@ export const Severe = {
    */
   IBM1908I: {
     code: "IBM1908I",
-    severity: "S",
+    severity: Severity.S,
     message: (attribute: string) =>
       `Extents for ${attribute} variables cannot be specified using asterisks or REFER.`,
     fullCode: "IBM1908IS",
@@ -17428,7 +17427,7 @@ export const Severe = {
    */
   IBM1909I: {
     code: "IBM1909I",
-    severity: "S",
+    severity: Severity.S,
     message: (attribute: string, attribute2: string) =>
       `The ${attribute} attribute conflicts with the ${attribute2} attribute.`,
     fullCode: "IBM1909IS",
@@ -17442,7 +17441,7 @@ export const Severe = {
    */
   IBM1910I: {
     code: "IBM1910I",
-    severity: "S",
+    severity: Severity.S,
     message: (identifier: string) =>
       `The attributes given in the declaration for ${identifier} conflict with its use as a parameter.`,
     fullCode: "IBM1910IS",
@@ -17454,7 +17453,7 @@ export const Severe = {
    */
   IBM1911I: {
     code: "IBM1911I",
-    severity: "S",
+    severity: Severity.S,
     message: (character: string) =>
       `Repeated specifications of the unsubscripted statement label ${character} are in error.`,
     fullCode: "IBM1911IS",
@@ -17466,7 +17465,7 @@ export const Severe = {
    */
   IBM1912I: {
     code: "IBM1912I",
-    severity: "S",
+    severity: Severity.S,
     message: (character: string) =>
       `Indices specified for the LABEL ${character} have already been specified.`,
     fullCode: "IBM1912IS",
@@ -17478,7 +17477,7 @@ export const Severe = {
    */
   IBM1913I: {
     code: "IBM1913I",
-    severity: "S",
+    severity: Severity.S,
     message: "ON-units may not be labeled. All such labels will be ignored.",
     fullCode: "IBM1913IS",
   } as SimplePLICode,
@@ -17489,7 +17488,7 @@ export const Severe = {
    */
   IBM1914I: {
     code: "IBM1914I",
-    severity: "S",
+    severity: Severity.S,
     message: "GOTO target must be a LABEL reference.",
     fullCode: "IBM1914IS",
   } as SimplePLICode,
@@ -17500,7 +17499,7 @@ export const Severe = {
    */
   IBM1915I: {
     code: "IBM1915I",
-    severity: "S",
+    severity: Severity.S,
     message: "GOTO target must be a scalar.",
     fullCode: "IBM1915IS",
   } as SimplePLICode,
@@ -17519,7 +17518,7 @@ export const Severe = {
    */
   IBM1916I: {
     code: "IBM1916I",
-    severity: "S",
+    severity: Severity.S,
     message: (procname: string) =>
       `The PROCEDURE/ENTRY ${procname} has already been defined.`,
     fullCode: "IBM1916IS",
@@ -17532,7 +17531,7 @@ export const Severe = {
    */
   IBM1917I: {
     code: "IBM1917I",
-    severity: "S",
+    severity: Severity.S,
     message: "Program contains no valid source lines.",
     fullCode: "IBM1917IS",
   } as SimplePLICode,
@@ -17544,7 +17543,7 @@ export const Severe = {
    */
   IBM1918I: {
     code: "IBM1918I",
-    severity: "S",
+    severity: Severity.S,
     message: (ordinalname: string) =>
       `All the names in the ORDINAL ${ordinalname} have been previously declared.`,
     fullCode: "IBM1918IS",
@@ -17562,7 +17561,7 @@ export const Severe = {
    */
   IBM1919I: {
     code: "IBM1919I",
-    severity: "S",
+    severity: Severity.S,
     message: (string: string, name: string, name2: string) =>
       `The EXTERNAL name ${string} is specified for the differing names ${name} and ${name2} .`,
     fullCode: "IBM1919IS",
@@ -17575,7 +17574,7 @@ export const Severe = {
    */
   IBM1920I: {
     code: "IBM1920I",
-    severity: "S",
+    severity: Severity.S,
     message: "FIXED BINARY constant contains too many digits.",
     fullCode: "IBM1920IS",
   } as SimplePLICode,
@@ -17587,7 +17586,7 @@ export const Severe = {
    */
   IBM1921I: {
     code: "IBM1921I",
-    severity: "S",
+    severity: Severity.S,
     message: "FIXED DECIMAL constant contains too many significant digits.",
     fullCode: "IBM1921IS",
   } as SimplePLICode,
@@ -17598,7 +17597,7 @@ export const Severe = {
    */
   IBM1922I: {
     code: "IBM1922I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Exponent in FLOAT BINARY constant contains more digits than the implementation maximum.",
     fullCode: "IBM1922IS",
@@ -17610,7 +17609,7 @@ export const Severe = {
    */
   IBM1923I: {
     code: "IBM1923I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Mantissa in FLOAT BINARY constant contains more significant digits than the implementation maximum.",
     fullCode: "IBM1923IS",
@@ -17622,7 +17621,7 @@ export const Severe = {
    */
   IBM1924I: {
     code: "IBM1924I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Exponent in FLOAT DECIMAL constant contains more digits than the implementation maximum.",
     fullCode: "IBM1924IS",
@@ -17635,7 +17634,7 @@ export const Severe = {
    */
   IBM1925I: {
     code: "IBM1925I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Mantissa in FLOAT DECIMAL constant contains more significant digits than the implementation maximum.",
     fullCode: "IBM1925IS",
@@ -17650,7 +17649,7 @@ export const Severe = {
    */
   IBM1926I: {
     code: "IBM1926I",
-    severity: "S",
+    severity: Severity.S,
     message: "Constants must not exceed 8192 bytes.",
     fullCode: "IBM1926IS",
   } as SimplePLICode,
@@ -17665,7 +17664,7 @@ export const Severe = {
    */
   IBM1927I: {
     code: "IBM1927I",
-    severity: "S",
+    severity: Severity.S,
     message: (sourcevalue: string, targetattributes: string) =>
       `SIZE condition raised by attempt to convert ${sourcevalue} to ${targetattributes}`,
     fullCode: "IBM1927IS",
@@ -17678,7 +17677,7 @@ export const Severe = {
    */
   IBM1928I: {
     code: "IBM1928I",
-    severity: "S",
+    severity: Severity.S,
     message: "ERROR raised while building CEEUOPT from PLIXOPT.",
     fullCode: "IBM1928IS",
   } as SimplePLICode,
@@ -17690,7 +17689,7 @@ export const Severe = {
    */
   IBM1929I: {
     code: "IBM1929I",
-    severity: "S",
+    severity: Severity.S,
     message: (filename: string, procname: string, linenumber: string) =>
       `Unable to open file ${filename} in routine ${procname} ( ${linenumber} ).`,
     fullCode: "IBM1929IS",
@@ -17704,7 +17703,7 @@ export const Severe = {
    */
   IBM1930I: {
     code: "IBM1930I",
-    severity: "S",
+    severity: Severity.S,
     message: (filename: string) =>
       `Unable to write to file ${filename} . Disk may be full.`,
     fullCode: "IBM1930IS",
@@ -17717,7 +17716,7 @@ export const Severe = {
    */
   IBM1932I: {
     code: "IBM1932I",
-    severity: "S",
+    severity: Severity.S,
     message: (filename: string, procname: string, linenumber: string) =>
       `Unable to close file ${filename} in routine ${procname} ( ${linenumber} ).`,
     fullCode: "IBM1932IS",
@@ -17730,7 +17729,7 @@ export const Severe = {
    */
   IBM1933I: {
     code: "IBM1933I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Unable to open temporary files because the path and filename are too long.",
     fullCode: "IBM1933IS",
@@ -17743,7 +17742,7 @@ export const Severe = {
    */
   IBM1934I: {
     code: "IBM1934I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "If a parameter is a structure with nonconstant extents, only matching structures are supported as arguments.",
     fullCode: "IBM1934IS",
@@ -17756,7 +17755,7 @@ export const Severe = {
    */
   IBM1935I: {
     code: "IBM1935I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Structure expressions as arguments are not supported for undescribed parameters.",
     fullCode: "IBM1935IS",
@@ -17771,7 +17770,7 @@ export const Severe = {
    */
   IBM1936I: {
     code: "IBM1936I",
-    severity: "S",
+    severity: Severity.S,
     message: "Invocation of compiler backend ended abnormally.",
     fullCode: "IBM1936IS",
   } as SimplePLICode,
@@ -17783,7 +17782,7 @@ export const Severe = {
    */
   IBM1937I: {
     code: "IBM1937I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Extents for parameters must be asterisks or restricted expressions with computational type.",
     fullCode: "IBM1937IS",
@@ -17796,7 +17795,7 @@ export const Severe = {
    */
   IBM1938I: {
     code: "IBM1938I",
-    severity: "S",
+    severity: Severity.S,
     message: (filename: string) => `Message file ${filename} not found.`,
     fullCode: "IBM1938IS",
   } as ParametricPLICode,
@@ -17807,7 +17806,7 @@ export const Severe = {
    */
   IBM1939I: {
     code: "IBM1939I",
-    severity: "S",
+    severity: Severity.S,
     message: "Exponentiation operands must have computational type.",
     fullCode: "IBM1939IS",
   } as SimplePLICode,
@@ -17818,7 +17817,7 @@ export const Severe = {
    */
   IBM1940I: {
     code: "IBM1940I",
-    severity: "S",
+    severity: Severity.S,
     message: (note: string) => `${note}`,
     fullCode: "IBM1940IS",
   } as ParametricPLICode,
@@ -17829,7 +17828,7 @@ export const Severe = {
    */
   IBM1941I: {
     code: "IBM1941I",
-    severity: "U",
+    severity: Severity.U,
     message: (note: string) => `${note}`,
     fullCode: "IBM1941IU",
   } as ParametricPLICode,
@@ -17840,7 +17839,7 @@ export const Severe = {
    */
   IBM1942I: {
     code: "IBM1942I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The scale factor specified in ${BUILTINname} built-in function must be a restricted expression with integer type.`,
     fullCode: "IBM1942IS",
@@ -17853,7 +17852,7 @@ export const Severe = {
    */
   IBM1943I: {
     code: "IBM1943I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The number of error messages allowed by the FLAG option has been exceeded.",
     fullCode: "IBM1943IS",
@@ -17865,7 +17864,7 @@ export const Severe = {
    */
   IBM1944I: {
     code: "IBM1944I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The precision specified in ${BUILTINname} built-in function must be a restricted expression with integer type.`,
     fullCode: "IBM1944IS",
@@ -17878,7 +17877,7 @@ export const Severe = {
    */
   IBM1945I: {
     code: "IBM1945I",
-    severity: "S",
+    severity: Severity.S,
     message: "Extents for BASED variable may not contain asterisks.",
     fullCode: "IBM1945IS",
   } as SimplePLICode,
@@ -17889,7 +17888,7 @@ export const Severe = {
    */
   IBM1946I: {
     code: "IBM1946I",
-    severity: "S",
+    severity: Severity.S,
     message: "Reference must be an AREA variable.",
     fullCode: "IBM1946IS",
   } as SimplePLICode,
@@ -17903,7 +17902,7 @@ export const Severe = {
    */
   IBM1947I: {
     code: "IBM1947I",
-    severity: "S",
+    severity: Severity.S,
     message: (GENERICvariablename: string) =>
       `The reference to the GENERIC variable ${GENERICvariablename} cannot be resolved.`,
     fullCode: "IBM1947IS",
@@ -17918,7 +17917,7 @@ export const Severe = {
    */
   IBM1948I: {
     code: "IBM1948I",
-    severity: "S",
+    severity: Severity.S,
     message: (conditionname: string, oncodevalue: string) =>
       `${conditionname} condition with ONCODE= ${oncodevalue} raised while evaluating restricted expression.`,
     fullCode: "IBM1948IS",
@@ -17933,7 +17932,7 @@ export const Severe = {
    */
   IBM1949I: {
     code: "IBM1949I",
-    severity: "S",
+    severity: Severity.S,
     message: (identifier: string) =>
       `Parameter name ${identifier} appears more than once in parameter list.`,
     fullCode: "IBM1949IS",
@@ -17947,7 +17946,7 @@ export const Severe = {
    */
   IBM1951I: {
     code: "IBM1951I",
-    severity: "S",
+    severity: Severity.S,
     message: (storageclass: string) =>
       `${storageclass} variables must be named.`,
     fullCode: "IBM1951IS",
@@ -17960,7 +17959,7 @@ export const Severe = {
    */
   IBM1952I: {
     code: "IBM1952I",
-    severity: "S",
+    severity: Severity.S,
     message: "INITIAL CALL cannot be used to initialize STATIC data.",
     fullCode: "IBM1952IS",
   } as SimplePLICode,
@@ -17972,7 +17971,7 @@ export const Severe = {
    */
   IBM1953I: {
     code: "IBM1953I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The attributes of the EXTERNAL variable ${variablename} do not match those in its previous declaration.`,
     fullCode: "IBM1953IS",
@@ -17984,7 +17983,7 @@ export const Severe = {
    */
   IBM1954I: {
     code: "IBM1954I",
-    severity: "S",
+    severity: Severity.S,
     message: "The base reference in the DEFINED attribute must be CONNECTED.",
     fullCode: "IBM1954IS",
   } as SimplePLICode,
@@ -17996,7 +17995,7 @@ export const Severe = {
    */
   IBM1955I: {
     code: "IBM1955I",
-    severity: "S",
+    severity: Severity.S,
     message: (attribute: string, variablename: string) =>
       `Repeated declarations of the EXTERNAL ${attribute} ${variablename} are not supported.`,
     fullCode: "IBM1955IS",
@@ -18008,7 +18007,7 @@ export const Severe = {
    */
   IBM1956I: {
     code: "IBM1956I",
-    severity: "S",
+    severity: Severity.S,
     message: "ITERATE is valid only for iterative DO-groups.",
     fullCode: "IBM1956IS",
   } as SimplePLICode,
@@ -18026,7 +18025,7 @@ export const Severe = {
    */
   IBM1957I: {
     code: "IBM1957I",
-    severity: "S",
+    severity: Severity.S,
     message: "The WAIT event number specification must be computational.",
     fullCode: "IBM1957IS",
   } as SimplePLICode,
@@ -18042,7 +18041,7 @@ export const Severe = {
    */
   IBM1958I: {
     code: "IBM1958I",
-    severity: "S",
+    severity: Severity.S,
     message: "References in the WAIT statement must be of type EVENT.",
     fullCode: "IBM1958IS",
   } as SimplePLICode,
@@ -18055,7 +18054,7 @@ export const Severe = {
    */
   IBM1959I: {
     code: "IBM1959I",
-    severity: "S",
+    severity: Severity.S,
     message: "Invalid aggregate expression specified in WAIT statement.",
     fullCode: "IBM1959IS",
   } as SimplePLICode,
@@ -18067,7 +18066,7 @@ export const Severe = {
    */
   IBM1960I: {
     code: "IBM1960I",
-    severity: "S",
+    severity: Severity.S,
     message: (typename: string) => `${typename} is not a type name.`,
     fullCode: "IBM1960IS",
   } as ParametricPLICode,
@@ -18079,7 +18078,7 @@ export const Severe = {
    */
   IBM1961I: {
     code: "IBM1961I",
-    severity: "S",
+    severity: Severity.S,
     message: (typetype: string, typename: string) =>
       `INITIAL values for ${typetype} type ${typename} must be in increasing order.`,
     fullCode: "IBM1961IS",
@@ -18091,7 +18090,7 @@ export const Severe = {
    */
   IBM1962I: {
     code: "IBM1962I",
-    severity: "S",
+    severity: Severity.S,
     message: (typetype: string, typename: string) =>
       `INITIAL values for ${typetype} type ${typename} must be less than 2G.`,
     fullCode: "IBM1962IS",
@@ -18105,7 +18104,7 @@ export const Severe = {
    */
   IBM1963I: {
     code: "IBM1963I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `${BUILTINname} argument must have ORDINAL type.`,
     fullCode: "IBM1963IS",
@@ -18119,7 +18118,7 @@ export const Severe = {
    */
   IBM1964I: {
     code: "IBM1964I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The attributes derived from the PROCEDURE statement for the ENTRY constant ${variablename} do not match those in its explicit declaration.`,
     fullCode: "IBM1964IS",
@@ -18131,7 +18130,7 @@ export const Severe = {
    */
   IBM1965I: {
     code: "IBM1965I",
-    severity: "S",
+    severity: Severity.S,
     message: (referencename: string, structurename: string) =>
       `There is more than one element named ${referencename} in the class ${structurename} .`,
     fullCode: "IBM1965IS",
@@ -18143,7 +18142,7 @@ export const Severe = {
    */
   IBM1966I: {
     code: "IBM1966I",
-    severity: "S",
+    severity: Severity.S,
     message: (referencename: string, structurename: string) =>
       `There is no element named ${referencename} in the class ${structurename} .`,
     fullCode: "IBM1966IS",
@@ -18156,7 +18155,7 @@ export const Severe = {
    */
   IBM1967I: {
     code: "IBM1967I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The ENTRY ${variablename} may not be used as a handle since it does not have the RETURNS attribute.`,
     fullCode: "IBM1967IS",
@@ -18168,7 +18167,7 @@ export const Severe = {
    */
   IBM1968I: {
     code: "IBM1968I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The ENTRY ${variablename} may not be used as a handle.`,
     fullCode: "IBM1968IS",
@@ -18180,7 +18179,7 @@ export const Severe = {
    */
   IBM1969I: {
     code: "IBM1969I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The variable ${variablename} is used as a handle, but it is not a scalar.`,
     fullCode: "IBM1969IS",
@@ -18192,7 +18191,7 @@ export const Severe = {
    */
   IBM1970I: {
     code: "IBM1970I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `${BUILTINname} built-in function may not be used as a handle.`,
     fullCode: "IBM1970IS",
@@ -18204,7 +18203,7 @@ export const Severe = {
    */
   IBM1971I: {
     code: "IBM1971I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The GENERIC variable ${variablename} may not be used as a handle.`,
     fullCode: "IBM1971IS",
@@ -18216,7 +18215,7 @@ export const Severe = {
    */
   IBM1972I: {
     code: "IBM1972I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `${variablename} may not be used as a handle.`,
     fullCode: "IBM1972IS",
@@ -18230,7 +18229,7 @@ export const Severe = {
    */
   IBM1976I: {
     code: "IBM1976I",
-    severity: "S",
+    severity: Severity.S,
     message: "DBCS characters are allowed only in G and M constants.",
     fullCode: "IBM1976IS",
   } as SimplePLICode,
@@ -18241,7 +18240,7 @@ export const Severe = {
    */
   IBM1977I: {
     code: "IBM1977I",
-    severity: "S",
+    severity: Severity.S,
     message: "SBCS characters are not allowed in G constants.",
     fullCode: "IBM1977IS",
   } as SimplePLICode,
@@ -18252,7 +18251,7 @@ export const Severe = {
    */
   IBM1978I: {
     code: "IBM1978I",
-    severity: "S",
+    severity: Severity.S,
     message: "Invalid use of SBCS encoded as DBCS.",
     fullCode: "IBM1978IS",
   } as SimplePLICode,
@@ -18263,7 +18262,7 @@ export const Severe = {
    */
   IBM1981I: {
     code: "IBM1981I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINfunction: string) =>
       `${BUILTINfunction} may not be used outside a PROCEDURE.`,
     fullCode: "IBM1981IS",
@@ -18277,7 +18276,7 @@ export const Severe = {
    */
   IBM1984I: {
     code: "IBM1984I",
-    severity: "S",
+    severity: Severity.S,
     message: (filename: string) => `File ${filename} could not be opened.`,
     fullCode: "IBM1984IS",
   } as ParametricPLICode,
@@ -18290,7 +18289,7 @@ export const Severe = {
    */
   IBM1985I: {
     code: "IBM1985I",
-    severity: "S",
+    severity: Severity.S,
     message: (filename: string, Clibrarymessage: string) =>
       `File ${filename} could not be opened. ${Clibrarymessage}`,
     fullCode: "IBM1985IS",
@@ -18304,7 +18303,7 @@ export const Severe = {
    */
   IBM1986I: {
     code: "IBM1986I",
-    severity: "S",
+    severity: Severity.S,
     message: "A system or user abend has occurred.",
     fullCode: "IBM1986IS",
   } as SimplePLICode,
@@ -18317,7 +18316,7 @@ export const Severe = {
    */
   IBM1987I: {
     code: "IBM1987I",
-    severity: "S",
+    severity: Severity.S,
     message: (filename: string) =>
       `File ${filename} could not be opened because too many files have been opened.`,
     fullCode: "IBM1987IS",
@@ -18330,7 +18329,7 @@ export const Severe = {
    */
   IBM1988I: {
     code: "IBM1988I",
-    severity: "S",
+    severity: Severity.S,
     message: (filename: string) =>
       `File ${filename} could not be opened due to an access violation.`,
     fullCode: "IBM1988IS",
@@ -18342,7 +18341,7 @@ export const Severe = {
    */
   IBM1989I: {
     code: "IBM1989I",
-    severity: "S",
+    severity: Severity.S,
     message: (filename: string) =>
       `File name or extension for ${filename} is too long.`,
     fullCode: "IBM1989IS",
@@ -18355,7 +18354,7 @@ export const Severe = {
    */
   IBM1990I: {
     code: "IBM1990I",
-    severity: "S",
+    severity: Severity.S,
     message: (filename: string) => `File name ${filename} has invalid format.`,
     fullCode: "IBM1990IS",
   } as ParametricPLICode,
@@ -18369,7 +18368,7 @@ export const Severe = {
    */
   IBM1992I: {
     code: "IBM1992I",
-    severity: "S",
+    severity: Severity.S,
     message: "A file name must be specified.",
     fullCode: "IBM1992IS",
   } as SimplePLICode,
@@ -18380,7 +18379,7 @@ export const Severe = {
    */
   IBM1993I: {
     code: "IBM1993I",
-    severity: "S",
+    severity: Severity.S,
     message: "Compilation terminated by ATTENTION condition.",
     fullCode: "IBM1993IS",
   } as SimplePLICode,
@@ -18392,7 +18391,7 @@ export const Severe = {
    */
   IBM1994I: {
     code: "IBM1994I",
-    severity: "S",
+    severity: Severity.S,
     message: "Internal compiler error: storage header has been overwritten",
     fullCode: "IBM1994IS",
   } as SimplePLICode,
@@ -18404,7 +18403,7 @@ export const Severe = {
    */
   IBM1995I: {
     code: "IBM1995I",
-    severity: "S",
+    severity: Severity.S,
     message: "Internal compiler error: storage tail has been overwritten.",
     fullCode: "IBM1995IS",
   } as SimplePLICode,
@@ -18416,7 +18415,7 @@ export const Severe = {
    */
   IBM1996I: {
     code: "IBM1996I",
-    severity: "S",
+    severity: Severity.S,
     message: (freerequestsize: string, allocatedsize: string) =>
       `Internal compiler error: free amount ${freerequestsize} does not match allocated size ${allocatedsize} .`,
     fullCode: "IBM1996IS",
@@ -18429,7 +18428,7 @@ export const Severe = {
    */
   IBM1997I: {
     code: "IBM1997I",
-    severity: "S",
+    severity: Severity.S,
     message: (modulename: string) =>
       `Internal compiler error: no WHEN clause satisfied within ${modulename}`,
     fullCode: "IBM1997IS",
@@ -18442,7 +18441,7 @@ export const Severe = {
    */
   IBM1998I: {
     code: "IBM1998I",
-    severity: "S",
+    severity: Severity.S,
     message: (modulename: string) =>
       `Internal compiler error: protection exception in ${modulename}`,
     fullCode: "IBM1998IS",
@@ -18455,7 +18454,7 @@ export const Severe = {
    */
   IBM1999I: {
     code: "IBM1999I",
-    severity: "S",
+    severity: Severity.S,
     message: (note: string) => `${note}`,
     fullCode: "IBM1999IS",
   } as ParametricPLICode,
@@ -18467,7 +18466,7 @@ export const Severe = {
    */
   IBM2000I: {
     code: "IBM2000I",
-    severity: "S",
+    severity: Severity.S,
     message: (
       sourceline: string,
       procedurename: string,
@@ -18485,7 +18484,7 @@ export const Severe = {
    */
   IBM2001I: {
     code: "IBM2001I",
-    severity: "S",
+    severity: Severity.S,
     message: (STATUSCODE: string, RETURNCODE: string) =>
       `A LICENSE REQUEST WAS DENIED FOR PL/I, PID 5655- B22. THE REQUEST ENDED WITH STATUS CODE ${STATUSCODE} AND RETURN CODE ${RETURNCODE} . THE COMPILATION WILL BE TERMINATED.`,
     fullCode: "IBM2001IS",
@@ -18497,7 +18496,7 @@ export const Severe = {
    */
   IBM2002I: {
     code: "IBM2002I",
-    severity: "S",
+    severity: Severity.S,
     message: (filename: string) =>
       `Close of file ${filename} failed. There may be a space problem.`,
     fullCode: "IBM2002IS",
@@ -18509,7 +18508,7 @@ export const Severe = {
    */
   IBM2003I: {
     code: "IBM2003I",
-    severity: "S",
+    severity: Severity.S,
     message: (filename: string) =>
       `Write to file ${filename} failed. There may be a space problem.`,
     fullCode: "IBM2003IS",
@@ -18522,7 +18521,7 @@ export const Severe = {
    */
   IBM2004I: {
     code: "IBM2004I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "ATTACH reference must be declared with either a null argument list or with an argument list specifying only one argument.",
     fullCode: "IBM2004IS",
@@ -18534,7 +18533,7 @@ export const Severe = {
    */
   IBM2005I: {
     code: "IBM2005I",
-    severity: "S",
+    severity: Severity.S,
     message: "ATTACH reference must be an ENTRY reference.",
     fullCode: "IBM2005IS",
   } as SimplePLICode,
@@ -18546,7 +18545,7 @@ export const Severe = {
    */
   IBM2006I: {
     code: "IBM2006I",
-    severity: "S",
+    severity: Severity.S,
     message: "ATTACH reference cannot be a function reference.",
     fullCode: "IBM2006IS",
   } as SimplePLICode,
@@ -18558,7 +18557,7 @@ export const Severe = {
    */
   IBM2007I: {
     code: "IBM2007I",
-    severity: "S",
+    severity: Severity.S,
     message: "ATTACH reference must use LINKAGE(SYSTEM).",
     fullCode: "IBM2007IS",
   } as SimplePLICode,
@@ -18569,7 +18568,7 @@ export const Severe = {
    */
   IBM2008I: {
     code: "IBM2008I",
-    severity: "S",
+    severity: Severity.S,
     message: "ATTACH reference cannot be FETCHABLE.",
     fullCode: "IBM2008IS",
   } as SimplePLICode,
@@ -18581,7 +18580,7 @@ export const Severe = {
    */
   IBM2009I: {
     code: "IBM2009I",
-    severity: "S",
+    severity: Severity.S,
     message: "ATTACH reference cannot be a nested PROCEDURE.",
     fullCode: "IBM2009IS",
   } as SimplePLICode,
@@ -18592,7 +18591,7 @@ export const Severe = {
    */
   IBM2010I: {
     code: "IBM2010I",
-    severity: "S",
+    severity: Severity.S,
     message: "ATTACH reference, if an ENTRY variable, must be a LIMITED ENTRY.",
     fullCode: "IBM2010IS",
   } as SimplePLICode,
@@ -18603,7 +18602,7 @@ export const Severe = {
    */
   IBM2011I: {
     code: "IBM2011I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "ATTACH reference, if it has an argument, must declare that argument as POINTER BYVALUE.",
     fullCode: "IBM2011IS",
@@ -18623,7 +18622,7 @@ export const Severe = {
    */
   IBM2012I: {
     code: "IBM2012I",
-    severity: "S",
+    severity: Severity.S,
     message: (attributekeyword: string) =>
       `The ${attributekeyword} attribute is invalid in an ALIAS definition.`,
     fullCode: "IBM2012IS",
@@ -18640,7 +18639,7 @@ export const Severe = {
    */
   IBM2013I: {
     code: "IBM2013I",
-    severity: "S",
+    severity: Severity.S,
     message: "Only one description is allowed in an ALIAS definition.",
     fullCode: "IBM2013IS",
   } as SimplePLICode,
@@ -18653,7 +18652,7 @@ export const Severe = {
    */
   IBM2014I: {
     code: "IBM2014I",
-    severity: "S",
+    severity: Severity.S,
     message: "Extents in type descriptors must be constant.",
     fullCode: "IBM2014IS",
   } as SimplePLICode,
@@ -18665,7 +18664,7 @@ export const Severe = {
    */
   IBM2015I: {
     code: "IBM2015I",
-    severity: "S",
+    severity: Severity.S,
     message: "VALUE attribute conflicts with data type.",
     fullCode: "IBM2015IS",
   } as SimplePLICode,
@@ -18676,7 +18675,7 @@ export const Severe = {
    */
   IBM2016I: {
     code: "IBM2016I",
-    severity: "S",
+    severity: Severity.S,
     message: "The VALUE attribute is not allowed with typed structures.",
     fullCode: "IBM2016IS",
   } as SimplePLICode,
@@ -18688,7 +18687,7 @@ export const Severe = {
    */
   IBM2017I: {
     code: "IBM2017I",
-    severity: "S",
+    severity: Severity.S,
     message: "INITIAL TO is valid only for NATIVE POINTER.",
     fullCode: "IBM2017IS",
   } as SimplePLICode,
@@ -18700,7 +18699,7 @@ export const Severe = {
    */
   IBM2018I: {
     code: "IBM2018I",
-    severity: "S",
+    severity: Severity.S,
     message: "INITIAL TO is supported only for STATIC variables.",
     fullCode: "IBM2018IS",
   } as SimplePLICode,
@@ -18713,7 +18712,7 @@ export const Severe = {
    */
   IBM2019I: {
     code: "IBM2019I",
-    severity: "S",
+    severity: Severity.S,
     message: "Unsupported LINKAGE used with the LIST attribute.",
     fullCode: "IBM2019IS",
   } as SimplePLICode,
@@ -18724,7 +18723,7 @@ export const Severe = {
    */
   IBM2020I: {
     code: "IBM2020I",
-    severity: "S",
+    severity: Severity.S,
     message: (referencename: string, structurename: string) =>
       `There is more than one element named ${referencename} in the typed structure ${structurename} .`,
     fullCode: "IBM2020IS",
@@ -18736,7 +18735,7 @@ export const Severe = {
    */
   IBM2021I: {
     code: "IBM2021I",
-    severity: "S",
+    severity: Severity.S,
     message: (referencename: string, structurename: string) =>
       `There is no element named ${referencename} in the structure ${structurename} .`,
     fullCode: "IBM2021IS",
@@ -18749,7 +18748,7 @@ export const Severe = {
    */
   IBM2022I: {
     code: "IBM2022I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The ENTRY ${variablename} may not be used as a typed structure qualifier since it does not have the RETURNS attribute.`,
     fullCode: "IBM2022IS",
@@ -18761,7 +18760,7 @@ export const Severe = {
    */
   IBM2023I: {
     code: "IBM2023I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The ENTRY ${variablename} may not be used as a typed structure qualifier.`,
     fullCode: "IBM2023IS",
@@ -18774,7 +18773,7 @@ export const Severe = {
    */
   IBM2024I: {
     code: "IBM2024I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The array variable ${variablename} may be used as a typed structure qualifier only if it is completely subscripted before its dot qualification.`,
     fullCode: "IBM2024IS",
@@ -18786,7 +18785,7 @@ export const Severe = {
    */
   IBM2025I: {
     code: "IBM2025I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `${BUILTINname} built-in function may not be used as a typed structure qualifier.`,
     fullCode: "IBM2025IS",
@@ -18798,7 +18797,7 @@ export const Severe = {
    */
   IBM2026I: {
     code: "IBM2026I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The GENERIC variable ${variablename} may not be used as a typed structure qualifier.`,
     fullCode: "IBM2026IS",
@@ -18811,7 +18810,7 @@ export const Severe = {
    */
   IBM2027I: {
     code: "IBM2027I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `${variablename} may not be used as a structure qualifier.`,
     fullCode: "IBM2027IS",
@@ -18832,7 +18831,7 @@ export const Severe = {
    */
   IBM2028I: {
     code: "IBM2028I",
-    severity: "S",
+    severity: Severity.S,
     message: "TYPEs must be defined before their use.",
     fullCode: "IBM2028IS",
   } as SimplePLICode,
@@ -18848,7 +18847,7 @@ export const Severe = {
    */
   IBM2029I: {
     code: "IBM2029I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "A DEFINE STRUCTURE statement must consist of a level one structure name optionally followed by its substructures. Use DEFINE ALIAS to set a name as a synonym for a data type.",
     fullCode: "IBM2029IS",
@@ -18860,7 +18859,7 @@ export const Severe = {
    */
   IBM2030I: {
     code: "IBM2030I",
-    severity: "S",
+    severity: Severity.S,
     message: "INITIAL attribute is invalid in structure definitions.",
     fullCode: "IBM2030IS",
   } as SimplePLICode,
@@ -18872,7 +18871,7 @@ export const Severe = {
    */
   IBM2031I: {
     code: "IBM2031I",
-    severity: "S",
+    severity: Severity.S,
     message: "Storage attributes are invalid in structure definition.",
     fullCode: "IBM2031IS",
   } as SimplePLICode,
@@ -18883,7 +18882,7 @@ export const Severe = {
    */
   IBM2032I: {
     code: "IBM2032I",
-    severity: "S",
+    severity: Severity.S,
     message: "DEFINE STRUCTURE may not specify an array of structures.",
     fullCode: "IBM2032IS",
   } as SimplePLICode,
@@ -18905,7 +18904,7 @@ export const Severe = {
    */
   IBM2033I: {
     code: "IBM2033I",
-    severity: "S",
+    severity: Severity.S,
     message: "Only one description is allowed in a structure definition.",
     fullCode: "IBM2033IS",
   } as SimplePLICode,
@@ -18917,7 +18916,7 @@ export const Severe = {
    */
   IBM2034I: {
     code: "IBM2034I",
-    severity: "S",
+    severity: Severity.S,
     message: (typefunction: string) =>
       `The argument to the type function ${typefunction} must be an ordinal type name.`,
     fullCode: "IBM2034IS",
@@ -18930,7 +18929,7 @@ export const Severe = {
    */
   IBM2035I: {
     code: "IBM2035I",
-    severity: "S",
+    severity: Severity.S,
     message: (typefunction: string) =>
       `The argument to the type function ${typefunction} must be a structure type name.`,
     fullCode: "IBM2035IS",
@@ -18944,7 +18943,7 @@ export const Severe = {
    */
   IBM2036I: {
     code: "IBM2036I",
-    severity: "S",
+    severity: Severity.S,
     message: (typefunction: string) =>
       `The second argument to the type function ${typefunction} must have locator type.`,
     fullCode: "IBM2036IS",
@@ -18957,7 +18956,7 @@ export const Severe = {
    */
   IBM2037I: {
     code: "IBM2037I",
-    severity: "S",
+    severity: Severity.S,
     message: (typefunction: string) =>
       `The first argument to the type function ${typefunction} must be a structure type name.`,
     fullCode: "IBM2037IS",
@@ -18970,7 +18969,7 @@ export const Severe = {
    */
   IBM2038I: {
     code: "IBM2038I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `${BUILTINname} argument must have HANDLE type.`,
     fullCode: "IBM2038IS",
@@ -18982,7 +18981,7 @@ export const Severe = {
    */
   IBM2039I: {
     code: "IBM2039I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `Argument to ${variablename} pseudovariable must be a HANDLE.`,
     fullCode: "IBM2039IS",
@@ -18995,7 +18994,7 @@ export const Severe = {
    */
   IBM2040I: {
     code: "IBM2040I",
-    severity: "S",
+    severity: Severity.S,
     message: (typefunction: string) =>
       `The argument to the type function ${typefunction} must be a defined type.`,
     fullCode: "IBM2040IS",
@@ -19008,7 +19007,7 @@ export const Severe = {
    */
   IBM2041I: {
     code: "IBM2041I",
-    severity: "S",
+    severity: Severity.S,
     message: (typefunction: string) =>
       `The first argument to the type function ${typefunction} must be a defined type.`,
     fullCode: "IBM2041IS",
@@ -19020,7 +19019,7 @@ export const Severe = {
    */
   IBM2042I: {
     code: "IBM2042I",
-    severity: "S",
+    severity: Severity.S,
     message: (typefunction: string) =>
       `The second argument to the type function ${typefunction} must be a scalar.`,
     fullCode: "IBM2042IS",
@@ -19033,7 +19032,7 @@ export const Severe = {
    */
   IBM2043I: {
     code: "IBM2043I",
-    severity: "S",
+    severity: Severity.S,
     message: (typefunction: string) =>
       `The second argument to the type function ${typefunction} must have the same size as the first argument.`,
     fullCode: "IBM2043IS",
@@ -19051,7 +19050,7 @@ export const Severe = {
    */
   IBM2044I: {
     code: "IBM2044I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The get storage function to ${BUILTINname} must be a LIMITED ENTRY with LINKAGE(OPTLINK) and an appropriate entry description list.`,
     fullCode: "IBM2044IS",
@@ -19068,7 +19067,7 @@ export const Severe = {
    */
   IBM2045I: {
     code: "IBM2045I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The free storage function to ${BUILTINname} must be a LIMITED ENTRY with LINKAGE(OPTLINK) and an appropriate entry description list.`,
     fullCode: "IBM2045IS",
@@ -19082,7 +19081,7 @@ export const Severe = {
    */
   IBM2046I: {
     code: "IBM2046I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "OPTIONS(NODESCRIPTOR) is required if the last parameter to an ENTRY or PROC has the LIST attribute.",
     fullCode: "IBM2046IS",
@@ -19097,7 +19096,7 @@ export const Severe = {
    */
   IBM2047I: {
     code: "IBM2047I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The VARGLIST built-in function may be used only inside PROCEDUREs whose last parameter had the LIST attribute.",
     fullCode: "IBM2047IS",
@@ -19111,7 +19110,7 @@ export const Severe = {
    */
   IBM2048I: {
     code: "IBM2048I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The LIST attribute may be specified only on non-nested PROCEDUREs, external entry constants, and limited entry variables.",
     fullCode: "IBM2048IS",
@@ -19124,7 +19123,7 @@ export const Severe = {
    */
   IBM2049I: {
     code: "IBM2049I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The LIST attribute may be specified only on the last element of an entry description list.",
     fullCode: "IBM2049IS",
@@ -19137,7 +19136,7 @@ export const Severe = {
    */
   IBM2050I: {
     code: "IBM2050I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Descriptors are supported for Fortran only for scalar character strings.",
     fullCode: "IBM2050IS",
@@ -19150,7 +19149,7 @@ export const Severe = {
    */
   IBM2051I: {
     code: "IBM2051I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Descriptors are not supported for Fortran for routines defined by or containing ENTRY statements.",
     fullCode: "IBM2051IS",
@@ -19163,7 +19162,7 @@ export const Severe = {
    */
   IBM2052I: {
     code: "IBM2052I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "A function defined by a PROCEDURE containing ENTRY statements must return aggregate values BYADDR.",
     fullCode: "IBM2052IS",
@@ -19176,7 +19175,7 @@ export const Severe = {
    */
   IBM2053I: {
     code: "IBM2053I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "A function defined by an ENTRY statement must return aggregate values BYADDR.",
     fullCode: "IBM2053IS",
@@ -19189,7 +19188,7 @@ export const Severe = {
    */
   IBM2054I: {
     code: "IBM2054I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "A PROCEDURE containing ENTRY statements must receive all non- pointer parameters BYADDR.",
     fullCode: "IBM2054IS",
@@ -19202,7 +19201,7 @@ export const Severe = {
    */
   IBM2055I: {
     code: "IBM2055I",
-    severity: "S",
+    severity: Severity.S,
     message: "An ENTRY statement must receive all parameters BYADDR.",
     fullCode: "IBM2055IS",
   } as SimplePLICode,
@@ -19214,7 +19213,7 @@ export const Severe = {
    */
   IBM2056I: {
     code: "IBM2056I",
-    severity: "S",
+    severity: Severity.S,
     message: "ENTRY statement is not allowed in DO loops.",
     fullCode: "IBM2056IS",
   } as SimplePLICode,
@@ -19226,7 +19225,7 @@ export const Severe = {
    */
   IBM2057I: {
     code: "IBM2057I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "RETURN statement is invalid inside a BEGIN in a PROCEDURE that contains ENTRY statements.",
     fullCode: "IBM2057IS",
@@ -19239,7 +19238,7 @@ export const Severe = {
    */
   IBM2058I: {
     code: "IBM2058I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "In a PROCEDURE without the RETURNS option, any ENTRY statement must use BYADDR for its RETURNS value.",
     fullCode: "IBM2058IS",
@@ -19251,7 +19250,7 @@ export const Severe = {
    */
   IBM2059I: {
     code: "IBM2059I",
-    severity: "S",
+    severity: Severity.S,
     message: "OPTIONS(FORTRAN) is invalid if any parameters are UNALIGNED BIT.",
     fullCode: "IBM2059IS",
   } as SimplePLICode,
@@ -19262,7 +19261,7 @@ export const Severe = {
    */
   IBM2060I: {
     code: "IBM2060I",
-    severity: "S",
+    severity: Severity.S,
     message: "Attributes may not be specified in ALLOCATEs of BASED variables.",
     fullCode: "IBM2060IS",
   } as SimplePLICode,
@@ -19274,7 +19273,7 @@ export const Severe = {
    */
   IBM2061I: {
     code: "IBM2061I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `Attributes specified for ${variablename} in ALLOCATE statement do not match those in its declaration.`,
     fullCode: "IBM2061IS",
@@ -19287,7 +19286,7 @@ export const Severe = {
    */
   IBM2062I: {
     code: "IBM2062I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `Structuring specified in ALLOCATE of ${variablename} does not match that in its declaration.`,
     fullCode: "IBM2062IS",
@@ -19301,7 +19300,7 @@ export const Severe = {
    */
   IBM2063I: {
     code: "IBM2063I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `Specification of extent for ${variablename} in ALLOCATE statement is invalid since it was declared with a constant extent.`,
     fullCode: "IBM2063IS",
@@ -19314,7 +19313,7 @@ export const Severe = {
    */
   IBM2064I: {
     code: "IBM2064I",
-    severity: "S",
+    severity: Severity.S,
     message: (dimensionvalue: string, variablename: string) =>
       `The extent specified for the lower bound for dimension ${dimensionvalue} of ${variablename} in ALLOCATE statement is invalid since that variable was declared with a different constant extent.`,
     fullCode: "IBM2064IS",
@@ -19327,7 +19326,7 @@ export const Severe = {
    */
   IBM2065I: {
     code: "IBM2065I",
-    severity: "S",
+    severity: Severity.S,
     message: (dimensionvalue: string, variablename: string) =>
       `The extent specified for the upper bound for dimension ${dimensionvalue} of ${variablename} in ALLOCATE statement is invalid since that variable was declared with a different constant extent.`,
     fullCode: "IBM2065IS",
@@ -19340,7 +19339,7 @@ export const Severe = {
    */
   IBM2075I: {
     code: "IBM2075I",
-    severity: "S",
+    severity: Severity.S,
     message: (typefunction: string) =>
       `ENTRY types and arguments in ${typefunction} must be LIMITED.`,
     fullCode: "IBM2075IS",
@@ -19353,7 +19352,7 @@ export const Severe = {
    */
   IBM2076I: {
     code: "IBM2076I",
-    severity: "S",
+    severity: Severity.S,
     message: (typefunction: string) =>
       `FLOAT types and arguments in ${typefunction} must be NATIVE REAL.`,
     fullCode: "IBM2076IS",
@@ -19366,7 +19365,7 @@ export const Severe = {
    */
   IBM2077I: {
     code: "IBM2077I",
-    severity: "S",
+    severity: Severity.S,
     message: (typefunction: string) =>
       `FIXED BIN types and arguments in ${typefunction} must be REAL with scale factor zero.`,
     fullCode: "IBM2077IS",
@@ -19379,7 +19378,7 @@ export const Severe = {
    */
   IBM2078I: {
     code: "IBM2078I",
-    severity: "S",
+    severity: Severity.S,
     message: (attributes: string, typefunction: string) =>
       `Types with the attributes ${attributes} are not supported as the target of the ${typefunction} function.`,
     fullCode: "IBM2078IS",
@@ -19392,7 +19391,7 @@ export const Severe = {
    */
   IBM2079I: {
     code: "IBM2079I",
-    severity: "S",
+    severity: Severity.S,
     message: (attributes: string, typefunction: string) =>
       `Arguments with the attributes ${attributes} are not supported as the source in the ${typefunction} function.`,
     fullCode: "IBM2079IS",
@@ -19404,7 +19403,7 @@ export const Severe = {
    */
   IBM2080I: {
     code: "IBM2080I",
-    severity: "S",
+    severity: Severity.S,
     message: "DATE pattern is invalid.",
     fullCode: "IBM2080IS",
   } as SimplePLICode,
@@ -19415,7 +19414,7 @@ export const Severe = {
    */
   IBM2081I: {
     code: "IBM2081I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "DATE attribute is valid only with NONVARYING CHARACTER, FIXED DECIMAL and arithmetic PICTURE.",
     fullCode: "IBM2081IS",
@@ -19428,7 +19427,7 @@ export const Severe = {
    */
   IBM2082I: {
     code: "IBM2082I",
-    severity: "S",
+    severity: Severity.S,
     message: "DATE attribute conflicts with non- zero scale factor.",
     fullCode: "IBM2082IS",
   } as SimplePLICode,
@@ -19439,7 +19438,7 @@ export const Severe = {
    */
   IBM2083I: {
     code: "IBM2083I",
-    severity: "S",
+    severity: Severity.S,
     message: "DATE attribute conflicts with COMPLEX attribute.",
     fullCode: "IBM2083IS",
   } as SimplePLICode,
@@ -19451,7 +19450,7 @@ export const Severe = {
    */
   IBM2084I: {
     code: "IBM2084I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "DATE attribute conflicts with PICTURE string containing characters other than 9.",
     fullCode: "IBM2084IS",
@@ -19464,7 +19463,7 @@ export const Severe = {
    */
   IBM2085I: {
     code: "IBM2085I",
-    severity: "S",
+    severity: Severity.S,
     message: "Length of DATE pattern and base precision do not match.",
     fullCode: "IBM2085IS",
   } as SimplePLICode,
@@ -19476,7 +19475,7 @@ export const Severe = {
    */
   IBM2086I: {
     code: "IBM2086I",
-    severity: "S",
+    severity: Severity.S,
     message: "Length of DATE pattern and base length do not match.",
     fullCode: "IBM2086IS",
   } as SimplePLICode,
@@ -19488,7 +19487,7 @@ export const Severe = {
    */
   IBM2087I: {
     code: "IBM2087I",
-    severity: "S",
+    severity: Severity.S,
     message: "DATE attribute conflicts with adjustable length.",
     fullCode: "IBM2087IS",
   } as SimplePLICode,
@@ -19500,7 +19499,7 @@ export const Severe = {
    */
   IBM2088I: {
     code: "IBM2088I",
-    severity: "S",
+    severity: Severity.S,
     message: "Response file is too large. Excess will be ignored.",
     fullCode: "IBM2088IS",
   } as SimplePLICode,
@@ -19511,7 +19510,7 @@ export const Severe = {
    */
   IBM2089I: {
     code: "IBM2089I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Line in response file is longer than 100 characters. That line and rest of file will be ignored.",
     fullCode: "IBM2089IS",
@@ -19523,7 +19522,7 @@ export const Severe = {
    */
   IBM2090I: {
     code: "IBM2090I",
-    severity: "S",
+    severity: Severity.S,
     message: (keyword: string) =>
       `The ${keyword} statement cannot be used under SYSTEM(CICS).`,
     fullCode: "IBM2090IS",
@@ -19535,7 +19534,7 @@ export const Severe = {
    */
   IBM2091I: {
     code: "IBM2091I",
-    severity: "S",
+    severity: Severity.S,
     message: "DISPLAY with REPLY cannot be used under SYSTEM(CICS).",
     fullCode: "IBM2091IS",
   } as SimplePLICode,
@@ -19546,7 +19545,7 @@ export const Severe = {
    */
   IBM2092I: {
     code: "IBM2092I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The ${BUILTINname} built-in function cannot be used under SYSTEM(CICS).`,
     fullCode: "IBM2092IS",
@@ -19559,7 +19558,7 @@ export const Severe = {
    */
   IBM2093I: {
     code: "IBM2093I",
-    severity: "S",
+    severity: Severity.S,
     message: (keyword: string) =>
       `The ${keyword} statement cannot be used under SYSTEM(CICS) except with SYSPRINT.`,
     fullCode: "IBM2093IS",
@@ -19571,7 +19570,7 @@ export const Severe = {
    */
   IBM2094I: {
     code: "IBM2094I",
-    severity: "S",
+    severity: Severity.S,
     message: "Source in CAST to FLOAT must be FLOAT, FIXED or ORDINAL.",
     fullCode: "IBM2094IS",
   } as SimplePLICode,
@@ -19582,7 +19581,7 @@ export const Severe = {
    */
   IBM2095I: {
     code: "IBM2095I",
-    severity: "S",
+    severity: Severity.S,
     message: "Target in CAST from FLOAT must be FLOAT, FIXED BIN or ORDINAL.",
     fullCode: "IBM2095IS",
   } as SimplePLICode,
@@ -19593,7 +19592,7 @@ export const Severe = {
    */
   IBM2096I: {
     code: "IBM2096I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Target in CAST from FIXED DEC must be FLOAT, FIXED BIN or ORDINAL.",
     fullCode: "IBM2096IS",
@@ -19606,7 +19605,7 @@ export const Severe = {
    */
   IBM2097I: {
     code: "IBM2097I",
-    severity: "S",
+    severity: Severity.S,
     message: (typefunction: string) =>
       `FIXED DEC types and arguments in ${typefunction} must be REAL with non-negative scale factor.`,
     fullCode: "IBM2097IS",
@@ -19618,7 +19617,7 @@ export const Severe = {
    */
   IBM2098I: {
     code: "IBM2098I",
-    severity: "S",
+    severity: Severity.S,
     message: "Source in CAST to FIXED DEC must be FLOAT, FIXED or ORDINAL.",
     fullCode: "IBM2098IS",
   } as SimplePLICode,
@@ -19631,7 +19630,7 @@ export const Severe = {
    */
   IBM2099I: {
     code: "IBM2099I",
-    severity: "S",
+    severity: Severity.S,
     message: "CASEX strings must have the same length.",
     fullCode: "IBM2099IS",
   } as SimplePLICode,
@@ -19643,7 +19642,7 @@ export const Severe = {
    */
   IBM2100I: {
     code: "IBM2100I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The attributes of the EXTERNAL variable ${variablename} do not match those in its previous declaration. The ORDINAL types do not match.`,
     fullCode: "IBM2100IS",
@@ -19656,7 +19655,7 @@ export const Severe = {
    */
   IBM2101I: {
     code: "IBM2101I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The attributes of the EXTERNAL variable ${variablename} do not match those in its previous declaration. The HANDLE types do not match.`,
     fullCode: "IBM2101IS",
@@ -19669,7 +19668,7 @@ export const Severe = {
    */
   IBM2102I: {
     code: "IBM2102I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The attributes of the EXTERNAL variable ${variablename} do not match those in its previous declaration. The STRUCTURE types do not match.`,
     fullCode: "IBM2102IS",
@@ -19682,7 +19681,7 @@ export const Severe = {
    */
   IBM2103I: {
     code: "IBM2103I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The attributes of the EXTERNAL variable ${variablename} do not match those in its previous declaration. Alignment does not match.`,
     fullCode: "IBM2103IS",
@@ -19695,7 +19694,7 @@ export const Severe = {
    */
   IBM2104I: {
     code: "IBM2104I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The attributes of the EXTERNAL variable ${variablename} do not match those in its previous declaration. Number and attributes of structure members do not match.`,
     fullCode: "IBM2104IS",
@@ -19708,7 +19707,7 @@ export const Severe = {
    */
   IBM2105I: {
     code: "IBM2105I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The attributes of the EXTERNAL variable ${variablename} do not match those in its previous declaration. The number of dimensions do not match.`,
     fullCode: "IBM2105IS",
@@ -19721,7 +19720,7 @@ export const Severe = {
    */
   IBM2106I: {
     code: "IBM2106I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The attributes of the EXTERNAL variable ${variablename} do not match those in its previous declaration. Lower bounds do not match.`,
     fullCode: "IBM2106IS",
@@ -19734,7 +19733,7 @@ export const Severe = {
    */
   IBM2107I: {
     code: "IBM2107I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The attributes of the EXTERNAL variable ${variablename} do not match those in its previous declaration. Upper bounds do not match.`,
     fullCode: "IBM2107IS",
@@ -19747,7 +19746,7 @@ export const Severe = {
    */
   IBM2108I: {
     code: "IBM2108I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The attributes of the EXTERNAL variable ${variablename} do not match those in its previous declaration. RETURNS attributes do not match.`,
     fullCode: "IBM2108IS",
@@ -19760,7 +19759,7 @@ export const Severe = {
    */
   IBM2109I: {
     code: "IBM2109I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The attributes of the EXTERNAL variable ${variablename} do not match those in its previous declaration. BYVALUE and BYADDR attributes in RETURNS do not match.`,
     fullCode: "IBM2109IS",
@@ -19773,7 +19772,7 @@ export const Severe = {
    */
   IBM2110I: {
     code: "IBM2110I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The attributes of the EXTERNAL variable ${variablename} do not match those in its previous declaration. LINKAGE values do not match.`,
     fullCode: "IBM2110IS",
@@ -19786,7 +19785,7 @@ export const Severe = {
    */
   IBM2111I: {
     code: "IBM2111I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The attributes of the EXTERNAL variable ${variablename} do not match those in its previous declaration. OPTIONS values do not match.`,
     fullCode: "IBM2111IS",
@@ -19799,7 +19798,7 @@ export const Severe = {
    */
   IBM2112I: {
     code: "IBM2112I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The attributes of the EXTERNAL variable ${variablename} do not match those in its previous declaration. Parameter counts do not match.`,
     fullCode: "IBM2112IS",
@@ -19812,7 +19811,7 @@ export const Severe = {
    */
   IBM2113I: {
     code: "IBM2113I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string, parameternumber: string) =>
       `The attributes of the EXTERNAL variable ${variablename} do not match those in its previous declaration. BYVALUE and BYADDR attributes in parameter ${parameternumber} do not match.`,
     fullCode: "IBM2113IS",
@@ -19825,7 +19824,7 @@ export const Severe = {
    */
   IBM2114I: {
     code: "IBM2114I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string, parameternumber: string) =>
       `The attributes of the EXTERNAL variable ${variablename} do not match those in its previous declaration. The number of dimensions for parameter ${parameternumber} do not match.`,
     fullCode: "IBM2114IS",
@@ -19838,7 +19837,7 @@ export const Severe = {
    */
   IBM2115I: {
     code: "IBM2115I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string, parameternumber: string) =>
       `The attributes of the EXTERNAL variable ${variablename} do not match those in its previous declaration. Lower bounds for parameter ${parameternumber} do not match.`,
     fullCode: "IBM2115IS",
@@ -19851,7 +19850,7 @@ export const Severe = {
    */
   IBM2116I: {
     code: "IBM2116I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string, parameternumber: string) =>
       `The attributes of the EXTERNAL variable ${variablename} do not match those in its previous declaration. Upper bounds for parameter ${parameternumber} do not match.`,
     fullCode: "IBM2116IS",
@@ -19864,7 +19863,7 @@ export const Severe = {
    */
   IBM2117I: {
     code: "IBM2117I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string, parameternumber: string) =>
       `The attributes of the EXTERNAL variable ${variablename} do 122 not match those in its previous declaration. Alignment of parameter ${parameternumber} does not match.`,
     fullCode: "IBM2117IS",
@@ -19877,7 +19876,7 @@ export const Severe = {
    */
   IBM2118I: {
     code: "IBM2118I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string, parameternumber: string) =>
       `The attributes of the EXTERNAL variable ${variablename} do not match those in its previous declaration. Number and attributes of structure members in parameter ${parameternumber} do not match.`,
     fullCode: "IBM2118IS",
@@ -19890,7 +19889,7 @@ export const Severe = {
    */
   IBM2119I: {
     code: "IBM2119I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string, parameternumber: string) =>
       `The attributes of the EXTERNAL variable ${variablename} do not match those in its previous declaration. Attributes of parameter ${parameternumber} do not match.`,
     fullCode: "IBM2119IS",
@@ -19902,7 +19901,7 @@ export const Severe = {
    */
   IBM2120I: {
     code: "IBM2120I",
-    severity: "S",
+    severity: Severity.S,
     message: "AREAs are not supported in RETURNS.",
     fullCode: "IBM2120IS",
   } as SimplePLICode,
@@ -19920,7 +19919,7 @@ export const Severe = {
    */
   IBM2121I: {
     code: "IBM2121I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, entryname: string) =>
       `Argument number ${argumentnumber} in ENTRY reference ${entryname} must have the same size as the corresponding parameter.`,
     fullCode: "IBM2121IS",
@@ -19933,7 +19932,7 @@ export const Severe = {
    */
   IBM2122I: {
     code: "IBM2122I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "User exit routine addresses are invalid. Check that the user exit routine is a PACKAGE that exports only IBMUEXIT.",
     fullCode: "IBM2122IS",
@@ -19946,7 +19945,7 @@ export const Severe = {
    */
   IBM2123I: {
     code: "IBM2123I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "When expanded, DEFINE STRUCTURE type would have an array with more than 15 total dimensions.",
     fullCode: "IBM2123IS",
@@ -19959,7 +19958,7 @@ export const Severe = {
    */
   IBM2124I: {
     code: "IBM2124I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "When expanded, DEFINE STRUCTURE type would contain more than 15 logical levels.",
     fullCode: "IBM2124IS",
@@ -19979,7 +19978,7 @@ export const Severe = {
    */
   IBM2125I: {
     code: "IBM2125I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `${variablename} is a typed structure and hence cannot be used in GET DATA.`,
     fullCode: "IBM2125IS",
@@ -20002,7 +20001,7 @@ export const Severe = {
    */
   IBM2126I: {
     code: "IBM2126I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `${variablename} is a member of a typed structure and hence cannot be used in data directed I/O.`,
     fullCode: "IBM2126IS",
@@ -20026,7 +20025,7 @@ export const Severe = {
    */
   IBM2127I: {
     code: "IBM2127I",
-    severity: "S",
+    severity: Severity.S,
     message: (ENTRYvariablename: string, GENERICvariablename: string) =>
       `The ENTRY named ${ENTRYvariablename} matches the reference to the GENERIC variable ${GENERICvariablename} , but while the GENERIC reference is used as a function, the matching ENTRY does not have the RETURNS attribute.`,
     fullCode: "IBM2127IS",
@@ -20052,7 +20051,7 @@ export const Severe = {
    */
   IBM2128I: {
     code: "IBM2128I",
-    severity: "S",
+    severity: Severity.S,
     message: (ENTRYvariablename: string, GENERICvariablename: string) =>
       `The ENTRY named ${ENTRYvariablename} matches the reference to the GENERIC variable ${GENERICvariablename} , but while the GENERIC reference is used as a function acting as a locator qualifier, the matching ENTRY does not return a POINTER.`,
     fullCode: "IBM2128IS",
@@ -20079,7 +20078,7 @@ export const Severe = {
    */
   IBM2129I: {
     code: "IBM2129I",
-    severity: "S",
+    severity: Severity.S,
     message: (ENTRYvariablename: string, GENERICvariablename: string) =>
       `The ENTRY named ${ENTRYvariablename} matches the reference to the GENERIC variable ${GENERICvariablename} , but while the GENERIC reference is used as a repeating function reference, the matching ENTRY cannot be so used.`,
     fullCode: "IBM2129IS",
@@ -20094,7 +20093,7 @@ export const Severe = {
    */
   IBM2130I: {
     code: "IBM2130I",
-    severity: "S",
+    severity: Severity.S,
     message: "iSUB defining is not valid with the POSITION attribute.",
     fullCode: "IBM2130IS",
   } as SimplePLICode,
@@ -20110,7 +20109,7 @@ export const Severe = {
    */
   IBM2131I: {
     code: "IBM2131I",
-    severity: "S",
+    severity: Severity.S,
     message: "In iSUB defining, the base and DEFINED variables must match.",
     fullCode: "IBM2131IS",
   } as SimplePLICode,
@@ -20126,7 +20125,7 @@ export const Severe = {
    */
   IBM2132I: {
     code: "IBM2132I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The i in an iSUB reference must not exceed the dimensionality of the DEFINED variable.",
     fullCode: "IBM2132IS",
@@ -20143,7 +20142,7 @@ export const Severe = {
    */
   IBM2133I: {
     code: "IBM2133I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "An iSUB variable cannot be defined on a cross-section of its base.",
     fullCode: "IBM2133IS",
@@ -20155,7 +20154,7 @@ export const Severe = {
    */
   IBM2134I: {
     code: "IBM2134I",
-    severity: "S",
+    severity: Severity.S,
     message: "iSUB defining is supported only for arrays of scalars.",
     fullCode: "IBM2134IS",
   } as SimplePLICode,
@@ -20167,7 +20166,7 @@ export const Severe = {
    */
   IBM2135I: {
     code: "IBM2135I",
-    severity: "S",
+    severity: Severity.S,
     message: (cmpatsuboption: string) =>
       `DFT(DESCLIST) conflicts with CMPAT( ${cmpatsuboption} ).`,
     fullCode: "IBM2135IS",
@@ -20185,7 +20184,7 @@ export const Severe = {
    */
   IBM2136I: {
     code: "IBM2136I",
-    severity: "S",
+    severity: Severity.S,
     message: (identifier: string) =>
       `The number of indices specified for the LABEL ${identifier} does not match the number previously specified.`,
     fullCode: "IBM2136IS",
@@ -20201,7 +20200,7 @@ export const Severe = {
    */
   IBM2137I: {
     code: "IBM2137I",
-    severity: "S",
+    severity: Severity.S,
     message: (identifier: string) =>
       `Indices have been specified for the LABEL ${identifier} when it was previously specified without indices.`,
     fullCode: "IBM2137IS",
@@ -20217,7 +20216,7 @@ export const Severe = {
    */
   IBM2138I: {
     code: "IBM2138I",
-    severity: "S",
+    severity: Severity.S,
     message: (identifier: string) =>
       `Indices have not been specified for the LABEL ${identifier} when it was previously specified with indices.`,
     fullCode: "IBM2138IS",
@@ -20229,7 +20228,7 @@ export const Severe = {
    */
   IBM2139I: {
     code: "IBM2139I",
-    severity: "S",
+    severity: Severity.S,
     message: "The Language Enviroment run- time is not current enough.",
     fullCode: "IBM2139IS",
   } as SimplePLICode,
@@ -20242,7 +20241,7 @@ export const Severe = {
    */
   IBM2140I: {
     code: "IBM2140I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Length of second argument to the REPLACEBY2 built-in function must be twice that of the third.",
     fullCode: "IBM2140IS",
@@ -20254,7 +20253,7 @@ export const Severe = {
    */
   IBM2141I: {
     code: "IBM2141I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `First argument to the ${BUILTINname} built-in function must be a structure.`,
     fullCode: "IBM2141IS",
@@ -20268,7 +20267,7 @@ export const Severe = {
    */
   IBM2142I: {
     code: "IBM2142I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Event structure argument to the ${BUILTINname} built-in function has too few elements.`,
     fullCode: "IBM2142IS",
@@ -20282,7 +20281,7 @@ export const Severe = {
    */
   IBM2143I: {
     code: "IBM2143I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Event structure argument to the ${BUILTINname} built-in function has too many elements.`,
     fullCode: "IBM2143IS",
@@ -20296,7 +20295,7 @@ export const Severe = {
    */
   IBM2144I: {
     code: "IBM2144I",
-    severity: "S",
+    severity: Severity.S,
     message: (membernumber: string, BUILTINname: string) =>
       `Member ${membernumber} in the event structure argument to the ${BUILTINname} built-in function is not a scalar.`,
     fullCode: "IBM2144IS",
@@ -20309,7 +20308,7 @@ export const Severe = {
    */
   IBM2145I: {
     code: "IBM2145I",
-    severity: "S",
+    severity: Severity.S,
     message: (membernumber: string, BUILTINname: string) =>
       `Member ${membernumber} in the event structure argument to the ${BUILTINname} built-in function must be a LIMITED ENTRY.`,
     fullCode: "IBM2145IS",
@@ -20323,7 +20322,7 @@ export const Severe = {
    */
   IBM2146I: {
     code: "IBM2146I",
-    severity: "S",
+    severity: Severity.S,
     message: (membernumber: string, BUILTINname: string) =>
       `Member ${membernumber} in the event structure argument to the ${BUILTINname} built-in function must return BYVALUE a NATIVE FIXED BIN(31).`,
     fullCode: "IBM2146IS",
@@ -20337,7 +20336,7 @@ export const Severe = {
    */
   IBM2147I: {
     code: "IBM2147I",
-    severity: "S",
+    severity: Severity.S,
     message: (membernumber: string, BUILTINname: string) =>
       `Member ${membernumber} in the event structure argument to the ${BUILTINname} built-in function must have a non-empty entry description list.`,
     fullCode: "IBM2147IS",
@@ -20351,7 +20350,7 @@ export const Severe = {
    */
   IBM2148I: {
     code: "IBM2148I",
-    severity: "S",
+    severity: Severity.S,
     message: (
       membernumber: string,
       BUILTINname: string,
@@ -20370,7 +20369,7 @@ export const Severe = {
    */
   IBM2149I: {
     code: "IBM2149I",
-    severity: "S",
+    severity: Severity.S,
     message: (membernumber: string, BUILTINname: string) =>
       `Member ${membernumber} in the event structure argument to the ${BUILTINname} built-in function must have a BYVALUE POINTER as its first parameter.`,
     fullCode: "IBM2149IS",
@@ -20384,7 +20383,7 @@ export const Severe = {
    */
   IBM2150I: {
     code: "IBM2150I",
-    severity: "S",
+    severity: Severity.S,
     message: (membernumber: string, BUILTINname: string) =>
       `Member ${membernumber} in the event structure argument to the ${BUILTINname} built-in function must have a BYVALUE POINTER as its second parameter.`,
     fullCode: "IBM2150IS",
@@ -20398,7 +20397,7 @@ export const Severe = {
    */
   IBM2151I: {
     code: "IBM2151I",
-    severity: "S",
+    severity: Severity.S,
     message: (membernumber: string, BUILTINname: string) =>
       `Member ${membernumber} in the event structure argument to the ${BUILTINname} built-in function must have a BYVALUE NATIVE FIXED BIN(31) as its third parameter.`,
     fullCode: "IBM2151IS",
@@ -20412,7 +20411,7 @@ export const Severe = {
    */
   IBM2152I: {
     code: "IBM2152I",
-    severity: "S",
+    severity: Severity.S,
     message: (membernumber: string, BUILTINname: string) =>
       `Member ${membernumber} in the event structure argument to the ${BUILTINname} built-in function must have a BYVALUE POINTER as its fourth parameter.`,
     fullCode: "IBM2152IS",
@@ -20426,7 +20425,7 @@ export const Severe = {
    */
   IBM2153I: {
     code: "IBM2153I",
-    severity: "S",
+    severity: Severity.S,
     message: (membernumber: string, BUILTINname: string) =>
       `Member ${membernumber} in the event structure argument to the ${BUILTINname} built-in function must have a BYVALUE NATIVE FIXED BIN(31) as its fifth parameter.`,
     fullCode: "IBM2153IS",
@@ -20440,7 +20439,7 @@ export const Severe = {
    */
   IBM2154I: {
     code: "IBM2154I",
-    severity: "S",
+    severity: Severity.S,
     message: (membernumber: string, BUILTINname: string) =>
       `Member ${membernumber} in the event structure argument to the ${BUILTINname} built-in function must have a BYVALUE POINTER as its second parameter.`,
     fullCode: "IBM2154IS",
@@ -20454,7 +20453,7 @@ export const Severe = {
    */
   IBM2155I: {
     code: "IBM2155I",
-    severity: "S",
+    severity: Severity.S,
     message: (membernumber: string, BUILTINname: string) =>
       `Member ${membernumber} in the event structure argument to the ${BUILTINname} built-in function must have a BYVALUE NATIVE FIXED BIN(31) as its fourth parameter.`,
     fullCode: "IBM2155IS",
@@ -20468,7 +20467,7 @@ export const Severe = {
    */
   IBM2156I: {
     code: "IBM2156I",
-    severity: "S",
+    severity: Severity.S,
     message: (membernumber: string, BUILTINname: string) =>
       `Member ${membernumber} in the event structure argument to the ${BUILTINname} built-in function must have a BYVALUE NATIVE FIXED BIN(31) as its second parameter.`,
     fullCode: "IBM2156IS",
@@ -20482,7 +20481,7 @@ export const Severe = {
    */
   IBM2157I: {
     code: "IBM2157I",
-    severity: "S",
+    severity: Severity.S,
     message: (membernumber: string, BUILTINname: string) =>
       `Member ${membernumber} in the event structure argument to the ${BUILTINname} built-in function must have a BYVALUE CHAR(1) or BYVALUE WCHAR(1) as its second parameter.`,
     fullCode: "IBM2157IS",
@@ -20496,7 +20495,7 @@ export const Severe = {
    */
   IBM2158I: {
     code: "IBM2158I",
-    severity: "S",
+    severity: Severity.S,
     message: (membernumber: string, BUILTINname: string) =>
       `Member ${membernumber} in the event structure argument to the ${BUILTINname} built-in function has the wrong linkage.`,
     fullCode: "IBM2158IS",
@@ -20509,7 +20508,7 @@ export const Severe = {
    */
   IBM2159I: {
     code: "IBM2159I",
-    severity: "S",
+    severity: Severity.S,
     message: (membernumber: string, BUILTINname: string) =>
       `Member ${membernumber} in the event structure argument to the ${BUILTINname} built-in function must have the NODESCRIPTOR option.`,
     fullCode: "IBM2159IS",
@@ -20522,7 +20521,7 @@ export const Severe = {
    */
   IBM2160I: {
     code: "IBM2160I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `All members of the input structure to the ${BUILTINname} built-in function must have computational type.`,
     fullCode: "IBM2160IS",
@@ -20535,7 +20534,7 @@ export const Severe = {
    */
   IBM2161I: {
     code: "IBM2161I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The input structure to the ${BUILTINname} built-in function must not be a UNION or contain any UNIONs.`,
     fullCode: "IBM2161IS",
@@ -20548,7 +20547,7 @@ export const Severe = {
    */
   IBM2162I: {
     code: "IBM2162I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The input structure to the ${BUILTINname} built-in function must not contain any GRAPHIC elements.`,
     fullCode: "IBM2162IS",
@@ -20561,7 +20560,7 @@ export const Severe = {
    */
   IBM2163I: {
     code: "IBM2163I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The input structure to the ${BUILTINname} built-in function must not contain any UTF-16 elements.`,
     fullCode: "IBM2163IS",
@@ -20574,7 +20573,7 @@ export const Severe = {
    */
   IBM2164I: {
     code: "IBM2164I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The input structure to the ${BUILTINname} built-in function must not contain any unnamed substructures.`,
     fullCode: "IBM2164IS",
@@ -20587,7 +20586,7 @@ export const Severe = {
    */
   IBM2165I: {
     code: "IBM2165I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "PRV support is provided only if the LIMITS(EXTNAME(7)) option is in effect.",
     fullCode: "IBM2165IS",
@@ -20600,7 +20599,7 @@ export const Severe = {
    */
   IBM2166I: {
     code: "IBM2166I",
-    severity: "S",
+    severity: Severity.S,
     message: "PRV support is provided only if the NORENT option is in effect.",
     fullCode: "IBM2166IS",
   } as SimplePLICode,
@@ -20612,7 +20611,7 @@ export const Severe = {
    */
   IBM2167I: {
     code: "IBM2167I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "PRV support is provided only if the CMPAT(V2) or CMPAT(V3) option is in effect.",
     fullCode: "IBM2167IS",
@@ -20625,7 +20624,7 @@ export const Severe = {
    */
   IBM2170I: {
     code: "IBM2170I",
-    severity: "S",
+    severity: Severity.S,
     message: "Too many INTERNAL CONTROLLED variables.",
     fullCode: "IBM2170IS",
   } as SimplePLICode,
@@ -20637,7 +20636,7 @@ export const Severe = {
    */
   IBM2171I: {
     code: "IBM2171I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Under the NOWRITABLE option, no FETCHABLE ENTRY may be declared at the PACKAGE level.",
     fullCode: "IBM2171IS",
@@ -20650,7 +20649,7 @@ export const Severe = {
    */
   IBM2172I: {
     code: "IBM2172I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Under the NOWRITABLE option, no FILE CONSTANT may be declared at the PACKAGE level.",
     fullCode: "IBM2172IS",
@@ -20663,7 +20662,7 @@ export const Severe = {
    */
   IBM2173I: {
     code: "IBM2173I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Under the NOWRITABLE option, no CONTROLLED may be declared at the PACKAGE level.",
     fullCode: "IBM2173IS",
@@ -20677,7 +20676,7 @@ export const Severe = {
    */
   IBM2174I: {
     code: "IBM2174I",
-    severity: "S",
+    severity: Severity.S,
     message: "Result of REPLACEBY2 is too long.",
     fullCode: "IBM2174IS",
   } as SimplePLICode,
@@ -20689,7 +20688,7 @@ export const Severe = {
    */
   IBM2175I: {
     code: "IBM2175I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The second and third arguments to REPLACEBY2 must be restricted expressions.",
     fullCode: "IBM2175IS",
@@ -20702,7 +20701,7 @@ export const Severe = {
    */
   IBM2176I: {
     code: "IBM2176I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The result of the ${BUILTINname} built-in function would require more than 32767 bytes.`,
     fullCode: "IBM2176IS",
@@ -20715,7 +20714,7 @@ export const Severe = {
    */
   IBM2177I: {
     code: "IBM2177I",
-    severity: "S",
+    severity: Severity.S,
     message: (filename: string) =>
       `The file ${filename} is a PDS member and hence cannot be used for SYSADATA.`,
     fullCode: "IBM2177IS",
@@ -20728,7 +20727,7 @@ export const Severe = {
    */
   IBM2178I: {
     code: "IBM2178I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "INCLUDE statements are not supported when the LINEDIR option is in effect.",
     fullCode: "IBM2178IS",
@@ -20742,7 +20741,7 @@ export const Severe = {
    */
   IBM2179I: {
     code: "IBM2179I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "There is too little room between the margins for the LINE directive. The PPTRACE option will be turned off.",
     fullCode: "IBM2179IS",
@@ -20755,7 +20754,7 @@ export const Severe = {
    */
   IBM2180I: {
     code: "IBM2180I",
-    severity: "S",
+    severity: Severity.S,
     message: (filename: string, keyword: string) =>
       `Use of the KEYED DIRECT file ${filename} in a ${keyword} statement without a KEY/KEYFROM clause is invalid.`,
     fullCode: "IBM2180IS",
@@ -20767,7 +20766,7 @@ export const Severe = {
    */
   IBM2181I: {
     code: "IBM2181I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `First argument to ${BUILTINname} built-in function must have type CHARACTER.`,
     fullCode: "IBM2181IS",
@@ -20780,7 +20779,7 @@ export const Severe = {
    */
   IBM2182I: {
     code: "IBM2182I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, BUILTINname: string) =>
       `Argument number ${argumentnumber} to ${BUILTINname} built-in function must be a constant.`,
     fullCode: "IBM2182IS",
@@ -20792,7 +20791,7 @@ export const Severe = {
    */
   IBM2183I: {
     code: "IBM2183I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The first argument to ${BUILTINname} built-in function must have constant length equal to that of the second argument.`,
     fullCode: "IBM2183IS",
@@ -20804,7 +20803,7 @@ export const Severe = {
    */
   IBM2184I: {
     code: "IBM2184I",
-    severity: "S",
+    severity: Severity.S,
     message: "Compiler input files must have less then 1000000 lines.",
     fullCode: "IBM2184IS",
   } as SimplePLICode,
@@ -20815,7 +20814,7 @@ export const Severe = {
    */
   IBM2185I: {
     code: "IBM2185I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Argument to ${BUILTINname} built- in function must have type REAL DECIMAL FLOAT, and the DFP option must be in effect.`,
     fullCode: "IBM2185IS",
@@ -20828,7 +20827,7 @@ export const Severe = {
    */
   IBM2186I: {
     code: "IBM2186I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `${BUILTINname} is not supported for DFP.`,
     fullCode: "IBM2186IS",
@@ -20843,7 +20842,7 @@ export const Severe = {
    */
   IBM2187I: {
     code: "IBM2187I",
-    severity: "S",
+    severity: Severity.S,
     message: (value: string, precision: string) =>
       `The exponent in the literal ${value} is too large for DECIMAL FLOAT with precision ${precision} .`,
     fullCode: "IBM2187IS",
@@ -20858,7 +20857,7 @@ export const Severe = {
    */
   IBM2188I: {
     code: "IBM2188I",
-    severity: "S",
+    severity: Severity.S,
     message: (value: string, precision: string) =>
       `The exponent in the literal ${value} is too small for DECIMAL FLOAT with precision ${precision} .`,
     fullCode: "IBM2188IS",
@@ -20871,7 +20870,7 @@ export const Severe = {
    */
   IBM2189I: {
     code: "IBM2189I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Under CMPAT(V2) and CMPAT(LE), bounds must not be greater than +2147483647.",
     fullCode: "IBM2189IS",
@@ -20884,7 +20883,7 @@ export const Severe = {
    */
   IBM2190I: {
     code: "IBM2190I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Under CMPAT(V2) and CMPAT(LE), bounds must not be less than -2147483648.",
     fullCode: "IBM2190IS",
@@ -20897,7 +20896,7 @@ export const Severe = {
    */
   IBM2191I: {
     code: "IBM2191I",
-    severity: "S",
+    severity: Severity.S,
     message: (option: string) =>
       `No valid character specified in the ${option} option.`,
     fullCode: "IBM2191IS",
@@ -20911,7 +20910,7 @@ export const Severe = {
    */
   IBM2192I: {
     code: "IBM2192I",
-    severity: "S",
+    severity: Severity.S,
     message: (
       membernumber: string,
       BUILTINname: string,
@@ -20929,7 +20928,7 @@ export const Severe = {
    */
   IBM2193I: {
     code: "IBM2193I",
-    severity: "S",
+    severity: Severity.S,
     message: (
       membernumber: string,
       BUILTINname: string,
@@ -20947,7 +20946,7 @@ export const Severe = {
    */
   IBM2194I: {
     code: "IBM2194I",
-    severity: "S",
+    severity: Severity.S,
     message: (
       membernumber: string,
       BUILTINname: string,
@@ -20965,7 +20964,7 @@ export const Severe = {
    */
   IBM2195I: {
     code: "IBM2195I",
-    severity: "S",
+    severity: Severity.S,
     message: (
       membernumber: string,
       BUILTINname: string,
@@ -20983,7 +20982,7 @@ export const Severe = {
    */
   IBM2196I: {
     code: "IBM2196I",
-    severity: "S",
+    severity: Severity.S,
     message: (
       membernumber: string,
       BUILTINname: string,
@@ -20999,7 +20998,7 @@ export const Severe = {
    */
   IBM2197I: {
     code: "IBM2197I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Argument to ${BUILTINname} built-in function must have type CHAR or WIDECHAR.`,
     fullCode: "IBM2197IS",
@@ -21011,7 +21010,7 @@ export const Severe = {
    */
   IBM2198I: {
     code: "IBM2198I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `First argument to ${BUILTINname} built-in function must have type CHAR or WIDECHAR.`,
     fullCode: "IBM2198IS",
@@ -21023,7 +21022,7 @@ export const Severe = {
    */
   IBM2199I: {
     code: "IBM2199I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The run-time option XPLINK(ON) must be in effect if object code is to be generated.",
     fullCode: "IBM2199IS",
@@ -21037,7 +21036,7 @@ export const Severe = {
    */
   IBM2200I: {
     code: "IBM2200I",
-    severity: "S",
+    severity: Severity.S,
     message: (sourcetype: string, targettype: string) =>
       `DFP conversion from ${sourcetype} to ${targettype} failed with an operation exception. The most likely cause for this is lack of DFP hardware.`,
     fullCode: "IBM2200IS",
@@ -21049,7 +21048,7 @@ export const Severe = {
    */
   IBM2201I: {
     code: "IBM2201I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `First argument to ${BUILTINname} built-in function must have type REAL DECIMAL FIXED, or REAL DECIMAL FLOAT, and in the latter case, the DFP option must be in effect.`,
     fullCode: "IBM2201IS",
@@ -21062,7 +21061,7 @@ export const Severe = {
    */
   IBM2202I: {
     code: "IBM2202I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string, level: string) =>
       `Use of the ${BUILTINname} built-in function requires ARCH( ${level} ) or greater.`,
     fullCode: "IBM2202IS",
@@ -21075,7 +21074,7 @@ export const Severe = {
    */
   IBM2203I: {
     code: "IBM2203I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The VALUE attribute may be used on a structure member only if it is used on all base members of that structure.",
     fullCode: "IBM2203IS",
@@ -21088,7 +21087,7 @@ export const Severe = {
    */
   IBM2204I: {
     code: "IBM2204I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The VALUE attribute may be used on a structure member only if no storage attribute is specified for the structure.",
     fullCode: "IBM2204IS",
@@ -21101,7 +21100,7 @@ export const Severe = {
    */
   IBM2205I: {
     code: "IBM2205I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The VALUE attribute may be used on a structure member only if no dimension attributes are specified for its parents.",
     fullCode: "IBM2205IS",
@@ -21113,7 +21112,7 @@ export const Severe = {
    */
   IBM2206I: {
     code: "IBM2206I",
-    severity: "S",
+    severity: Severity.S,
     message: "The VALUE attribute conflicts with the DIMENSION attribute.",
     fullCode: "IBM2206IS",
   } as SimplePLICode,
@@ -21124,7 +21123,7 @@ export const Severe = {
    */
   IBM2207I: {
     code: "IBM2207I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The VALUE attribute may be used on a structure member only if no parent has the UNION attribute.",
     fullCode: "IBM2207IS",
@@ -21138,7 +21137,7 @@ export const Severe = {
    */
   IBM2208I: {
     code: "IBM2208I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Structure references that contain the VALUE attribute are invalid.",
     fullCode: "IBM2208IS",
@@ -21156,7 +21155,7 @@ export const Severe = {
    */
   IBM2209I: {
     code: "IBM2209I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Use of nonconstant extents in BASED variables without REFER is invalid except on scalars.",
     fullCode: "IBM2209IS",
@@ -21169,7 +21168,7 @@ export const Severe = {
    */
   IBM2210I: {
     code: "IBM2210I",
-    severity: "S",
+    severity: Severity.S,
     message: (typename: string) =>
       `The VALUE type function cannot be applied to ${typename} since that structure has no members with an INITIAL attribute.`,
     fullCode: "IBM2210IS",
@@ -21182,7 +21181,7 @@ export const Severe = {
    */
   IBM2211I: {
     code: "IBM2211I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Shift-out code has no closing shift- in code before the right margin.",
     fullCode: "IBM2211IS",
@@ -21194,7 +21193,7 @@ export const Severe = {
    */
   IBM2212I: {
     code: "IBM2212I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Argument to the ${BUILTINname} built-in function must be a structure.`,
     fullCode: "IBM2212IS",
@@ -21206,7 +21205,7 @@ export const Severe = {
    */
   IBM2213I: {
     code: "IBM2213I",
-    severity: "S",
+    severity: Severity.S,
     message: "Block contains too many label arrays.",
     fullCode: "IBM2213IS",
   } as SimplePLICode,
@@ -21217,7 +21216,7 @@ export const Severe = {
    */
   IBM2214I: {
     code: "IBM2214I",
-    severity: "S",
+    severity: Severity.S,
     message: (Attribute: string) =>
       `${Attribute} is invalid on structure parents.`,
     fullCode: "IBM2214IS",
@@ -21229,7 +21228,7 @@ export const Severe = {
    */
   IBM2215I: {
     code: "IBM2215I",
-    severity: "S",
+    severity: Severity.S,
     message: (Attribute: string) =>
       `${Attribute} is invalid on unnamed structure elements.`,
     fullCode: "IBM2215IS",
@@ -21242,7 +21241,7 @@ export const Severe = {
    */
   IBM2216I: {
     code: "IBM2216I",
-    severity: "S",
+    severity: Severity.S,
     message: (Attribute: string) => `${Attribute} is invalid on arrays.`,
     fullCode: "IBM2216IS",
   } as ParametricPLICode,
@@ -21254,7 +21253,7 @@ export const Severe = {
    */
   IBM2217I: {
     code: "IBM2217I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "XMLATTR is invalid if the previous element at that logical level does not also have the XMLATTR attribute.",
     fullCode: "IBM2217IS",
@@ -21267,7 +21266,7 @@ export const Severe = {
    */
   IBM2218I: {
     code: "IBM2218I",
-    severity: "S",
+    severity: Severity.S,
     message: (Attribute: string) =>
       `${Attribute} is invalid on non-native FLOAT elements.`,
     fullCode: "IBM2218IS",
@@ -21280,7 +21279,7 @@ export const Severe = {
    */
   IBM2219I: {
     code: "IBM2219I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Parameters declared as INONLY must not contain any elements declared with the ASSIGNABLE attribute.",
     fullCode: "IBM2219IS",
@@ -21293,7 +21292,7 @@ export const Severe = {
    */
   IBM2220I: {
     code: "IBM2220I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Parameters declared as OUTONLY must contain at least one element declared with the ASSIGNABLE attribute.",
     fullCode: "IBM2220IS",
@@ -21306,7 +21305,7 @@ export const Severe = {
    */
   IBM2221I: {
     code: "IBM2221I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "A non-constant array extent in a BASED variable is invalid if the array has more than one dimension.",
     fullCode: "IBM2221IS",
@@ -21319,7 +21318,7 @@ export const Severe = {
    */
   IBM2222I: {
     code: "IBM2222I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "A non-constant array extent in a BASED variable is invalid if the array has a non-constant lower bound.",
     fullCode: "IBM2222IS",
@@ -21333,7 +21332,7 @@ export const Severe = {
    */
   IBM2223I: {
     code: "IBM2223I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "A non-constant array extent in a BASED structure is invalid if any other fields in the structure have non-constant extents.",
     fullCode: "IBM2223IS",
@@ -21347,7 +21346,7 @@ export const Severe = {
    */
   IBM2224I: {
     code: "IBM2224I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "A non-constant AREA, BIT, GRAPHIC, or WIDECHAR extent in a BASED variable is invalid if the variable is an array element or part of a structure.",
     fullCode: "IBM2224IS",
@@ -21361,7 +21360,7 @@ export const Severe = {
    */
   IBM2225I: {
     code: "IBM2225I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "A non-constant CHARACTER extent in a BASED variable is invalid if the string is ALIGNED and either VARYING or VARYING4.",
     fullCode: "IBM2225IS",
@@ -21375,7 +21374,7 @@ export const Severe = {
    */
   IBM2226I: {
     code: "IBM2226I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "A non-constant array extent in a BASED variable is invalid if there are any sibling fields after the array or any of the array's parents.",
     fullCode: "IBM2226IS",
@@ -21389,7 +21388,7 @@ export const Severe = {
    */
   IBM2227I: {
     code: "IBM2227I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "A non-constant CHARACTER extent in a BASED structure is invalid if the string is a member of an array of structures.",
     fullCode: "IBM2227IS",
@@ -21403,7 +21402,7 @@ export const Severe = {
    */
   IBM2228I: {
     code: "IBM2228I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "A non-constant CHARACTER extent in a BASED structure is invalid unless the string is the last field in the structure and not part of a union.",
     fullCode: "IBM2228IS",
@@ -21415,7 +21414,7 @@ export const Severe = {
    */
   IBM2230I: {
     code: "IBM2230I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The argument to the ${BUILTINname} built-in function must have the attributes REAL FIXED BIN and scale factor zero.`,
     fullCode: "IBM2230IS",
@@ -21428,7 +21427,7 @@ export const Severe = {
    */
   IBM2231I: {
     code: "IBM2231I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The ${BUILTINname} built-in function is supported only with the native character set.`,
     fullCode: "IBM2231IS",
@@ -21447,7 +21446,7 @@ export const Severe = {
    */
   IBM2232I: {
     code: "IBM2232I",
-    severity: "S",
+    severity: Severity.S,
     message: "There must be only one target in a BY DIMACROSS assignment.",
     fullCode: "IBM2232IS",
   } as SimplePLICode,
@@ -21466,7 +21465,7 @@ export const Severe = {
    */
   IBM2233I: {
     code: "IBM2233I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The target in a BY DIMACROSS assignment must be a structure reference.",
     fullCode: "IBM2233IS",
@@ -21478,7 +21477,7 @@ export const Severe = {
    */
   IBM2234I: {
     code: "IBM2234I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "No arrays are permitted in the source in a BY DIMACROSS assignment.",
     fullCode: "IBM2234IS",
@@ -21499,7 +21498,7 @@ export const Severe = {
    */
   IBM2235I: {
     code: "IBM2235I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "In a BY DIMACROSS assignment, the immediate children of any structure not declared with DIMACROSS must not be arrays.",
     fullCode: "IBM2235IS",
@@ -21512,7 +21511,7 @@ export const Severe = {
    */
   IBM2236I: {
     code: "IBM2236I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `${BUILTINname} argument must have the DIMACROSS attribute.`,
     fullCode: "IBM2236IS",
@@ -21525,7 +21524,7 @@ export const Severe = {
    */
   IBM2237I: {
     code: "IBM2237I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The third argument to the ALLCOMPARE built-in function must be a CHAR(2) constant.",
     fullCode: "IBM2237IS",
@@ -21538,7 +21537,7 @@ export const Severe = {
    */
   IBM2238I: {
     code: "IBM2238I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The third argument to the ALLCOMPARE built-in function must specify the name of a comparison operator.",
     fullCode: "IBM2238IS",
@@ -21551,7 +21550,7 @@ export const Severe = {
    */
   IBM2239I: {
     code: "IBM2239I",
-    severity: "S",
+    severity: Severity.S,
     message: (typename: string) =>
       `Invalid use of unspecified STRUCT type ${typename} .`,
     fullCode: "IBM2239IS",
@@ -21564,7 +21563,7 @@ export const Severe = {
    */
   IBM2240I: {
     code: "IBM2240I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Arithmetic operations are not allowed on handles for unspecified structure definitions.",
     fullCode: "IBM2240IS",
@@ -21577,7 +21576,7 @@ export const Severe = {
    */
   IBM2241I: {
     code: "IBM2241I",
-    severity: "S",
+    severity: Severity.S,
     message: (typefunction: string) =>
       `The argument to the type function ${typefunction} must be a specified structure type name.`,
     fullCode: "IBM2241IS",
@@ -21590,7 +21589,7 @@ export const Severe = {
    */
   IBM2242I: {
     code: "IBM2242I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Subtraction of HANDLE from HANDLE is invalid unless both point to the same type.",
     fullCode: "IBM2242IS",
@@ -21604,7 +21603,7 @@ export const Severe = {
    */
   IBM2243I: {
     code: "IBM2243I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The attributes derived from the PROCEDURE statement for the ENTRY constant ${variablename} do not match those in its explicit declaration. RETURNS attributes do not match.`,
     fullCode: "IBM2243IS",
@@ -21618,7 +21617,7 @@ export const Severe = {
    */
   IBM2244I: {
     code: "IBM2244I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The attributes derived from the PROCEDURE statement for the ENTRY constant ${variablename} do not match those in its explicit declaration. BYVALUE/BYADDR attributes in RETURNS do not match.`,
     fullCode: "IBM2244IS",
@@ -21632,7 +21631,7 @@ export const Severe = {
    */
   IBM2245I: {
     code: "IBM2245I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The attributes derived from the PROCEDURE statement for the ENTRY constant ${variablename} do not match those in its explicit declaration. LINKAGE values do not match.`,
     fullCode: "IBM2245IS",
@@ -21646,7 +21645,7 @@ export const Severe = {
    */
   IBM2246I: {
     code: "IBM2246I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The attributes derived from the PROCEDURE statement for the ENTRY constant ${variablename} do not match those in its explicit declaration. OPTIONS values do not match.`,
     fullCode: "IBM2246IS",
@@ -21660,7 +21659,7 @@ export const Severe = {
    */
   IBM2247I: {
     code: "IBM2247I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `The attributes derived from the PROCEDURE statement for the ENTRY constant ${variablename} do not match those in its explicit declaration. Parameter counts do not match.`,
     fullCode: "IBM2247IS",
@@ -21674,7 +21673,7 @@ export const Severe = {
    */
   IBM2248I: {
     code: "IBM2248I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string, parameternumber: string) =>
       `The attributes derived from the PROCEDURE statement for the ENTRY constant ${variablename} do not match those in its explicit declaration. BYVALUE/BYADDR attributes in parameter ${parameternumber} do not match.`,
     fullCode: "IBM2248IS",
@@ -21688,7 +21687,7 @@ export const Severe = {
    */
   IBM2249I: {
     code: "IBM2249I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string, parameternumber: string) =>
       `The attributes derived from the PROCEDURE statement for the ENTRY constant ${variablename} do not match those in its explicit declaration. Number of dimensions for parameter ${parameternumber} do not match.`,
     fullCode: "IBM2249IS",
@@ -21702,7 +21701,7 @@ export const Severe = {
    */
   IBM2250I: {
     code: "IBM2250I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string, parameternumber: string) =>
       `The attributes derived from the PROCEDURE statement for the ENTRY constant ${variablename} do not match those in its explicit declaration. Lower bounds for parameter ${parameternumber} do not match.`,
     fullCode: "IBM2250IS",
@@ -21716,7 +21715,7 @@ export const Severe = {
    */
   IBM2251I: {
     code: "IBM2251I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string, parameternumber: string) =>
       `The attributes derived from the PROCEDURE statement for the ENTRY constant ${variablename} do not match those in its explicit declaration. Upper bounds for parameter ${parameternumber} do not match.`,
     fullCode: "IBM2251IS",
@@ -21730,7 +21729,7 @@ export const Severe = {
    */
   IBM2252I: {
     code: "IBM2252I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string, parameternumber: string) =>
       `The attributes derived from the PROCEDURE statement for the ENTRY constant ${variablename} do not match those in its explicit declaration. Alignment of parameter ${parameternumber} does not match.`,
     fullCode: "IBM2252IS",
@@ -21744,7 +21743,7 @@ export const Severe = {
    */
   IBM2253I: {
     code: "IBM2253I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string, parameternumber: string) =>
       `The attributes derived from the PROCEDURE statement for the ENTRY constant ${variablename} do not match those in its explicit declaration. Number and attributes of structure members in parameter ${parameternumber} do not match.`,
     fullCode: "IBM2253IS",
@@ -21758,7 +21757,7 @@ export const Severe = {
    */
   IBM2254I: {
     code: "IBM2254I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string, parameternumber: string) =>
       `The attributes derived from the PROCEDURE statement for the ENTRY constant ${variablename} do not match those in its explicit declaration. Attributes of parameter ${parameternumber} do not match.`,
     fullCode: "IBM2254IS",
@@ -21771,7 +21770,7 @@ export const Severe = {
    */
   IBM2255I: {
     code: "IBM2255I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The argument to the ${BUILTINname} built-in function must be numeric, BIT, or CHARACTER.`,
     fullCode: "IBM2255IS",
@@ -21787,7 +21786,7 @@ export const Severe = {
    */
   IBM2256I: {
     code: "IBM2256I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The result of the ${BUILTINname} built-in function would have a length greater than the the maximum allowed for a CHARACTER string.`,
     fullCode: "IBM2256IS",
@@ -21799,7 +21798,7 @@ export const Severe = {
    */
   IBM2257I: {
     code: "IBM2257I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The argument to the ${BUILTINname} built-in function must hold valid UTF-16.`,
     fullCode: "IBM2257IS",
@@ -21811,7 +21810,7 @@ export const Severe = {
    */
   IBM2258I: {
     code: "IBM2258I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The argument to the ${BUILTINname} built-in function must have type CHARACTER.`,
     fullCode: "IBM2258IS",
@@ -21823,7 +21822,7 @@ export const Severe = {
    */
   IBM2259I: {
     code: "IBM2259I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The argument to the ${BUILTINname} built-in function must contain valid UTF-8.`,
     fullCode: "IBM2259IS",
@@ -21836,7 +21835,7 @@ export const Severe = {
    */
   IBM2260I: {
     code: "IBM2260I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "INITIAL expressions in DEFINE STRUCT must not depend on any address values.",
     fullCode: "IBM2260IS",
@@ -21848,7 +21847,7 @@ export const Severe = {
    */
   IBM2261I: {
     code: "IBM2261I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Overpunch and currency characters are not allowed in WIDEPIC specifications.",
     fullCode: "IBM2261IS",
@@ -21860,7 +21859,7 @@ export const Severe = {
    */
   IBM2262I: {
     code: "IBM2262I",
-    severity: "S",
+    severity: Severity.S,
     message: "A and X characters are not allowed in WIDEPIC specifications.",
     fullCode: "IBM2262IS",
   } as SimplePLICode,
@@ -21871,7 +21870,7 @@ export const Severe = {
    */
   IBM2263I: {
     code: "IBM2263I",
-    severity: "S",
+    severity: Severity.S,
     message: "REFER objects must not be COMPLEX WIDEPIC.",
     fullCode: "IBM2263IS",
   } as SimplePLICode,
@@ -21887,7 +21886,7 @@ export const Severe = {
    */
   IBM2264I: {
     code: "IBM2264I",
-    severity: "S",
+    severity: Severity.S,
     message: (attribute: string) =>
       `The ${attribute} attribute is invalid in a LOCATES descriptor.`,
     fullCode: "IBM2264IS",
@@ -21900,7 +21899,7 @@ export const Severe = {
    */
   IBM2265I: {
     code: "IBM2265I",
-    severity: "S",
+    severity: Severity.S,
     message: "Extents in LOCATES descriptors must be constants.",
     fullCode: "IBM2265IS",
   } as SimplePLICode,
@@ -21911,7 +21910,7 @@ export const Severe = {
    */
   IBM2266I: {
     code: "IBM2266I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The argument to ${BUILTINname} built-in function must have the LOCATES attribute.`,
     fullCode: "IBM2266IS",
@@ -21923,7 +21922,7 @@ export const Severe = {
    */
   IBM2267I: {
     code: "IBM2267I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The first argument to ${BUILTINname} built-in function must have the LOCATES attribute.`,
     fullCode: "IBM2267IS",
@@ -21936,7 +21935,7 @@ export const Severe = {
    */
   IBM2268I: {
     code: "IBM2268I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Argument to the LOCVAL pseudovariable must have the LOCATES attribute.",
     fullCode: "IBM2268IS",
@@ -21948,7 +21947,7 @@ export const Severe = {
    */
   IBM2269I: {
     code: "IBM2269I",
-    severity: "S",
+    severity: Severity.S,
     message: "LOCATES attribute is valid only with OFFSET.",
     fullCode: "IBM2269IS",
   } as SimplePLICode,
@@ -21963,7 +21962,7 @@ export const Severe = {
    */
   IBM2270I: {
     code: "IBM2270I",
-    severity: "S",
+    severity: Severity.S,
     message: "Only one description is allowed in a LOCATES descriptor.",
     fullCode: "IBM2270IS",
   } as SimplePLICode,
@@ -21974,7 +21973,7 @@ export const Severe = {
    */
   IBM2271I: {
     code: "IBM2271I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The first argument to ${BUILTINname} built-in function must be a scalar reference.`,
     fullCode: "IBM2271IS",
@@ -21986,7 +21985,7 @@ export const Severe = {
    */
   IBM2272I: {
     code: "IBM2272I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The second argument to ${BUILTINname} built-in function must be a scalar reference.`,
     fullCode: "IBM2272IS",
@@ -21998,7 +21997,7 @@ export const Severe = {
    */
   IBM2273I: {
     code: "IBM2273I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The OFFSET argument to ${BUILTINname} built-in function must have an AREA qualification.`,
     fullCode: "IBM2273IS",
@@ -22010,7 +22009,7 @@ export const Severe = {
    */
   IBM2274I: {
     code: "IBM2274I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The second argument to ${BUILTINname} built-in function must have the LOCATES attribute.`,
     fullCode: "IBM2274IS",
@@ -22022,7 +22021,7 @@ export const Severe = {
    */
   IBM2275I: {
     code: "IBM2275I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Third argument to ${BUILTINname} built-in function must have type AREA.`,
     fullCode: "IBM2275IS",
@@ -22034,7 +22033,7 @@ export const Severe = {
    */
   IBM2276I: {
     code: "IBM2276I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The argument to ${BUILTINname} built-in function must have the LOCATES attribute or contain subelements with the LOCATES attribute.`,
     fullCode: "IBM2276IS",
@@ -22047,7 +22046,7 @@ export const Severe = {
    */
   IBM2277I: {
     code: "IBM2277I",
-    severity: "S",
+    severity: Severity.S,
     message: "INCLUDE statements are not allowed under NOINCLUDE.",
     fullCode: "IBM2277IS",
   } as SimplePLICode,
@@ -22059,7 +22058,7 @@ export const Severe = {
    */
   IBM2278I: {
     code: "IBM2278I",
-    severity: "S",
+    severity: Severity.S,
     message: "Source is not valid UTF-8.",
     fullCode: "IBM2278IS",
   } as SimplePLICode,
@@ -22071,7 +22070,7 @@ export const Severe = {
    */
   IBM2279I: {
     code: "IBM2279I",
-    severity: "S",
+    severity: Severity.S,
     message: (option: string) => `${option} option contains invalid UTF-8.`,
     fullCode: "IBM2279IS",
   } as ParametricPLICode,
@@ -22084,7 +22083,7 @@ export const Severe = {
    */
   IBM2280I: {
     code: "IBM2280I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The corresponding characters in the two NAMES strings must have the same length.",
     fullCode: "IBM2280IS",
@@ -22098,7 +22097,7 @@ export const Severe = {
    */
   IBM2281I: {
     code: "IBM2281I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The first argument to ${BUILTINname} built-in function must have computational type or ordinal type.`,
     fullCode: "IBM2281IS",
@@ -22110,7 +22109,7 @@ export const Severe = {
    */
   IBM2282I: {
     code: "IBM2282I",
-    severity: "S",
+    severity: Severity.S,
     message: "REINIT reference must be a level 1 item.",
     fullCode: "IBM2282IS",
   } as SimplePLICode,
@@ -22121,7 +22120,7 @@ export const Severe = {
    */
   IBM2283I: {
     code: "IBM2283I",
-    severity: "S",
+    severity: Severity.S,
     message: "REINIT references must be BASED, AUTO, CTL or STATIC.",
     fullCode: "IBM2283IS",
   } as SimplePLICode,
@@ -22134,7 +22133,7 @@ export const Severe = {
    */
   IBM2284I: {
     code: "IBM2284I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The first and second arguments to the ${BUILTINname} built-in function must have matching types.`,
     fullCode: "IBM2284IS",
@@ -22146,7 +22145,7 @@ export const Severe = {
    */
   IBM2285I: {
     code: "IBM2285I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The argument to the ${BUILTINname} built-in function must have the attributes UNSIGNED REAL FIXED BIN(64,0).`,
     fullCode: "IBM2285IS",
@@ -22159,7 +22158,7 @@ export const Severe = {
    */
   IBM2286I: {
     code: "IBM2286I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string, length: string) =>
       `The argument to the ${BUILTINname} built-in function must have the attributes CHAR NONVARYING and length ${length} .`,
     fullCode: "IBM2286IS",
@@ -22174,7 +22173,7 @@ export const Severe = {
    */
   IBM2287I: {
     code: "IBM2287I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, BUILTINname: string) =>
       `Argument number ${argumentnumber} to the ${BUILTINname} built- in function must contain only standard computational types.`,
     fullCode: "IBM2287IS",
@@ -22187,7 +22186,7 @@ export const Severe = {
    */
   IBM2288I: {
     code: "IBM2288I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, BUILTINname: string) =>
       `Argument number ${argumentnumber} to the ${BUILTINname} built- in function must not be a UNION or contain any UNIONs.`,
     fullCode: "IBM2288IS",
@@ -22200,7 +22199,7 @@ export const Severe = {
    */
   IBM2289I: {
     code: "IBM2289I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, BUILTINname: string) =>
       `Argument number ${argumentnumber} to the ${BUILTINname} built- in function must not contain any GRAPHIC elements.`,
     fullCode: "IBM2289IS",
@@ -22214,7 +22213,7 @@ export const Severe = {
    */
   IBM2290I: {
     code: "IBM2290I",
-    severity: "S",
+    severity: Severity.S,
     message: (
       membernumber: string,
       BUILTINname: string,
@@ -22231,7 +22230,7 @@ export const Severe = {
    */
   IBM2291I: {
     code: "IBM2291I",
-    severity: "S",
+    severity: Severity.S,
     message: (attribute: string) => `${attribute} precision is invalid.`,
     fullCode: "IBM2291IS",
   } as ParametricPLICode,
@@ -22243,7 +22242,7 @@ export const Severe = {
    */
   IBM2292I: {
     code: "IBM2292I",
-    severity: "S",
+    severity: Severity.S,
     message: (statement: string) =>
       `Target in ${statement} statement must not be the name of a PROC or ENTRY statement.`,
     fullCode: "IBM2292IS",
@@ -22256,7 +22255,7 @@ export const Severe = {
    */
   IBM2293I: {
     code: "IBM2293I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The ${BUILTINname} built-in function is not supported under CMPAT(V1).`,
     fullCode: "IBM2293IS",
@@ -22268,7 +22267,7 @@ export const Severe = {
    */
   IBM2294I: {
     code: "IBM2294I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "A value greater than 64K for the STRING suboption of the 139 LIMITS option is valid only under CMPAT(V3) and CMPAT(LE).",
     fullCode: "IBM2294IS",
@@ -22280,7 +22279,7 @@ export const Severe = {
    */
   IBM2295I: {
     code: "IBM2295I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "A value greater than 32K for the STRING suboption of the LIMITS option is valid only under BIFPREC(31).",
     fullCode: "IBM2295IS",
@@ -22295,7 +22294,7 @@ export const Severe = {
    */
   IBM2296I: {
     code: "IBM2296I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, BUILTINname: string) =>
       `Argument number ${argumentnumber} to ${BUILTINname} built- in function must have the same ordinal type as the first argument.`,
     fullCode: "IBM2296IS",
@@ -22308,7 +22307,7 @@ export const Severe = {
    */
   IBM2297I: {
     code: "IBM2297I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The ${BUILTINname} built-in function is supported only under LP(64).`,
     fullCode: "IBM2297IS",
@@ -22321,7 +22320,7 @@ export const Severe = {
    */
   IBM2298I: {
     code: "IBM2298I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The ${BUILTINname} built-in function is supported only when the compiler option CHECK(STORAGE) is used.`,
     fullCode: "IBM2298IS",
@@ -22335,7 +22334,7 @@ export const Severe = {
    */
   IBM2299I: {
     code: "IBM2299I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `No value can fall in the interval defined by the second and third arguments to the ${BUILTINname} built-in function.`,
     fullCode: "IBM2299IS",
@@ -22348,7 +22347,7 @@ export const Severe = {
    */
   IBM2300I: {
     code: "IBM2300I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The compiler was disabled in the IFAPRDxx parmlib member. The compilation will terminate without further processing.",
     fullCode: "IBM2300IS",
@@ -22360,7 +22359,7 @@ export const Severe = {
    */
   IBM2301I: {
     code: "IBM2301I",
-    severity: "S",
+    severity: Severity.S,
     message: (returncode: string) =>
       `The IFAEDREG registration of the compiler failed with return code ${returncode} . The compilation will terminate without further processing.`,
     fullCode: "IBM2301IS",
@@ -22373,7 +22372,7 @@ export const Severe = {
    */
   IBM2302I: {
     code: "IBM2302I",
-    severity: "S",
+    severity: Severity.S,
     message: (option: string) =>
       `The option ${option} is not supported under LP(64).`,
     fullCode: "IBM2302IS",
@@ -22386,7 +22385,7 @@ export const Severe = {
    */
   IBM2303I: {
     code: "IBM2303I",
-    severity: "S",
+    severity: Severity.S,
     message: (codepage: string) => `${codepage} is not a supported codepage.`,
     fullCode: "IBM2303IS",
   } as ParametricPLICode,
@@ -22398,7 +22397,7 @@ export const Severe = {
    */
   IBM2304I: {
     code: "IBM2304I",
-    severity: "S",
+    severity: Severity.S,
     message: (attribute: string) =>
       `The ${attribute} attribute is not supported under CMPAT(V1).`,
     fullCode: "IBM2304IS",
@@ -22411,7 +22410,7 @@ export const Severe = {
    */
   IBM2305I: {
     code: "IBM2305I",
-    severity: "S",
+    severity: Severity.S,
     message: "The ASSERT COMPARE operator must be a CHAR(2) constant.",
     fullCode: "IBM2305IS",
   } as SimplePLICode,
@@ -22423,7 +22422,7 @@ export const Severe = {
    */
   IBM2306I: {
     code: "IBM2306I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The ASSERT COMPARE operator must specify the name of a comparison operator.",
     fullCode: "IBM2306IS",
@@ -22437,7 +22436,7 @@ export const Severe = {
    */
   IBM2307I: {
     code: "IBM2307I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The first argument to the ${BUILTINname} built-in function must be a suitable one-dimensional array.`,
     fullCode: "IBM2307IS",
@@ -22451,7 +22450,7 @@ export const Severe = {
    */
   IBM2308I: {
     code: "IBM2308I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The first argument to the ${BUILTINname} built-in function must be ALIGNED if NONVARYING BIT.`,
     fullCode: "IBM2308IS",
@@ -22466,7 +22465,7 @@ export const Severe = {
    */
   IBM2309I: {
     code: "IBM2309I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Comparison in ${BUILTINname} built-in function is unsupported.`,
     fullCode: "IBM2309IS",
@@ -22482,7 +22481,7 @@ export const Severe = {
    */
   IBM2310I: {
     code: "IBM2310I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The compare function passed to the ${BUILTINname} built-in function must be a LIMITED ENTRY, must return BYVALUE a NATIVE FIXED BIN(31), must have exactly two BYVALUE POINTER arguments, and must have the OPTLINK linkage.`,
     fullCode: "IBM2310IS",
@@ -22494,7 +22493,7 @@ export const Severe = {
    */
   IBM2311I: {
     code: "IBM2311I",
-    severity: "S",
+    severity: Severity.S,
     message: "Labels are not allowed on the END statement for a PACKAGE.",
     fullCode: "IBM2311IS",
   } as SimplePLICode,
@@ -22506,7 +22505,7 @@ export const Severe = {
    */
   IBM2312I: {
     code: "IBM2312I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, BUILTINname: string) =>
       `Argument number ${argumentnumber} to ${BUILTINname} built- in function must be a scalar expression.`,
     fullCode: "IBM2312IS",
@@ -22519,7 +22518,7 @@ export const Severe = {
    */
   IBM2313I: {
     code: "IBM2313I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, BUILTINname: string) =>
       `Argument number ${argumentnumber} to ${BUILTINname} built- in function must be an array expression.`,
     fullCode: "IBM2313IS",
@@ -22532,7 +22531,7 @@ export const Severe = {
    */
   IBM2314I: {
     code: "IBM2314I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `${BUILTINname} built-in function does not support arrays of this type.`,
     fullCode: "IBM2314IS",
@@ -22546,7 +22545,7 @@ export const Severe = {
    */
   IBM2315I: {
     code: "IBM2315I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, BUILTINname: string) =>
       `Argument number ${argumentnumber} to ${BUILTINname} built-in function must have type size_t.`,
     fullCode: "IBM2315IS",
@@ -22559,7 +22558,7 @@ export const Severe = {
    */
   IBM2316I: {
     code: "IBM2316I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, BUILTINname: string) =>
       `Argument number ${argumentnumber} to ${BUILTINname} built-in function must have CHARACTER type.`,
     fullCode: "IBM2316IS",
@@ -22573,7 +22572,7 @@ export const Severe = {
    */
   IBM2317I: {
     code: "IBM2317I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, BUILTINname: string) =>
       `Argument number ${argumentnumber} to ${BUILTINname} built-in function must be an ASSIGNABLE reference.`,
     fullCode: "IBM2317IS",
@@ -22586,7 +22585,7 @@ export const Severe = {
    */
   IBM2318I: {
     code: "IBM2318I",
-    severity: "S",
+    severity: Severity.S,
     message: (attribute: string) =>
       `${attribute} attribute is valid only with computational types.`,
     fullCode: "IBM2318IS",
@@ -22598,7 +22597,7 @@ export const Severe = {
    */
   IBM2319I: {
     code: "IBM2319I",
-    severity: "S",
+    severity: Severity.S,
     message: (attribute: string) =>
       `${attribute} attribute is not valid with COMPLEX types.`,
     fullCode: "IBM2319IS",
@@ -22611,7 +22610,7 @@ export const Severe = {
    */
   IBM2320I: {
     code: "IBM2320I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `First argument to ${BUILTINname} built-in function must be a reference to a variable with the VALIDLIST or VALIDRANGE attribute.`,
     fullCode: "IBM2320IS",
@@ -22623,7 +22622,7 @@ export const Severe = {
    */
   IBM2321I: {
     code: "IBM2321I",
-    severity: "S",
+    severity: Severity.S,
     message: (attribute: string) => `${attribute} contains duplicate values.`,
     fullCode: "IBM2321IS",
   } as ParametricPLICode,
@@ -22639,7 +22638,7 @@ export const Severe = {
    */
   IBM2322I: {
     code: "IBM2322I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The second value in the VALUERANGE attribute must be larger than the first.",
     fullCode: "IBM2322IS",
@@ -22655,7 +22654,7 @@ export const Severe = {
    */
   IBM2323I: {
     code: "IBM2323I",
-    severity: "S",
+    severity: Severity.S,
     message: (number: string, number2: string, BUILTINname: string) =>
       `Arguments ${number} and ${number2} to the ${BUILTINname} built-in function must have comparable types.`,
     fullCode: "IBM2323IS",
@@ -22669,7 +22668,7 @@ export const Severe = {
    */
   IBM2324I: {
     code: "IBM2324I",
-    severity: "S",
+    severity: Severity.S,
     message: (
       variablename: string,
       externalname: string,
@@ -22687,7 +22686,7 @@ export const Severe = {
    */
   IBM2325I: {
     code: "IBM2325I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The values specified for the ROUTCDE and DESC in a WTO must be between 1 and 16.",
     fullCode: "IBM2325IS",
@@ -22700,7 +22699,7 @@ export const Severe = {
    */
   IBM2326I: {
     code: "IBM2326I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The argument to the ${BUILTINname} built-in function must have UCHAR type.`,
     fullCode: "IBM2326IS",
@@ -22714,7 +22713,7 @@ export const Severe = {
    */
   IBM2327I: {
     code: "IBM2327I",
-    severity: "S",
+    severity: Severity.S,
     message: "TRANSLATE of a UCHAR string requires 3 arguments.",
     fullCode: "IBM2327IS",
   } as SimplePLICode,
@@ -22726,7 +22725,7 @@ export const Severe = {
    */
   IBM2328I: {
     code: "IBM2328I",
-    severity: "S",
+    severity: Severity.S,
     message: "UX literal specifies an invalid UTF-8 string.",
     fullCode: "IBM2328IS",
   } as SimplePLICode,
@@ -22737,7 +22736,7 @@ export const Severe = {
    */
   IBM2329I: {
     code: "IBM2329I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Argument to ${BUILTINname} built- in function must have type CHAR, UCHAR or WCHAR.`,
     fullCode: "IBM2329IS",
@@ -22749,7 +22748,7 @@ export const Severe = {
    */
   IBM2330I: {
     code: "IBM2330I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The ${BUILTINname} built-in function does not support UCHAR arguments.`,
     fullCode: "IBM2330IS",
@@ -22762,7 +22761,7 @@ export const Severe = {
    */
   IBM2331I: {
     code: "IBM2331I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The input structure to the ${BUILTINname} built-in function must not contain any UTF-8 elements.`,
     fullCode: "IBM2331IS",
@@ -22774,7 +22773,7 @@ export const Severe = {
    */
   IBM2332I: {
     code: "IBM2332I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The base reference in the DEFINED attribute cannot have a UTF-8 type.",
     fullCode: "IBM2332IS",
@@ -22788,7 +22787,7 @@ export const Severe = {
    */
   IBM2333I: {
     code: "IBM2333I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, BUILTINname: string) =>
       `Argument number ${argumentnumber} to ${BUILTINname} built- in function must have a computational, ordinal or pointer type.`,
     fullCode: "IBM2333IS",
@@ -22802,7 +22801,7 @@ export const Severe = {
    */
   IBM2334I: {
     code: "IBM2334I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, BUILTINname: string) =>
       `Argument number ${argumentnumber} to ${BUILTINname} built-in function must be nonvarying with a known length.`,
     fullCode: "IBM2334IS",
@@ -22815,7 +22814,7 @@ export const Severe = {
    */
   IBM2335I: {
     code: "IBM2335I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "VALUELISTFROM reference must name a structure consisting only of elements with the VALUE attribute.",
     fullCode: "IBM2335IS",
@@ -22828,7 +22827,7 @@ export const Severe = {
    */
   IBM2336I: {
     code: "IBM2336I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The fourth argument to the ${BUILTINname} built-in function must be a constant specifying the name of a casing rule.`,
     fullCode: "IBM2336IS",
@@ -22841,7 +22840,7 @@ export const Severe = {
    */
   IBM2337I: {
     code: "IBM2337I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `${BUILTINname} argument must have numeric type.`,
     fullCode: "IBM2337IS",
@@ -22853,7 +22852,7 @@ export const Severe = {
    */
   IBM2338I: {
     code: "IBM2338I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "A QUALIFY block may contain only DEFINE statements, DECLARE statements, and nested QUALIFY blocks.",
     fullCode: "IBM2338IS",
@@ -22865,7 +22864,7 @@ export const Severe = {
    */
   IBM2339I: {
     code: "IBM2339I",
-    severity: "S",
+    severity: Severity.S,
     message: "A QUALIFY block must have a name, but only one.",
     fullCode: "IBM2339IS",
   } as SimplePLICode,
@@ -22877,7 +22876,7 @@ export const Severe = {
    */
   IBM2340I: {
     code: "IBM2340I",
-    severity: "S",
+    severity: Severity.S,
     message: "A name declared in a QUALIFY block must be a scalar.",
     fullCode: "IBM2340IS",
   } as SimplePLICode,
@@ -22889,7 +22888,7 @@ export const Severe = {
    */
   IBM2341I: {
     code: "IBM2341I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "A name declared in a QUALIFY block must have the VALUE attribute.",
     fullCode: "IBM2341IS",
@@ -22901,7 +22900,7 @@ export const Severe = {
    */
   IBM2342I: {
     code: "IBM2342I",
-    severity: "S",
+    severity: Severity.S,
     message: (sourcevalue: string) =>
       `CONVERSION condition raised by attempt to convert the GRAPHIC character with hex value ${sourcevalue} to CHARACTER.`,
     fullCode: "IBM2342IS",
@@ -22913,7 +22912,7 @@ export const Severe = {
    */
   IBM2343I: {
     code: "IBM2343I",
-    severity: "S",
+    severity: Severity.S,
     message: (typename: string) => `The type name ${typename} is ambiguous.`,
     fullCode: "IBM2343IS",
   } as ParametricPLICode,
@@ -22925,7 +22924,7 @@ export const Severe = {
    */
   IBM2344I: {
     code: "IBM2344I",
-    severity: "S",
+    severity: Severity.S,
     message: (typename: string) =>
       `${typename} is a type name, but not the name of a STRUCTURE type.`,
     fullCode: "IBM2344IS",
@@ -22938,7 +22937,7 @@ export const Severe = {
    */
   IBM2345I: {
     code: "IBM2345I",
-    severity: "S",
+    severity: Severity.S,
     message: (typename: string) =>
       `${typename} is a type name, but not the name of an ORDINAL type.`,
     fullCode: "IBM2345IS",
@@ -22950,7 +22949,7 @@ export const Severe = {
    */
   IBM2346I: {
     code: "IBM2346I",
-    severity: "S",
+    severity: Severity.S,
     message: (argumentnumber: string, BUILTINname: string) =>
       `Argument number ${argumentnumber} to ${BUILTINname} built-in function built-in function must be either a scalar or a one- dimensional array of scalars.`,
     fullCode: "IBM2346IS",
@@ -22963,7 +22962,7 @@ export const Severe = {
    */
   IBM2347I: {
     code: "IBM2347I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `The second argument to the ${BUILTINname} built-in function must have the same number of dimensions as the first argument.`,
     fullCode: "IBM2347IS",
@@ -22975,7 +22974,7 @@ export const Severe = {
    */
   IBM2348I: {
     code: "IBM2348I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string, lbound: string, lbound2: string) =>
       `The second argument to the ${BUILTINname} built-in function must have the same lower bound as the first argument. But its lower bound is ${lbound} while the first argument's lower bound is ${lbound2} .`,
     fullCode: "IBM2348IS",
@@ -22987,7 +22986,7 @@ export const Severe = {
    */
   IBM2349I: {
     code: "IBM2349I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string, hbound: string, hbound2: string) =>
       `The second argument to the ${BUILTINname} built-in function must have the same upper bound as the first argument. But its upper bound is ${hbound} while the first argument's upper bound is ${hbound2} .`,
     fullCode: "IBM2349IS",
@@ -22999,7 +22998,7 @@ export const Severe = {
    */
   IBM2350I: {
     code: "IBM2350I",
-    severity: "S",
+    severity: Severity.S,
     message: (attribute: string) => `${attribute} must be returned BYADDR.`,
     fullCode: "IBM2350IS",
   } as ParametricPLICode,
@@ -23016,7 +23015,7 @@ export const Severe = {
    */
   IBM2351I: {
     code: "IBM2351I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Scale factor in ${BUILTINname} is less than 0.`,
     fullCode: "IBM2351IS",
@@ -23033,7 +23032,7 @@ export const Severe = {
    */
   IBM2352I: {
     code: "IBM2352I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Scale factor in ${BUILTINname} must not be greater than the precision.`,
     fullCode: "IBM2352IS",
@@ -23046,7 +23045,7 @@ export const Severe = {
    */
   IBM2353I: {
     code: "IBM2353I",
-    severity: "S",
+    severity: Severity.S,
     message: (
       precision: string,
       scalefactor: string,
@@ -23065,7 +23064,7 @@ export const Severe = {
    */
   IBM2354I: {
     code: "IBM2354I",
-    severity: "S",
+    severity: Severity.S,
     message: (
       precision: string,
       scalefactor: string,
@@ -23084,7 +23083,7 @@ export const Severe = {
    */
   IBM2355I: {
     code: "IBM2355I",
-    severity: "S",
+    severity: Severity.S,
     message: (
       precision: string,
       scalefactor: string,
@@ -23118,7 +23117,7 @@ export const Severe = {
    */
   IBM2356I: {
     code: "IBM2356I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "In commalist number ${commalist_count} , the number of expressions is ${element_count} , but the number of expressions in the first commalist is ${element_count} . The number of expressions in each commalist must match.",
     fullCode: "IBM2356IS",
@@ -23148,7 +23147,7 @@ export const Severe = {
    */
   IBM2357I: {
     code: "IBM2357I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "INITACROSS structure member count of ${member_count} does not match the implied member count of ${element_count} from the INITACROSS attribute.",
     fullCode: "IBM2357IS",
@@ -23161,7 +23160,7 @@ export const Severe = {
    */
   IBM2358I: {
     code: "IBM2358I",
-    severity: "S",
+    severity: Severity.S,
     message: "INITACROSS structures must be one-dimensional arrays.",
     fullCode: "IBM2358IS",
   } as SimplePLICode,
@@ -23174,7 +23173,7 @@ export const Severe = {
    */
   IBM2359I: {
     code: "IBM2359I",
-    severity: "S",
+    severity: Severity.S,
     message: "INITACROSS structure members must all be scalars.",
     fullCode: "IBM2359IS",
   } as SimplePLICode,
@@ -23186,7 +23185,7 @@ export const Severe = {
    */
   IBM2364I: {
     code: "IBM2364I",
-    severity: "S",
+    severity: Severity.S,
     message: (amodeoption: string, optionname: string) =>
       `ENTRY declared with OPTIONS( ${amodeoption} ) must also specify OPTIONS( ${optionname} ).`,
     fullCode: "IBM2364IS",
@@ -23200,7 +23199,7 @@ export const Severe = {
    */
   IBM2365I: {
     code: "IBM2365I",
-    severity: "S",
+    severity: Severity.S,
     message: (amodeoption: string) =>
       `ENTRY declared with OPTIONS( ${amodeoption} ) must specify either RETURNS BYVALUE of a small integer type, or RETURNS BYADDR, or no RETURNS.`,
     fullCode: "IBM2365IS",
@@ -23213,7 +23212,7 @@ export const Severe = {
    */
   IBM2366I: {
     code: "IBM2366I",
-    severity: "S",
+    severity: Severity.S,
     message: (amodeoption: string) =>
       `With the exception of addresses and integers, all arguments passed to an ENTRY declared with OPTIONS( ${amodeoption} ) must be passed BYADDR.`,
     fullCode: "IBM2366IS",
@@ -23226,7 +23225,7 @@ export const Severe = {
    */
   IBM2367I: {
     code: "IBM2367I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "An ENTRY declared with OPTIONS( AMODE31 ) or OPTIONS( AMODE64 ) cannot be implicitly or explicitly assigned to another ENTRY.",
     fullCode: "IBM2367IS",
@@ -23241,7 +23240,7 @@ export const Severe = {
    */
   IBM2368I: {
     code: "IBM2368I",
-    severity: "S",
+    severity: Severity.S,
     message: (amodeoption: string) =>
       `ENTRY declared with OPTIONS( ${amodeoption} ) must specify a (possibly empty) parenthesized list of no more than 64 parameters.`,
     fullCode: "IBM2368IS",
@@ -23254,7 +23253,7 @@ export const Severe = {
    */
   IBM2369I: {
     code: "IBM2369I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "All aggregate arguments passed to an ENTRY declared with OPTIONS( AMODE31 ) must be connected variable references.",
     fullCode: "IBM2369IS",
@@ -23266,7 +23265,7 @@ export const Severe = {
    */
   IBM2370I: {
     code: "IBM2370I",
-    severity: "S",
+    severity: Severity.S,
     message: (keyword: string, name: string) =>
       `The attributes specified in the ${keyword} of ${name} do not match those in its original definition.`,
     fullCode: "IBM2370IS",
@@ -23279,7 +23278,7 @@ export const Severe = {
    */
   IBM2371I: {
     code: "IBM2371I",
-    severity: "S",
+    severity: Severity.S,
     message: (sourcelength: string, sourcepattern: string) =>
       `Source has length ${sourcelength} which is less than the length of the source pattern ${sourcepattern} . Since the pattern has no zero suppression, invoking this REPATTERN will cause the ERROR condition to be raised.`,
     fullCode: "IBM2371IS",
@@ -23292,7 +23291,7 @@ export const Severe = {
    */
   IBM2372I: {
     code: "IBM2372I",
-    severity: "S",
+    severity: Severity.S,
     message: "XDECLARE statement must specify a name.",
     fullCode: "IBM2372IS",
   } as SimplePLICode,
@@ -23304,7 +23303,7 @@ export const Severe = {
    */
   IBM3750I: {
     code: "IBM3750I",
-    severity: "S",
+    severity: Severity.S,
     message: (note: string) => `${note}`,
     fullCode: "IBM3750IS",
   } as ParametricPLICode,
@@ -23316,7 +23315,7 @@ export const Severe = {
    */
   IBM3751I: {
     code: "IBM3751I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "A colon in an EXEC SQL statement must be followed by an identifier that starts a host variable reference.",
     fullCode: "IBM3751IS",
@@ -23330,7 +23329,7 @@ export const Severe = {
    */
   IBM3752I: {
     code: "IBM3752I",
-    severity: "S",
+    severity: Severity.S,
     message: "Dot-qualified reference implies too many structure levels.",
     fullCode: "IBM3752IS",
   } as SimplePLICode,
@@ -23342,7 +23341,7 @@ export const Severe = {
    */
   IBM3753I: {
     code: "IBM3753I",
-    severity: "S",
+    severity: Severity.S,
     message: (typename: string) =>
       `Length in SQL TYPE IS ${typename} is too large.`,
     fullCode: "IBM3753IS",
@@ -23354,7 +23353,7 @@ export const Severe = {
    */
   IBM3754I: {
     code: "IBM3754I",
-    severity: "S",
+    severity: Severity.S,
     message: (typename: string) =>
       `SQL TYPE IS ${typename} must be followed by an opening left parenthesis.`,
     fullCode: "IBM3754IS",
@@ -23366,7 +23365,7 @@ export const Severe = {
    */
   IBM3755I: {
     code: "IBM3755I",
-    severity: "S",
+    severity: Severity.S,
     message: (typename: string) =>
       `SQL TYPE IS ${typename} must have an integer specifying its length after the opening left parenthesis.`,
     fullCode: "IBM3755IS",
@@ -23378,7 +23377,7 @@ export const Severe = {
    */
   IBM3756I: {
     code: "IBM3756I",
-    severity: "S",
+    severity: Severity.S,
     message: (typename: string) =>
       `SQL TYPE IS ${typename} must have a closing right parenthesis after the integer specifying its length.`,
     fullCode: "IBM3756IS",
@@ -23390,7 +23389,7 @@ export const Severe = {
    */
   IBM3757I: {
     code: "IBM3757I",
-    severity: "S",
+    severity: Severity.S,
     message: (typename: string) =>
       `SQL TYPE IS XML AS ${typename} must be followed by an opening left parenthesis.`,
     fullCode: "IBM3757IS",
@@ -23402,7 +23401,7 @@ export const Severe = {
    */
   IBM3758I: {
     code: "IBM3758I",
-    severity: "S",
+    severity: Severity.S,
     message: (typename: string) =>
       `SQL TYPE IS XML AS ${typename} must have an integer specifying its length after the opening left parenthesis.`,
     fullCode: "IBM3758IS",
@@ -23414,7 +23413,7 @@ export const Severe = {
    */
   IBM3759I: {
     code: "IBM3759I",
-    severity: "S",
+    severity: Severity.S,
     message: (typename: string) =>
       `SQL TYPE IS XML AS ${typename} must have a closing right parenthesis after the integer specifying its length.`,
     fullCode: "IBM3759IS",
@@ -23427,7 +23426,7 @@ export const Severe = {
    */
   IBM3760I: {
     code: "IBM3760I",
-    severity: "S",
+    severity: Severity.S,
     message: (ENTRYname: string) =>
       `Too few arguments have been specified for the ENTRY ${ENTRYname} .`,
     fullCode: "IBM3760IS",
@@ -23439,7 +23438,7 @@ export const Severe = {
    */
   IBM3761I: {
     code: "IBM3761I",
-    severity: "S",
+    severity: Severity.S,
     message: "Procedures may not be nested.",
     fullCode: "IBM3761IS",
   } as SimplePLICode,
@@ -23457,7 +23456,7 @@ export const Severe = {
    */
   IBM3762I: {
     code: "IBM3762I",
-    severity: "S",
+    severity: Severity.S,
     message: "No percent statements are allowed inside procedures.",
     fullCode: "IBM3762IS",
   } as SimplePLICode,
@@ -23470,7 +23469,7 @@ export const Severe = {
    */
   IBM3763I: {
     code: "IBM3763I",
-    severity: "S",
+    severity: Severity.S,
     message: "Not enough virtual memory is available to continue the compile.",
     fullCode: "IBM3763IS",
   } as SimplePLICode,
@@ -23482,7 +23481,7 @@ export const Severe = {
    */
   IBM3764I: {
     code: "IBM3764I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `${BUILTINname} argument must be a parameter.`,
     fullCode: "IBM3764IS",
@@ -23495,7 +23494,7 @@ export const Severe = {
    */
   IBM3765I: {
     code: "IBM3765I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `${BUILTINname} argument must be a reference.`,
     fullCode: "IBM3765IS",
@@ -23507,7 +23506,7 @@ export const Severe = {
    */
   IBM3766I: {
     code: "IBM3766I",
-    severity: "S",
+    severity: Severity.S,
     message: "Aggregate contains more than 15 logical levels.",
     fullCode: "IBM3766IS",
   } as SimplePLICode,
@@ -23518,7 +23517,7 @@ export const Severe = {
    */
   IBM3767I: {
     code: "IBM3767I",
-    severity: "S",
+    severity: Severity.S,
     message: (typename: string) =>
       `Length in SQL TYPE IS ${typename} must be greater than zero.`,
     fullCode: "IBM3767IS",
@@ -23530,7 +23529,7 @@ export const Severe = {
    */
   IBM3768I: {
     code: "IBM3768I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The use of asterisks as subscripts is not permitted in the macro facility.",
     fullCode: "IBM3768IS",
@@ -23542,7 +23541,7 @@ export const Severe = {
    */
   IBM3769I: {
     code: "IBM3769I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Argument to ${BUILTINname} built- in must have type CHARACTER(1) NONVARYING.`,
     fullCode: "IBM3769IS",
@@ -23556,7 +23555,7 @@ export const Severe = {
    */
   IBM3770I: {
     code: "IBM3770I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `First argument to ${BUILTINname} built-in must be an array.`,
     fullCode: "IBM3770IS",
@@ -23568,7 +23567,7 @@ export const Severe = {
    */
   IBM3771I: {
     code: "IBM3771I",
-    severity: "S",
+    severity: Severity.S,
     message: (note: string) => `${note}`,
     fullCode: "IBM3771IS",
   } as ParametricPLICode,
@@ -23580,7 +23579,7 @@ export const Severe = {
    */
   IBM3772I: {
     code: "IBM3772I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Third argument to ${BUILTINname} built-in would force STRINGRANGE.`,
     fullCode: "IBM3772IS",
@@ -23593,7 +23592,7 @@ export const Severe = {
    */
   IBM3773I: {
     code: "IBM3773I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Second argument to ${BUILTINname} built-in must be nonnegative.`,
     fullCode: "IBM3773IS",
@@ -23605,7 +23604,7 @@ export const Severe = {
    */
   IBM3774I: {
     code: "IBM3774I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Too few arguments have been specified for the ${BUILTINname} built-in.`,
     fullCode: "IBM3774IS",
@@ -23618,7 +23617,7 @@ export const Severe = {
    */
   IBM3775I: {
     code: "IBM3775I",
-    severity: "S",
+    severity: Severity.S,
     message: (preprocessorname: string) =>
       `The ${preprocessorname} preprocessor requires the DFT(EBCDIC) option.`,
     fullCode: "IBM3775IS",
@@ -23631,7 +23630,7 @@ export const Severe = {
    */
   IBM3778I: {
     code: "IBM3778I",
-    severity: "S",
+    severity: Severity.S,
     message: "Syntax of the %INCLUDE statement is incorrect.",
     fullCode: "IBM3778IS",
   } as SimplePLICode,
@@ -23642,7 +23641,7 @@ export const Severe = {
    */
   IBM3779I: {
     code: "IBM3779I",
-    severity: "S",
+    severity: Severity.S,
     message: "File specification after %INCLUDE is too long.",
     fullCode: "IBM3779IS",
   } as SimplePLICode,
@@ -23653,7 +23652,7 @@ export const Severe = {
    */
   IBM3780I: {
     code: "IBM3780I",
-    severity: "S",
+    severity: Severity.S,
     message: "File specification missing after %INCLUDE.",
     fullCode: "IBM3780IS",
   } as SimplePLICode,
@@ -23664,7 +23663,7 @@ export const Severe = {
    */
   IBM3781I: {
     code: "IBM3781I",
-    severity: "S",
+    severity: Severity.S,
     message: "Procedures may have no more than 63 parameters.",
     fullCode: "IBM3781IS",
   } as SimplePLICode,
@@ -23675,7 +23674,7 @@ export const Severe = {
    */
   IBM3782I: {
     code: "IBM3782I",
-    severity: "S",
+    severity: Severity.S,
     message: "SQL TYPE IS XML must be followed by the keyword AS.",
     fullCode: "IBM3782IS",
   } as SimplePLICode,
@@ -23686,7 +23685,7 @@ export const Severe = {
    */
   IBM3783I: {
     code: "IBM3783I",
-    severity: "S",
+    severity: Severity.S,
     message: "SQL TYPE IS XML AS must be followed by a valid type name.",
     fullCode: "IBM3783IS",
   } as SimplePLICode,
@@ -23697,7 +23696,7 @@ export const Severe = {
    */
   IBM3784I: {
     code: "IBM3784I",
-    severity: "S",
+    severity: Severity.S,
     message: "SQL TYPE IS TABLE must be followed by the keyword LIKE.",
     fullCode: "IBM3784IS",
   } as SimplePLICode,
@@ -23708,7 +23707,7 @@ export const Severe = {
    */
   IBM3785I: {
     code: "IBM3785I",
-    severity: "S",
+    severity: Severity.S,
     message: "SQL TYPE IS TABLE LIKE must be followed by a table name.",
     fullCode: "IBM3785IS",
   } as SimplePLICode,
@@ -23719,7 +23718,7 @@ export const Severe = {
    */
   IBM3786I: {
     code: "IBM3786I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "SQL TYPE IS TABLE LIKE must be followed by the keyword AS after the table name.",
     fullCode: "IBM3786IS",
@@ -23731,7 +23730,7 @@ export const Severe = {
    */
   IBM3787I: {
     code: "IBM3787I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "SQL TYPE IS TABLE must be followed by the keyword LOCATOR after the table name and the AS keyword.",
     fullCode: "IBM3787IS",
@@ -23743,7 +23742,7 @@ export const Severe = {
    */
   IBM3788I: {
     code: "IBM3788I",
-    severity: "S",
+    severity: Severity.S,
     message: "SQL TYPE IS must be followed by a valid type name.",
     fullCode: "IBM3788IS",
   } as SimplePLICode,
@@ -23758,7 +23757,7 @@ export const Severe = {
    */
   IBM3789I: {
     code: "IBM3789I",
-    severity: "S",
+    severity: Severity.S,
     message: (indexnumber: string, variablename: string) =>
       `Index number ${indexnumber} into the variable ${variablename} is less than the lower bound for that dimension.`,
     fullCode: "IBM3789IS",
@@ -23774,7 +23773,7 @@ export const Severe = {
    */
   IBM3790I: {
     code: "IBM3790I",
-    severity: "S",
+    severity: Severity.S,
     message: (indexnumber: string, variablename: string) =>
       `Index number ${indexnumber} into the variable ${variablename} is greater than the upper bound for that dimension.`,
     fullCode: "IBM3790IS",
@@ -23787,7 +23786,7 @@ export const Severe = {
    */
   IBM3791I: {
     code: "IBM3791I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Each dimension of an array must contain no more than 2147483647 elements.",
     fullCode: "IBM3791IS",
@@ -23799,7 +23798,7 @@ export const Severe = {
    */
   IBM3792I: {
     code: "IBM3792I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `Array ${variablename} has too many elements. Bounds set to 1.`,
     fullCode: "IBM3792IS",
@@ -23812,7 +23811,7 @@ export const Severe = {
    */
   IBM3793I: {
     code: "IBM3793I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `Too few subscripts specified for the variable ${variablename} .`,
     fullCode: "IBM3793IS",
@@ -23825,7 +23824,7 @@ export const Severe = {
    */
   IBM3794I: {
     code: "IBM3794I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `Too many subscripts specified for the variable ${variablename} .`,
     fullCode: "IBM3794IS",
@@ -23838,7 +23837,7 @@ export const Severe = {
    */
   IBM3795I: {
     code: "IBM3795I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Shift-out code has no closing shift- in code before the right margin.",
     fullCode: "IBM3795IS",
@@ -23850,7 +23849,7 @@ export const Severe = {
    */
   IBM3796I: {
     code: "IBM3796I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Array expressions cannot be assigned to non-arrays, and if any target in a multiple assignment is an array, then all the targets must be arrays.",
     fullCode: "IBM3796IS",
@@ -23867,7 +23866,7 @@ export const Severe = {
    */
   IBM3797I: {
     code: "IBM3797I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "RETURN statement without an expression is invalid inside a PROCEDURE that specified the RETURNS attribute.",
     fullCode: "IBM3797IS",
@@ -23885,7 +23884,7 @@ export const Severe = {
    */
   IBM3798I: {
     code: "IBM3798I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "RETURN statement with an expression is invalid inside a 168 PROCEDURE that did not specify the RETURNS attribute.",
     fullCode: "IBM3798IS",
@@ -23898,7 +23897,7 @@ export const Severe = {
    */
   IBM3799I: {
     code: "IBM3799I",
-    severity: "S",
+    severity: Severity.S,
     message: (reference: string) =>
       `The DECLARE statement for the host variable ${reference} is not inside an SQL DECLARE SECTION.`,
     fullCode: "IBM3799IS",
@@ -23910,7 +23909,7 @@ export const Severe = {
    */
   IBM3800I: {
     code: "IBM3800I",
-    severity: "S",
+    severity: Severity.S,
     message: (functionname: string) =>
       `Function ${functionname} contains no RETURN statement.`,
     fullCode: "IBM3800IS",
@@ -23923,7 +23922,7 @@ export const Severe = {
    */
   IBM3801I: {
     code: "IBM3801I",
-    severity: "S",
+    severity: Severity.S,
     message: "Target in assignment is invalid.",
     fullCode: "IBM3801IS",
   } as SimplePLICode,
@@ -23934,7 +23933,7 @@ export const Severe = {
    */
   IBM3802I: {
     code: "IBM3802I",
-    severity: "S",
+    severity: Severity.S,
     message: "Statement labels may not be used in expressions.",
     fullCode: "IBM3802IS",
   } as SimplePLICode,
@@ -23950,7 +23949,7 @@ export const Severe = {
    */
   IBM3803I: {
     code: "IBM3803I",
-    severity: "S",
+    severity: Severity.S,
     message: "Target in concatenate-equals assignment must have type char.",
     fullCode: "IBM3803IS",
   } as SimplePLICode,
@@ -23966,7 +23965,7 @@ export const Severe = {
    */
   IBM3804I: {
     code: "IBM3804I",
-    severity: "S",
+    severity: Severity.S,
     message: "Target in arithmetic-equals assignment must have type fixed.",
     fullCode: "IBM3804IS",
   } as SimplePLICode,
@@ -23977,7 +23976,7 @@ export const Severe = {
    */
   IBM3805I: {
     code: "IBM3805I",
-    severity: "S",
+    severity: Severity.S,
     message: (type: string) =>
       `SQL TYPE IS XML ${type} must be followed by the keyword LARGE.`,
     fullCode: "IBM3805IS",
@@ -23989,7 +23988,7 @@ export const Severe = {
    */
   IBM3806I: {
     code: "IBM3806I",
-    severity: "S",
+    severity: Severity.S,
     message: (type: string) =>
       `SQL TYPE IS XML ${type} LARGE must be followed by the keyword OBJECT.`,
     fullCode: "IBM3806IS",
@@ -24001,7 +24000,7 @@ export const Severe = {
    */
   IBM3807I: {
     code: "IBM3807I",
-    severity: "S",
+    severity: Severity.S,
     message: "SQL TYPE IS CHARACTER must be followed by the keyword LARGE.",
     fullCode: "IBM3807IS",
   } as SimplePLICode,
@@ -24013,7 +24012,7 @@ export const Severe = {
    */
   IBM3808I: {
     code: "IBM3808I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "SQL TYPE IS BINARY must be followed by the keyword LARGE or by a length enclosed in parentheses.",
     fullCode: "IBM3808IS",
@@ -24025,7 +24024,7 @@ export const Severe = {
    */
   IBM3809I: {
     code: "IBM3809I",
-    severity: "S",
+    severity: Severity.S,
     message: (type: string) =>
       `SQL TYPE IS ${type} LARGE must be followed by the keyword OBJECT.`,
     fullCode: "IBM3809IS",
@@ -24038,7 +24037,7 @@ export const Severe = {
    */
   IBM3810I: {
     code: "IBM3810I",
-    severity: "S",
+    severity: Severity.S,
     message: "Statement has too many labels.",
     fullCode: "IBM3810IS",
   } as SimplePLICode,
@@ -24050,7 +24049,7 @@ export const Severe = {
    */
   IBM3811I: {
     code: "IBM3811I",
-    severity: "S",
+    severity: Severity.S,
     message: "Expression contains too many nested subexpressions.",
     fullCode: "IBM3811IS",
   } as SimplePLICode,
@@ -24062,7 +24061,7 @@ export const Severe = {
    */
   IBM3812I: {
     code: "IBM3812I",
-    severity: "S",
+    severity: Severity.S,
     message: (stringlength: string, stringlength2: string) =>
       `Result of concatenating a string of length ${stringlength} to a string of length ${stringlength2} would produce a string that is too long.`,
     fullCode: "IBM3812IS",
@@ -24075,7 +24074,7 @@ export const Severe = {
    */
   IBM3813I: {
     code: "IBM3813I",
-    severity: "S",
+    severity: Severity.S,
     message: (
       BUILTINname: string,
       repetitionvalue: string,
@@ -24092,7 +24091,7 @@ export const Severe = {
    */
   IBM3814I: {
     code: "IBM3814I",
-    severity: "S",
+    severity: Severity.S,
     message: "Unsupported use of aggregate expression.",
     fullCode: "IBM3814IS",
   } as SimplePLICode,
@@ -24103,7 +24102,7 @@ export const Severe = {
    */
   IBM3815I: {
     code: "IBM3815I",
-    severity: "S",
+    severity: Severity.S,
     message: "Operand in bit operation must have length less than 32768.",
     fullCode: "IBM3815IS",
   } as SimplePLICode,
@@ -24115,7 +24114,7 @@ export const Severe = {
    */
   IBM3816I: {
     code: "IBM3816I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Second and third arguments to the TRANSLATE built-in function must have length less than 32768.",
     fullCode: "IBM3816IS",
@@ -24128,7 +24127,7 @@ export const Severe = {
    */
   IBM3817I: {
     code: "IBM3817I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Result of ${BUILTINname} would exceed maximum string length.`,
     fullCode: "IBM3817IS",
@@ -24141,7 +24140,7 @@ export const Severe = {
    */
   IBM3820I: {
     code: "IBM3820I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Under the INCONLY option, the use of INCLUDE or XINCLUDE as a macro procedure name is invalid unless the colon follows immediately after the name.",
     fullCode: "IBM3820IS",
@@ -24154,7 +24153,7 @@ export const Severe = {
    */
   IBM3821I: {
     code: "IBM3821I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Under the INCONLY option, the use of INCLUDE or XINCLUDE as a macro statement label is invalid unless the colon follows immediately after the name.",
     fullCode: "IBM3821IS",
@@ -24173,7 +24172,7 @@ export const Severe = {
    */
   IBM3822I: {
     code: "IBM3822I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Under the INCONLY option, the use of INCLUDE or XINCLUDE as a macro variable that is the target of an assignment is invalid unless the equals sign follows immediately after the name.",
     fullCode: "IBM3822IS",
@@ -24185,7 +24184,7 @@ export const Severe = {
    */
   IBM3823I: {
     code: "IBM3823I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "A QUALIFY block may contain only DEFINE statements, DECLARE 170 statements, and nested QUALIFY blocks.",
     fullCode: "IBM3823IS",
@@ -24198,7 +24197,7 @@ export const Severe = {
    */
   IBM3824I: {
     code: "IBM3824I",
-    severity: "S",
+    severity: Severity.S,
     message: "A name declared in a QUALIFY block must be a scalar.",
     fullCode: "IBM3824IS",
   } as SimplePLICode,
@@ -24210,7 +24209,7 @@ export const Severe = {
    */
   IBM3825I: {
     code: "IBM3825I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "A name declared in a QUALIFY block must have the VALUE attribute.",
     fullCode: "IBM3825IS",
@@ -24222,7 +24221,7 @@ export const Severe = {
    */
   IBM3826I: {
     code: "IBM3826I",
-    severity: "S",
+    severity: Severity.S,
     message: (typename: string) => `The type name ${typename} is ambiguous.`,
     fullCode: "IBM3826IS",
   } as ParametricPLICode,
@@ -24234,7 +24233,7 @@ export const Severe = {
    */
   IBM3827I: {
     code: "IBM3827I",
-    severity: "S",
+    severity: Severity.S,
     message: (typename: string) =>
       `${typename} is a type name, but not the name of an ORDINAL type.`,
     fullCode: "IBM3827IS",
@@ -24247,7 +24246,7 @@ export const Severe = {
    */
   IBM3837I: {
     code: "IBM3837I",
-    severity: "S",
+    severity: Severity.S,
     message: "GOTO target is inside a (different) DO loop.",
     fullCode: "IBM3837IS",
   } as SimplePLICode,
@@ -24258,7 +24257,7 @@ export const Severe = {
    */
   IBM3841I: {
     code: "IBM3841I",
-    severity: "S",
+    severity: Severity.S,
     message: (includefilename: string) =>
       `The INCLUDE file ${includefilename} could not be opened.`,
     fullCode: "IBM3841IS",
@@ -24271,7 +24270,7 @@ export const Severe = {
    */
   IBM3842I: {
     code: "IBM3842I",
-    severity: "S",
+    severity: Severity.S,
     message: "Statements are nested too deep.",
     fullCode: "IBM3842IS",
   } as SimplePLICode,
@@ -24282,7 +24281,7 @@ export const Severe = {
    */
   IBM3844I: {
     code: "IBM3844I",
-    severity: "S",
+    severity: Severity.S,
     message: (functionname: string) =>
       `The ${functionname} built-in is not supported.`,
     fullCode: "IBM3844IS",
@@ -24294,7 +24293,7 @@ export const Severe = {
    */
   IBM3846I: {
     code: "IBM3846I",
-    severity: "S",
+    severity: Severity.S,
     message: (keyword: string) => `The ${keyword} statement is not supported.`,
     fullCode: "IBM3846IS",
   } as ParametricPLICode,
@@ -24305,7 +24304,7 @@ export const Severe = {
    */
   IBM3848I: {
     code: "IBM3848I",
-    severity: "S",
+    severity: Severity.S,
     message: "Use of iSUB is not supported.",
     fullCode: "IBM3848IS",
   } as SimplePLICode,
@@ -24316,7 +24315,7 @@ export const Severe = {
    */
   IBM3849I: {
     code: "IBM3849I",
-    severity: "S",
+    severity: Severity.S,
     message: (typename: string) => `${typename} is not a type name.`,
     fullCode: "IBM3849IS",
   } as ParametricPLICode,
@@ -24336,7 +24335,7 @@ export const Severe = {
    */
   IBM3850I: {
     code: "IBM3850I",
-    severity: "S",
+    severity: Severity.S,
     message: "TYPEs must be defined before their use.",
     fullCode: "IBM3850IS",
   } as SimplePLICode,
@@ -24348,7 +24347,7 @@ export const Severe = {
    */
   IBM3851I: {
     code: "IBM3851I",
-    severity: "S",
+    severity: Severity.S,
     message: (typetype: string, typename: string) =>
       `INITIAL values for ${typetype} type ${typename} must be in increasing order.`,
     fullCode: "IBM3851IS",
@@ -24360,7 +24359,7 @@ export const Severe = {
    */
   IBM3852I: {
     code: "IBM3852I",
-    severity: "S",
+    severity: Severity.S,
     message: (typetype: string, typename: string) =>
       `INITIAL values for ${typetype} type ${typename} must be less than 2G.`,
     fullCode: "IBM3852IS",
@@ -24372,7 +24371,7 @@ export const Severe = {
    */
   IBM3853I: {
     code: "IBM3853I",
-    severity: "S",
+    severity: Severity.S,
     message: "Nesting of DO statements exceeds the maximum.",
     fullCode: "IBM3853IS",
   } as SimplePLICode,
@@ -24383,7 +24382,7 @@ export const Severe = {
    */
   IBM3854I: {
     code: "IBM3854I",
-    severity: "S",
+    severity: Severity.S,
     message: "Nesting of IF statements exceeds the maximum.",
     fullCode: "IBM3854IS",
   } as SimplePLICode,
@@ -24394,7 +24393,7 @@ export const Severe = {
    */
   IBM3855I: {
     code: "IBM3855I",
-    severity: "S",
+    severity: Severity.S,
     message: "Nesting of SELECT statements exceeds the maximum.",
     fullCode: "IBM3855IS",
   } as SimplePLICode,
@@ -24405,7 +24404,7 @@ export const Severe = {
    */
   IBM3856I: {
     code: "IBM3856I",
-    severity: "S",
+    severity: Severity.S,
     message: "Nesting of blocks exceeds the maximum.",
     fullCode: "IBM3856IS",
   } as SimplePLICode,
@@ -24427,7 +24426,7 @@ export const Severe = {
    */
   IBM3857I: {
     code: "IBM3857I",
-    severity: "S",
+    severity: Severity.S,
     message: "Only one description is allowed in a structure definition.",
     fullCode: "IBM3857IS",
   } as SimplePLICode,
@@ -24439,7 +24438,7 @@ export const Severe = {
    */
   IBM3858I: {
     code: "IBM3858I",
-    severity: "S",
+    severity: Severity.S,
     message: (ordinalname: string) =>
       `All the names in the ORDINAL ${ordinalname} have been previously declared.`,
     fullCode: "IBM3858IS",
@@ -24452,7 +24451,7 @@ export const Severe = {
    */
   IBM3859I: {
     code: "IBM3859I",
-    severity: "S",
+    severity: Severity.S,
     message: "Storage attributes are invalid in structure definition.",
     fullCode: "IBM3859IS",
   } as SimplePLICode,
@@ -24463,7 +24462,7 @@ export const Severe = {
    */
   IBM3860I: {
     code: "IBM3860I",
-    severity: "S",
+    severity: Severity.S,
     message: "DEFINE STRUCTURE may not specify an array of structures.",
     fullCode: "IBM3860IS",
   } as SimplePLICode,
@@ -24475,7 +24474,7 @@ export const Severe = {
    */
   IBM3861I: {
     code: "IBM3861I",
-    severity: "S",
+    severity: Severity.S,
     message: "Open of dbrm dataset failed.",
     fullCode: "IBM3861IS",
   } as SimplePLICode,
@@ -24487,7 +24486,7 @@ export const Severe = {
    */
   IBM3862I: {
     code: "IBM3862I",
-    severity: "S",
+    severity: Severity.S,
     message: (infocode: string, errorcode: string) =>
       `Dynamic allocation of DBRMLIB failed with the SVC 99 info code ${infocode} and the SVC 99 error code ${errorcode} .`,
     fullCode: "IBM3862IS",
@@ -24500,7 +24499,7 @@ export const Severe = {
    */
   IBM3863I: {
     code: "IBM3863I",
-    severity: "S",
+    severity: Severity.S,
     message: "The DBRMLIB compiler option must be specified.",
     fullCode: "IBM3863IS",
   } as SimplePLICode,
@@ -24511,7 +24510,7 @@ export const Severe = {
    */
   IBM3870I: {
     code: "IBM3870I",
-    severity: "S",
+    severity: Severity.S,
     message: "The FETCH of the CICS backend failed.",
     fullCode: "IBM3870IS",
   } as SimplePLICode,
@@ -24522,7 +24521,7 @@ export const Severe = {
    */
   IBM3871I: {
     code: "IBM3871I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The CICS backend reported an internal error while attempting to perform its initialization.",
     fullCode: "IBM3871IS",
@@ -24534,7 +24533,7 @@ export const Severe = {
    */
   IBM3872I: {
     code: "IBM3872I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The CICS backend reported an internal error while attempting to parse its options.",
     fullCode: "IBM3872IS",
@@ -24546,7 +24545,7 @@ export const Severe = {
    */
   IBM3873I: {
     code: "IBM3873I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The CICS backend reported an internal error while attempting to build and emit the local declares.",
     fullCode: "IBM3873IS",
@@ -24558,7 +24557,7 @@ export const Severe = {
    */
   IBM3874I: {
     code: "IBM3874I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The CICS backend reported an internal error while attempting to translate an EXEC statement.",
     fullCode: "IBM3874IS",
@@ -24570,7 +24569,7 @@ export const Severe = {
    */
   IBM3875I: {
     code: "IBM3875I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The CICS backend reported an internal error while attempting to translate a CICS macro (such as DFHVALUE).",
     fullCode: "IBM3875IS",
@@ -24582,7 +24581,7 @@ export const Severe = {
    */
   IBM3876I: {
     code: "IBM3876I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The CICS backend reported an internal error while attempting to perform its termination.",
     fullCode: "IBM3876IS",
@@ -24594,7 +24593,7 @@ export const Severe = {
    */
   IBM3877I: {
     code: "IBM3877I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The SQL backend reported an internal error while attempting to perform its initialization.",
     fullCode: "IBM3877IS",
@@ -24606,7 +24605,7 @@ export const Severe = {
    */
   IBM3878I: {
     code: "IBM3878I",
-    severity: "S",
+    severity: Severity.S,
     message: "SQL initialization did not complete successfully.",
     fullCode: "IBM3878IS",
   } as SimplePLICode,
@@ -24617,7 +24616,7 @@ export const Severe = {
    */
   IBM3880I: {
     code: "IBM3880I",
-    severity: "S",
+    severity: Severity.S,
     message: (reference: string) =>
       `The reference ${reference} could not be resolved.`,
     fullCode: "IBM3880IS",
@@ -24630,7 +24629,7 @@ export const Severe = {
    */
   IBM3881I: {
     code: "IBM3881I",
-    severity: "S",
+    severity: Severity.S,
     message: (reference: string) => `The reference ${reference} is ambiguous.`,
     fullCode: "IBM3881IS",
   } as ParametricPLICode,
@@ -24641,7 +24640,7 @@ export const Severe = {
    */
   IBM3882I: {
     code: "IBM3882I",
-    severity: "S",
+    severity: Severity.S,
     message: (reference: string) =>
       `The indicator array ${reference} must have only one dimension.`,
     fullCode: "IBM3882IS",
@@ -24654,7 +24653,7 @@ export const Severe = {
    */
   IBM3883I: {
     code: "IBM3883I",
-    severity: "S",
+    severity: Severity.S,
     message: (reference: string) =>
       `The indicator array ${reference} must have constant bounds.`,
     fullCode: "IBM3883IS",
@@ -24667,7 +24666,7 @@ export const Severe = {
    */
   IBM3884I: {
     code: "IBM3884I",
-    severity: "S",
+    severity: Severity.S,
     message: (reference: string) =>
       `The indicator variable ${reference} is used with a structure and hence must be an array or a structure.`,
     fullCode: "IBM3884IS",
@@ -24679,7 +24678,7 @@ export const Severe = {
    */
   IBM3885I: {
     code: "IBM3885I",
-    severity: "S",
+    severity: Severity.S,
     message: (hostvariable: string) =>
       `The host variable ${hostvariable} must have only one dimension.`,
     fullCode: "IBM3885IS",
@@ -24692,7 +24691,7 @@ export const Severe = {
    */
   IBM3886I: {
     code: "IBM3886I",
-    severity: "S",
+    severity: Severity.S,
     message: (hostvariable: string) =>
       `The host variable ${hostvariable} must have constant bounds.`,
     fullCode: "IBM3886IS",
@@ -24706,7 +24705,7 @@ export const Severe = {
    */
   IBM3887I: {
     code: "IBM3887I",
-    severity: "S",
+    severity: Severity.S,
     message: (hostvariable: string) =>
       `The host variable ${hostvariable} must be CONNECTED.`,
     fullCode: "IBM3887IS",
@@ -24720,7 +24719,7 @@ export const Severe = {
    */
   IBM3888I: {
     code: "IBM3888I",
-    severity: "S",
+    severity: Severity.S,
     message: (hostreference: string) =>
       `The reference ${hostreference} has no corresponding DB2 type.`,
     fullCode: "IBM3888IS",
@@ -24733,7 +24732,7 @@ export const Severe = {
    */
   IBM3889I: {
     code: "IBM3889I",
-    severity: "S",
+    severity: Severity.S,
     message: (hostreference: string) =>
       `The reference ${hostreference} is a union and thus must not be used as a host variable.`,
     fullCode: "IBM3889IS",
@@ -24745,7 +24744,7 @@ export const Severe = {
    */
   IBM3890I: {
     code: "IBM3890I",
-    severity: "S",
+    severity: Severity.S,
     message: (hostreference: string) =>
       `The reference ${hostreference} is an array of structures and thus must not be used as a host variable.`,
     fullCode: "IBM3890IS",
@@ -24758,7 +24757,7 @@ export const Severe = {
    */
   IBM3891I: {
     code: "IBM3891I",
-    severity: "S",
+    severity: Severity.S,
     message: (hostreference: string) =>
       `Since the structure reference ${hostreference} contains an array, it must not have an indicator that is a scalar or an array of scalars.`,
     fullCode: "IBM3891IS",
@@ -24771,7 +24770,7 @@ export const Severe = {
    */
   IBM3892I: {
     code: "IBM3892I",
-    severity: "S",
+    severity: Severity.S,
     message: (hostreference: string) =>
       `The reference ${hostreference} contains a substructure and thus must not be used as a host variable.`,
     fullCode: "IBM3892IS",
@@ -24783,7 +24782,7 @@ export const Severe = {
    */
   IBM3893I: {
     code: "IBM3893I",
-    severity: "S",
+    severity: Severity.S,
     message: (hostreference: string) =>
       `The reference ${hostreference} contains unnamed elements and thus must not be used as a host variable.`,
     fullCode: "IBM3893IS",
@@ -24795,7 +24794,7 @@ export const Severe = {
    */
   IBM3894I: {
     code: "IBM3894I",
-    severity: "S",
+    severity: Severity.S,
     message: (reference: string) =>
       `The indicator variable ${reference} must be FIXED BIN(15).`,
     fullCode: "IBM3894IS",
@@ -24808,7 +24807,7 @@ export const Severe = {
    */
   IBM3895I: {
     code: "IBM3895I",
-    severity: "S",
+    severity: Severity.S,
     message: (reference: string) =>
       `The indicator variable ${reference} is used with an array and hence must be an array as well.`,
     fullCode: "IBM3895IS",
@@ -24822,7 +24821,7 @@ export const Severe = {
    */
   IBM3896I: {
     code: "IBM3896I",
-    severity: "S",
+    severity: Severity.S,
     message: (hostreference: string) =>
       `The VALUE reference ${hostreference} could not be reduced to a character literal and thus must not be used as a host variable.`,
     fullCode: "IBM3896IS",
@@ -24836,7 +24835,7 @@ export const Severe = {
    */
   IBM3897I: {
     code: "IBM3897I",
-    severity: "S",
+    severity: Severity.S,
     message: (hostreference: string) =>
       `The VALUE reference ${hostreference} could not be reduced to a numeric literal and thus must not be used as a host variable.`,
     fullCode: "IBM3897IS",
@@ -24849,7 +24848,7 @@ export const Severe = {
    */
   IBM3898I: {
     code: "IBM3898I",
-    severity: "S",
+    severity: Severity.S,
     message: (hostreference: string) =>
       `The VALUE reference ${hostreference} does not have character, integer or decimal type and thus must not be used as a host variable.`,
     fullCode: "IBM3898IS",
@@ -24861,7 +24860,7 @@ export const Severe = {
    */
   IBM3899I: {
     code: "IBM3899I",
-    severity: "S",
+    severity: Severity.S,
     message: (referencename: string) =>
       `The reference ${referencename} is ambiguous.`,
     fullCode: "IBM3899IS",
@@ -24874,7 +24873,7 @@ export const Severe = {
    */
   IBM3900I: {
     code: "IBM3900I",
-    severity: "S",
+    severity: Severity.S,
     message: (referencename: string) =>
       `The dot-qualified reference ${referencename} is unknown.`,
     fullCode: "IBM3900IS",
@@ -24888,7 +24887,7 @@ export const Severe = {
    */
   IBM3901I: {
     code: "IBM3901I",
-    severity: "S",
+    severity: Severity.S,
     message: (referencename: string) =>
       `The element ${referencename} in the indicator structure must have the same array bounds as the corresponding element in the host structure.`,
     fullCode: "IBM3901IS",
@@ -24900,7 +24899,7 @@ export const Severe = {
    */
   IBM3902I: {
     code: "IBM3902I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINname: string) =>
       `Argument to the ${BUILTINname} built-in must be a structure.`,
     fullCode: "IBM3902IS",
@@ -24912,7 +24911,7 @@ export const Severe = {
    */
   IBM3903I: {
     code: "IBM3903I",
-    severity: "S",
+    severity: Severity.S,
     message: (referencename: string) =>
       `The indicator ${referencename} must not be a uinon.`,
     fullCode: "IBM3903IS",
@@ -24924,7 +24923,7 @@ export const Severe = {
    */
   IBM3909I: {
     code: "IBM3909I",
-    severity: "S",
+    severity: Severity.S,
     message: (attribute: string, attribute2: string) =>
       `The ${attribute} attribute conflicts with the ${attribute2} attribute.`,
     fullCode: "IBM3909IS",
@@ -24936,7 +24935,7 @@ export const Severe = {
    */
   IBM3911I: {
     code: "IBM3911I",
-    severity: "S",
+    severity: Severity.S,
     message: (identifier: string) =>
       `The statement label ${identifier} has already been declared.`,
     fullCode: "IBM3911IS",
@@ -24948,7 +24947,7 @@ export const Severe = {
    */
   IBM3914I: {
     code: "IBM3914I",
-    severity: "S",
+    severity: Severity.S,
     message: "GOTO target must be a LABEL reference.",
     fullCode: "IBM3914IS",
   } as SimplePLICode,
@@ -24959,7 +24958,7 @@ export const Severe = {
    */
   IBM3915I: {
     code: "IBM3915I",
-    severity: "S",
+    severity: Severity.S,
     message: "GOTO target must be a scalar.",
     fullCode: "IBM3915IS",
   } as SimplePLICode,
@@ -24976,7 +24975,7 @@ export const Severe = {
    */
   IBM3916I: {
     code: "IBM3916I",
-    severity: "S",
+    severity: Severity.S,
     message: (procname: string) =>
       `The procedure ${procname} has already been defined.`,
     fullCode: "IBM3916IS",
@@ -24989,7 +24988,7 @@ export const Severe = {
    */
   IBM3917I: {
     code: "IBM3917I",
-    severity: "S",
+    severity: Severity.S,
     message: "Program contains no valid source lines.",
     fullCode: "IBM3917IS",
   } as SimplePLICode,
@@ -25000,7 +24999,7 @@ export const Severe = {
    */
   IBM3920I: {
     code: "IBM3920I",
-    severity: "S",
+    severity: Severity.S,
     message: "FIXED BINARY constant contains too many digits.",
     fullCode: "IBM3920IS",
   } as SimplePLICode,
@@ -25012,7 +25011,7 @@ export const Severe = {
    */
   IBM3921I: {
     code: "IBM3921I",
-    severity: "S",
+    severity: Severity.S,
     message: "FIXED DECIMAL constant contains too many significant digits.",
     fullCode: "IBM3921IS",
   } as SimplePLICode,
@@ -25023,7 +25022,7 @@ export const Severe = {
    */
   IBM3922I: {
     code: "IBM3922I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Exponent in FLOAT BINARY constant contains more digits than the implementation maximum.",
     fullCode: "IBM3922IS",
@@ -25035,7 +25034,7 @@ export const Severe = {
    */
   IBM3923I: {
     code: "IBM3923I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Mantissa in FLOAT BINARY constant contains more significant digits than the implementation maximum.",
     fullCode: "IBM3923IS",
@@ -25047,7 +25046,7 @@ export const Severe = {
    */
   IBM3924I: {
     code: "IBM3924I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Exponent in FLOAT DECIMAL constant contains more digits than the implementation maximum.",
     fullCode: "IBM3924IS",
@@ -25059,7 +25058,7 @@ export const Severe = {
    */
   IBM3925I: {
     code: "IBM3925I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Mantissa in FLOAT DECIMAL constant contains more significant digits than the implementation maximum.",
     fullCode: "IBM3925IS",
@@ -25074,7 +25073,7 @@ export const Severe = {
    */
   IBM3926I: {
     code: "IBM3926I",
-    severity: "S",
+    severity: Severity.S,
     message: "Constants must not exceed 30720 bytes.",
     fullCode: "IBM3926IS",
   } as SimplePLICode,
@@ -25089,7 +25088,7 @@ export const Severe = {
    */
   IBM3927I: {
     code: "IBM3927I",
-    severity: "S",
+    severity: Severity.S,
     message: "Numeric constants must be real, unscaled and fixed.",
     fullCode: "IBM3927IS",
   } as SimplePLICode,
@@ -25103,7 +25102,7 @@ export const Severe = {
    */
   IBM3928I: {
     code: "IBM3928I",
-    severity: "S",
+    severity: Severity.S,
     message: "Only B, BX and X string suffixes are supported.",
     fullCode: "IBM3928IS",
   } as SimplePLICode,
@@ -25116,7 +25115,7 @@ export const Severe = {
    */
   IBM3929I: {
     code: "IBM3929I",
-    severity: "S",
+    severity: Severity.S,
     message: "EXEC SQL statement must be in a PROCEDURE.",
     fullCode: "IBM3929IS",
   } as SimplePLICode,
@@ -25138,7 +25137,7 @@ export const Severe = {
    */
   IBM3930I: {
     code: "IBM3930I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Invalid syntax in statement-form of procedure invocation. Text up to next semicolon will be ignored.",
     fullCode: "IBM3930IS",
@@ -25151,7 +25150,7 @@ export const Severe = {
    */
   IBM3931I: {
     code: "IBM3931I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Under the FIXED(DEC) option, decimal constants must have no more than 5 digits.",
     fullCode: "IBM3931IS",
@@ -25163,7 +25162,7 @@ export const Severe = {
    */
   IBM3934I: {
     code: "IBM3934I",
-    severity: "S",
+    severity: Severity.S,
     message: "EXEC SQL INCLUDE statement has incorrect syntax.",
     fullCode: "IBM3934IS",
   } as SimplePLICode,
@@ -25174,7 +25173,7 @@ export const Severe = {
    */
   IBM3935I: {
     code: "IBM3935I",
-    severity: "S",
+    severity: Severity.S,
     message: "The FETCH of the SQL backend failed.",
     fullCode: "IBM3935IS",
   } as SimplePLICode,
@@ -25185,7 +25184,7 @@ export const Severe = {
    */
   IBM3936I: {
     code: "IBM3936I",
-    severity: "S",
+    severity: Severity.S,
     message: "The SQL backend must be from DB2 V9 or later.",
     fullCode: "IBM3936IS",
   } as SimplePLICode,
@@ -25196,7 +25195,7 @@ export const Severe = {
    */
   IBM3937I: {
     code: "IBM3937I",
-    severity: "S",
+    severity: Severity.S,
     message: "EXEC SQL statement is too long.",
     fullCode: "IBM3937IS",
   } as SimplePLICode,
@@ -25209,7 +25208,7 @@ export const Severe = {
    */
   IBM3938I: {
     code: "IBM3938I",
-    severity: "S",
+    severity: Severity.S,
     message: "EXEC SQL statement has too many host variable references.",
     fullCode: "IBM3938IS",
   } as SimplePLICode,
@@ -25221,7 +25220,7 @@ export const Severe = {
    */
   IBM3939I: {
     code: "IBM3939I",
-    severity: "S",
+    severity: Severity.S,
     message: "The DBNAME option must specify a valid database name.",
     fullCode: "IBM3939IS",
   } as SimplePLICode,
@@ -25233,7 +25232,7 @@ export const Severe = {
    */
   IBM3943I: {
     code: "IBM3943I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "The number of error messages allowed by the FLAG option has been exceeded.",
     fullCode: "IBM3943IS",
@@ -25248,7 +25247,7 @@ export const Severe = {
    */
   IBM3948I: {
     code: "IBM3948I",
-    severity: "S",
+    severity: Severity.S,
     message: (conditionname: string, oncodevalue: string) =>
       `${conditionname} condition with ONCODE= ${oncodevalue} raised while evaluating expression.`,
     fullCode: "IBM3948IS",
@@ -25263,7 +25262,7 @@ export const Severe = {
    */
   IBM3949I: {
     code: "IBM3949I",
-    severity: "S",
+    severity: Severity.S,
     message: (identifier: string) =>
       `Parameter name ${identifier} appears more than once in parameter list.`,
     fullCode: "IBM3949IS",
@@ -25279,7 +25278,7 @@ export const Severe = {
    */
   IBM3950I: {
     code: "IBM3950I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `An asterisk iteration factor can be applied only to the last expression in the INITIAL item list for ${variablename} .`,
     fullCode: "IBM3950IS",
@@ -25295,7 +25294,7 @@ export const Severe = {
    */
   IBM3951I: {
     code: "IBM3951I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `An asterisk iteration factor cannot be used in the nested INITIAL item list for ${variablename} .`,
     fullCode: "IBM3951IS",
@@ -25307,7 +25306,7 @@ export const Severe = {
    */
   IBM3952I: {
     code: "IBM3952I",
-    severity: "S",
+    severity: Severity.S,
     message: (variablename: string) =>
       `INITIAL attribute on the parameter ${variablename} is invalid.`,
     fullCode: "IBM3952IS",
@@ -25323,7 +25322,7 @@ export const Severe = {
    */
   IBM3953I: {
     code: "IBM3953I",
-    severity: "S",
+    severity: Severity.S,
     message: (count: string, variablename: string, arraysize: string) =>
       `INITIAL list contains ${count} items, but the array ${variablename} contains only ${arraysize} . Excess is ignored.`,
     fullCode: "IBM3953IS",
@@ -25335,7 +25334,7 @@ export const Severe = {
    */
   IBM3956I: {
     code: "IBM3956I",
-    severity: "S",
+    severity: Severity.S,
     message: "ITERATE is valid only for iterative DO-groups.",
     fullCode: "IBM3956IS",
   } as SimplePLICode,
@@ -25346,7 +25345,7 @@ export const Severe = {
    */
   IBM3957I: {
     code: "IBM3957I",
-    severity: "S",
+    severity: Severity.S,
     message: "RETURN statement outside of a PROCEDURE is invalid.",
     fullCode: "IBM3957IS",
   } as SimplePLICode,
@@ -25362,7 +25361,7 @@ export const Severe = {
    */
   IBM3958I: {
     code: "IBM3958I",
-    severity: "S",
+    severity: Severity.S,
     message: "INCLUDE statement inside of a PROCEDURE is invalid.",
     fullCode: "IBM3958IS",
   } as SimplePLICode,
@@ -25373,7 +25372,7 @@ export const Severe = {
    */
   IBM3959I: {
     code: "IBM3959I",
-    severity: "S",
+    severity: Severity.S,
     message: "Length of parameter exceeds 32767 bytes.",
     fullCode: "IBM3959IS",
   } as SimplePLICode,
@@ -25384,7 +25383,7 @@ export const Severe = {
    */
   IBM3960I: {
     code: "IBM3960I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "End-of-source has been encountered after an unmatched comment marker.",
     fullCode: "IBM3960IS",
@@ -25396,7 +25395,7 @@ export const Severe = {
    */
   IBM3961I: {
     code: "IBM3961I",
-    severity: "S",
+    severity: Severity.S,
     message: "End-of-source has been encountered after an unmatched quote.",
     fullCode: "IBM3961IS",
   } as SimplePLICode,
@@ -25407,7 +25406,7 @@ export const Severe = {
    */
   IBM3962I: {
     code: "IBM3962I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Replacement value contains no end-of-comment delimiter. A comment delimiter will be assumed at the end of the replacement value.",
     fullCode: "IBM3962IS",
@@ -25419,7 +25418,7 @@ export const Severe = {
    */
   IBM3963I: {
     code: "IBM3963I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Replacement value contains no end-of-string delimiter. A string delimiter will be assumed at the end of the replacement value.",
     fullCode: "IBM3963IS",
@@ -25431,7 +25430,7 @@ export const Severe = {
    */
   IBM3964I: {
     code: "IBM3964I",
-    severity: "S",
+    severity: Severity.S,
     message: "ANSWER statement outside of a PROCEDURE is invalid.",
     fullCode: "IBM3964IS",
   } as SimplePLICode,
@@ -25451,7 +25450,7 @@ export const Severe = {
    */
   IBM3965I: {
     code: "IBM3965I",
-    severity: "S",
+    severity: Severity.S,
     message: "ANSWER statement inside of a PROCEDURE with RETURNS is invalid.",
     fullCode: "IBM3965IS",
   } as SimplePLICode,
@@ -25477,7 +25476,7 @@ export const Severe = {
    */
   IBM3966I: {
     code: "IBM3966I",
-    severity: "S",
+    severity: Severity.S,
     message: "Source has caused too many rescans.",
     fullCode: "IBM3966IS",
   } as SimplePLICode,
@@ -25488,7 +25487,7 @@ export const Severe = {
    */
   IBM3967I: {
     code: "IBM3967I",
-    severity: "S",
+    severity: Severity.S,
     message: "CALL statement outside of a PROCEDURE is invalid.",
     fullCode: "IBM3967IS",
   } as SimplePLICode,
@@ -25499,7 +25498,7 @@ export const Severe = {
    */
   IBM3968I: {
     code: "IBM3968I",
-    severity: "S",
+    severity: Severity.S,
     message: "CALL reference is undefined.",
     fullCode: "IBM3968IS",
   } as SimplePLICode,
@@ -25510,7 +25509,7 @@ export const Severe = {
    */
   IBM3969I: {
     code: "IBM3969I",
-    severity: "S",
+    severity: Severity.S,
     message: "CALL reference is not a macro entry.",
     fullCode: "IBM3969IS",
   } as SimplePLICode,
@@ -25521,7 +25520,7 @@ export const Severe = {
    */
   IBM3970I: {
     code: "IBM3970I",
-    severity: "S",
+    severity: Severity.S,
     message: "CALL reference must not be a function.",
     fullCode: "IBM3970IS",
   } as SimplePLICode,
@@ -25532,7 +25531,7 @@ export const Severe = {
    */
   IBM3971I: {
     code: "IBM3971I",
-    severity: "S",
+    severity: Severity.S,
     message: "CALL reference must not have the STATEMENT option.",
     fullCode: "IBM3971IS",
   } as SimplePLICode,
@@ -25543,7 +25542,7 @@ export const Severe = {
    */
   IBM3972I: {
     code: "IBM3972I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "End-of-file has been encountered after an unmatched comment marker.",
     fullCode: "IBM3972IS",
@@ -25555,7 +25554,7 @@ export const Severe = {
    */
   IBM3973I: {
     code: "IBM3973I",
-    severity: "S",
+    severity: Severity.S,
     message: "End-of-file has been encountered after an unmatched quote.",
     fullCode: "IBM3973IS",
   } as SimplePLICode,
@@ -25566,7 +25565,7 @@ export const Severe = {
    */
   IBM3974I: {
     code: "IBM3974I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Every shift-in character after the left margin of a source line must have a matching shift-out character before the right margin of the same line.",
     fullCode: "IBM3974IS",
@@ -25578,7 +25577,7 @@ export const Severe = {
    */
   IBM3975I: {
     code: "IBM3975I",
-    severity: "S",
+    severity: Severity.S,
     message:
       "Every shift-in character within a string generated for rescan must have a matching shift-out character within that same string.",
     fullCode: "IBM3975IS",
@@ -25592,7 +25591,7 @@ export const Severe = {
    */
   IBM3976I: {
     code: "IBM3976I",
-    severity: "S",
+    severity: Severity.S,
     message: "DBCS characters are allowed only in G and M constants.",
     fullCode: "IBM3976IS",
   } as SimplePLICode,
@@ -25603,7 +25602,7 @@ export const Severe = {
    */
   IBM3977I: {
     code: "IBM3977I",
-    severity: "S",
+    severity: Severity.S,
     message: "SBCS characters are not allowed in G constants.",
     fullCode: "IBM3977IS",
   } as SimplePLICode,
@@ -25614,7 +25613,7 @@ export const Severe = {
    */
   IBM3978I: {
     code: "IBM3978I",
-    severity: "S",
+    severity: Severity.S,
     message: "Invalid use of SBCS encoded as DBCS.",
     fullCode: "IBM3978IS",
   } as SimplePLICode,
@@ -25626,7 +25625,7 @@ export const Severe = {
    */
   IBM3979I: {
     code: "IBM3979I",
-    severity: "S",
+    severity: Severity.S,
     message: "UX literal specifies an invalid UTF-8 string.",
     fullCode: "IBM3979IS",
   } as SimplePLICode,
@@ -25637,7 +25636,7 @@ export const Severe = {
    */
   IBM3980I: {
     code: "IBM3980I",
-    severity: "S",
+    severity: Severity.S,
     message: "Recursion of procedures is not allowed.",
     fullCode: "IBM3980IS",
   } as SimplePLICode,
@@ -25648,7 +25647,7 @@ export const Severe = {
    */
   IBM3981I: {
     code: "IBM3981I",
-    severity: "S",
+    severity: Severity.S,
     message: (BUILTINfunction: string) =>
       `${BUILTINfunction} may not be used outside a procedure.`,
     fullCode: "IBM3981IS",
@@ -25660,7 +25659,7 @@ export const Severe = {
    */
   IBM3982I: {
     code: "IBM3982I",
-    severity: "S",
+    severity: Severity.S,
     message: (procedurename: string) =>
       `Procedure ${procedurename} is undefined and cannot be invoked.`,
     fullCode: "IBM3982IS",
@@ -25680,7 +25679,7 @@ export const Severe = {
    */
   IBM3983I: {
     code: "IBM3983I",
-    severity: "S",
+    severity: Severity.S,
     message: "Premature end-of-source in scan.",
     fullCode: "IBM3983IS",
   } as SimplePLICode,
@@ -25692,7 +25691,7 @@ export const Severe = {
    */
   IBM3984I: {
     code: "IBM3984I",
-    severity: "S",
+    severity: Severity.S,
     message: (filename: string) => `File ${filename} could not be opened.`,
     fullCode: "IBM3984IS",
   } as ParametricPLICode,
@@ -25707,7 +25706,7 @@ export const Severe = {
    */
   IBM3985I: {
     code: "IBM3985I",
-    severity: "S",
+    severity: Severity.S,
     message: "Semicolon found before required closing right parenthesis.",
     fullCode: "IBM3985IS",
   } as SimplePLICode,
@@ -25721,7 +25720,7 @@ export const Severe = {
    */
   IBM3986I: {
     code: "IBM3986I",
-    severity: "S",
+    severity: Severity.S,
     message: "IF statement syntax is invalid.",
     fullCode: "IBM3986IS",
   } as SimplePLICode,
@@ -25739,7 +25738,7 @@ export const Severe = {
    */
   IBM3987I: {
     code: "IBM3987I",
-    severity: "S",
+    severity: Severity.S,
     message: "Statement must start with a keyword or assignment target.",
     fullCode: "IBM3987IS",
   } as SimplePLICode,
@@ -25755,7 +25754,7 @@ export const Severe = {
    */
   IBM3988I: {
     code: "IBM3988I",
-    severity: "S",
+    severity: Severity.S,
     message: "Statement has invalid syntax.",
     fullCode: "IBM3988IS",
   } as SimplePLICode,
@@ -25767,7 +25766,7 @@ export const Severe = {
    */
   IBM3993I: {
     code: "IBM3993I",
-    severity: "S",
+    severity: Severity.S,
     message: (sourceline: string, procedurename: string, packagename: string) =>
       `Internal preprocessor error: assertion failed on line ${sourceline} in ${procedurename} in ${packagename}`,
     fullCode: "IBM3993IS",
@@ -25780,7 +25779,7 @@ export const Severe = {
    */
   IBM3994I: {
     code: "IBM3994I",
-    severity: "S",
+    severity: Severity.S,
     message: "Source is not valid UTF-8.",
     fullCode: "IBM3994IS",
   } as SimplePLICode,
@@ -25792,7 +25791,7 @@ export const Severe = {
    */
   IBM3995I: {
     code: "IBM3995I",
-    severity: "S",
+    severity: Severity.S,
     message: "Generated text contains invalid UTF-8.",
     fullCode: "IBM3995IS",
   } as SimplePLICode,
@@ -25804,7 +25803,7 @@ export const Severe = {
    */
   IBM3996I: {
     code: "IBM3996I",
-    severity: "S",
+    severity: Severity.S,
     message: (modulename: string) =>
       `Internal preprocessor error: protection exception in ${modulename} .`,
     fullCode: "IBM3996IS",
@@ -25817,7 +25816,7 @@ export const Severe = {
    */
   IBM3997I: {
     code: "IBM3997I",
-    severity: "S",
+    severity: Severity.S,
     message: (modulename: string) =>
       `Internal preprocessor error: no WHEN clause satisfied within ${modulename} .`,
     fullCode: "IBM3997IS",
@@ -25830,7 +25829,7 @@ export const Severe = {
    */
   IBM3998I: {
     code: "IBM3998I",
-    severity: "S",
+    severity: Severity.S,
     message: (note: string) => `${note}`,
     fullCode: "IBM3998IS",
   } as ParametricPLICode,
@@ -25841,7 +25840,7 @@ export const Severe = {
    */
   IBM3999I: {
     code: "IBM3999I",
-    severity: "U",
+    severity: Severity.U,
     message: (note: string) => "${note}",
     fullCode: "IBM3999IU",
   } as ParametricPLICode,

--- a/packages/language/test/fourslash-harness/execute.test.ts
+++ b/packages/language/test/fourslash-harness/execute.test.ts
@@ -131,6 +131,34 @@ function getLocationOverrides(
   );
 }
 
+interface FileTree {
+  [key: string]: FileTree | string[];
+  _files: string[];
+}
+
+function getFileTree(files: string[]): FileTree {
+  const tree: FileTree = { _files: [] };
+  for (const file of files) {
+    const relativePath = path.relative(fourslashPath, file);
+    const segments = relativePath
+      .split(path.sep)
+      .filter((segment) => segment !== "." && segment !== "..");
+    let current = tree;
+    for (let i = 0; i < segments.length; i++) {
+      const segment = segments[i];
+      if (i === segments.length - 1) {
+        current._files.push(segment);
+      } else {
+        if (!current[segment]) {
+          current[segment] = { _files: [] };
+        }
+        current = current[segment] as FileTree;
+      }
+    }
+  }
+  return tree;
+}
+
 /**
  * Get all test files in the `tests` directory, parse them, and create a
  * vitest test for each test.
@@ -138,10 +166,26 @@ function getLocationOverrides(
 function runHarnessTests() {
   const files = getTestFiles();
 
-  for (const filePath of files) {
-    const fullPath = path.resolve(testsPath, filePath);
-    runSingleHarnessTest(fullPath);
-  }
+  // Get a tree with all files sorted into their relative path.
+  const fileTree = getFileTree(files);
+
+  const traverseFileTree = (tree: FileTree, currentPath: string) => {
+    for (const key in tree) {
+      if (key === "_files") {
+        continue;
+      }
+      describe(key, () => {
+        traverseFileTree(tree[key] as FileTree, path.join(currentPath, key));
+      });
+    }
+    for (const file of tree._files) {
+      const filepath = path.join(currentPath, file);
+      const fullPath = path.resolve(testsPath, filepath);
+      runSingleHarnessTest(fullPath);
+    }
+  };
+
+  traverseFileTree(fileTree, "");
 }
 
 /**
@@ -154,8 +198,11 @@ function runSingleHarnessTest(filePath: string) {
   const relativePath = path.relative(fourslashPath, filePath);
   // e.g. 'packages/language/test/fourslash/linker/implicit-declaration.ts'
   const relativePathToProjectRoot = path.relative(projectRoot, filePath);
+  const testName = relativePath.includes(path.sep)
+    ? path.basename(relativePath)
+    : relativePath;
 
-  test(`${relativePath}`, () => {
+  test(`${testName}`, () => {
     const wrappers = getWrappers();
     const testFile = parseHarnessTestFile(relativePath, filePath, {
       wrappers,

--- a/packages/language/test/fourslash-harness/harness-interface.ts
+++ b/packages/language/test/fourslash-harness/harness-interface.ts
@@ -12,12 +12,13 @@
 import { CompletionKeywords } from "../../src/language-server/completion/keywords";
 import { Diagnostic } from "../../src/language-server/types";
 import { InternalCodes, PLICodes } from "../../src/validation/messages";
-import { ExpectedCompletion, TestBuilder } from "../test-builder";
+import { ExpectedCompletion, Label, TestBuilder } from "../test-builder";
 import { type Severity } from "../../src/language-server/types";
 import { SemanticTokenTypes } from "vscode-languageserver-types";
 import { PliMarginsProcessor } from "../../src/preprocessor/pli-margins-processor";
+import { CompilerOptionsCodes } from "../../src/preprocessor/compiler-options/codes";
+import { CompilerOptions } from "../../src/preprocessor/compiler-options/options";
 
-type Label = string | number;
 type SemanticTokenTypesValues = `${SemanticTokenTypes}`;
 
 export interface HarnessTesterInterface {
@@ -72,6 +73,12 @@ export interface HarnessTesterInterface {
     noDiagnostics(label?: string | number): void;
 
     /**
+     * Expect that the compilation unit has no diagnostics apart from the given regexes.
+     * @param regexes The regexes to expect no diagnostics apart from.
+     */
+    noDiagnosticsExcept(regexes: RegExp[]): void;
+
+    /**
      * Expect that the given function throws an error.
      *
      * @param fn The function that should throw an error.
@@ -82,6 +89,12 @@ export interface HarnessTesterInterface {
      * ```
      */
     expectToThrow(fn: () => void, messageToThrow?: string): void;
+
+    /**
+     * Expect that the compiler options are set to the given options.
+     * @param expectedOptions The expected compiler options.
+     */
+    expectCompilerOptions(expectedOptions: Partial<CompilerOptions>): void;
   };
 
   linker: {
@@ -173,6 +186,7 @@ export interface HarnessTesterInterface {
         ErrorRight: typeof PliMarginsProcessor.MARGIN_ERROR_MESSAGE_RIGHT;
       };
     };
+    CompilerOptions: typeof CompilerOptionsCodes;
   };
 
   constants: {

--- a/packages/language/test/fourslash-harness/harness.test.ts
+++ b/packages/language/test/fourslash-harness/harness.test.ts
@@ -55,7 +55,9 @@ function createTestingHarnessImplementation(
       ),
       expectDiagnosticsAt: listen("verify.expectDiagnosticsAt"),
       noDiagnostics: listen("verify.noDiagnostics"),
+      noDiagnosticsExcept: listen("verify.noDiagnosticsExcept"),
       expectToThrow: listen("verify.expectToThrow"),
+      expectCompilerOptions: listen("verify.expectCompilerOptions"),
     },
     completion: {
       expectAt: listen("completion.expectAt"),

--- a/packages/language/test/fourslash-harness/implementation/codes.ts
+++ b/packages/language/test/fourslash-harness/implementation/codes.ts
@@ -12,6 +12,7 @@
 import { PLICodes, InternalCodes } from "../../../src/validation/messages";
 import { HarnessTesterInterface } from "../harness-interface";
 import { PliMarginsProcessor } from "../../../src/preprocessor/pli-margins-processor";
+import { CompilerOptionsCodes } from "../../../src/preprocessor/compiler-options/codes";
 
 export const HarnessCodes: HarnessTesterInterface["code"] = {
   Severe: PLICodes.Severe,
@@ -25,4 +26,5 @@ export const HarnessCodes: HarnessTesterInterface["code"] = {
       ErrorRight: PliMarginsProcessor.MARGIN_ERROR_MESSAGE_RIGHT,
     },
   },
+  CompilerOptions: CompilerOptionsCodes,
 };

--- a/packages/language/test/fourslash-harness/implementation/test-builder.ts
+++ b/packages/language/test/fourslash-harness/implementation/test-builder.ts
@@ -42,13 +42,17 @@ export function createTestBuilderHarnessImplementation(
       expectExclusiveDiagnosticsAt: (label, diagnostics) =>
         testBuilder.expectExclusiveDiagnosticsAt(label.toString(), diagnostics),
       expectDiagnosticsAt: (label, diagnostics) =>
-        testBuilder.expectDiagnosticsAt(label.toString(), diagnostics),
+        testBuilder.expectDiagnosticsAt(label, diagnostics),
       noDiagnostics: (label) =>
         label !== undefined
           ? testBuilder.expectNoDiagnosticsAt(label.toString())
           : testBuilder.expectNoDiagnostics(),
+      noDiagnosticsExcept: (regex: RegExp[]) =>
+        testBuilder.noDiagnosticsExcept(regex),
       expectToThrow: (fn, messageToThrow) =>
         testBuilder.expectToThrow(fn, messageToThrow),
+      expectCompilerOptions: (expectedOptions) =>
+        testBuilder.expectCompilerOptions(expectedOptions),
     },
     completion: {
       expectAt: (label, content) =>

--- a/packages/language/test/fourslash-harness/wrappers/process.ts
+++ b/packages/language/test/fourslash-harness/wrappers/process.ts
@@ -1,0 +1,3 @@
+////<...>
+//// STARTPR: PROCEDURE OPTIONS (MAIN);
+//// END STARTPR;`;

--- a/packages/language/test/fourslash/preprocessor/compiler-options/gonumber.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/gonumber.ts
@@ -1,0 +1,54 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS GONUMBER(SEPARATE);
+////*PROCESS GONUMBER(<|1:Nxx|>);
+////*PROCESS <|2:NOGONUMBER|>(SEPARATE);
+////*PROCESS <|3:GONUMBER|>(NOSEPARATE);
+////*PROCESS <|4:NOGONUMBER|>;
+////*PROCESS <|5:GN|>(NOSEPARATE);
+////*PROCESS <|6:NGN|>;
+////*PROCESS <|7:GN|>(SEPARATE);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.gonumber.WrongParameter.message("Nxx"),
+});
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.WrongParameterCount.message("1", "0", "0"),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.DupeOptionIssue.message("GONUMBER"),
+});
+
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.MutexOptionIssue.message("NOGONUMBER"),
+});
+
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.DupeOptionIssue.message("GN"),
+});
+
+verify.expectDiagnosticsAt(6, {
+  message: code.CompilerOptions.MutexOptionIssue.message("NGN"),
+});
+
+verify.expectDiagnosticsAt(7, {
+  message: code.CompilerOptions.DupeOptionIssue.message("GN"),
+});
+
+verify.expectCompilerOptions({
+  goNumber: {
+    separate: true,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/graphic.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/graphic.ts
@@ -1,0 +1,41 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS GRAPHIC;
+////*PROCESS <|1:NOGRAPHIC|>;
+////*PROCESS <|2:NGR|>;
+////*PROCESS <|3:GR|>;
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.MutexOptionIssue.message("NOGRAPHIC"),
+});
+
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.MutexOptionIssue.message("NGR"),
+});
+
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.DupeOptionIssue.message("GR"),
+});
+
+verify.noDiagnosticsExcept([
+  new RegExp(code.CompilerOptions.DupeOptionIssue.message("").substring(0, 20)),
+  new RegExp(
+    code.CompilerOptions.MutexOptionIssue.message("").substring(0, 20),
+  ),
+]);
+
+verify.expectCompilerOptions({
+  graphic: true,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/header.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/header.ts
@@ -1,0 +1,41 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS HEADER(ALL);
+////*PROCESS <|1:HEADER|>(FILE);
+////*PROCESS <|2:HEADER|>(FIRST);
+////*PROCESS <|3:HEADER|>(SOURCE);
+////*PROCESS HEADER(<|4:INVALID|>);
+////*PROCESS HEADER(<|5:)|>;
+////*PROCESS <|6:HEADER|>;
+
+verify.expectDiagnosticsAt([1, 2, 3], {
+  message: code.CompilerOptions.DupeOptionIssue.message("HEADER"),
+});
+
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.header.WrongParameter.message("INVALID"),
+});
+
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.header.WrongParameter.message(""),
+});
+
+verify.expectDiagnosticsAt(6, {
+  message: code.CompilerOptions.WrongParameterCount.message("0", "1", "1"),
+});
+
+verify.expectCompilerOptions({
+  header: "SOURCE",
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/hgpr.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/hgpr.ts
@@ -1,0 +1,41 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS HGPR(NOPRESERVE);
+////*PROCESS <|1:HGPR|>(<|2:INVALID|>);
+////*PROCESS <|3:HGPR|>(PRESERVE);
+////*PROCESS <|4:HGPR|>(<|5:)|>;
+////*PROCESS <|6:HGPR|>;
+
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.DupeOptionIssue.message("HGPR"),
+});
+
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.hgpr.WrongParameter.message("INVALID"),
+});
+
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.hgpr.WrongParameter.message(""),
+});
+
+verify.expectDiagnosticsAt(6, {
+  message: code.CompilerOptions.WrongParameterCount.message("0", "1", "1"),
+});
+
+verify.expectCompilerOptions({
+  hgpr: {
+    preserve: true,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/ignore.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/ignore.ts
@@ -1,0 +1,37 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NOIGNORE;
+////*PROCESS IGNORE();
+////*PROCESS IGNORE(<|1:INVALID|>);
+////*PROCESS IGNORE(ASSERT, DISPLAY, <|2:INVALID|>);
+////*PROCESS <|3:IGNORE|>(ASSERT, PUT);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ignore.WrongParameter.message("INVALID"),
+});
+
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.ignore.WrongParameter.message("INVALID"),
+});
+
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.MutexOptionIssue.message("IGNORE"),
+});
+
+verify.expectCompilerOptions({
+  ignore: {
+    items: ["ASSERT", "PUT"],
+  },
+});

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -37,6 +37,9 @@ import {
   setPluginConfigurationProvider,
 } from "../src/workspace/plugin-configuration-provider";
 import { InternalCodes } from "../src/validation/messages";
+import { CompilerOptions } from "../src/preprocessor/compiler-options/options";
+
+export type Label = string | number | string[] | number[];
 
 export const DEFAULT_FILE_URI = "file:///main.pli";
 
@@ -409,9 +412,19 @@ export class TestBuilder {
   }
 
   expectDiagnosticsAt(
-    label: string,
+    label: Label,
     diagnostics: Partial<Diagnostic> | Partial<Diagnostic>[],
   ): TestBuilder {
+    if (Array.isArray(label)) {
+      for (const l of label) {
+        this.expectDiagnosticsAt(l, diagnostics);
+      }
+      return this;
+    }
+    if (typeof label === "number") {
+      label = label.toString();
+    }
+
     const expectedDiagnostics = Array.isArray(diagnostics)
       ? diagnostics
       : [diagnostics];
@@ -462,6 +475,22 @@ export class TestBuilder {
     return this;
   }
 
+  noDiagnosticsExcept(regex: RegExp[]): TestBuilder {
+    const remainingDiagnostics = this.diagnostics.filter((diagnostic) => {
+      const message = this.createDiagnosticMessage(diagnostic);
+      return !regex.some((r) => r.test(message));
+    });
+    if (remainingDiagnostics.length > 0) {
+      const message = remainingDiagnostics
+        .map((diagnostic) => this.createDiagnosticMessage(diagnostic))
+        .join("\n- ");
+      fail(
+        `Expected no diagnostics apart from ${regex.map((r) => r.source).join(", ")}, but received:\n- ${message}`,
+      );
+    }
+    return this;
+  }
+
   expectToThrow(fn: () => void, messageToThrow?: string) {
     const message = `Expected function to throw an error ${
       messageToThrow ? `with message "${messageToThrow}"` : ""
@@ -478,6 +507,16 @@ export class TestBuilder {
         throw error;
       }
     }
+  }
+
+  expectCompilerOptions(
+    expectedOptions: Partial<CompilerOptions>,
+  ): TestBuilder {
+    const actualOptions = this.unit.compilerOptions;
+    for (const [key, value] of Object.entries(expectedOptions)) {
+      expect(actualOptions[key as keyof CompilerOptions]).toEqual(value);
+    }
+    return this;
   }
 
   /**


### PR DESCRIPTION
I added the first batch of missing compiler options (https://github.com/zowe/zowe-pli-language-support/issues/296): `gonu` - `ign`.
To test the compiler options conveniently in the new harness, I added new error codes for the options and extended the harness. I created the draft so that we can agree on further steps, before I implement the rest of the options.

- Added `gonumber`, `graphic`, `header`, `hgpr`, `ignore` compiler options.
- Added harness functions to test compiler options and specific diagnostics. 
- `expectDiagnosticsAt` also takes arrays for labels now to test for similar diagnostics at different locations (should/could be added for other expect methods as well in the future).
- The test runner now also creates `describe` blocks according to the relative path structure.
- Added compiler option codes for more convenient testing (should be completed over time).

The compiler option task (https://github.com/zowe/zowe-pli-language-support/issues/296) will be split up into several PRs to make reviewing more convenient.