### PR TITLE
Normalize PP Include option

### DIFF
--- a/packages/language/src/parser/tokenizer.ts
+++ b/packages/language/src/parser/tokenizer.ts
@@ -410,7 +410,12 @@ function tokenizeIncludeAlt(
     return undefined;
   }
   for (let i = 0; i < includeAlt.length; i++) {
-    if (context.input[context.index + i] !== includeAlt[i]) {
+    let charCode = context.input.charCodeAt(context.index + i);
+    if (charCode >= 97 && charCode <= 122) {
+      // Lowercase character, must be uppercased
+      charCode &= ~0x20;
+    }
+    if (charCode !== includeAlt.charCodeAt(i)) {
       return undefined;
     }
   }

--- a/packages/language/src/preprocessor/compiler-options/translator.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator.ts
@@ -1622,7 +1622,7 @@ translator.rule(["PP"], (option, options) => {
       // set this as the effective INCLUDE PP option value, overriding any previous INCLUDE options
       const match = value.match(/ID\(([^\)]+)\)\s*$/);
       if (match && match.length > 0) {
-        const ppInclude = match[0].slice(3, -1).toLowerCase();
+        const ppInclude = match[0].slice(3, -1).toUpperCase();
         options.pp.ppInclude = {
           value: ppInclude,
         };

--- a/packages/language/test/compiler/options-parser.test.ts
+++ b/packages/language/test/compiler/options-parser.test.ts
@@ -369,7 +369,7 @@ describe("CompilerOptions translator", () => {
     // expect ppInclude to be normalized & set
     const ppInclude = pp.ppInclude as CompilerOptions.PPInclude;
     expect(ppInclude).toBeDefined();
-    expect(ppInclude.value).toBe("++include");
+    expect(ppInclude.value).toBe("++INCLUDE");
   });
 
   const testCasesSensitivity: {

--- a/packages/language/test/fourslash/preprocessor/include/using-ppinclude-mixed-case1.ts
+++ b/packages/language/test/fourslash/preprocessor/include/using-ppinclude-mixed-case1.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: cpy/lib.pli
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: main.pli
+////*PROCESS PP(INCLUDE('ID(++I)'));
+//// ++i lib
+
+preprocessor.expectTokens(`
+  DECLARE LIB_VAR FIXED;
+`);

--- a/packages/language/test/fourslash/preprocessor/include/using-ppinclude-mixed-case2.ts
+++ b/packages/language/test/fourslash/preprocessor/include/using-ppinclude-mixed-case2.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: cpy/lib.pli
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: main.pli
+////*PROCESS PP(INCLUDE('ID(++i)'));
+//// ++I lib
+
+preprocessor.expectTokens(`
+  DECLARE LIB_VAR FIXED;
+`);


### PR DESCRIPTION
We're currently normalizing the include option to always be lower cased. This works if the user actually writes a lower case version of the PP include option, but not if they use an upper case version. This change will always normalize both the option as well as the input text to both be upper cased.