### PR TITLE
Add caching for tokenizer + preprocessor

### DIFF
--- a/packages/language/src/preprocessor/instruction-cache.ts
+++ b/packages/language/src/preprocessor/instruction-cache.ts
@@ -37,20 +37,12 @@ export class InstructionCache {
   private previousCompilerOptions = getDefaultCompilerOptions();
 
   update(compilerOptions: CompilerOptions): void {
-    let update = false;
-    if (compilerOptions.or !== this.previousCompilerOptions.or) {
-      update = true;
-    }
-    if (compilerOptions.not !== this.previousCompilerOptions.not) {
-      update = true;
-    }
     if (
+      compilerOptions.or !== this.previousCompilerOptions.or ||
+      compilerOptions.not !== this.previousCompilerOptions.not ||
       compilerOptions.pp?.ppInclude?.value !==
-      this.previousCompilerOptions.pp?.ppInclude?.value
+        this.previousCompilerOptions.pp?.ppInclude?.value
     ) {
-      update = true;
-    }
-    if (update) {
       this.cache.clear();
     }
     this.previousCompilerOptions = compilerOptions;

--- a/packages/language/src/preprocessor/instruction-cache.ts
+++ b/packages/language/src/preprocessor/instruction-cache.ts
@@ -1,0 +1,75 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { Token } from "../parser/tokens";
+import { Statement } from "../syntax-tree/ast";
+import { URI } from "../utils/uri";
+import {
+  CompilerOptions,
+  getDefaultCompilerOptions,
+} from "./compiler-options/options";
+import * as inst from "./instructions";
+import { LexingIssue } from "./pli-lexer";
+
+interface CachedInstructions {
+  text: string;
+  instructions: FileInstructionResult;
+}
+
+export interface FileInstructionResult {
+  tokens: Token[];
+  issues: LexingIssue[];
+  statements: Statement[];
+  node: inst.InstructionNode;
+}
+
+export class InstructionCache {
+  private cache = new Map<string, CachedInstructions>();
+
+  private previousCompilerOptions = getDefaultCompilerOptions();
+
+  update(compilerOptions: CompilerOptions): void {
+    let update = false;
+    if (compilerOptions.or !== this.previousCompilerOptions.or) {
+      update = true;
+    }
+    if (compilerOptions.not !== this.previousCompilerOptions.not) {
+      update = true;
+    }
+    if (
+      compilerOptions.pp?.ppInclude?.value !==
+      this.previousCompilerOptions.pp?.ppInclude?.value
+    ) {
+      update = true;
+    }
+    if (update) {
+      this.cache.clear();
+    }
+    this.previousCompilerOptions = compilerOptions;
+  }
+
+  get(
+    uri: URI,
+    text: string,
+    getter: () => FileInstructionResult,
+  ): FileInstructionResult {
+    const key = uri.toString();
+    if (this.cache.has(key)) {
+      const cached = this.cache.get(key)!;
+      if (cached.text === text) {
+        return cached.instructions;
+      }
+    }
+    const instructions = getter();
+    this.cache.set(key, { text, instructions });
+    return instructions;
+  }
+}

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -12,7 +12,10 @@
 import { TextDocuments } from "../language-server/text-documents";
 import { Token } from "../parser/tokens";
 import { URI, UriUtils } from "../utils/uri";
-import { CompilationUnitTokens } from "../workspace/compilation-unit";
+import {
+  CompilationUnit,
+  CompilationUnitTokens,
+} from "../workspace/compilation-unit";
 import { FileSystemProviderInstance } from "../workspace/file-system-provider";
 import { PluginConfigurationProviderInstance } from "../workspace/plugin-configuration-provider";
 import { CompilerOptionResult } from "./compiler-options/options";
@@ -153,9 +156,11 @@ export interface EvaluationResults {
 }
 
 interface InterpreterContext {
+  unit: CompilationUnit;
   currentUri?: URI;
   entryUri?: URI;
   variables: Map<string, Variable>;
+  statements: ast.Statement[];
   result: CompilationUnitTokens;
   errors: LexingIssue[];
   counter: Map<inst.InstructionNode, number>;
@@ -169,6 +174,7 @@ interface InterpreterContext {
 export type InstructionInterpreterResult = CompilationUnitTokens & {
   evaluationResults: EvaluationResults;
   errors: LexingIssue[];
+  statements: ast.Statement[];
   references: ast.Reference[];
 };
 
@@ -181,15 +187,18 @@ export interface InterpreterOptions {
 }
 
 export function runInstructions(
+  unit: CompilationUnit,
   uri: URI,
   start: inst.InstructionNode,
   options: InterpreterOptions,
 ): InstructionInterpreterResult {
   const context: InterpreterContext = {
+    unit,
     currentUri: uri,
     entryUri: uri,
     uris: [uri.toString()],
     errors: [],
+    statements: [],
     xIncludes: new Set(),
     variables: new Map(),
     references: [],
@@ -210,6 +219,7 @@ export function runInstructions(
     evaluationResults: context.evaluations,
     errors: context.errors,
     references: context.references,
+    statements: context.statements,
   };
 }
 
@@ -845,27 +855,36 @@ function runInclude(item: IncludeItem, context: InterpreterContext): void {
 
   try {
     const content = TextDocuments.get(uri)?.getText() ?? "";
-    const processedContent = context.options.marginsProcessor.processMargins(
-      {
-        result: context.options.compilerOptions,
-        text: content,
-      },
-      uri,
-    );
-    const subState = context.options.parser.initializeState(
-      processedContent,
-      uri,
-    );
-    const subProgram = context.options.parser.parse(subState);
-    context.result.fileTokens.set(uri.toString(), subProgram.tokens);
-    context.errors.push(...subProgram.errors);
-    const instruction = generateInstructions(subProgram.statements);
+    const cachedResult = context.unit.instructionCache.get(uri, content, () => {
+      const processedContent = context.options.marginsProcessor.processMargins(
+        {
+          result: context.options.compilerOptions,
+          text: content,
+        },
+        uri,
+      );
+      const subState = context.options.parser.initializeState(
+        processedContent,
+        uri,
+      );
+      const subProgram = context.options.parser.parse(subState);
+      const instruction = generateInstructions(subProgram.statements);
+      return {
+        tokens: subProgram.tokens,
+        issues: subProgram.errors,
+        statements: subProgram.statements,
+        node: instruction,
+      };
+    });
+    context.statements.push(...cachedResult.statements);
+    context.result.fileTokens.set(uri.toString(), cachedResult.tokens);
+    context.errors.push(...cachedResult.issues);
     const newContext: InterpreterContext = {
       ...context,
       currentUri: uri,
       uris: [uri.toString(), ...context.uris],
     };
-    doRunInstructions(newContext, instruction);
+    doRunInstructions(newContext, cachedResult.node);
   } catch (err) {
     failToResolve(err);
   }

--- a/packages/language/src/preprocessor/pli-lexer.ts
+++ b/packages/language/src/preprocessor/pli-lexer.ts
@@ -21,7 +21,6 @@ import { CompilationUnit } from "../workspace/compilation-unit";
 import { Reference, Statement } from "../syntax-tree/ast";
 import { Range, Severity } from "../language-server/types";
 import { Token } from "../parser/tokens";
-import { recursivelySetContainer } from "../linking/symbol-table";
 import { generateInstructions } from "./instruction-generator";
 import { EvaluationResults, runInstructions } from "./instruction-interpreter";
 import { createIncludeInstruction, InstructionNode } from "./instructions";
@@ -67,49 +66,61 @@ export class PliLexer {
   tokenize(unit: CompilationUnit, inputText: string, uri: URI): LexerResult {
     const compilerOptionsResult =
       this.compilerOptionsPreprocessor.extractCompilerOptions(inputText, uri);
-    initLexer(
-      compilerOptionsResult.result?.options ?? getDefaultCompilerOptions(),
-    );
-    const textWithoutMargins = this.marginsProcessor.processMargins(
-      compilerOptionsResult,
-      uri,
-    );
-    const state = this.preprocessorParser.initializeState(
-      textWithoutMargins,
-      uri,
-    );
-    // Do a full parsing of the input text to extract all *local* statements
-    const {
-      statements,
-      errors,
-      tokens: fileTokens,
-    } = this.preprocessorParser.parse(state);
-    unit.preprocessorAst.statements = statements;
-    recursivelySetContainer(unit.preprocessorAst);
-    errors.push(...this.marginsProcessor.issues);
+    const opts =
+      compilerOptionsResult.result?.options ?? getDefaultCompilerOptions();
+    initLexer(opts);
+    unit.instructionCache.update(opts);
+    const allErrors: LexingIssue[] = [];
+    const instruction = unit.instructionCache.get(uri, inputText, () => {
+      const textWithoutMargins = this.marginsProcessor.processMargins(
+        compilerOptionsResult,
+        uri,
+      );
+      const state = this.preprocessorParser.initializeState(
+        textWithoutMargins,
+        uri,
+      );
+      // Do a full parsing of the input text to extract all *local* statements
+      const {
+        statements,
+        errors,
+        tokens: fileTokens,
+      } = this.preprocessorParser.parse(state);
+      const instructionNode = generateInstructions(statements);
+      return {
+        tokens: fileTokens,
+        node: instructionNode,
+        issues: errors,
+        statements: statements,
+      };
+    });
+    allErrors.push(...instruction.issues);
+    allErrors.push(...this.marginsProcessor.issues);
 
-    let instructionNode = generateInstructions(statements);
     const incAfter = compilerOptionsResult.result?.options.incAfter;
     if (incAfter?.process) {
-      instructionNode = generateIncAfterInstruction(instructionNode, incAfter);
+      instruction.node = generateIncAfterInstruction(
+        instruction.node,
+        incAfter,
+      );
     }
-    const output = runInstructions(uri, instructionNode, {
+    const output = runInstructions(unit, uri, instruction.node, {
       compilerOptions: compilerOptionsResult.result,
       marginsProcessor: this.marginsProcessor,
       parser: this.preprocessorParser,
     });
-    output.fileTokens.set(uri.toString(), fileTokens);
+    output.fileTokens.set(uri.toString(), instruction.tokens);
     if (compilerOptionsResult.result) {
       output.fileTokens
         .get(uri.toString())
         ?.unshift(...compilerOptionsResult.result.tokens);
     }
-    errors.push(...output.errors);
+    allErrors.push(...output.errors);
     return {
       all: output.all,
       compilerOptions: compilerOptionsResult,
-      errors,
-      statements,
+      errors: allErrors,
+      statements: [...instruction.statements, ...output.statements],
       fileTokens: output.fileTokens,
       evaluationResults: output.evaluationResults,
       tokenReferences: output.references,

--- a/packages/language/src/preprocessor/pli-preprocessor-parser.ts
+++ b/packages/language/src/preprocessor/pli-preprocessor-parser.ts
@@ -29,6 +29,7 @@ import { LexingIssue } from "./pli-lexer";
 import { Token } from "../parser/tokens";
 import { performAssignmentLookahead } from "../parser/parser";
 import { tokenMatcher } from "chevrotain";
+import { recursivelySetContainer } from "../linking/symbol-table";
 
 export type PreprocessorParserResult = {
   statements: ast.Statement[];
@@ -68,6 +69,9 @@ export class PliPreprocessorParser {
           throw error;
         }
       }
+    }
+    for (const statement of statements) {
+      recursivelySetContainer(statement);
     }
     return {
       statements,

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -36,6 +36,7 @@ import {
 import { Builtins, BuiltinsUri, BuiltinsUriSchema } from "./builtins.js";
 import { PluginConfigurationProviderInstance } from "./plugin-configuration-provider.js";
 import { EvaluationResults } from "../preprocessor/instruction-interpreter.js";
+import { InstructionCache } from "../preprocessor/instruction-cache.js";
 
 /**
  * A compilation unit is a representation of a PL/I program in the language server.
@@ -63,6 +64,7 @@ export interface CompilationUnit {
   diagnostics: CompilationUnitDiagnostics;
   scopeCaches: ScopeCacheGroups;
   requestCaches: LSRequestCache;
+  instructionCache: InstructionCache;
   rootScope: Scope;
   rootPreprocessorScope: Scope;
 }
@@ -153,6 +155,7 @@ export function createCompilationUnit(uri: URI): CompilationUnit {
     referencesCache: new ReferencesCache(),
     statementOrderCache: new StatementOrderCache(),
     scopeCaches: new ScopeCacheGroups(),
+    instructionCache: new InstructionCache(),
     diagnostics: {
       lexer: [],
       compilerOptions: [],


### PR DESCRIPTION
A small change that adds a cache for tokenizer and preprocessor results to the lexing infrastructure: As long as the input text (and the important compiler options don't change), the whole tokenization + parsing result for any file (i.e. tokens, parser errors, statements and preprocessor instruction) can be cached. Note that the result of the preprocessor **is not cached**. It is still recomputed on every change since the result of the preprocessor for an individual file is not independent of other files.

This seems to have a rather profound impact on the lexing time :) Tests should still pass just like before.