### PR TITLE
Increased Hover Support

### DIFF
--- a/packages/language/src/language-server/hover-request.ts
+++ b/packages/language/src/language-server/hover-request.ts
@@ -20,11 +20,17 @@ import {
 import { Token } from "../parser/tokens";
 import { getAttributes } from "../preprocessor/util";
 import {
+  Bound,
   DeclaredVariable,
+  DimensionBound,
+  Dimensions,
+  Expression,
   IncludeItem,
   LabelPrefix,
+  ProcedureStatement,
   SyntaxKind,
   SyntaxNode,
+  Wildcard,
 } from "../syntax-tree/ast";
 import { formatPliCodeBlock } from "../utils/code-block";
 import { binaryTokenSearch } from "../utils/search";
@@ -86,21 +92,44 @@ function getDeclaredVariableRepresentation(
 }
 
 /**
- * Retrieves string rep for a label prefix
- * Ex. "MyLabel: PROC;"
+ * Extracts the parameters from a procedure statement as a string.
+ * @returns Decoded string representation of parameters or null if any fail to resolve
  */
-function getLabelPrefixRepresentation(labelPrefix: LabelPrefix): string | null {
-  // currently assumes we're dealing with a procedure label prefix
-  const procedureStatement = retrieveProcedureFromLabelPrefix(labelPrefix);
-
-  if (!procedureStatement) {
-    return null;
+function extractProcedureParams(
+  procedureStatement: ProcedureStatement,
+): string | null {
+  if (!procedureStatement?.parameters) {
+    return "";
   }
+  const params: string[] = [];
+  for (const param of procedureStatement.parameters) {
+    const ref = param.ref;
+    if (!ref) {
+      // unresolved param, dip out prematurely
+      return null;
+    }
+    params.push(ref.text);
+  }
+  return params.length ? `(${params.join(",")})` : "";
+}
 
-  const name = labelPrefix.name ?? "<unnamed>";
+/**
+ * Extracts the options from a procedure statement as a string.
+ * Handles OPTIONS, ORDER, RECURSIVE, and RETURNS options.
+ * If no options are present, returns an empty string.
+ * RETURNS options require further decoding of attribute exprs.
+ * @returns string representation of options
+ */
+function extractProcedureOptions(
+  procedureStatement: ProcedureStatement,
+): string {
+  if (!procedureStatement?.options) {
+    return "";
+  }
   const optionStrings: string[] = [];
   for (const option of procedureStatement.options) {
     if (option.kind === SyntaxKind.Options) {
+      // simple options
       const internalOptions: string[] = [];
       for (const item of option.items) {
         if (item.kind === SyntaxKind.SimpleOptionsItem && item.value) {
@@ -110,17 +139,96 @@ function getLabelPrefixRepresentation(labelPrefix: LabelPrefix): string | null {
       if (internalOptions.length > 0) {
         optionStrings.push(`OPTIONS(${internalOptions.join(", ")})`);
       }
-    } else if (option.kind === SyntaxKind.ProcedureOrderOption) {
-      if (option.order) {
-        optionStrings.push(option.order);
-      }
+    } else if (
+      option.kind === SyntaxKind.ProcedureOrderOption &&
+      option.order
+    ) {
+      optionStrings.push(option.order);
     } else if (option.kind === SyntaxKind.ProcedureRecursiveOption) {
       optionStrings.push("RECURSIVE");
+    } else if (option.kind === SyntaxKind.ReturnsOption) {
+      // returns options
+      const attrArr: string[] = [];
+      const attrs = option.returnAttributes;
+      for (const attr of attrs) {
+        if (attr.kind === SyntaxKind.ComputationDataAttribute && attr.type) {
+          if (attr.dimensions) {
+            // type w/ dimens, need to be decoded
+            attrArr.push(attr.type + decodeDimensions(attr.dimensions));
+          } else {
+            // just the type
+            attrArr.push(attr.type);
+          }
+        }
+      }
+      optionStrings.push(`RETURNS(${attrArr.join(" ")})`);
     }
-    // TODO @montymxb add additional procedure cases cases as they come up
+    // TODO @montymxb add additional options cases as they come up
   }
-  const options = optionStrings.length > 0 ? optionStrings.join(" ") : "";
-  return formatPliCodeBlock(`${name}: PROC ${options};`);
+  return optionStrings.length > 0 ? optionStrings.join(" ") : "";
+}
+
+/**
+ * Gets the string representation of a label prefix
+ * (e.g. procedure currently).
+ */
+function getLabelPrefixRepresentation(labelPrefix: LabelPrefix): string | null {
+  // NOTE: currently assumes we're dealing with a procedure label prefix
+  const procedureStatement = retrieveProcedureFromLabelPrefix(labelPrefix);
+
+  if (!procedureStatement) {
+    return null;
+  }
+
+  // extract params
+  const paramsStr = extractProcedureParams(procedureStatement);
+  if (paramsStr === null) {
+    return null;
+  }
+
+  // extract options
+  const optionsStr = extractProcedureOptions(procedureStatement);
+  if (optionsStr === null) {
+    return null;
+  }
+
+  return formatPliCodeBlock(
+    `${labelPrefix.name ?? ""}: PROC${paramsStr} ${optionsStr};`,
+  );
+}
+
+/**
+ * Helper function for decoding dimensions for hover support
+ */
+function decodeDimensions(dimensions: Dimensions): string {
+  const dimensionBounds: DimensionBound[] = dimensions.dimensions;
+  const decodedBounds: string[] = [];
+  for (const bound of dimensionBounds) {
+    const lower: string | null = decodeBound(bound.lower);
+    const upper: string | null = decodeBound(bound.upper);
+    decodedBounds.push(`(${[lower, upper].filter((v) => v).join(",")})`);
+  }
+  return decodedBounds.join("");
+}
+
+/**
+ * Decodes a bound expression to a string.
+ * Handles wildcards and literal expressions.
+ * @returns Decoded bound as a string, or null if we encounter a non lit or missing value
+ */
+function decodeBound(bound: Bound | null): string | null {
+  if (!bound || !bound.expression) {
+    return null;
+  }
+  const expr: Wildcard<Expression> = bound.expression;
+  if (expr === "*") {
+    return "*";
+  } else if (expr.kind === SyntaxKind.Literal) {
+    return expr.value?.value ?? null;
+  } else {
+    // fail to decode on non-literal exprs
+    return null;
+  }
 }
 
 /**

--- a/packages/language/src/language-server/hover-request.ts
+++ b/packages/language/src/language-server/hover-request.ts
@@ -31,7 +31,7 @@ import { binaryTokenSearch } from "../utils/search";
 import { URI } from "../utils/uri";
 import { retrieveProcedureFromLabelPrefix } from "../validation/utils";
 import { CompilationUnit } from "../workspace/compilation-unit";
-import { FileSystemProviderInstance } from "../workspace/file-system-provider";
+import { TextDocuments } from "./text-documents";
 import { HoverResponse, tokenToRange } from "./types";
 
 type MarkupResponse = string | null;
@@ -132,13 +132,28 @@ function getIncludeItemRepresentation(node: IncludeItem): string | null {
     return null;
   }
 
-  // load up the first 200 chars of content from the file
+  let partialContent = node.sourceText;
   const fileUri = URI.parse(node.filePath);
-  const fileContent = FileSystemProviderInstance.readFileSync(fileUri) || "";
-  const partialContent = fileContent.slice(
-      0,
-      200,
-    ) + (fileContent.length > 200 ? '...' : '');
+
+  if (!partialContent) {
+    // load up the first 20 lines of content from the file (semi-arbitrary cutoff)
+    const lineCutoff = 20;
+    const doc = TextDocuments.get(fileUri);
+    if (!doc) {
+      return null;
+    }
+    const fileContent = doc.getText({
+      start: { line: 0, character: 0 },
+      end: { line: lineCutoff + 1, character: 0 },
+    });
+    const lineCount = fileContent.matchAll(/\n/g);
+    partialContent =
+      Array.from(lineCount).length > lineCutoff
+        ? fileContent + "\n...\n"
+        : fileContent;
+    // cache for later requests
+    node.sourceText = partialContent;
+  }
 
   return formatPliCodeBlock(`%INCLUDE "${fileUri.fsPath}"\n\n---\n${partialContent}`);
 }

--- a/packages/language/src/language-server/hover-request.ts
+++ b/packages/language/src/language-server/hover-request.ts
@@ -18,7 +18,7 @@ import {
   isReferenceToken,
 } from "../linking/tokens";
 import { Token } from "../parser/tokens";
-import { getAttributes } from "../preprocessor/instruction-generator";
+import { getAttributes } from "../preprocessor/util";
 import {
   DeclaredVariable,
   IncludeItem,
@@ -155,7 +155,9 @@ function getIncludeItemRepresentation(node: IncludeItem): string | null {
     node.sourceText = partialContent;
   }
 
-  return formatPliCodeBlock(`%INCLUDE "${fileUri.fsPath}"\n\n---\n${partialContent}`);
+  return formatPliCodeBlock(
+    `%INCLUDE "${fileUri.fsPath}"\n\n---\n${partialContent}`,
+  );
 }
 
 /**

--- a/packages/language/src/language-server/hover-request.ts
+++ b/packages/language/src/language-server/hover-request.ts
@@ -92,16 +92,35 @@ function getDeclaredVariableRepresentation(
 function getLabelPrefixRepresentation(labelPrefix: LabelPrefix): string | null {
   // currently assumes we're dealing with a procedure label prefix
   const procedureStatement = retrieveProcedureFromLabelPrefix(labelPrefix);
+
   if (!procedureStatement) {
     return null;
   }
 
   const name = labelPrefix.name ?? "<unnamed>";
-  if (!procedureStatement.sourceText) {
-    return null;
+  const optionStrings: string[] = [];
+  for (const option of procedureStatement.options) {
+    if (option.kind === SyntaxKind.Options) {
+      const internalOptions: string[] = [];
+      for (const item of option.items) {
+        if (item.kind === SyntaxKind.SimpleOptionsItem && item.value) {
+          internalOptions.push(item.value);
+        }
+      }
+      if (internalOptions.length > 0) {
+        optionStrings.push(`OPTIONS(${internalOptions.join(", ")})`);
+      }
+    } else if (option.kind === SyntaxKind.ProcedureOrderOption) {
+      if (option.order) {
+        optionStrings.push(option.order);
+      }
+    } else if (option.kind === SyntaxKind.ProcedureRecursiveOption) {
+      optionStrings.push("RECURSIVE");
+    }
+    // TODO @montymxb add additional procedure cases cases as they come up
   }
-
-  return formatPliCodeBlock(`${name}: ${procedureStatement.sourceText}`);
+  const options = optionStrings.length > 0 ? optionStrings.join(" ") : "";
+  return formatPliCodeBlock(`${name}: PROC ${options};`);
 }
 
 /**
@@ -113,17 +132,15 @@ function getIncludeItemRepresentation(node: IncludeItem): string | null {
     return null;
   }
 
-  // load up the first 200 chars of content from the file (semi-arbitrary cutoff)
-  const cutoff = 200;
+  // load up the first 200 chars of content from the file
   const fileUri = URI.parse(node.filePath);
-  // TODO use the text document approach to cache file content across requests
   const fileContent = FileSystemProviderInstance.readFileSync(fileUri) || "";
-  const partialContent =
-    fileContent.slice(0, cutoff) + (fileContent.length > cutoff ? "..." : "");
+  const partialContent = fileContent.slice(
+      0,
+      200,
+    ) + (fileContent.length > 200 ? '...' : '');
 
-  return formatPliCodeBlock(
-    `%INCLUDE "${fileUri.fsPath}"\n\n---\n${partialContent}`,
-  );
+  return formatPliCodeBlock(`%INCLUDE "${fileUri.fsPath}"\n\n---\n${partialContent}`);
 }
 
 /**

--- a/packages/language/src/language-server/hover-request.ts
+++ b/packages/language/src/language-server/hover-request.ts
@@ -9,16 +9,29 @@
  *
  */
 
-import { CompilationUnit } from "../workspace/compilation-unit";
-import { binaryTokenSearch } from "../utils/search";
-import { HoverResponse, tokenToRange } from "./types";
-import { URI } from "../utils/uri";
 import { MarkupKind } from "vscode-languageserver-types";
-import { getReference, isReferenceToken } from "../linking/tokens";
-import { Token } from "../parser/tokens";
-import { DeclaredVariable, SyntaxKind, SyntaxNode } from "../syntax-tree/ast";
-import { formatPliCodeBlock } from "../utils/code-block";
 import { QualifiedSyntaxNode } from "../linking/qualified-syntax-node";
+import {
+  getReference,
+  isIncludeItemToken,
+  isNameToken,
+  isReferenceToken,
+} from "../linking/tokens";
+import { Token } from "../parser/tokens";
+import { getAttributes } from "../preprocessor/instruction-generator";
+import {
+  DeclaredVariable,
+  IncludeItem,
+  LabelPrefix,
+  SyntaxKind,
+  SyntaxNode,
+} from "../syntax-tree/ast";
+import { formatPliCodeBlock } from "../utils/code-block";
+import { binaryTokenSearch } from "../utils/search";
+import { URI } from "../utils/uri";
+import { retrieveProcedureFromLabelPrefix } from "../validation/utils";
+import { CompilationUnit } from "../workspace/compilation-unit";
+import { HoverResponse, tokenToRange } from "./types";
 
 type MarkupResponse = string | null;
 
@@ -29,19 +42,6 @@ interface MarkupGeneratorContext {
 
 interface MarkupGenerator {
   (context: MarkupGeneratorContext): MarkupResponse;
-}
-
-function getParents(node: QualifiedSyntaxNode): QualifiedSyntaxNode[] {
-  const parent = node.getParent();
-  if (!parent) {
-    return [];
-  }
-
-  return [...getParents(parent), parent];
-}
-
-function getQualifiedNodeRepresentation(node: QualifiedSyntaxNode): string {
-  return `${node.level} ${node.name}`;
 }
 
 /**
@@ -59,16 +59,81 @@ function getDeclaredVariableRepresentation(
   const qualifiedNode = unit.scopeCaches.regular
     .get(node)
     ?.symbolTable.nodeLookup.get(node);
+
   if (!qualifiedNode) {
     throw new Error("Qualified node not found");
   }
 
-  const parents = getParents(qualifiedNode).map(getQualifiedNodeRepresentation);
-  const elements = [...parents, getQualifiedNodeRepresentation(qualifiedNode)];
-
-  return formatPliCodeBlock(`DCL ${elements.join(", ")};`);
+  if (qualifiedNode.level > 1) {
+    // structure member
+    const hierarchy: string[] = [];
+    let current: QualifiedSyntaxNode | null = qualifiedNode;
+    while (current) {
+      hierarchy.unshift(`${current.level} ${current.name}`);
+      current = current.getParent();
+    }
+    return formatPliCodeBlock(`DCL ${hierarchy.join(", ")};`);
+  } else {
+    // regular declaration
+    const name = node.name;
+    const attrs = getAttributes(node);
+    const decl = attrs.length
+      ? `DCL ${name} ${attrs.join(" ")};`
+      : `DCL ${name};`;
+    return formatPliCodeBlock(decl);
+  }
 }
 
+/**
+ * Retrieves string rep for a label prefix
+ * Ex. "MyLabel: PROC;"
+ */
+function getLabelPrefixRepresentation(labelPrefix: LabelPrefix): string | null {
+  // currently assumes we're dealing with a procedure label prefix
+  const procedureStatement = retrieveProcedureFromLabelPrefix(labelPrefix);
+
+  if (!procedureStatement) {
+    return null;
+  }
+
+  const name = labelPrefix.name ?? "<unnamed>";
+  const optionStrings: string[] = [];
+  for (const option of procedureStatement.options) {
+    if (option.kind === SyntaxKind.Options) {
+      const internalOptions: string[] = [];
+      for (const item of option.items) {
+        if (item.kind === SyntaxKind.SimpleOptionsItem && item.value) {
+          internalOptions.push(item.value);
+        }
+      }
+      if (internalOptions.length > 0) {
+        optionStrings.push(`OPTIONS(${internalOptions.join(", ")})`);
+      }
+    } else if (option.kind === SyntaxKind.ProcedureOrderOption) {
+      if (option.order) {
+        optionStrings.push(option.order);
+      }
+    } else if (option.kind === SyntaxKind.ProcedureRecursiveOption) {
+      optionStrings.push("RECURSIVE");
+    }
+    // TODO @montymxb add additional procedure cases cases as they come up
+  }
+  const options = optionStrings.length > 0 ? optionStrings.join(" ") : "";
+  return formatPliCodeBlock(`${name}: PROC ${options};`);
+}
+
+/**
+ * Converts an IncludeItem node to a string representation.
+ * Ex. %INCLUDE "file:///path/to/file.pli"
+ */
+function getIncludeItemRepresentation(node: IncludeItem): string {
+  const filePath = node.filePath ?? "<unknown>";
+  return formatPliCodeBlock(`%INCLUDE "${filePath}"`);
+}
+
+/**
+ * Get the string representation of a node based on its kind.
+ */
 function getNodeRepresentation(
   unit: CompilationUnit,
   node: SyntaxNode,
@@ -76,12 +141,20 @@ function getNodeRepresentation(
   switch (node.kind) {
     case SyntaxKind.DeclaredVariable:
       return getDeclaredVariableRepresentation(unit, node);
+    case SyntaxKind.LabelPrefix:
+      return getLabelPrefixRepresentation(node);
+    case SyntaxKind.IncludeItem:
+      return getIncludeItemRepresentation(node);
     default:
       return null;
   }
 }
 
-const getReferenceTokenContent: MarkupGenerator = ({ unit, token }) => {
+/**
+ * Generates markup from a reference token
+ * @returns Markup or null if not applicable
+ */
+const generateReferenceTokenMarkup: MarkupGenerator = ({ unit, token }) => {
   if (!isReferenceToken(token.kind) || !token.element) {
     return null;
   }
@@ -94,6 +167,32 @@ const getReferenceTokenContent: MarkupGenerator = ({ unit, token }) => {
   return getNodeRepresentation(unit, ref.node);
 };
 
+/**
+ * Generates markup from an include item token
+ * @returns Markup or null if not applicable
+ */
+const generateIncludeItemTokenMarkup: MarkupGenerator = ({ unit, token }) => {
+  if (token.element && isIncludeItemToken(token.kind)) {
+    return getNodeRepresentation(unit, token.element);
+  }
+  return null;
+};
+
+/**
+ * Generates markup from a name token
+ * @returns Markup or null if not applicable
+ */
+const generateNameTokenMarkup: MarkupGenerator = ({ unit, token }) => {
+  if (token.element && isNameToken(token.kind)) {
+    return getNodeRepresentation(unit, token.element);
+  }
+  return null;
+};
+
+/**
+ * Generates hover content based on the provided generators and context.
+ * Returns an array of all non-null results from all generators.
+ */
 function generateMarkup(
   generators: MarkupGenerator[],
   context: MarkupGeneratorContext,
@@ -125,9 +224,15 @@ export function hoverRequest(
     return null;
   }
 
-  const generators: MarkupGenerator[] = [getReferenceTokenContent];
+  const generators: MarkupGenerator[] = [
+    generateReferenceTokenMarkup,
+    generateIncludeItemTokenMarkup,
+    generateNameTokenMarkup,
+  ];
   const context: MarkupGeneratorContext = { unit, token };
 
+  // attempt to generate markup using these generators
+  // all matching generators will produce a response here
   const responses = generateMarkup(generators, context);
   const value = responses.join("\n\n");
 

--- a/packages/language/src/language-server/hover-request.ts
+++ b/packages/language/src/language-server/hover-request.ts
@@ -92,35 +92,16 @@ function getDeclaredVariableRepresentation(
 function getLabelPrefixRepresentation(labelPrefix: LabelPrefix): string | null {
   // currently assumes we're dealing with a procedure label prefix
   const procedureStatement = retrieveProcedureFromLabelPrefix(labelPrefix);
-
   if (!procedureStatement) {
     return null;
   }
 
   const name = labelPrefix.name ?? "<unnamed>";
-  const optionStrings: string[] = [];
-  for (const option of procedureStatement.options) {
-    if (option.kind === SyntaxKind.Options) {
-      const internalOptions: string[] = [];
-      for (const item of option.items) {
-        if (item.kind === SyntaxKind.SimpleOptionsItem && item.value) {
-          internalOptions.push(item.value);
-        }
-      }
-      if (internalOptions.length > 0) {
-        optionStrings.push(`OPTIONS(${internalOptions.join(", ")})`);
-      }
-    } else if (option.kind === SyntaxKind.ProcedureOrderOption) {
-      if (option.order) {
-        optionStrings.push(option.order);
-      }
-    } else if (option.kind === SyntaxKind.ProcedureRecursiveOption) {
-      optionStrings.push("RECURSIVE");
-    }
-    // TODO @montymxb add additional procedure cases cases as they come up
+  if (!procedureStatement.sourceText) {
+    return null;
   }
-  const options = optionStrings.length > 0 ? optionStrings.join(" ") : "";
-  return formatPliCodeBlock(`${name}: PROC ${options};`);
+
+  return formatPliCodeBlock(`${name}: ${procedureStatement.sourceText}`);
 }
 
 /**
@@ -132,15 +113,17 @@ function getIncludeItemRepresentation(node: IncludeItem): string | null {
     return null;
   }
 
-  // load up the first 200 chars of content from the file
+  // load up the first 200 chars of content from the file (semi-arbitrary cutoff)
+  const cutoff = 200;
   const fileUri = URI.parse(node.filePath);
+  // TODO use the text document approach to cache file content across requests
   const fileContent = FileSystemProviderInstance.readFileSync(fileUri) || "";
-  const partialContent = fileContent.slice(
-      0,
-      200,
-    ) + (fileContent.length > 200 ? '...' : '');
+  const partialContent =
+    fileContent.slice(0, cutoff) + (fileContent.length > cutoff ? "..." : "");
 
-  return formatPliCodeBlock(`%INCLUDE "${fileUri.fsPath}"\n\n---\n${partialContent}`);
+  return formatPliCodeBlock(
+    `%INCLUDE "${fileUri.fsPath}"\n\n---\n${partialContent}`,
+  );
 }
 
 /**

--- a/packages/language/src/language-server/hover-request.ts
+++ b/packages/language/src/language-server/hover-request.ts
@@ -262,10 +262,7 @@ function getIncludeItemRepresentation(node: IncludeItem): string | null {
     // cache for later requests
     node.sourceText = partialContent;
   }
-
-  return formatPliCodeBlock(
-    `%INCLUDE "${fileUri.fsPath}"\n\n---\n${partialContent}`,
-  );
+  return `%INCLUDE "${fileUri.fsPath}"\n\n---\n${formatPliCodeBlock(partialContent)}`;
 }
 
 /**

--- a/packages/language/src/language-server/hover-request.ts
+++ b/packages/language/src/language-server/hover-request.ts
@@ -31,6 +31,7 @@ import { binaryTokenSearch } from "../utils/search";
 import { URI } from "../utils/uri";
 import { retrieveProcedureFromLabelPrefix } from "../validation/utils";
 import { CompilationUnit } from "../workspace/compilation-unit";
+import { FileSystemProviderInstance } from "../workspace/file-system-provider";
 import { HoverResponse, tokenToRange } from "./types";
 
 type MarkupResponse = string | null;
@@ -126,9 +127,20 @@ function getLabelPrefixRepresentation(labelPrefix: LabelPrefix): string | null {
  * Converts an IncludeItem node to a string representation.
  * Ex. %INCLUDE "file:///path/to/file.pli"
  */
-function getIncludeItemRepresentation(node: IncludeItem): string {
-  const filePath = node.filePath ?? "<unknown>";
-  return formatPliCodeBlock(`%INCLUDE "${filePath}"`);
+function getIncludeItemRepresentation(node: IncludeItem): string | null {
+  if (!node.filePath) {
+    return null;
+  }
+
+  // load up the first 200 chars of content from the file
+  const fileUri = URI.parse(node.filePath);
+  const fileContent = FileSystemProviderInstance.readFileSync(fileUri) || "";
+  const partialContent = fileContent.slice(
+      0,
+      200,
+    ) + (fileContent.length > 200 ? '...' : '');
+
+  return formatPliCodeBlock(`%INCLUDE "${fileUri.fsPath}"\n\n---\n${partialContent}`);
 }
 
 /**

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -17,8 +17,6 @@ import * as tokens from "./tokens";
 import * as ast from "../syntax-tree/ast";
 import { CstNodeKind } from "../syntax-tree/cst";
 import { ParserMethod, tokenMatcher } from "chevrotain";
-import { TextDocuments } from "../language-server/text-documents";
-import { Range, tokenToRange } from "../language-server/types";
 
 export class PliParser extends AbstractParser {
   constructor() {
@@ -537,7 +535,6 @@ export class PliParser extends AbstractParser {
 
   ProcedureStatement = this.RULE("ProcedureStatement", () => {
     let element = this.push(ast.createProcedureStatement());
-    let startRange: Range | undefined;
 
     this.CONSUME_ASSIGN1(tokens.PROCEDURE, (token) => {
       this.tokenPayload(
@@ -545,7 +542,6 @@ export class PliParser extends AbstractParser {
         element,
         CstNodeKind.ProcedureStatement_PROCEDURE,
       );
-      startRange = tokenToRange(token);
     });
     this.OPTION2(() => {
       this.CONSUME_ASSIGN1(tokens.OpenParen, (token) => {
@@ -662,18 +658,6 @@ export class PliParser extends AbstractParser {
         element,
         CstNodeKind.ProcedureStatement_Semicolon0,
       );
-      // use token ranges to compute returns option src txt, for hover
-      const endRange = tokenToRange(token);
-      if (token.payload.uri && startRange) {
-        const textDoc = TextDocuments.get(token.payload.uri);
-        if (textDoc) {
-          const text = textDoc.getText({
-            start: textDoc.positionAt(startRange.start),
-            end: textDoc.positionAt(endRange.end),
-          });
-          element.sourceText = text;
-        }
-      }
     });
     this.MANY3(() => {
       this.SUBRULE_ASSIGN1(this.Statement, {

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -17,6 +17,8 @@ import * as tokens from "./tokens";
 import * as ast from "../syntax-tree/ast";
 import { CstNodeKind } from "../syntax-tree/cst";
 import { ParserMethod, tokenMatcher } from "chevrotain";
+import { TextDocuments } from "../language-server/text-documents";
+import { Range, tokenToRange } from "../language-server/types";
 
 export class PliParser extends AbstractParser {
   constructor() {
@@ -535,6 +537,7 @@ export class PliParser extends AbstractParser {
 
   ProcedureStatement = this.RULE("ProcedureStatement", () => {
     let element = this.push(ast.createProcedureStatement());
+    let startRange: Range | undefined;
 
     this.CONSUME_ASSIGN1(tokens.PROCEDURE, (token) => {
       this.tokenPayload(
@@ -542,6 +545,7 @@ export class PliParser extends AbstractParser {
         element,
         CstNodeKind.ProcedureStatement_PROCEDURE,
       );
+      startRange = tokenToRange(token);
     });
     this.OPTION2(() => {
       this.CONSUME_ASSIGN1(tokens.OpenParen, (token) => {
@@ -658,6 +662,18 @@ export class PliParser extends AbstractParser {
         element,
         CstNodeKind.ProcedureStatement_Semicolon0,
       );
+      // use token ranges to compute returns option src txt, for hover
+      const endRange = tokenToRange(token);
+      if (token.payload.uri && startRange) {
+        const textDoc = TextDocuments.get(token.payload.uri);
+        if (textDoc) {
+          const text = textDoc.getText({
+            start: textDoc.positionAt(startRange.start),
+            end: textDoc.positionAt(endRange.end),
+          });
+          element.sourceText = text;
+        }
+      }
     });
     this.MANY3(() => {
       this.SUBRULE_ASSIGN1(this.Statement, {

--- a/packages/language/src/preprocessor/instruction-generator.ts
+++ b/packages/language/src/preprocessor/instruction-generator.ts
@@ -234,7 +234,7 @@ function getAllDeclarations(
   return declarations;
 }
 
-function getAttributes(item: ast.DeclaredVariable): string[] {
+export function getAttributes(item: ast.DeclaredVariable): string[] {
   const attributes: string[] = [];
   let container = item.container;
   while (container?.kind === ast.SyntaxKind.DeclaredItem) {

--- a/packages/language/src/preprocessor/instruction-generator.ts
+++ b/packages/language/src/preprocessor/instruction-generator.ts
@@ -11,6 +11,7 @@
 
 import * as inst from "./instructions";
 import * as ast from "../syntax-tree/ast";
+import { getAttributes } from "./util";
 
 interface GenerateInstructionContext {
   labels: Map<string, inst.InstructionNode>;
@@ -232,21 +233,6 @@ function getAllDeclarations(
     }
   }
   return declarations;
-}
-
-export function getAttributes(item: ast.DeclaredVariable): string[] {
-  const attributes: string[] = [];
-  let container = item.container;
-  while (container?.kind === ast.SyntaxKind.DeclaredItem) {
-    const itemAttributes = container.attributes;
-    for (const attr of itemAttributes) {
-      if (attr.kind === ast.SyntaxKind.ComputationDataAttribute && attr.type) {
-        attributes.push(attr.type.toUpperCase());
-      }
-    }
-    container = container.container;
-  }
-  return attributes;
 }
 
 function getDimensions(

--- a/packages/language/src/preprocessor/util.ts
+++ b/packages/language/src/preprocessor/util.ts
@@ -9,4 +9,21 @@
  *
  */
 
+import { DeclaredVariable, SyntaxKind } from "../syntax-tree/ast";
+
 export function assertType<T>(value: unknown): asserts value is T {}
+
+export function getAttributes(item: DeclaredVariable): string[] {
+  const attributes: string[] = [];
+  let container = item.container;
+  while (container?.kind === SyntaxKind.DeclaredItem) {
+    const itemAttributes = container.attributes;
+    for (const attr of itemAttributes) {
+      if (attr.kind === SyntaxKind.ComputationDataAttribute && attr.type) {
+        attributes.push(attr.type.toUpperCase());
+      }
+    }
+    container = container.container;
+  }
+  return attributes;
+}

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -1903,6 +1903,7 @@ export interface ProcedureStatement extends AstNode {
   statements: Statement[];
   options: ProcedureOption[];
   end: EndStatement | null;
+  sourceText: string | null;
 }
 export function createProcedureStatement(): ProcedureStatement {
   return {
@@ -1914,6 +1915,7 @@ export function createProcedureStatement(): ProcedureStatement {
     statements: [],
     options: [],
     end: null,
+    sourceText: null,
   };
 }
 export type ProcedureOption =

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -1903,7 +1903,6 @@ export interface ProcedureStatement extends AstNode {
   statements: Statement[];
   options: ProcedureOption[];
   end: EndStatement | null;
-  sourceText: string | null;
 }
 export function createProcedureStatement(): ProcedureStatement {
   return {
@@ -1915,7 +1914,6 @@ export function createProcedureStatement(): ProcedureStatement {
     statements: [],
     options: [],
     end: null,
-    sourceText: null,
   };
 }
 export type ProcedureOption =

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -1505,6 +1505,7 @@ export interface IncludeItem extends AstNode {
   ddname: string | null;
   filePath: string | null;
   token: Token | null;
+  sourceText: string | null;
 }
 export function createIncludeItem(): IncludeItem {
   return {
@@ -1515,6 +1516,7 @@ export function createIncludeItem(): IncludeItem {
     ddname: null,
     filePath: null,
     token: null,
+    sourceText: null,
   };
 }
 export interface InscanDirective extends AstNode {

--- a/packages/language/src/validation/utils.ts
+++ b/packages/language/src/validation/utils.ts
@@ -9,7 +9,11 @@
  *
  */
 
-import { LabelPrefix, SyntaxKind } from "../syntax-tree/ast";
+import {
+  LabelPrefix,
+  ProcedureStatement,
+  SyntaxKind,
+} from "../syntax-tree/ast";
 
 export function normalizeIdentifier<T extends string>(id: T): Uppercase<T> {
   return id.toUpperCase() as Uppercase<T>;
@@ -20,18 +24,32 @@ export function compareIdentifiers<T extends string>(lhs: T, rhs: T) {
 }
 
 /**
+ * Helper to attempt to retrieve a procedure statement from a label prefix.
+ */
+export function retrieveProcedureFromLabelPrefix(
+  labelPrefix: LabelPrefix,
+): ProcedureStatement | null {
+  const statement = labelPrefix.container;
+  if (statement?.kind !== SyntaxKind.Statement) {
+    return null;
+  }
+
+  const procedureStatement = statement.value;
+  if (procedureStatement?.kind !== SyntaxKind.ProcedureStatement) {
+    return null;
+  }
+
+  return procedureStatement;
+}
+
+/**
  * Checks if the given label prefix references a main procedure.
  * @param node Label prefix node to check
  * @returns True if the node is a main procedure, false otherwise
  */
 export function isMainProcedure(node: LabelPrefix): boolean {
-  const statement = node.container;
-  if (statement?.kind !== SyntaxKind.Statement) {
-    return false;
-  }
-
-  const procedureStatement = statement.value;
-  if (procedureStatement?.kind !== SyntaxKind.ProcedureStatement) {
+  const procedureStatement = retrieveProcedureFromLabelPrefix(node);
+  if (!procedureStatement) {
     return false;
   }
 

--- a/packages/language/test/fourslash-harness/harness-interface.ts
+++ b/packages/language/test/fourslash-harness/harness-interface.ts
@@ -111,6 +111,14 @@ export interface HarnessTesterInterface {
 
   hover: {
     /**
+     * Expect that the hover at the given label is an include directive.
+     *
+     * @param label The label to expect the hover at.
+     * @param filePath File path to resolve in an OS-dependent fashion
+     * @param content The expected hover content of the included file
+     */
+    expectIncludeAt(label: Label, filePath: string, content: string): void;
+    /**
      * Expect that the hover at the given label is the given markdown.
      *
      * @param label The label to expect the hover at.

--- a/packages/language/test/fourslash-harness/harness.test.ts
+++ b/packages/language/test/fourslash-harness/harness.test.ts
@@ -64,6 +64,7 @@ function createTestingHarnessImplementation(
     },
     hover: {
       codeBlock: (text) => text,
+      expectIncludeAt: listen("hover.expectIncludeAt"),
       expectMarkdownAt: listen("hover.expectMarkdownAt"),
       expectTextAt: listen("hover.expectTextAt"),
     },

--- a/packages/language/test/fourslash-harness/implementation/test-builder.ts
+++ b/packages/language/test/fourslash-harness/implementation/test-builder.ts
@@ -10,12 +10,13 @@
  */
 
 import { MarkupKind } from "vscode-languageserver";
+import { SemanticTokenTypes } from "vscode-languageserver-types";
+import { URI } from "vscode-uri";
+import { formatPliCodeBlock } from "../../../src/utils/code-block";
 import { TestBuilder } from "../../test-builder";
 import { HarnessTesterInterface } from "../harness-interface";
 import { HarnessCodes } from "./codes";
 import { HarnessConstants } from "./constants";
-import { formatPliCodeBlock } from "../../../src/utils/code-block";
-import { SemanticTokenTypes } from "vscode-languageserver-types";
 
 /**
  * Create a harness implementation that can be used to run the harness test.
@@ -59,6 +60,12 @@ export function createTestBuilderHarnessImplementation(
         testBuilder.expectCompletions(label.toString(), content),
     },
     hover: {
+      expectIncludeAt(label, filePath, markdown) {
+        testBuilder.expectHover(label.toString(), {
+          kind: MarkupKind.Markdown,
+          value: `%INCLUDE "${URI.parse(filePath).fsPath}"\n\n---\n${markdown}`,
+        });
+      },
       expectMarkdownAt: (label, markdown) =>
         testBuilder.expectHover(label.toString(), {
           kind: MarkupKind.Markdown,

--- a/packages/language/test/fourslash/hover/copybook.ts
+++ b/packages/language/test/fourslash/hover/copybook.ts
@@ -12,10 +12,12 @@
 /// <reference path="../framework.ts" />
 
 /**
- * Strip away irrelevant nested nodes in the hover response to show the structure of the declaration.
+ * Failing test for hover on copybook (include) directive
  */
 
-//// DCL 1 A, 2 A2, 3 A3, 2 B, 3 B3, 2 C2, 3 C3;
-//// PUT(<|1>C3);
+// @filename: cpy/lib.pli
+//// DECLARE LIB_VAR FIXED;
 
-hover.expectMarkdownAt(1, hover.codeBlock("DCL 1 A, 2 C2, 3 C3;"));
+//// %include <|1>"lib.pli";
+
+hover.expectMarkdownAt(1, hover.codeBlock('%INCLUDE "file:///cpy/lib.pli"'));

--- a/packages/language/test/fourslash/hover/copybook.ts
+++ b/packages/language/test/fourslash/hover/copybook.ts
@@ -20,4 +20,11 @@
 
 //// %include <|1>"lib.pli";
 
-hover.expectMarkdownAt(1, hover.codeBlock('%INCLUDE "file:///cpy/lib.pli"'));
+hover.expectMarkdownAt(
+  1,
+  hover.codeBlock(
+    ['%INCLUDE "/cpy/lib.pli"', "", "---", " DECLARE LIB_VAR FIXED;"].join(
+      "\n",
+    ),
+  ),
+);

--- a/packages/language/test/fourslash/hover/copybook.ts
+++ b/packages/language/test/fourslash/hover/copybook.ts
@@ -20,11 +20,8 @@
 
 //// %include <|1>"lib.pli";
 
-hover.expectMarkdownAt(
+hover.expectIncludeAt(
   1,
-  hover.codeBlock(
-    ['%INCLUDE "/cpy/lib.pli"', "", "---", " DECLARE LIB_VAR FIXED;"].join(
-      "\n",
-    ),
-  ),
+  "/cpy/lib.pli",
+  hover.codeBlock(" DECLARE LIB_VAR FIXED;"),
 );

--- a/packages/language/test/fourslash/hover/pp-generated-procedure.ts
+++ b/packages/language/test/fourslash/hover/pp-generated-procedure.ts
@@ -1,0 +1,32 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+/**
+ * Failing test for hover on procedure PP synthesized procedure
+ */
+
+//// %DCL GENPROC INIT("MyProc: PROC(A,B,C) OPTIONS(MAIN) RETURNS(fixed bin(31));");
+//// GENPROC
+//// END <|1>MyProc;
+//// CALL <|2>MyProc;
+
+verify.noDiagnostics();
+const expectedMarkdown2 = hover.codeBlock(
+  "MyProc: PROC(A,B,C) OPTIONS(MAIN,ORDER) RECURSIVE REORDER RETURNS(FIXED BIN(31));",
+);
+hover.expectMarkdownAt(1, expectedMarkdown);
+hover.expectMarkdownAt(2, expectedMarkdown);
+hover.expectMarkdownAt(
+  3,
+  hover.codeBlock("MyProc2: PROC(A) RETURNS(FIXED BIN(15));"),
+);

--- a/packages/language/test/fourslash/hover/pp-generated-procedure.ts
+++ b/packages/language/test/fourslash/hover/pp-generated-procedure.ts
@@ -15,18 +15,15 @@
  * Failing test for hover on procedure PP synthesized procedure
  */
 
-//// %DCL GENPROC INIT("MyProc: PROC(A,B,C) OPTIONS(MAIN) RETURNS(fixed bin(31));");
+//// %DCL GENPROC FIXED CHAR(64);
+//// %GENPROC = "P1: PROC(A,B) OPTIONS(MAIN) RETURNS(fixed bin(15));";
 //// GENPROC
-//// END <|1>MyProc;
-//// CALL <|2>MyProc;
+//// END <|1>P1;
+//// CALL <|2>P1;
 
 verify.noDiagnostics();
 const expectedMarkdown2 = hover.codeBlock(
-  "MyProc: PROC(A,B,C) OPTIONS(MAIN,ORDER) RECURSIVE REORDER RETURNS(FIXED BIN(31));",
+  "P1: PROC(A,B) OPTIONS(MAIN) RETURNS(FIXED BIN(15));",
 );
-hover.expectMarkdownAt(1, expectedMarkdown);
-hover.expectMarkdownAt(2, expectedMarkdown);
-hover.expectMarkdownAt(
-  3,
-  hover.codeBlock("MyProc2: PROC(A) RETURNS(FIXED BIN(15));"),
-);
+hover.expectMarkdownAt(1, expectedMarkdown2);
+hover.expectMarkdownAt(2, expectedMarkdown2);

--- a/packages/language/test/fourslash/hover/procedure.ts
+++ b/packages/language/test/fourslash/hover/procedure.ts
@@ -15,10 +15,31 @@
  * Failing test for hover on procedure declaration and call
  */
 
-//// MyProc: PROCEDURE OPTIONS(MAIN) REORDER;
+// @filename: cpy/lib.pli
+//// MyProc2: PROC (A) RETURNS(fixed bin(15));
+//// dcl A fixed bin(15);
+//// END MyProc2;
+
+//// %include "lib.pli";
+//// MyProc: PROC (A, B, C) OPTIONS(MAIN, Order)
+////    RECURSIVE REORDER RETURNS (fixed bin(31));
+//// dcl A fixed bin(31);
+//// dcl B fixed bin(15);
+//// dcl C fixed bin(7);
 //// END <|1>MyProc;
 //// CALL <|2>MyProc;
+//// CALL <|3>MyProc2;
 
-const expectedMarkdown = hover.codeBlock("MyProc: PROC OPTIONS(MAIN) REORDER;");
+verify.noDiagnostics();
+const expectedMarkdown = hover.codeBlock(
+  [
+    "MyProc: PROC (A, B, C) OPTIONS(MAIN, Order)",
+    "    RECURSIVE REORDER RETURNS (fixed bin(31));",
+  ].join("\n"),
+);
 hover.expectMarkdownAt(1, expectedMarkdown);
 hover.expectMarkdownAt(2, expectedMarkdown);
+hover.expectMarkdownAt(
+  3,
+  hover.codeBlock("MyProc2: PROC (A) RETURNS(fixed bin(15));"),
+);

--- a/packages/language/test/fourslash/hover/procedure.ts
+++ b/packages/language/test/fourslash/hover/procedure.ts
@@ -32,14 +32,11 @@
 
 verify.noDiagnostics();
 const expectedMarkdown = hover.codeBlock(
-  [
-    "MyProc: PROC (A, B, C) OPTIONS(MAIN, Order)",
-    "    RECURSIVE REORDER RETURNS (fixed bin(31));",
-  ].join("\n"),
+  "MYPROC: PROC(A,B,C) OPTIONS(MAIN, ORDER) RECURSIVE REORDER RETURNS(FIXED BIN(31));",
 );
 hover.expectMarkdownAt(1, expectedMarkdown);
 hover.expectMarkdownAt(2, expectedMarkdown);
 hover.expectMarkdownAt(
   3,
-  hover.codeBlock("MyProc2: PROC (A) RETURNS(fixed bin(15));"),
+  hover.codeBlock("MYPROC2: PROC(A) RETURNS(FIXED BIN(15));"),
 );

--- a/packages/language/test/fourslash/hover/procedure.ts
+++ b/packages/language/test/fourslash/hover/procedure.ts
@@ -12,10 +12,13 @@
 /// <reference path="../framework.ts" />
 
 /**
- * Strip away irrelevant nested nodes in the hover response to show the structure of the declaration.
+ * Failing test for hover on procedure declaration and call
  */
 
-//// DCL 1 A, 2 A2, 3 A3, 2 B, 3 B3, 2 C2, 3 C3;
-//// PUT(<|1>C3);
+//// MyProc: PROCEDURE OPTIONS(MAIN) REORDER;
+//// END <|1>MyProc;
+//// CALL <|2>MyProc;
 
-hover.expectMarkdownAt(1, hover.codeBlock("DCL 1 A, 2 C2, 3 C3;"));
+const expectedMarkdown = hover.codeBlock("MyProc: PROC OPTIONS(MAIN) REORDER;");
+hover.expectMarkdownAt(1, expectedMarkdown);
+hover.expectMarkdownAt(2, expectedMarkdown);

--- a/packages/language/test/fourslash/hover/regular-declaration.ts
+++ b/packages/language/test/fourslash/hover/regular-declaration.ts
@@ -12,10 +12,10 @@
 /// <reference path="../framework.ts" />
 
 /**
- * Strip away irrelevant nested nodes in the hover response to show the structure of the declaration.
+ * Failing test for hover on regular variable declaration
  */
 
-//// DCL 1 A, 2 A2, 3 A3, 2 B, 3 B3, 2 C2, 3 C3;
-//// PUT(<|1>C3);
+//// DCL MyVar FIXED DECIMAL(2,5);
+//// <|1>MyVar = 12.1234;
 
-hover.expectMarkdownAt(1, hover.codeBlock("DCL 1 A, 2 C2, 3 C3;"));
+hover.expectMarkdownAt(1, hover.codeBlock("DCL MyVar FIXED DECIMAL;"));

--- a/packages/language/test/fourslash/hover/regular-declaration.ts
+++ b/packages/language/test/fourslash/hover/regular-declaration.ts
@@ -18,4 +18,4 @@
 //// DCL MyVar FIXED DECIMAL(2,5);
 //// <|1>MyVar = 12.1234;
 
-hover.expectMarkdownAt(1, hover.codeBlock("DCL MyVar FIXED DECIMAL;"));
+hover.expectMarkdownAt(1, hover.codeBlock("DCL MYVAR FIXED DECIMAL;"));

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -762,7 +762,7 @@ export class TestBuilder {
 
   private createDiagnosticMessage(diagnostic: Diagnostic): string {
     const position = this.createPositionMessage(
-      diagnostic.range.start,
+      diagnostic.range?.start ?? -1, // range may not be present in some cases
       diagnostic.uri,
     );
     const severity = Severity[diagnostic.severity];


### PR DESCRIPTION
Closes #206, by adding in additional support for handling hover requests:

- Hover support for include items (ex. `%INCLUDE abc;` or `%INCLUDE "myfile.pli";`), which will now show the full path of the the include on hover
- Hover support for label references, which are then used to generate a hover value for the associated procedure:
```pli
 MyProc: PROC OPTIONS(MAIN) RECURSIVE;
 ...
 END MyProc; // <-- hover here
 ...
 CALL MyProc; // <-- or here
```
On either label ref, we should see the full procedure declaration there.

There are still additional options that need handling, which I've added a little stub for as well. It's just a matter of extending later on.

- Improved hover support for regular declarations (ex. `DCL MyVar FIXED DECIMAL(2,5);`). These now show the full declaration (sans the decimal params at this time). Looks like before it was mixed up a bit with structure members, giving results like `DCL 1 MyVar`, so that's been cleaned up too
- Structure members were already supported for generating hover values
- Added 4slash tests for each case