### PR TITLE
Extend compiler options and tests #2

### DIFF
--- a/packages/language/src/preprocessor/compiler-options/codes.ts
+++ b/packages/language/src/preprocessor/compiler-options/codes.ts
@@ -13,121 +13,303 @@ import { Severity } from "../../language-server/types";
 import { ParametricPLICode } from "../../validation/messages/pli-codes";
 
 export const CompilerOptionsCodes = {
-  WrongParameterCount: {
-    code: "_COOP01",
+  // At the moment, the actual codes are only used internally.
+  // Only the message is presented to the user.
+  InvalidParameterCount: {
+    code: "COOP01",
     severity: Severity.W,
-    message: (received: string, min: string, max?: string) => {
+    message: (received: number, min: number, max?: number) => {
       if (min === max) {
-        return `Expected ${min} arguments, but received ${received}.`;
-      } else if (max === "") {
-        return `Expected at least ${min} arguments, but received ${received}.`;
+        return `Expected ${min} argument${min === 1 ? "" : "s"}, but received ${received}.`;
+      } else if (max === undefined) {
+        return `Expected at least ${min} argument${min === 1 ? "" : "s"}, but received ${received}.`;
       } else {
-        return `Expected between ${min} and ${max} arguments, but received ${received}.`;
+        return `Expected between ${min} and ${max} argument${max === 1 ? "" : "s"}, but received ${received}.`;
       }
     },
-    fullCode: "_COOP01W",
+    fullCode: "COOP01W",
   } as ParametricPLICode,
 
   DupeOptionIssue: {
-    code: "_COOP02",
+    code: "COOP02",
     severity: Severity.W,
     message: (name: string) => `Duplicate compiler option ${name}`,
-    fullCode: "_COOP02W",
+    fullCode: "COOP02W",
   } as ParametricPLICode,
 
   MutexOptionIssue: {
-    code: "_COOP03",
+    code: "COOP03",
     severity: Severity.W,
     message: (name: string) =>
       `Mutually exclusive compiler options found for ${name}, only the last one will take effect.`,
-    fullCode: "_COOP03W",
+    fullCode: "COOP03W",
   } as ParametricPLICode,
 
   ExpectedOption: {
-    code: "_COOP04",
+    code: "COOP04",
     severity: Severity.W,
-    message: (name: string) => `Expected a compiler option with arguments.`,
-    fullCode: "_COOP04W",
+    message: () => `Expected a compiler option with arguments.`,
+    fullCode: "COOP04W",
   } as ParametricPLICode,
 
   ExpectedPlain: {
-    code: "_COOP05",
+    code: "COOP05",
     severity: Severity.W,
-    message: (name: string) => `Expected a plain text value.`,
-    fullCode: "_COOP05W",
+    message: () => `Expected a plain text value.`,
+    fullCode: "COOP05W",
   } as ParametricPLICode,
 
   ExpectedString: {
-    code: "_COOP06",
+    code: "COOP06",
     severity: Severity.W,
-    message: (name: string) => `Expected a string value.`,
-    fullCode: "_COOP06W",
+    message: () => `Expected a string value.`,
+    fullCode: "COOP06W",
   } as ParametricPLICode,
 
   ExpectedPlainOrString: {
-    code: "_COOP07",
+    code: "COOP07",
     severity: Severity.W,
-    message: (name: string) => `Expected a plain text or string value.`,
-    fullCode: "_COOP07W",
+    message: () => `Expected a plain text or string value.`,
+    fullCode: "COOP07W",
   } as ParametricPLICode,
 
-  gonumber: {
-    WrongParameter: {
-      code: "_COGN01",
+  ExpectedNumber: {
+    code: "COOP08",
+    severity: Severity.W,
+    message: () => `Expected a number.`,
+    fullCode: "COOP08W",
+  } as ParametricPLICode,
+
+  ExpectedNumberRange: {
+    code: "COOP09",
+    severity: Severity.W,
+    message: (number: number, min: number, max: number) => {
+      if (min !== undefined && max !== undefined) {
+        return `Expected a number between ${min} and ${max}, but received ${number}.`;
+      } else if (min) {
+        return `Expected a number greater than or equal to ${min}, but received ${number}.`;
+      } else {
+        return `Expected a number less than or equal to ${max}, but received ${number}.`;
+      }
+    },
+    fullCode: "COOP09W",
+  } as ParametricPLICode,
+
+  ExpectedPlainNotEmpty: {
+    code: "COOP10",
+    severity: Severity.W,
+    message: () => `Expected a value.`,
+    fullCode: "COOP10W",
+  } as ParametricPLICode,
+
+  GoNumber: {
+    InvalidParameter: {
+      code: "COGN01",
       severity: Severity.W,
       message: (value: string) =>
         `Expected "SEPARATE" or "NOSEPARATE", but received '${value}'.`,
-      fullCode: "_COGN01W",
+      fullCode: "COGN01W",
     } as ParametricPLICode,
   },
 
-  header: {
-    WrongParameter: {
-      code: "_COHE01",
+  Header: {
+    InvalidParameter: {
+      code: "COHE01",
       severity: Severity.W,
       message: (value: string) =>
         `Expected "ALL", "FILE", "FIRST" or "SOURCE", but received '${value}'.`,
-      fullCode: "_COHE01W",
+      fullCode: "COHE01W",
     } as ParametricPLICode,
   },
 
-  hgpr: {
-    WrongParameter: {
-      code: "_COHG01",
+  Hgpr: {
+    InvalidParameter: {
+      code: "COHG01",
       severity: Severity.W,
       message: (value: string) =>
         `Expected "PRESERVE" or "NOPRESERVE", but received '${value}'.`,
-      fullCode: "_COHG01W",
+      fullCode: "COHG01W",
     } as ParametricPLICode,
   },
 
-  ignore: {
-    WrongParameter: {
-      code: "_COIG01",
+  Ignore: {
+    InvalidParameter: {
+      code: "COIG01",
       severity: Severity.W,
       message: (value: string) =>
         `Expected "ASSERT", "DISPLAY" or "PUT", but received '${value}'.`,
-      fullCode: "_COIG01W",
+      fullCode: "COIG01W",
     } as ParametricPLICode,
   },
 
-  initAuto: {
-    WrongParameter: {
-      code: "_COIA01",
+  InitAuto: {
+    InvalidParameter: {
+      code: "COIA01",
       severity: Severity.W,
       message: (value: string) =>
         `Expected "SHORT" or "FULL", but received '${value}'.`,
-      fullCode: "_COIA01W",
+      fullCode: "COIA01W",
     } as ParametricPLICode,
   },
 
-  inSource: {
-    WrongParameter: {
-      code: "_COIS01",
+  InSource: {
+    InvalidParameter: {
+      code: "COIS01",
       severity: Severity.W,
       message: (value: string) =>
         `Expected "FULL", "SHORT", "ALL" or "FIRST", but received '${value}'.`,
-      fullCode: "_COIS01W",
+      fullCode: "COIS01W",
+    } as ParametricPLICode,
+  },
+
+  Json: {
+    InvalidParameter: {
+      code: "COJS01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "CASE", "ENCODING", "GET", "PARSE" or "TRIMR", but received '${value}'.`,
+      fullCode: "COJS01W",
+    } as ParametricPLICode,
+    InvalidCaseParameter: {
+      code: "COJS02",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "UPPER", "LOWER" or "ASIS", but received '${value}'.`,
+      fullCode: "COJS02W",
+    } as ParametricPLICode,
+    InvalidEncodingParameter: {
+      code: "COJS03",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "UTF8", "EBCDIC", "37" or "1047", but received '${value}'.`,
+      fullCode: "COJS03W",
+    } as ParametricPLICode,
+    InvalidGetParameter: {
+      code: "COJS04",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "HEEDCASE" or "IGNORECASE", but received '${value}'.`,
+      fullCode: "COJS04W",
+    } as ParametricPLICode,
+    InvalidParseParameter: {
+      code: "COJS05",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "V1" or "V2", but received '${value}'.`,
+      fullCode: "COJS05W",
+    } as ParametricPLICode,
+  },
+
+  LangLvl: {
+    InvalidParameter: {
+      code: "COLL01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "OS" or "NOEXT", but received '${value}'.`,
+      fullCode: "COLL01W",
+    } as ParametricPLICode,
+  },
+
+  Limits: {
+    InvalidParameter: {
+      code: "COLI01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "EXTNAME", "FIXEDBIN", "FIXEDDEC", "NAME" or "STRING", but received '${value}'.`,
+      fullCode: "COLI01W",
+    } as ParametricPLICode,
+    InvalidFixedBinMinParameter: {
+      code: "COLI02",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "31" or "63", but received '${value}'.`,
+      fullCode: "COLI02W",
+    } as ParametricPLICode,
+    InvalidFixedBinMaxParameter: {
+      code: "COLI03",
+      severity: Severity.W,
+      message: (value: string) => `Expected "63", but received '${value}'.`,
+      fullCode: "COLI03W",
+    } as ParametricPLICode,
+    InvalidFixedDecMinParameter: {
+      code: "COLI04",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "15" or "31", but received '${value}'.`,
+      fullCode: "COLI04W",
+    } as ParametricPLICode,
+    InvalidFixedDecMaxParameter: {
+      code: "COLI05",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "15" or "31", but received '${value}'.`,
+      fullCode: "COLI05W",
+    } as ParametricPLICode,
+    InvalidFixedDecRange: {
+      code: "COLI06",
+      severity: Severity.W,
+      message: () =>
+        `The minimum fixed decimal value must be less or equal to the maximum fixed decimal value.`,
+      fullCode: "COLI06W",
+    } as ParametricPLICode,
+    InvalidStringParameter: {
+      code: "COLI07",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "32K", "64K", "512K", "8M" or "128M", but received '${value}'.`,
+      fullCode: "COLI07W",
+    } as ParametricPLICode,
+  },
+
+  LineCount: {
+    InvalidRange: {
+      code: "COLC01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `The line count must be between 10 and 65535, or 0, but received '${value}'.`,
+      fullCode: "COLC01W",
+    } as ParametricPLICode,
+  },
+
+  ListView: {
+    InvalidParameter: {
+      code: "COLV01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "SOURCE", "AFTERALL", "AFTERCICS", "AFTERMACRO" or "AFTERSQL", but received '${value}'.`,
+      fullCode: "COLV01W",
+    } as ParametricPLICode,
+  },
+
+  Lp: {
+    InvalidParameter: {
+      code: "COLP01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "32" or "64", but received '${value}'.`,
+      fullCode: "COLP01W",
+    } as ParametricPLICode,
+  },
+
+  Margini: {
+    InvalidParameter: {
+      code: "COMI01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected a single character, but received '${value}'.`,
+      fullCode: "COMI01W",
+    } as ParametricPLICode,
+  },
+
+  // TODO ssmifi: Add codes for margins.
+
+  MaxInit: {
+    InvalidParameter: {
+      code: "COMN01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected a number followed by "K", "M" or "G", but received '${value}'.`,
+      fullCode: "COMN01W",
     } as ParametricPLICode,
   },
 };

--- a/packages/language/src/preprocessor/compiler-options/codes.ts
+++ b/packages/language/src/preprocessor/compiler-options/codes.ts
@@ -43,6 +43,34 @@ export const CompilerOptionsCodes = {
     fullCode: "_COOP03W",
   } as ParametricPLICode,
 
+  ExpectedOption: {
+    code: "_COOP04",
+    severity: Severity.W,
+    message: (name: string) => `Expected a compiler option with arguments.`,
+    fullCode: "_COOP04W",
+  } as ParametricPLICode,
+
+  ExpectedPlain: {
+    code: "_COOP05",
+    severity: Severity.W,
+    message: (name: string) => `Expected a plain text value.`,
+    fullCode: "_COOP05W",
+  } as ParametricPLICode,
+
+  ExpectedString: {
+    code: "_COOP06",
+    severity: Severity.W,
+    message: (name: string) => `Expected a string value.`,
+    fullCode: "_COOP06W",
+  } as ParametricPLICode,
+
+  ExpectedPlainOrString: {
+    code: "_COOP07",
+    severity: Severity.W,
+    message: (name: string) => `Expected a plain text or string value.`,
+    fullCode: "_COOP07W",
+  } as ParametricPLICode,
+
   gonumber: {
     WrongParameter: {
       code: "_COGN01",
@@ -80,6 +108,26 @@ export const CompilerOptionsCodes = {
       message: (value: string) =>
         `Expected "ASSERT", "DISPLAY" or "PUT", but received '${value}'.`,
       fullCode: "_COIG01W",
+    } as ParametricPLICode,
+  },
+
+  initAuto: {
+    WrongParameter: {
+      code: "_COIA01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "SHORT" or "FULL", but received '${value}'.`,
+      fullCode: "_COIA01W",
+    } as ParametricPLICode,
+  },
+
+  inSource: {
+    WrongParameter: {
+      code: "_COIS01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "FULL", "SHORT", "ALL" or "FIRST", but received '${value}'.`,
+      fullCode: "_COIS01W",
     } as ParametricPLICode,
   },
 };

--- a/packages/language/src/preprocessor/compiler-options/options.ts
+++ b/packages/language/src/preprocessor/compiler-options/options.ts
@@ -237,7 +237,7 @@ export interface CompilerOptions {
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-incpds
    */
-  incPds?: string | false;
+  incPds?: CompilerOptions.IncPds | false;
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-initauto
    */
@@ -257,7 +257,7 @@ export interface CompilerOptions {
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-insource
    */
-  inSource?: CompilerOptions.InSource;
+  inSource?: CompilerOptions.InSource | false;
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-interrupt
    */
@@ -716,13 +716,18 @@ export declare namespace CompilerOptions {
     token?: Token;
   }
   export interface IncDir {
-    directory: string;
+    directories: string[];
   }
+
+  export interface IncPds {
+    pds: string[];
+  }
+
   export interface InitAuto {
     length?: Length;
   }
   export interface InSource {
-    type: "FULL" | "SHORT" | "ALL" | "FIRST";
+    type?: "FULL" | "SHORT" | "ALL" | "FIRST";
   }
   export interface Json {
     case?: "UPPER" | "LOWER" | "ASIS";

--- a/packages/language/src/preprocessor/compiler-options/options.ts
+++ b/packages/language/src/preprocessor/compiler-options/options.ts
@@ -305,7 +305,7 @@ export interface CompilerOptions {
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-margini
    */
-  margini?: CompilerOptions.Margini;
+  margini?: CompilerOptions.Margini | false;
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-margins
    */
@@ -317,7 +317,7 @@ export interface CompilerOptions {
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-maxinit
    */
-  maxinit?: string;
+  maxinit?: number;
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-maxgen
    */
@@ -329,7 +329,7 @@ export interface CompilerOptions {
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-maxmsg
    */
-  maxmsg?: (CompilerOptions.Flag | number)[];
+  maxmsg?: CompilerOptions.MaxMsg;
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-maxnest
    */
@@ -572,18 +572,6 @@ export interface CompilerOptions {
   xRef?: CompilerOptions.XRef;
 }
 
-const defaultCompilerOptions: CompilerOptions = {
-  system: "MVS",
-  sysParm: "",
-};
-
-/**
- * Returns a fresh copy of the default compiler options.
- */
-export function getDefaultCompilerOptions(): CompilerOptions {
-  return { ...defaultCompilerOptions };
-}
-
 export declare namespace CompilerOptions {
   export type Length = "SHORT" | "FULL";
   export interface Attributes {
@@ -723,9 +711,7 @@ export declare namespace CompilerOptions {
     pds: string[];
   }
 
-  export interface InitAuto {
-    length?: Length;
-  }
+  export type InitAuto = "SHORT" | "FULL" | false;
   export interface InSource {
     type?: "FULL" | "SHORT" | "ALL" | "FIRST";
   }
@@ -736,18 +722,19 @@ export declare namespace CompilerOptions {
     trimr?: boolean;
     parse?: "V1" | "V2";
   }
-  export interface LangLvl {
-    os?: boolean;
-    noext?: boolean;
-  }
+  export type LangLvl = "OS" | "NOEXT";
   export interface Limits {
     extname?: number;
-    fixedDec?: {
-      max?: number;
+    fixedBin?: {
       min?: number;
+      max?: number;
+    };
+    fixedDec?: {
+      min?: number;
+      max?: number;
     };
     name?: number;
-    string?: string;
+    string?: number;
   }
   export type ListView =
     | "SOURCE"
@@ -756,7 +743,6 @@ export declare namespace CompilerOptions {
     | "AFTERMACRO"
     | "AFTERSQL";
   export interface Margini {
-    active: boolean;
     character: string;
   }
   export interface Margins {
@@ -783,6 +769,10 @@ export declare namespace CompilerOptions {
      * Specifying MARGINS(,,c) is an alternative to using %PAGE and %SKIP statements .
      */
     c?: string;
+  }
+  export interface MaxMsg {
+    severity: Flag;
+    n: number;
   }
   export interface MaxNest {
     /**
@@ -1099,4 +1089,52 @@ export declare namespace CompilerOptions {
     length?: Length;
     structure?: "EXPLICIT" | "IMPLICIT";
   };
+}
+
+const $1K = 1024;
+const $1M = 1024 * 1024;
+
+const defaultCompilerOptions: CompilerOptions = {
+  json: {
+    case: "UPPER",
+    get: "HEEDCASE",
+    parse: "V1",
+    trimr: true,
+  },
+  limits: {
+    extname: 7,
+    fixedBin: {
+      min: 31,
+      max: 63,
+    },
+    fixedDec: {
+      min: 15,
+      max: 31,
+    },
+    name: 100,
+    string: 32 * $1K,
+  },
+  lineCount: 31415,
+  initAuto: "FULL",
+  margins: {
+    m: 2,
+    n: 72,
+  },
+  maxbranch: 2000,
+  maxinit: 64 * $1K,
+  maxgen: 100000,
+  maxmem: $1M,
+  maxmsg: {
+    severity: "W",
+    n: 250,
+  },
+  system: "MVS",
+  sysParm: "",
+};
+
+/**
+ * Returns a fresh copy of the default compiler options.
+ */
+export function getDefaultCompilerOptions(): CompilerOptions {
+  return { ...defaultCompilerOptions };
 }

--- a/packages/language/src/preprocessor/compiler-options/translator.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator.ts
@@ -43,7 +43,7 @@ type Translate = (option: CompilerOption, options: CompilerOptions) => void;
 /**
  * Tracks how a rule is applied, either positively or negatively
  */
-enum Applied {
+enum RuleAlignment {
   POSITIVE = 1,
   NEGATIVE = -1,
 }
@@ -58,7 +58,7 @@ class Translator {
    * Translator rules that have been applied to the current options,
    * along w/ info on whether they were applied positively or negatively
    */
-  appliedRules = new Map<TranslatorRule, Applied>();
+  appliedRules = new Map<TranslatorRule, RuleAlignment>();
 
   private rules: TranslatorRule[] = [];
 
@@ -101,53 +101,14 @@ class Translator {
   /**
    * Assumes a rule has been applied, checks if it was applied positively
    */
-  isRuleAppliedPositively(rule: TranslatorRule): boolean {
-    return this.appliedRules.get(rule) === Applied.POSITIVE;
+  isRuleAlignedWith(rule: TranslatorRule, alignment: RuleAlignment): boolean {
+    return this.appliedRules.get(rule) === alignment;
   }
 
   translate(option: CompilerOption) {
     const name = option.name.toUpperCase();
-    let found = false;
 
-    try {
-      for (const rule of this.rules) {
-        if (rule.positive && rule.positive.includes(name)) {
-          found = true;
-          rule.positiveTranslate?.(option, this.options);
-
-          if (!this.isRuleApplied(rule)) {
-            // new application
-            this.appliedRules.set(rule, Applied.POSITIVE);
-          } else if (this.isRuleAppliedPositively(rule)) {
-            // duplicate application (pos)
-            this.reportDupeOptIssue(option, name);
-          } else {
-            // mutex application
-            this.reportMutexOptIssue(option, name);
-          }
-          return;
-        }
-
-        if (rule.negative && rule.negative.includes(name)) {
-          found = true;
-          rule.negativeTranslate?.(option, this.options);
-
-          if (!this.isRuleApplied(rule)) {
-            // new application
-            this.appliedRules.set(rule, Applied.NEGATIVE);
-          } else if (!this.isRuleAppliedPositively(rule)) {
-            // duplicate application (neg)
-            this.reportDupeOptIssue(option, name);
-          } else {
-            // mutex application
-            this.reportMutexOptIssue(option, name);
-          }
-
-          return;
-        }
-      }
-    } catch (err) {
-      // We create a new diagnostic for the error
+    const reportError = (err: unknown) => {
       if (err instanceof TranslationError) {
         this.issues.push({
           range: tokenToRange(err.token),
@@ -160,9 +121,36 @@ class Translator {
           String(err),
         );
       }
-    }
+    };
 
-    if (!found) {
+    const rule = this.rules.find(
+      (r) => r.positive?.includes(name) || r.negative?.includes(name),
+    );
+
+    if (rule) {
+      const alignment =
+        rule.positive && rule.positive.includes(name)
+          ? RuleAlignment.POSITIVE
+          : RuleAlignment.NEGATIVE;
+      const translate =
+        alignment === RuleAlignment.POSITIVE
+          ? rule.positiveTranslate
+          : rule.negativeTranslate;
+
+      if (!this.isRuleApplied(rule)) {
+        this.appliedRules.set(rule, alignment);
+      } else if (this.isRuleAlignedWith(rule, alignment)) {
+        this.reportDupeOptIssue(option, name);
+      } else {
+        this.reportMutexOptIssue(option, name);
+      }
+
+      try {
+        translate?.(option, this.options);
+      } catch (err) {
+        reportError(err);
+      }
+    } else {
       this.issues.push({
         range: tokenToRange(option.token),
         message: PLIWarning.IBM1159I.message(option.name),
@@ -249,7 +237,7 @@ function ensureType(
     if (value.kind !== SyntaxKind.CompilerOption) {
       throw new TranslationError(
         value.token,
-        `Expected a compiler option with arguments.`,
+        CompilerOptionsCodes.ExpectedOption.message(),
         1,
       );
     }
@@ -257,13 +245,17 @@ function ensureType(
     if (value.kind !== SyntaxKind.CompilerOptionText) {
       throw new TranslationError(
         value.token,
-        `Expected a plain text value.`,
+        CompilerOptionsCodes.ExpectedPlain.message(),
         1,
       );
     }
   } else if (type === "string") {
     if (value.kind !== SyntaxKind.CompilerOptionString) {
-      throw new TranslationError(value.token, `Expected a string value.`, 1);
+      throw new TranslationError(
+        value.token,
+        CompilerOptionsCodes.ExpectedString.message(),
+        1,
+      );
     }
   } else if (type === "plainOrString") {
     if (
@@ -272,7 +264,7 @@ function ensureType(
     ) {
       throw new TranslationError(
         value.token,
-        `Expected a plain text or string value.`,
+        CompilerOptionsCodes.ExpectedPlainOrString.message(),
         1,
       );
     }
@@ -1476,14 +1468,120 @@ translator.rule(["INCAFTER"], (option, options) => {
 });
 
 /** {@link CompilerOptions.incDir} */
+translator.rule(
+  ["INCDIR"],
+  (option, options) => {
+    ensureArguments(option, 1, 1);
+    const value = option.values[0];
+    ensureType(value, "string");
+    if (!options.incDir) {
+      options.incDir = {
+        directories: [],
+      };
+    }
+    options.incDir.directories.push(value.value);
+  },
+  ["NOINCDIR"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.incDir = false;
+  },
+);
+
 /** {@link CompilerOptions.include} */
+translator.flag("include", ["INCLUDE"], ["NOINCLUDE"]);
+
 /** {@link CompilerOptions.incPds} */
+translator.rule(
+  ["INCPDS"],
+  (option, options) => {
+    ensureArguments(option, 1, 1);
+    const value = option.values[0];
+    ensureType(value, "string");
+    if (!options.incPds) {
+      options.incPds = {
+        pds: [],
+      };
+    }
+    options.incPds.pds.push(value.value);
+  },
+  ["NOINCPDS"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.incPds = false;
+  },
+);
+
 /** {@link CompilerOptions.initAuto} */
+translator.rule(
+  ["INITAUTO"],
+  (option, options) => {
+    ensureArguments(option, 0, 1);
+    if (option.values.length === 0) {
+      // TODO ssmifi: The spec does not say which one is the default.
+      options.initAuto = {};
+    } else {
+      ensureType(option.values[0], "plain");
+      const value = option.values[0].value.toUpperCase();
+      if (["SHORT", "FULL"].includes(value)) {
+        options.initAuto = {
+          length: value as CompilerOptions.InitAuto["length"],
+        };
+      } else {
+        throw TranslationError.fromCode(
+          option.values[0].token,
+          CompilerOptionsCodes.initAuto.WrongParameter,
+          option.values[0].value,
+        );
+      }
+    }
+  },
+  ["NOINITAUTO"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.initAuto = false;
+  },
+);
+
 /** {@link CompilerOptions.initBased} */
+translator.flag("initBased", ["INITBASED"], ["NOINITBASED"]);
+
 /** {@link CompilerOptions.initCtl} */
+translator.flag("initCtl", ["INITCTL"], ["NOINITCTL"]);
+
 /** {@link CompilerOptions.initStatic} */
+translator.flag("initStatic", ["INITSTATIC"], ["NOINITSTATIC"]);
+
 /** {@link CompilerOptions.inSource} */
+translator.rule(
+  ["INSOURCE"],
+  (option, options) => {
+    ensureArguments(option, 0, 1);
+    options.inSource = {};
+    if (option.values.length > 0) {
+      ensureType(option.values[0], "plain");
+      const value = option.values[0].value.toUpperCase();
+      if (["FULL", "SHORT", "ALL", "FIRST"].includes(value)) {
+        options.inSource!.type = value as CompilerOptions.InSource["type"];
+      } else {
+        throw TranslationError.fromCode(
+          option.values[0].token,
+          CompilerOptionsCodes.inSource.WrongParameter,
+          option.values[0].value,
+        );
+      }
+    }
+  },
+  ["NOINSOURCE"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.inSource = false;
+  },
+);
+
 /** {@link CompilerOptions.interrupt} */
+translator.flag("interrupt", ["INTERRUPT"], ["NOINTERRUPT"]);
+
 /** {@link CompilerOptions.json} */
 /** {@link CompilerOptions.langlvl} */
 /** {@link CompilerOptions.limits} */

--- a/packages/language/src/preprocessor/compiler-options/translator.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator.ts
@@ -193,7 +193,11 @@ class TranslationError {
     this.severity = severity;
   }
 
-  static fromCode(token: Token, code: ParametricPLICode, ...args: string[]) {
+  static fromCode(
+    token: Token,
+    code: ParametricPLICode,
+    ...args: (string | number | undefined)[]
+  ) {
     return new TranslationError(token, code.message(...args), code.severity);
   }
 }
@@ -205,10 +209,10 @@ function ensureArguments(option: CompilerOption, min: number, max?: number) {
   ) {
     throw TranslationError.fromCode(
       option.token,
-      CompilerOptionsCodes.WrongParameterCount,
-      option.values.length.toString(),
-      min.toString(),
-      max?.toString() ?? "",
+      CompilerOptionsCodes.InvalidParameterCount,
+      option.values.length,
+      min,
+      max,
     );
   }
 }
@@ -216,6 +220,10 @@ function ensureArguments(option: CompilerOption, min: number, max?: number) {
 function ensureType(
   value: CompilerOptionValue,
   type: "plain",
+): asserts value is CompilerOptionText;
+function ensureType(
+  value: CompilerOptionValue,
+  type: "plainNotEmpty",
 ): asserts value is CompilerOptionText;
 function ensureType(
   value: CompilerOptionValue,
@@ -231,22 +239,29 @@ function ensureType(
 ): asserts value is CompilerOption;
 function ensureType(
   value: CompilerOptionValue,
-  type: "option" | "plainOrString" | "string" | "plain",
+  type: "option" | "plainOrString" | "string" | "plain" | "plainNotEmpty",
 ): void {
   if (type === "option") {
     if (value.kind !== SyntaxKind.CompilerOption) {
       throw new TranslationError(
         value.token,
         CompilerOptionsCodes.ExpectedOption.message(),
-        1,
+        CompilerOptionsCodes.ExpectedOption.severity,
       );
     }
-  } else if (type === "plain") {
+  } else if (type === "plain" || type === "plainNotEmpty") {
     if (value.kind !== SyntaxKind.CompilerOptionText) {
       throw new TranslationError(
         value.token,
         CompilerOptionsCodes.ExpectedPlain.message(),
-        1,
+        CompilerOptionsCodes.ExpectedPlain.severity,
+      );
+    }
+    if (type === "plainNotEmpty" && value.value.length === 0) {
+      throw new TranslationError(
+        value.token,
+        CompilerOptionsCodes.ExpectedPlainNotEmpty.message(),
+        CompilerOptionsCodes.ExpectedPlainNotEmpty.severity,
       );
     }
   } else if (type === "string") {
@@ -254,7 +269,7 @@ function ensureType(
       throw new TranslationError(
         value.token,
         CompilerOptionsCodes.ExpectedString.message(),
-        1,
+        CompilerOptionsCodes.ExpectedString.severity,
       );
     }
   } else if (type === "plainOrString") {
@@ -265,11 +280,61 @@ function ensureType(
       throw new TranslationError(
         value.token,
         CompilerOptionsCodes.ExpectedPlainOrString.message(),
-        1,
+        CompilerOptionsCodes.ExpectedPlainOrString.severity,
       );
     }
   }
 }
+
+function ensureNumberValue(
+  value: CompilerOptionText,
+  min?: number,
+  max?: number,
+): number {
+  const num = stringToNumber(value.value);
+  if (isNaN(num)) {
+    throw TranslationError.fromCode(
+      value.token,
+      CompilerOptionsCodes.ExpectedNumber,
+    );
+  }
+  if ((min !== undefined && num < min) || (max !== undefined && num > max)) {
+    throw TranslationError.fromCode(
+      value.token,
+      CompilerOptionsCodes.ExpectedNumberRange,
+      num,
+      min,
+      max,
+    );
+  }
+  return num;
+}
+
+function stringToNumber(text: string): number {
+  const numRegex = /^\s*(\-?\d+)([kmg])?\s*$/i;
+  const match = numRegex.exec(text);
+  if (!match) {
+    return NaN;
+  }
+  let num = Number(match[1]);
+  if (match[2]) {
+    switch (match[2]) {
+      case "G":
+      case "g":
+        num *= 1024;
+      case "M":
+      case "m":
+        num *= 1024;
+      case "K":
+      case "k":
+        num *= 1024;
+    }
+  }
+  return num;
+}
+
+const $1K = 1024;
+const $1M = 1024 * 1024;
 
 const translator = new Translator();
 
@@ -282,6 +347,15 @@ function stringTranslate(
     ensureType(value, "string");
     callback(options, value);
   };
+}
+
+function isEmptyParameterList(option: CompilerOption): boolean {
+  // Is only true if there are parentheses without any text inside.
+  return (
+    option.values.length == 1 &&
+    option.values[0].kind == SyntaxKind.CompilerOptionText &&
+    option.values[0].value.length == 0
+  );
 }
 
 function plainTranslate(
@@ -1360,7 +1434,7 @@ translator.rule(
     } else {
       throw TranslationError.fromCode(
         value.token,
-        CompilerOptionsCodes.gonumber.WrongParameter,
+        CompilerOptionsCodes.GoNumber.InvalidParameter,
         value.value,
       );
     }
@@ -1386,7 +1460,7 @@ translator.rule(["HEADER"], (option, options) => {
   } else {
     throw TranslationError.fromCode(
       value.token,
-      CompilerOptionsCodes.header.WrongParameter,
+      CompilerOptionsCodes.Header.InvalidParameter,
       value.value,
     );
   }
@@ -1405,7 +1479,7 @@ translator.rule(["HGPR"], (option, options) => {
   } else {
     throw TranslationError.fromCode(
       value.token,
-      CompilerOptionsCodes.hgpr.WrongParameter,
+      CompilerOptionsCodes.Hgpr.InvalidParameter,
       value.value,
     );
   }
@@ -1429,7 +1503,7 @@ translator.rule(
       } else {
         throw TranslationError.fromCode(
           opt.token,
-          CompilerOptionsCodes.ignore.WrongParameter,
+          CompilerOptionsCodes.Ignore.InvalidParameter,
           opt.value,
         );
       }
@@ -1518,19 +1592,16 @@ translator.rule(
   (option, options) => {
     ensureArguments(option, 0, 1);
     if (option.values.length === 0) {
-      // TODO ssmifi: The spec does not say which one is the default.
-      options.initAuto = {};
+      options.initAuto = getDefaultCompilerOptions().initAuto;
     } else {
       ensureType(option.values[0], "plain");
       const value = option.values[0].value.toUpperCase();
       if (["SHORT", "FULL"].includes(value)) {
-        options.initAuto = {
-          length: value as CompilerOptions.InitAuto["length"],
-        };
+        options.initAuto = value as CompilerOptions.InitAuto;
       } else {
         throw TranslationError.fromCode(
           option.values[0].token,
-          CompilerOptionsCodes.initAuto.WrongParameter,
+          CompilerOptionsCodes.InitAuto.InvalidParameter,
           option.values[0].value,
         );
       }
@@ -1566,7 +1637,7 @@ translator.rule(
       } else {
         throw TranslationError.fromCode(
           option.values[0].token,
-          CompilerOptionsCodes.inSource.WrongParameter,
+          CompilerOptionsCodes.InSource.InvalidParameter,
           option.values[0].value,
         );
       }
@@ -1580,20 +1651,306 @@ translator.rule(
 );
 
 /** {@link CompilerOptions.interrupt} */
-translator.flag("interrupt", ["INTERRUPT"], ["NOINTERRUPT"]);
+translator.flag("interrupt", ["INTERRUPT", "INT"], ["NOINTERRUPT", "NINT"]);
 
 /** {@link CompilerOptions.json} */
+translator.rule(["JSON"], (option, options) => {
+  ensureArguments(option, 1);
+  if (!options.json) {
+    options.json = getDefaultCompilerOptions().json;
+  }
+  for (const opt of option.values) {
+    const name =
+      opt.kind === SyntaxKind.CompilerOption
+        ? opt.name.toUpperCase()
+        : opt.value.toUpperCase();
+    if (/^(NO)?TRIMR$/.test(name)) {
+      ensureType(opt, "plain");
+      options.json!.trimr = !name.startsWith("NO");
+    } else if (["CASE", "ENCODING", "GET", "PARSE"].includes(name)) {
+      ensureType(opt, "option");
+      ensureArguments(opt, 1, 1);
+      const value = opt.values[0];
+      ensureType(value, "plain");
+      const valueName = value.value.toUpperCase();
+      switch (name) {
+        case "CASE":
+          if (!["UPPER", "LOWER", "ASIS"].includes(valueName)) {
+            throw TranslationError.fromCode(
+              value.token,
+              CompilerOptionsCodes.Json.InvalidCaseParameter,
+              value.value,
+            );
+          }
+          options.json!.case = valueName as CompilerOptions.Json["case"];
+          break;
+        case "ENCODING":
+          if (!["UTF8", "EBCDIC", "37", "1047"].includes(valueName)) {
+            throw TranslationError.fromCode(
+              value.token,
+              CompilerOptionsCodes.Json.InvalidEncodingParameter,
+              value.value,
+            );
+          }
+          options.json!.encoding =
+            valueName as CompilerOptions.Json["encoding"];
+          break;
+        case "GET":
+          if (!["HEEDCASE", "IGNORECASE"].includes(valueName)) {
+            throw TranslationError.fromCode(
+              value.token,
+              CompilerOptionsCodes.Json.InvalidGetParameter,
+              value.value,
+            );
+          }
+          options.json!.get = valueName as CompilerOptions.Json["get"];
+          break;
+        case "PARSE":
+          if (!["V1", "V2"].includes(valueName)) {
+            throw TranslationError.fromCode(
+              value.token,
+              CompilerOptionsCodes.Json.InvalidParseParameter,
+              value.value,
+            );
+          }
+          options.json!.parse = valueName as CompilerOptions.Json["parse"];
+          break;
+      }
+    } else {
+      throw TranslationError.fromCode(
+        opt.token,
+        CompilerOptionsCodes.Json.InvalidParameter,
+        name,
+      );
+    }
+  }
+});
+
 /** {@link CompilerOptions.langlvl} */
+translator.rule(["LANGLVL"], (option, options) => {
+  ensureArguments(option, 1);
+  for (const value of option.values) {
+    ensureType(value, "plain");
+    const valueName = value.value.toUpperCase();
+    if (["OS", "NOEXT"].includes(valueName)) {
+      options.langlvl = valueName as CompilerOptions.LangLvl;
+    } else {
+      throw TranslationError.fromCode(
+        value.token,
+        CompilerOptionsCodes.LangLvl.InvalidParameter,
+        value.value,
+      );
+    }
+  }
+});
+
 /** {@link CompilerOptions.limits} */
+translator.rule(["LIMITS"], (option, options) => {
+  const optionNumberValue = (
+    option: CompilerOption,
+    index: number,
+    min?: number,
+    max?: number,
+  ) => {
+    const value = option.values[index];
+    ensureType(value, "plainNotEmpty");
+    return ensureNumberValue(value, min, max);
+  };
+
+  ensureArguments(option, 1);
+  if (!options.limits) {
+    options.limits = getDefaultCompilerOptions().limits;
+  }
+  for (const value of option.values) {
+    ensureType(value, "option");
+    const name = value.name.toUpperCase();
+    if (["EXTNAME", "FIXEDBIN", "FIXEDDEC", "NAME", "STRING"].includes(name)) {
+      switch (name) {
+        case "EXTNAME":
+          ensureArguments(value, 1, 1);
+          options.limits!.extname = optionNumberValue(value, 0, 7, 100);
+          break;
+        case "FIXEDBIN":
+          ensureArguments(value, 1, 2);
+          const minBin = optionNumberValue(value, 0);
+          const maxBin =
+            value.values.length > 1 ? optionNumberValue(value, 1) : 63;
+          if (minBin !== 31 && minBin !== 63) {
+            throw TranslationError.fromCode(
+              value.values[0].token,
+              CompilerOptionsCodes.Limits.InvalidFixedBinMinParameter,
+              minBin.toString(),
+            );
+          }
+          if (maxBin !== 63) {
+            throw TranslationError.fromCode(
+              value.values[1].token,
+              CompilerOptionsCodes.Limits.InvalidFixedBinMaxParameter,
+              maxBin.toString(),
+            );
+          }
+          options.limits!.fixedBin = {
+            min: minBin,
+            max: maxBin,
+          };
+          break;
+        case "FIXEDDEC":
+          ensureArguments(value, 1, 2);
+          const minDec = optionNumberValue(value, 0);
+          const maxDec =
+            value.values.length > 1 ? optionNumberValue(value, 1) : minDec;
+          if (minDec !== 15 && minDec !== 31) {
+            throw TranslationError.fromCode(
+              value.values[0].token,
+              CompilerOptionsCodes.Limits.InvalidFixedDecMinParameter,
+              minDec.toString(),
+            );
+          }
+          if (maxDec !== 15 && maxDec !== 31) {
+            throw TranslationError.fromCode(
+              value.values[1].token,
+              CompilerOptionsCodes.Limits.InvalidFixedDecMaxParameter,
+              maxDec.toString(),
+            );
+          }
+          if (minDec > maxDec) {
+            throw TranslationError.fromCode(
+              value.values[0].token,
+              CompilerOptionsCodes.Limits.InvalidFixedDecRange,
+            );
+          }
+          options.limits!.fixedDec = {
+            min: minDec,
+            max: maxDec,
+          };
+          break;
+        case "NAME":
+          ensureArguments(value, 1, 1);
+          options.limits!.name = optionNumberValue(value, 0, 31, 100);
+          break;
+        case "STRING":
+          ensureArguments(value, 1, 1);
+          ensureType(value.values[0], "plainNotEmpty");
+          const stringValue = ensureNumberValue(
+            value.values[0],
+            32 * $1K,
+            128 * $1M,
+          );
+          if (
+            [32 * $1K, 64 * $1K, 512 * $1K, 8 * $1M, 128 * $1M].includes(
+              stringValue,
+            )
+          ) {
+            options.limits!.string = stringValue;
+          } else {
+            throw TranslationError.fromCode(
+              value.values[0].token,
+              CompilerOptionsCodes.Limits.InvalidStringParameter,
+              stringValue,
+            );
+          }
+          break;
+      }
+    } else {
+      throw TranslationError.fromCode(
+        value.token,
+        CompilerOptionsCodes.Limits.InvalidParameter,
+        name,
+      );
+    }
+  }
+});
+
 /** {@link CompilerOptions.lineCount} */
+translator.rule(["LINECOUNT", "LC"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "plainNotEmpty");
+  const lineCount = ensureNumberValue(value, 0, 65535);
+  if (lineCount > 0 && lineCount < 10) {
+    throw TranslationError.fromCode(
+      value.token,
+      CompilerOptionsCodes.LineCount.InvalidRange,
+      value.value,
+    );
+  }
+  options.lineCount = lineCount;
+});
+
 /** {@link CompilerOptions.lineDir} */
+translator.flag("lineDir", ["LINEDIR"], ["NOLINEDIR"]);
+
 /** {@link CompilerOptions.list} */
 translator.flag("list", ["LIST"], ["NOLIST"]);
+
 /** {@link CompilerOptions.listView} */
+translator.rule(["LISTVIEW"], (option, options) => {
+  ensureArguments(option, 1);
+  for (const value of option.values) {
+    ensureType(value, "plain");
+    const valueName = value.value.toUpperCase();
+    if (
+      ["SOURCE", "AFTERALL", "AFTERCICS", "AFTERMACRO", "AFTERSQL"].includes(
+        valueName,
+      )
+    ) {
+      options.listView = valueName as CompilerOptions.ListView;
+    } else {
+      throw TranslationError.fromCode(
+        value.token,
+        CompilerOptionsCodes.ListView.InvalidParameter,
+        value.value,
+      );
+    }
+  }
+});
+
 /** {@link CompilerOptions.LP} */
+translator.rule(["LP"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  ensureType(option.values[0], "plain");
+  const value = option.values[0].value.toUpperCase();
+  if (["32", "64"].includes(value)) {
+    options.LP = value as "32" | "64";
+  } else {
+    throw TranslationError.fromCode(
+      option.values[0].token,
+      CompilerOptionsCodes.Lp.InvalidParameter,
+      option.values[0].value,
+    );
+  }
+});
+
 /** {@link CompilerOptions.macro} */
+translator.flag("macro", ["MACRO"], ["NOMACRO"]);
+
 /** {@link CompilerOptions.map} */
+translator.flag("map", ["MAP"], ["NOMAP"]);
+
 /** {@link CompilerOptions.margini} */
+translator.rule(
+  ["MARGINI", "MI"],
+  (option, options) => {
+    ensureArguments(option, 1, 1);
+    const value = option.values[0];
+    ensureType(value, "string");
+    if (value.value.length !== 1) {
+      throw TranslationError.fromCode(
+        value.token,
+        CompilerOptionsCodes.Margini.InvalidParameter,
+        value.value,
+      );
+    }
+    options.margini = {
+      character: value.value,
+    };
+  },
+  ["NOMARGINI", "NMI"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.margini = false;
+  },
+);
 
 /** {@link CompilerOptions.margins} */
 translator.rule(
@@ -1639,10 +1996,59 @@ translator.rule(
 );
 
 /** {@link CompilerOptions.maxbranch} */
+translator.rule(["MAXBRANCH"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "plainNotEmpty");
+  options.maxbranch = ensureNumberValue(value, 0);
+});
+
 /** {@link CompilerOptions.maxinit} */
+translator.rule(["MAXINIT"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "plainNotEmpty");
+  options.maxinit = ensureNumberValue(value, 0);
+});
+
 /** {@link CompilerOptions.maxgen} */
+translator.rule(["MAXGEN"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "plainNotEmpty");
+  options.maxgen = ensureNumberValue(value, 0);
+});
+
 /** {@link CompilerOptions.maxmem} */
+translator.rule(["MAXMEM", "MAXM"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "plainNotEmpty");
+  options.maxmem = ensureNumberValue(value, 1, 2097152);
+});
+
 /** {@link CompilerOptions.maxmsg} */
+translator.rule(["MAXMSG"], (option, options) => {
+  ensureArguments(option, 1);
+  // MAXMSG only recognizes the last letter or number, respectively.
+  // The letter/number order does not matter.
+  if (!options.maxmsg) {
+    options.maxmsg = getDefaultCompilerOptions().maxmsg;
+  }
+  if (isEmptyParameterList(option)) {
+    return;
+  }
+  for (const value of option.values) {
+    ensureType(value, "plain");
+    const valueName = value.value.toUpperCase();
+    if (["I", "W", "E", "S"].includes(valueName)) {
+      options.maxmsg!.severity = valueName as CompilerOptions.Flag;
+    } else {
+      options.maxmsg!.n = ensureNumberValue(value, 0, 32767);
+    }
+  }
+});
+
 /** {@link CompilerOptions.maxnest} */
 /** {@link CompilerOptions.maxRunOnIf} */
 /** {@link CompilerOptions.maxStatic} */

--- a/packages/language/src/validation/messages/pli-codes.ts
+++ b/packages/language/src/validation/messages/pli-codes.ts
@@ -67,7 +67,7 @@ export interface ParametricPLICode {
    * Message for the code, with placeholders for parameters
    */
   // Todo: add a generic type for the arguments to the interface
-  message: (...args: string[]) => string;
+  message: (...args: (string | number | undefined)[]) => string;
 }
 
 export const Info = {

--- a/packages/language/test/compiler/options-parser.test.ts
+++ b/packages/language/test/compiler/options-parser.test.ts
@@ -115,8 +115,8 @@ describe("CompilerOptions translator", async () => {
     // Margins requires two or three arguments
     const options = await parseAbstractCompilerOptions("MARGINS(4)");
     const translated = translateCompilerOptions(options).options;
-    // If the parsing fails, the option is not set
-    expect(translated.margins).toBeUndefined();
+    // If the parsing fails, the option is set to its default values
+    expect(translated.margins).toEqual({ m: 2, n: 72 });
   });
 
   test("Translates MARGINS with c", async () => {
@@ -340,7 +340,7 @@ describe("CompilerOptions translator", async () => {
     const issues = translateCompilerOptions(options).issues;
     expect(issues).toHaveLength(1);
     expect(issues[0].message).toBe(
-      "Expected at least 1 arguments, but received 0.",
+      "Expected at least 1 argument, but received 0.",
     );
   });
 

--- a/packages/language/test/fourslash-harness/harness-interface.ts
+++ b/packages/language/test/fourslash-harness/harness-interface.ts
@@ -70,7 +70,7 @@ export interface HarnessTesterInterface {
      * verify.noDiagnostics('i');
      * ```
      */
-    noDiagnostics(label?: string | number): void;
+    noDiagnostics(label?: Label): void;
 
     /**
      * Expect that the compilation unit has no diagnostics apart from the given regexes.

--- a/packages/language/test/fourslash-harness/implementation/test-builder.ts
+++ b/packages/language/test/fourslash-harness/implementation/test-builder.ts
@@ -46,7 +46,7 @@ export function createTestBuilderHarnessImplementation(
         testBuilder.expectDiagnosticsAt(label, diagnostics),
       noDiagnostics: (label) =>
         label !== undefined
-          ? testBuilder.expectNoDiagnosticsAt(label.toString())
+          ? testBuilder.expectNoDiagnosticsAt(label)
           : testBuilder.expectNoDiagnostics(),
       noDiagnosticsExcept: (regex: RegExp[]) =>
         testBuilder.noDiagnosticsExcept(regex),

--- a/packages/language/test/fourslash/preprocessor/compiler-options/gonumber.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/gonumber.ts
@@ -22,31 +22,26 @@
 ////*PROCESS <|7:GN|>(SEPARATE);
 
 verify.expectDiagnosticsAt(1, {
-  message: code.CompilerOptions.gonumber.WrongParameter.message("Nxx"),
+  message: code.CompilerOptions.GoNumber.InvalidParameter.message("Nxx"),
 });
 verify.expectDiagnosticsAt(2, {
-  message: code.CompilerOptions.WrongParameterCount.message("1", "0", "0"),
+  message: code.CompilerOptions.InvalidParameterCount.message(1, 0, 0),
 });
 verify.expectDiagnosticsAt(3, {
   message: code.CompilerOptions.DupeOptionIssue.message("GONUMBER"),
 });
-
 verify.expectDiagnosticsAt(4, {
   message: code.CompilerOptions.MutexOptionIssue.message("NOGONUMBER"),
 });
-
 verify.expectDiagnosticsAt(5, {
   message: code.CompilerOptions.DupeOptionIssue.message("GN"),
 });
-
 verify.expectDiagnosticsAt(6, {
   message: code.CompilerOptions.MutexOptionIssue.message("NGN"),
 });
-
 verify.expectDiagnosticsAt(7, {
   message: code.CompilerOptions.DupeOptionIssue.message("GN"),
 });
-
 verify.expectCompilerOptions({
   goNumber: {
     separate: true,

--- a/packages/language/test/fourslash/preprocessor/compiler-options/graphic.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/graphic.ts
@@ -20,11 +20,9 @@
 verify.expectDiagnosticsAt(1, {
   message: code.CompilerOptions.MutexOptionIssue.message("NOGRAPHIC"),
 });
-
 verify.expectDiagnosticsAt(2, {
   message: code.CompilerOptions.MutexOptionIssue.message("NGR"),
 });
-
 verify.expectDiagnosticsAt(3, {
   message: code.CompilerOptions.DupeOptionIssue.message("GR"),
 });
@@ -35,7 +33,6 @@ verify.noDiagnosticsExcept([
     code.CompilerOptions.MutexOptionIssue.message("").substring(0, 20),
   ),
 ]);
-
 verify.expectCompilerOptions({
   graphic: true,
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/header.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/header.ts
@@ -23,19 +23,15 @@
 verify.expectDiagnosticsAt([1, 2, 3], {
   message: code.CompilerOptions.DupeOptionIssue.message("HEADER"),
 });
-
 verify.expectDiagnosticsAt(4, {
-  message: code.CompilerOptions.header.WrongParameter.message("INVALID"),
+  message: code.CompilerOptions.Header.InvalidParameter.message("INVALID"),
 });
-
 verify.expectDiagnosticsAt(5, {
-  message: code.CompilerOptions.header.WrongParameter.message(""),
+  message: code.CompilerOptions.Header.InvalidParameter.message(""),
 });
-
 verify.expectDiagnosticsAt(6, {
-  message: code.CompilerOptions.WrongParameterCount.message("0", "1", "1"),
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
 });
-
 verify.expectCompilerOptions({
   header: "SOURCE",
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/hgpr.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/hgpr.ts
@@ -21,19 +21,15 @@
 verify.expectDiagnosticsAt(3, {
   message: code.CompilerOptions.DupeOptionIssue.message("HGPR"),
 });
-
 verify.expectDiagnosticsAt(2, {
-  message: code.CompilerOptions.hgpr.WrongParameter.message("INVALID"),
+  message: code.CompilerOptions.Hgpr.InvalidParameter.message("INVALID"),
 });
-
 verify.expectDiagnosticsAt(5, {
-  message: code.CompilerOptions.hgpr.WrongParameter.message(""),
+  message: code.CompilerOptions.Hgpr.InvalidParameter.message(""),
 });
-
 verify.expectDiagnosticsAt(6, {
-  message: code.CompilerOptions.WrongParameterCount.message("0", "1", "1"),
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
 });
-
 verify.expectCompilerOptions({
   hgpr: {
     preserve: true,

--- a/packages/language/test/fourslash/preprocessor/compiler-options/incdir.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/incdir.ts
@@ -1,0 +1,33 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NOINCDIR;
+////*PROCESS <|1:INCDIR|>(<|2:)|>;
+////*PROCESS <|3:INCDIR|>(<|4:NoString|>);
+////*PROCESS <|5:INCDIR|>('lib');
+////*PROCESS <|6:INCDIR|>('lib2');
+
+verify.expectDiagnosticsAt([1, 3, 5, 6], {
+  message: code.CompilerOptions.MutexOptionIssue.message("INCDIR"),
+});
+
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.ExpectedString.message(),
+});
+
+verify.expectCompilerOptions({
+  incDir: {
+    directories: ["lib", "lib2"],
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/incdir.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/incdir.ts
@@ -21,11 +21,9 @@
 verify.expectDiagnosticsAt([1, 3, 5, 6], {
   message: code.CompilerOptions.MutexOptionIssue.message("INCDIR"),
 });
-
 verify.expectDiagnosticsAt(2, {
   message: code.CompilerOptions.ExpectedString.message(),
 });
-
 verify.expectCompilerOptions({
   incDir: {
     directories: ["lib", "lib2"],

--- a/packages/language/test/fourslash/preprocessor/compiler-options/include.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/include.ts
@@ -1,0 +1,29 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NOINCLUDE;
+////*PROCESS <|1:INCLUDE|>;
+////*PROCESS <|2:INCLUDE|>(INVALID);
+
+verify.expectDiagnosticsAt([1, 2], {
+  message: code.CompilerOptions.MutexOptionIssue.message("INCLUDE"),
+});
+
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.WrongParameterCount.message("1", "0", "0"),
+});
+
+verify.expectCompilerOptions({
+  include: true,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/incpds.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/incpds.ts
@@ -1,0 +1,37 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NOINCPDS;
+////*PROCESS <|1:INCPDS|>;
+////*PROCESS <|2:INCPDS|>(<|3:INVALID|>);
+////*PROCESS <|4:INCPDS|>('PDSName');
+////*PROCESS <|5:INCPDS|>('PDSName2');
+
+verify.expectDiagnosticsAt([1, 2, 4, 5], {
+  message: code.CompilerOptions.MutexOptionIssue.message("INCPDS"),
+});
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.WrongParameterCount.message("0", "1", "1"),
+});
+
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.ExpectedString.message(),
+});
+
+verify.expectCompilerOptions({
+  incPds: {
+    pds: ["PDSName", "PDSName2"],
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/incpds.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/incpds.ts
@@ -21,15 +21,12 @@
 verify.expectDiagnosticsAt([1, 2, 4, 5], {
   message: code.CompilerOptions.MutexOptionIssue.message("INCPDS"),
 });
-
 verify.expectDiagnosticsAt(1, {
-  message: code.CompilerOptions.WrongParameterCount.message("0", "1", "1"),
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
 });
-
 verify.expectDiagnosticsAt(3, {
   message: code.CompilerOptions.ExpectedString.message(),
 });
-
 verify.expectCompilerOptions({
   incPds: {
     pds: ["PDSName", "PDSName2"],

--- a/packages/language/test/fourslash/preprocessor/compiler-options/initauto.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/initauto.ts
@@ -1,0 +1,42 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NOINITAUTO;
+////*PROCESS <|1:INITAUTO|>;
+////*PROCESS <|2:INITAUTO|>(<|3:)|>;
+////*PROCESS <|4:INITAUTO|>(<|5:'SHORT'|>);
+////*PROCESS <|6:INITAUTO|>(<|7:LONG|>);
+////*PROCESS <|8:INITAUTO|>(<|9:FULL|>);
+
+verify.expectDiagnosticsAt([1, 2, 4, 6, 8], {
+  message: code.CompilerOptions.MutexOptionIssue.message("INITAUTO"),
+});
+
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.initAuto.WrongParameter.message(""),
+});
+
+verify.expectDiagnosticsAt(7, {
+  message: code.CompilerOptions.initAuto.WrongParameter.message("LONG"),
+});
+
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.ExpectedPlain.message(),
+});
+
+verify.expectCompilerOptions({
+  initAuto: {
+    length: "FULL",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/initauto.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/initauto.ts
@@ -22,21 +22,15 @@
 verify.expectDiagnosticsAt([1, 2, 4, 6, 8], {
   message: code.CompilerOptions.MutexOptionIssue.message("INITAUTO"),
 });
-
 verify.expectDiagnosticsAt(3, {
-  message: code.CompilerOptions.initAuto.WrongParameter.message(""),
+  message: code.CompilerOptions.InitAuto.InvalidParameter.message(""),
 });
-
 verify.expectDiagnosticsAt(7, {
-  message: code.CompilerOptions.initAuto.WrongParameter.message("LONG"),
+  message: code.CompilerOptions.InitAuto.InvalidParameter.message("LONG"),
 });
-
 verify.expectDiagnosticsAt(5, {
   message: code.CompilerOptions.ExpectedPlain.message(),
 });
-
 verify.expectCompilerOptions({
-  initAuto: {
-    length: "FULL",
-  },
+  initAuto: "FULL",
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/initbased.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/initbased.ts
@@ -19,11 +19,9 @@
 verify.expectDiagnosticsAt([1, 2], {
   message: code.CompilerOptions.MutexOptionIssue.message("INITBASED"),
 });
-
 verify.expectDiagnosticsAt(1, {
-  message: code.CompilerOptions.WrongParameterCount.message("1", "0", "0"),
+  message: code.CompilerOptions.InvalidParameterCount.message(1, 0, 0),
 });
-
 verify.expectCompilerOptions({
   initBased: true,
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/initbased.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/initbased.ts
@@ -1,0 +1,29 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NOINITBASED;
+////*PROCESS <|1:INITBASED|>();
+////*PROCESS <|2:INITBASED|>;
+
+verify.expectDiagnosticsAt([1, 2], {
+  message: code.CompilerOptions.MutexOptionIssue.message("INITBASED"),
+});
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.WrongParameterCount.message("1", "0", "0"),
+});
+
+verify.expectCompilerOptions({
+  initBased: true,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/initctl.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/initctl.ts
@@ -1,0 +1,29 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NOINITCTL;
+////*PROCESS <|1:INITCTL|>();
+////*PROCESS <|2:INITCTL|>;
+
+verify.expectDiagnosticsAt([1, 2], {
+  message: code.CompilerOptions.MutexOptionIssue.message("INITCTL"),
+});
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.WrongParameterCount.message("1", "0", "0"),
+});
+
+verify.expectCompilerOptions({
+  initCtl: true,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/initctl.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/initctl.ts
@@ -19,11 +19,9 @@
 verify.expectDiagnosticsAt([1, 2], {
   message: code.CompilerOptions.MutexOptionIssue.message("INITCTL"),
 });
-
 verify.expectDiagnosticsAt(1, {
-  message: code.CompilerOptions.WrongParameterCount.message("1", "0", "0"),
+  message: code.CompilerOptions.InvalidParameterCount.message(1, 0, 0),
 });
-
 verify.expectCompilerOptions({
   initCtl: true,
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/initstatic.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/initstatic.ts
@@ -19,11 +19,9 @@
 verify.expectDiagnosticsAt([1, 2], {
   message: code.CompilerOptions.MutexOptionIssue.message("INITSTATIC"),
 });
-
 verify.expectDiagnosticsAt(1, {
-  message: code.CompilerOptions.WrongParameterCount.message("1", "0", "0"),
+  message: code.CompilerOptions.InvalidParameterCount.message(1, 0, 0),
 });
-
 verify.expectCompilerOptions({
   initStatic: true,
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/initstatic.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/initstatic.ts
@@ -1,0 +1,29 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NOINITSTATIC;
+////*PROCESS <|1:INITSTATIC|>();
+////*PROCESS <|2:INITSTATIC|>;
+
+verify.expectDiagnosticsAt([1, 2], {
+  message: code.CompilerOptions.MutexOptionIssue.message("INITSTATIC"),
+});
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.WrongParameterCount.message("1", "0", "0"),
+});
+
+verify.expectCompilerOptions({
+  initStatic: true,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/insource.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/insource.ts
@@ -1,0 +1,37 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NOINSOURCE;
+////*PROCESS <|1:INSOURCE|>;
+////*PROCESS <|2:INSOURCE|>(<|3:INVALID|>);
+////*PROCESS <|4:INSOURCE|>(<|5:'FULL'|>);
+////*PROCESS <|6:INSOURCE|>(FULL);
+
+verify.expectDiagnosticsAt([1, 2, 4, 6], {
+  message: code.CompilerOptions.MutexOptionIssue.message("INSOURCE"),
+});
+
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.inSource.WrongParameter.message("INVALID"),
+});
+
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.ExpectedPlain.message(),
+});
+
+verify.expectCompilerOptions({
+  inSource: {
+    type: "FULL",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/insource.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/insource.ts
@@ -21,15 +21,12 @@
 verify.expectDiagnosticsAt([1, 2, 4, 6], {
   message: code.CompilerOptions.MutexOptionIssue.message("INSOURCE"),
 });
-
 verify.expectDiagnosticsAt(3, {
-  message: code.CompilerOptions.inSource.WrongParameter.message("INVALID"),
+  message: code.CompilerOptions.InSource.InvalidParameter.message("INVALID"),
 });
-
 verify.expectDiagnosticsAt(5, {
   message: code.CompilerOptions.ExpectedPlain.message(),
 });
-
 verify.expectCompilerOptions({
   inSource: {
     type: "FULL",

--- a/packages/language/test/fourslash/preprocessor/compiler-options/interruppt.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/interruppt.ts
@@ -1,0 +1,29 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NOINTERRUPT;
+////*PROCESS <|1:INTERRUPT|>();
+////*PROCESS <|2:INTERRUPT|>;
+
+verify.expectDiagnosticsAt([1, 2], {
+  message: code.CompilerOptions.MutexOptionIssue.message("INTERRUPT"),
+});
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.WrongParameterCount.message("1", "0", "0"),
+});
+
+verify.expectCompilerOptions({
+  interrupt: true,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/interruppt.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/interruppt.ts
@@ -15,15 +15,21 @@
 ////*PROCESS NOINTERRUPT;
 ////*PROCESS <|1:INTERRUPT|>();
 ////*PROCESS <|2:INTERRUPT|>;
+////*PROCESS <|3:NINT|>;
+////*PROCESS <|4:INT|>;
 
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(1, 0, 0),
+});
 verify.expectDiagnosticsAt([1, 2], {
   message: code.CompilerOptions.MutexOptionIssue.message("INTERRUPT"),
 });
-
-verify.expectDiagnosticsAt(1, {
-  message: code.CompilerOptions.WrongParameterCount.message("1", "0", "0"),
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.MutexOptionIssue.message("INT"),
 });
-
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.DupeOptionIssue.message("NINT"),
+});
 verify.expectCompilerOptions({
   interrupt: true,
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/json.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/json.ts
@@ -1,0 +1,53 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:JSON|>;
+////*PROCESS <|2:JSON|>(<|3:)|>;
+////*PROCESS <|4:JSON|>(<|5:INVALID|>, <|6:INVALID|>);
+////*PROCESS <|7:JSON|>(CASE(<|8:INVALID|>));
+////*PROCESS <|9:JSON|>(GET(<|10:INVALID|>));
+////*PROCESS <|11:JSON|>(PARSE(<|12:INVALID|>));
+////*PROCESS <|13:JSON|>(CASE(ASIS), NOTRIMR);
+////*PROCESS <|14:JSON|>(GET(IGNORECASE) PARSE(V2));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.Json.InvalidParameter.message(""),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.Json.InvalidParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt(8, {
+  message: code.CompilerOptions.Json.InvalidCaseParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt(10, {
+  message: code.CompilerOptions.Json.InvalidGetParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt(12, {
+  message: code.CompilerOptions.Json.InvalidParseParameter.message("INVALID"),
+});
+// TODO ssmifi: In an upcoming revision, the JSON compiler option should not report dupes. (#321)
+verify.expectDiagnosticsAt([2, 4, 7, 9, 11, 13, 14], {
+  message: code.CompilerOptions.DupeOptionIssue.message("JSON"),
+});
+verify.expectCompilerOptions({
+  json: {
+    case: "ASIS",
+    trimr: false,
+    get: "IGNORECASE",
+    parse: "V2",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/langlvl.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/langlvl.ts
@@ -1,0 +1,38 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:LANGLVL|>;
+////*PROCESS <|2:LANGLVL|>(<|3:)|>;
+////*PROCESS <|4:LANGLVL|>(<|5:INVALID|>);
+////*PROCESS <|6:LANGLVL|>(<|7:'OS'|>, NOEXT);
+////*PROCESS <|8:LANGLVL|>(OS, NOEXT);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1),
+});
+verify.expectDiagnosticsAt([2, 4, 6, 8], {
+  message: code.CompilerOptions.DupeOptionIssue.message("LANGLVL"),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.LangLvl.InvalidParameter.message(""),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.LangLvl.InvalidParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt(7, {
+  message: code.CompilerOptions.ExpectedPlain.message(),
+});
+verify.expectCompilerOptions({
+  langlvl: "NOEXT",
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/limits.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/limits.ts
@@ -1,0 +1,107 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:LIMITS|>;
+////*PROCESS <|dupe0:LIMITS|>(<|2:)|>;
+////*PROCESS <|dupe1:LIMITS|>(<|3:INVALID|>);
+////*PROCESS <|dupe2:LIMITS|>(<|4:INVALID|>());
+////*PROCESS <|dupe3:LIMITS|>(FIXEDBIN(<|5:INVALID|>));
+////*PROCESS <|dupe4:LIMITS|>(FIXEDDEC(<|6:INVALID|>));
+////*PROCESS <|dupe5:LIMITS|>(NAME(<|7:INVALID|>));
+////*PROCESS <|dupe6:LIMITS|>(STRING(<|8:INVALID|>));
+////*PROCESS <|dupe7:LIMITS|>(EXTNAME(<|9:INVALID|>));
+////*PROCESS <|dupe8:LIMITS|>(FIXEDBIN(<|10:30|>));
+////*PROCESS <|dupe9:LIMITS|>(FIXEDBIN(31, <|11:31|>));
+////*PROCESS <|dupe10:LIMITS|>(FIXEDDEC(<|12:30|>));
+////*PROCESS <|dupe12:LIMITS|>(FIXEDDEC(15, <|13:30|>));
+////*PROCESS <|dupe11:LIMITS|>(FIXEDDEC(<|14:31|>, 15));
+////*PROCESS <|dupe13:LIMITS|>(NAME(<|15:3|>));
+////*PROCESS <|dupe14:LIMITS|>(EXTNAME(<|16:3|>));
+////*PROCESS <|dupe15:LIMITS|>(FIXEDBIN(31, 63));
+////*PROCESS <|dupe16:LIMITS|>(FIXEDDEC(15, 15));
+////*PROCESS <|dupe17:LIMITS|>(NAME(64));
+////*PROCESS <|dupe18:LIMITS|>(EXTNAME(80));
+////*PROCESS <|dupe19:LIMITS|>(STRING(32K));
+////*PROCESS <|dupe20:LIMITS|>(STRING(512K));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1),
+});
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.ExpectedOption.message(),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.ExpectedOption.message(),
+});
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.Limits.InvalidParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt([5, 6, 7], {
+  message: code.CompilerOptions.ExpectedNumber.message(),
+});
+verify.expectDiagnosticsAt(8, {
+  message: code.CompilerOptions.ExpectedNumber.message("INVALID"),
+});
+verify.expectDiagnosticsAt(9, {
+  message: code.CompilerOptions.ExpectedNumber.message(),
+});
+verify.expectDiagnosticsAt(10, {
+  message:
+    code.CompilerOptions.Limits.InvalidFixedBinMinParameter.message("30"),
+});
+verify.expectDiagnosticsAt(11, {
+  message:
+    code.CompilerOptions.Limits.InvalidFixedBinMaxParameter.message("31"),
+});
+verify.expectDiagnosticsAt(12, {
+  message:
+    code.CompilerOptions.Limits.InvalidFixedDecMinParameter.message("30"),
+});
+verify.expectDiagnosticsAt(13, {
+  message:
+    code.CompilerOptions.Limits.InvalidFixedDecMaxParameter.message("30"),
+});
+verify.expectDiagnosticsAt(14, {
+  message: code.CompilerOptions.Limits.InvalidFixedDecRange.message(),
+});
+verify.expectDiagnosticsAt(15, {
+  message: code.CompilerOptions.ExpectedNumberRange.message("3", "31", "100"),
+});
+verify.expectDiagnosticsAt(16, {
+  message: code.CompilerOptions.ExpectedNumberRange.message("3", "7", "100"),
+});
+// TODO ssmifi: In an upcoming revision, the LIMITS compiler option should not report dupes. (#321)
+verify.expectDiagnosticsAt(
+  Array.from({ length: 21 }, (_, i) => `dupe${i}`),
+  {
+    message: code.CompilerOptions.DupeOptionIssue.message("LIMITS"),
+  },
+);
+verify.expectCompilerOptions({
+  limits: {
+    fixedBin: {
+      min: 31,
+      max: 63,
+    },
+    fixedDec: {
+      min: 15,
+      max: 15,
+    },
+    name: 64,
+    extname: 80,
+    // TODO ssmifi: Note that the string sub-option also depends on BIFPREC and CMPAT (#322).
+    // A check for compiler option dependencies should be added in the future.
+    string: 512 * 1024,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/linecount.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/linecount.ts
@@ -1,0 +1,42 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:LINECOUNT|>;
+////*PROCESS <|2:LINECOUNT|>(<|3:)|>;
+////*PROCESS <|4:LINECOUNT|>(<|5:INVALID|>);
+////*PROCESS <|6:LINECOUNT|>(<|7:3|>);
+////*PROCESS <|8:LC|>(11411);
+////*PROCESS <|9:LINECOUNT|>(44144);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.ExpectedNumber.message(),
+});
+verify.expectDiagnosticsAt(7, {
+  message: code.CompilerOptions.LineCount.InvalidRange.message("3"),
+});
+verify.expectDiagnosticsAt([2, 4, 6, 9], {
+  message: code.CompilerOptions.DupeOptionIssue.message("LINECOUNT"),
+});
+verify.expectDiagnosticsAt(8, {
+  message: code.CompilerOptions.DupeOptionIssue.message("LC"),
+});
+verify.expectCompilerOptions({
+  lineCount: 44144,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/linedir.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/linedir.ts
@@ -12,16 +12,16 @@
 /// <reference path="../../framework.ts" />
 
 // @wrap: process
-////*PROCESS NOINCLUDE;
-////*PROCESS <|1:INCLUDE|>;
-////*PROCESS <|2:INCLUDE|>(INVALID);
+////*PROCESS NOLINEDIR;
+////*PROCESS <|1:LINEDIR|>();
+////*PROCESS <|2:LINEDIR|>;
 
-verify.expectDiagnosticsAt([1, 2], {
-  message: code.CompilerOptions.MutexOptionIssue.message("INCLUDE"),
-});
-verify.expectDiagnosticsAt(2, {
+verify.expectDiagnosticsAt(1, {
   message: code.CompilerOptions.InvalidParameterCount.message(1, 0, 0),
 });
+verify.expectDiagnosticsAt([1, 2], {
+  message: code.CompilerOptions.MutexOptionIssue.message("LINEDIR"),
+});
 verify.expectCompilerOptions({
-  include: true,
+  lineDir: true,
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/list.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/list.ts
@@ -12,16 +12,16 @@
 /// <reference path="../../framework.ts" />
 
 // @wrap: process
-////*PROCESS NOINCLUDE;
-////*PROCESS <|1:INCLUDE|>;
-////*PROCESS <|2:INCLUDE|>(INVALID);
+////*PROCESS NOLIST;
+////*PROCESS <|1:LIST|>();
+////*PROCESS <|2:LIST|>;
 
-verify.expectDiagnosticsAt([1, 2], {
-  message: code.CompilerOptions.MutexOptionIssue.message("INCLUDE"),
-});
-verify.expectDiagnosticsAt(2, {
+verify.expectDiagnosticsAt(1, {
   message: code.CompilerOptions.InvalidParameterCount.message(1, 0, 0),
 });
+verify.expectDiagnosticsAt([1, 2], {
+  message: code.CompilerOptions.MutexOptionIssue.message("LIST"),
+});
 verify.expectCompilerOptions({
-  include: true,
+  list: true,
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/listview.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/listview.ts
@@ -1,0 +1,36 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:LISTVIEW|>;
+////*PROCESS <|2:LISTVIEW|>(<|3:)|>;
+////*PROCESS <|4:LISTVIEW|>(<|5:INVALID|>);
+////*PROCESS <|6:LISTVIEW|>(<|7:SOURCE|> AFTERSQL);
+////*PROCESS <|8:LISTVIEW|>(SOURCE, AFTERALL);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.ListView.InvalidParameter.message(""),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.ListView.InvalidParameter.message("INVALID"),
+});
+verify.noDiagnostics(7); // Verified.
+verify.expectDiagnosticsAt([2, 4, 6, 8], {
+  message: code.CompilerOptions.DupeOptionIssue.message("LISTVIEW"),
+});
+verify.expectCompilerOptions({
+  listView: "AFTERALL",
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/lp.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/lp.ts
@@ -12,23 +12,23 @@
 /// <reference path="../../framework.ts" />
 
 // @wrap: process
-////*PROCESS NOIGNORE;
-////*PROCESS IGNORE();
-////*PROCESS IGNORE(<|1:INVALID|>);
-////*PROCESS IGNORE(ASSERT, DISPLAY, <|2:INVALID|>);
-////*PROCESS <|3:IGNORE|>(ASSERT, PUT);
+////*PROCESS <|1:LP|>;
+////*PROCESS <|2:LP|>(<|3:)|>;
+////*PROCESS <|4:LP|>(<|5:INVALID|>);
+////*PROCESS <|6:LP|>(<32);
 
 verify.expectDiagnosticsAt(1, {
-  message: code.CompilerOptions.Ignore.InvalidParameter.message("INVALID"),
-});
-verify.expectDiagnosticsAt(2, {
-  message: code.CompilerOptions.Ignore.InvalidParameter.message("INVALID"),
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
 });
 verify.expectDiagnosticsAt(3, {
-  message: code.CompilerOptions.MutexOptionIssue.message("IGNORE"),
+  message: code.CompilerOptions.Lp.InvalidParameter.message(""),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.Lp.InvalidParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt([2, 4, 6], {
+  message: code.CompilerOptions.DupeOptionIssue.message("LP"),
 });
 verify.expectCompilerOptions({
-  ignore: {
-    items: ["ASSERT", "PUT"],
-  },
+  LP: "32",
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/macro.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/macro.ts
@@ -12,16 +12,16 @@
 /// <reference path="../../framework.ts" />
 
 // @wrap: process
-////*PROCESS NOINCLUDE;
-////*PROCESS <|1:INCLUDE|>;
-////*PROCESS <|2:INCLUDE|>(INVALID);
+////*PROCESS NOMACRO;
+////*PROCESS <|1:MACRO|>();
+////*PROCESS <|2:MACRO|>;
 
-verify.expectDiagnosticsAt([1, 2], {
-  message: code.CompilerOptions.MutexOptionIssue.message("INCLUDE"),
-});
-verify.expectDiagnosticsAt(2, {
+verify.expectDiagnosticsAt(1, {
   message: code.CompilerOptions.InvalidParameterCount.message(1, 0, 0),
 });
+verify.expectDiagnosticsAt([1, 2], {
+  message: code.CompilerOptions.MutexOptionIssue.message("MACRO"),
+});
 verify.expectCompilerOptions({
-  include: true,
+  macro: true,
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/map.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/map.ts
@@ -12,16 +12,16 @@
 /// <reference path="../../framework.ts" />
 
 // @wrap: process
-////*PROCESS NOINCLUDE;
-////*PROCESS <|1:INCLUDE|>;
-////*PROCESS <|2:INCLUDE|>(INVALID);
+////*PROCESS NOMAP;
+////*PROCESS <|1:MAP|>();
+////*PROCESS <|2:MAP|>;
 
-verify.expectDiagnosticsAt([1, 2], {
-  message: code.CompilerOptions.MutexOptionIssue.message("INCLUDE"),
-});
-verify.expectDiagnosticsAt(2, {
+verify.expectDiagnosticsAt(1, {
   message: code.CompilerOptions.InvalidParameterCount.message(1, 0, 0),
 });
+verify.expectDiagnosticsAt([1, 2], {
+  message: code.CompilerOptions.MutexOptionIssue.message("MAP"),
+});
 verify.expectCompilerOptions({
-  include: true,
+  map: true,
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/margini.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/margini.ts
@@ -1,0 +1,48 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NOMARGINI;
+////*PROCESS <|1:NOMARGINI|>();
+////*PROCESS <|2:MARGINI|>(<|3:)|>;
+////*PROCESS <|4:MARGINI|>(<|5:INVALID|>);
+////*PROCESS <|6:MARGINI|>(<|7:"INVALID"|>);
+////*PROCESS <|8:NMI|>;
+////*PROCESS <|9:MI|>('c');
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.DupeOptionIssue.message("NOMARGINI"),
+});
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(1, 0, 0),
+});
+verify.expectDiagnosticsAt([2, 4, 6], {
+  message: code.CompilerOptions.MutexOptionIssue.message("MARGINI"),
+});
+verify.expectDiagnosticsAt([3, 5], {
+  message: code.CompilerOptions.ExpectedString.message(),
+});
+verify.expectDiagnosticsAt(7, {
+  message: code.CompilerOptions.Margini.InvalidParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt(8, {
+  message: code.CompilerOptions.DupeOptionIssue.message("NMI"),
+});
+verify.expectDiagnosticsAt(9, {
+  message: code.CompilerOptions.MutexOptionIssue.message("MI"),
+});
+verify.expectCompilerOptions({
+  margini: {
+    character: "c",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/maxbranch.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/maxbranch.ts
@@ -1,0 +1,38 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:MAXBRANCH|>;
+////*PROCESS <|2:MAXBRANCH|>(<|3:)|>;
+////*PROCESS <|4:MAXBRANCH|>(<|5:INVALID|>);
+////*PROCESS <|6:MAXBRANCH|>(<|7:-5|>);
+////*PROCESS <|8:MAXBRANCH|>(2222);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
+});
+verify.expectDiagnosticsAt([2, 4, 6, 8], {
+  message: code.CompilerOptions.DupeOptionIssue.message("MAXBRANCH"),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.ExpectedNumber.message("INVALID"),
+});
+verify.expectDiagnosticsAt(7, {
+  message: code.CompilerOptions.ExpectedNumberRange.message(-5, 0),
+});
+verify.expectCompilerOptions({
+  maxbranch: 2222,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/maxgen.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/maxgen.ts
@@ -1,0 +1,38 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:MAXGEN|>;
+////*PROCESS <|2:MAXGEN|>(<|3:)|>;
+////*PROCESS <|4:MAXGEN|>(<|5:INVALID|>);
+////*PROCESS <|6:MAXGEN|>(<|7:-5|>);
+////*PROCESS <|8:MAXGEN|>(2222);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
+});
+verify.expectDiagnosticsAt([2, 4, 6, 8], {
+  message: code.CompilerOptions.DupeOptionIssue.message("MAXGEN"),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.ExpectedNumber.message("INVALID"),
+});
+verify.expectDiagnosticsAt(7, {
+  message: code.CompilerOptions.ExpectedNumberRange.message(-5, 0),
+});
+verify.expectCompilerOptions({
+  maxgen: 2222,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/maxmem.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/maxmem.ts
@@ -1,0 +1,41 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:MAXMEM|>;
+////*PROCESS <|2:MAXMEM|>(<|3:)|>;
+////*PROCESS <|4:MAXMEM|>(<|5:INVALID|>);
+////*PROCESS <|6:MAXMEM|>(<|7:-5|>);
+////*PROCESS <|8:MAXM|>(2222);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
+});
+verify.expectDiagnosticsAt([2, 4, 6], {
+  message: code.CompilerOptions.DupeOptionIssue.message("MAXMEM"),
+});
+verify.expectDiagnosticsAt(8, {
+  message: code.CompilerOptions.DupeOptionIssue.message("MAXM"),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.ExpectedNumber.message("INVALID"),
+});
+verify.expectDiagnosticsAt(7, {
+  message: code.CompilerOptions.ExpectedNumberRange.message(-5, 1, 2097152),
+});
+verify.expectCompilerOptions({
+  maxmem: 2222,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/maxmsg.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/maxmsg.ts
@@ -1,0 +1,42 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:MAXMSG|>;
+////*PROCESS <|2:MAXMSG|>(<|3:)|>;
+////*PROCESS <|4:MAXMSG|>(<|5:INVALID|>);
+////*PROCESS <|6:MAXMSG|>(<|7:-5|>);
+////*PROCESS <|8:MAXMSG|>(<|9:E|>);
+////*PROCESS <|10:MAXMSG|>(<|11:0|>);
+////*PROCESS <|12:MAXMSG|>(<|13:I, 200, E, 20, 5, W, 100|>);
+////*PROCESS <|14:MAXMSG|>(<|15:I 200 E 20 5 W 100|>);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1),
+});
+verify.expectDiagnosticsAt([2, 4, 6, 8, 10, 12, 14], {
+  message: code.CompilerOptions.DupeOptionIssue.message("MAXMSG"),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.ExpectedNumber.message("INVALID"),
+});
+verify.expectDiagnosticsAt(7, {
+  message: code.CompilerOptions.ExpectedNumberRange.message(-5, 0, 32767),
+});
+verify.noDiagnostics([3, 9, 11, 13, 15]);
+verify.expectCompilerOptions({
+  maxmsg: {
+    severity: "W",
+    n: 100,
+  },
+});

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -451,15 +451,22 @@ export class TestBuilder {
     return this;
   }
 
-  expectNoDiagnosticsAt(label: string): TestBuilder {
-    const { exactMatches } = this.getMatchingDiagnostics(label);
+  expectNoDiagnosticsAt(label: Label): TestBuilder {
+    if (Array.isArray(label)) {
+      for (const l of label) {
+        this.expectNoDiagnosticsAt(l);
+      }
+      return this;
+    }
+
+    const { exactMatches } = this.getMatchingDiagnostics(label.toString());
 
     if (exactMatches.length > 0) {
       const message = exactMatches
         .map((diagnostic) => this.createDiagnosticMessage(diagnostic))
         .join("\n- ");
       fail(
-        `Expected no diagnostics at label "${label}" (${this.createLabelRangeMessage(label)}) but received:\n- ${message}`,
+        `Expected no diagnostics at label "${label}" (${this.createLabelRangeMessage(label.toString())}) but received:\n- ${message}`,
       );
     }
 


### PR DESCRIPTION
Part of https://github.com/zowe/zowe-pli-language-support/issues/296
Based on https://github.com/zowe/zowe-pli-language-support/pull/314

- Implemented compiler options `incDir`, `include`, `incPds`, `initAuto`, `initBased`, `initCtl`, `initStatic`, `insource`, `interrupt`,  `json`, `langLvl`, `limits`, `lineCount`, `lineDir`, `list`, `listView`, `lp`, `macro`, `map`, `margini`, `maxbranch`, `maxgen`, `maxmem`, and `maxmsg`.
- Dupes and Mutex are now still reported if the corresponding rule throws another error.
- `noDiagnostics` also accept arrays now.