### PR TITLE
Make compilation unit lifecycle async

### DIFF
--- a/packages/language/src/language-server/connection-handler.ts
+++ b/packages/language/src/language-server/connection-handler.ts
@@ -11,6 +11,7 @@
 
 import { CompilationUnitHandler } from "../workspace/compilation-unit";
 import {
+  CancellationToken,
   Connection,
   DocumentHighlight,
   TextDocumentSyncKind,
@@ -36,6 +37,7 @@ import { completionRequest } from "./completion/completion-request";
 import { BuiltinsTextDocument } from "../workspace/builtins";
 import { BuiltinDocuments, TextDocuments } from "./text-documents";
 import { hoverRequest } from "./hover-request";
+import { Mutex } from "../workspace/mutex";
 
 /**
  * Notification sent to the LS when the workspace's plugin configuration changes.
@@ -88,7 +90,8 @@ export function startLanguageServer(connection: Connection): void {
       },
     };
   });
-  connection.onHover((params) => {
+  connection.onHover(async (params) => {
+    await Mutex.ready();
     const uri = params.textDocument.uri;
     const position = params.position;
     const textDocument = TextDocuments.get(uri);
@@ -108,7 +111,8 @@ export function startLanguageServer(connection: Connection): void {
 
     return hoverResponseToLSP(textDocument, response);
   });
-  connection.onCompletion((params) => {
+  connection.onCompletion(async (params) => {
+    await Mutex.ready();
     const uri = params.textDocument.uri;
     const position = params.position;
     const textDocument = TextDocuments.get(uri);
@@ -125,7 +129,8 @@ export function startLanguageServer(connection: Connection): void {
     }
     return [];
   });
-  connection.onDefinition((params) => {
+  connection.onDefinition(async (params) => {
+    await Mutex.ready();
     const position = params.position;
     const textDocument = TextDocuments.get(params.textDocument.uri);
     const uri = URI.parse(params.textDocument.uri);
@@ -148,7 +153,8 @@ export function startLanguageServer(connection: Connection): void {
     }
     return [];
   });
-  connection.onReferences((params) => {
+  connection.onReferences(async (params) => {
+    await Mutex.ready();
     const uri = params.textDocument.uri;
     const position = params.position;
     const textDocument = TextDocuments.get(uri);
@@ -173,7 +179,8 @@ export function startLanguageServer(connection: Connection): void {
     }
     return [];
   });
-  connection.languages.semanticTokens.on((params) => {
+  connection.languages.semanticTokens.on(async (params) => {
+    await Mutex.ready();
     const uri = params.textDocument.uri;
     const textDocument = TextDocuments.get(uri);
     const compilationUnit = compilationUnitHandler.getCompilationUnit(
@@ -188,7 +195,8 @@ export function startLanguageServer(connection: Connection): void {
       data: [],
     };
   });
-  connection.onDocumentHighlight((params) => {
+  connection.onDocumentHighlight(async (params) => {
+    await Mutex.ready();
     const uri = UriUtils.normalize(params.textDocument.uri);
     const position = params.position;
     const textDocument = TextDocuments.get(uri);
@@ -205,7 +213,8 @@ export function startLanguageServer(connection: Connection): void {
     }
     return [];
   });
-  connection.onRenameRequest((params) => {
+  connection.onRenameRequest(async (params) => {
+    await Mutex.ready();
     const uri = params.textDocument.uri;
     const position = params.position;
     const textDocument = TextDocuments.get(uri);
@@ -236,7 +245,8 @@ export function startLanguageServer(connection: Connection): void {
 
     return null;
   });
-  connection.onDocumentSymbol((params) => {
+  connection.onDocumentSymbol(async (params) => {
+    await Mutex.ready();
     const uri = params.textDocument.uri;
     const textDocument = TextDocuments.get(uri);
     const parsedUri = URI.parse(uri);
@@ -249,7 +259,8 @@ export function startLanguageServer(connection: Connection): void {
     }
     return [];
   });
-  connection.onWorkspaceSymbol((params) => {
+  connection.onWorkspaceSymbol(async (params) => {
+    await Mutex.ready();
     return workspaceSymbolRequest(
       params.query,
       compilationUnitHandler.getAllCompilationUnits(),
@@ -261,7 +272,7 @@ export function startLanguageServer(connection: Connection): void {
       // handle changes to the .pliplugin config folder's contents
       PluginConfigurationProviderInstance.reloadConfigurations();
       // reindex reachable compilation units
-      compilationUnitHandler.reindex(connection);
+      compilationUnitHandler.reindex(connection, CancellationToken.None);
     },
   );
   connection.listen();

--- a/packages/language/src/utils/promises.ts
+++ b/packages/language/src/utils/promises.ts
@@ -1,0 +1,121 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import {
+  CancellationToken,
+  CancellationTokenSource,
+} from "vscode-languageserver";
+
+export type MaybePromise<T> = T | Promise<T>;
+
+/**
+ * Delays the execution of the current code to the next tick of the event loop.
+ * Don't call this method directly in a tight loop to prevent too many promises from being created.
+ */
+export function delayNextTick(): Promise<void> {
+  return new Promise((resolve) => {
+    // In case we are running in a non-node environment, `setImmediate` isn't available.
+    // Using `setTimeout` of the browser API accomplishes the same result.
+    if (typeof setImmediate === "undefined") {
+      setTimeout(resolve, 0);
+    } else {
+      setImmediate(resolve);
+    }
+  });
+}
+
+let lastTick = 0;
+let globalInterruptionPeriod = 10;
+
+/**
+ * Reset the global interruption period and create a cancellation token source.
+ */
+export function startCancelableOperation(): CancellationTokenSource {
+  lastTick = performance.now();
+  return new CancellationTokenSource();
+}
+
+/**
+ * Change the period duration for `interruptAndCheck` to the given number of milliseconds.
+ * The default value is 10ms.
+ */
+export function setInterruptionPeriod(period: number): void {
+  globalInterruptionPeriod = period;
+}
+
+/**
+ * This symbol may be thrown in an asynchronous context by any Langium service that receives
+ * a `CancellationToken`. This means that the promise returned by such a service is rejected with
+ * this symbol as rejection reason.
+ */
+export const OperationCancelled = Symbol("OperationCancelled");
+
+/**
+ * Use this in a `catch` block to check whether the thrown object indicates that the operation
+ * has been cancelled.
+ */
+export function isOperationCancelled(
+  err: unknown,
+): err is typeof OperationCancelled {
+  return err === OperationCancelled;
+}
+
+/**
+ * This function does two things:
+ *  1. Check the elapsed time since the last call to this function or to `startCancelableOperation`. If the predefined
+ *     period (configured with `setInterruptionPeriod`) is exceeded, execution is delayed with `delayNextTick`.
+ *  2. If the predefined period is not met yet or execution is resumed after an interruption, the given cancellation
+ *     token is checked, and if cancellation is requested, `OperationCanceled` is thrown.
+ *
+ * All services in Langium that receive a `CancellationToken` may potentially call this function, so the
+ * `CancellationToken` must be caught (with an `async` try-catch block or a `catch` callback attached to
+ * the promise) to avoid that event being exposed as an error.
+ */
+export async function interruptAndCheck(
+  token: CancellationToken,
+): Promise<void> {
+  if (token === CancellationToken.None) {
+    // Early exit in case cancellation was disabled by the caller
+    return;
+  }
+  const current = performance.now();
+  if (current - lastTick >= globalInterruptionPeriod) {
+    lastTick = current;
+    await delayNextTick();
+    // prevent calling delayNextTick every iteration of loop
+    // where delayNextTick takes up the majority or all of the
+    // globalInterruptionPeriod itself
+    lastTick = performance.now();
+  }
+  if (token.isCancellationRequested) {
+    throw OperationCancelled;
+  }
+}
+
+/**
+ * Simple implementation of the deferred pattern.
+ * An object that exposes a promise and functions to resolve and reject it.
+ */
+export class Deferred<T = void> {
+  resolve: (value: T) => this = (value: T) => this;
+  reject: (err?: unknown) => this = (err?: unknown) => this;
+
+  promise = new Promise<T>((resolve, reject) => {
+    this.resolve = (arg) => {
+      resolve(arg);
+      return this;
+    };
+    this.reject = (err) => {
+      reject(err);
+      return this;
+    };
+  });
+}

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -11,7 +11,7 @@
 
 import { PliProgram, SyntaxKind } from "../syntax-tree/ast.js";
 import { URI } from "../utils/uri.js";
-import { Connection } from "vscode-languageserver";
+import { CancellationToken, Connection } from "vscode-languageserver";
 import { ReferencesCache, StatementOrderCache } from "../linking/resolver.js";
 import { Diagnostic, diagnosticsToLSP } from "../language-server/types.js";
 import {
@@ -36,6 +36,8 @@ import {
 import { Builtins, BuiltinsUri, BuiltinsUriSchema } from "./builtins.js";
 import { PluginConfigurationProviderInstance } from "./plugin-configuration-provider.js";
 import { EvaluationResults } from "../preprocessor/instruction-interpreter.js";
+import { Mutex } from "./mutex.js";
+import { isOperationCancelled } from "../utils/promises.js";
 import { InstructionCache } from "../preprocessor/instruction-cache.js";
 
 /**
@@ -183,6 +185,7 @@ export function createCompilationUnit(uri: URI): CompilationUnit {
 
 export class CompilationUnitHandler {
   private compilationUnits: Map<string, CompilationUnit> = new Map();
+  private connection!: Connection;
 
   getCompilationUnit(uri: URI): CompilationUnit | undefined {
     return this.compilationUnits.get(uri.toString());
@@ -197,11 +200,7 @@ export class CompilationUnitHandler {
     if (this.compilationUnits.has(uri.toString())) {
       // existing compilation unit
       return this.compilationUnits.get(uri.toString());
-    } else if (
-      !PluginConfigurationProviderInstance.isLibFileCandidate(
-        uri.toString(true),
-      )
-    ) {
+    } else if (!PluginConfigurationProviderInstance.isLibFileCandidate(uri)) {
       // non-library files should always generate a compilation unit
       return this.createAndStoreCompilationUnit(uri);
     } else {
@@ -235,19 +234,13 @@ export class CompilationUnitHandler {
   }
 
   listen(connection: Connection): void {
+    this.connection = connection;
     const textDocuments = EditorDocuments;
     textDocuments.listen(connection);
     textDocuments.onDidChangeContent((event) => {
-      const unit = this.getOrCreateCompilationUnit(
-        URI.parse(event.document.uri),
-      );
-      if (!unit) {
-        // standalone library files do not synthesize new compilation units
-        return;
-      }
-      const document = textDocuments.get(unit.uri) ?? event.document;
-      this.process(unit, document.getText(), connection);
-      unit.requestCaches.revalidateAll({ connection, unit });
+      Mutex.cancel();
+      const uri = URI.parse(event.document.uri);
+      Mutex.run((token) => this.updateUri(uri, token));
     });
     textDocuments.onDidClose((event) => {
       connection.sendDiagnostics({
@@ -257,28 +250,58 @@ export class CompilationUnitHandler {
     });
   }
 
+  async updateUri(
+    uri: URI,
+    cancellationToken: CancellationToken,
+  ): Promise<void> {
+    const unit = this.getOrCreateCompilationUnit(uri);
+    if (!unit) {
+      // standalone library files do not synthesize new compilation units
+      return;
+    }
+    const document = EditorDocuments.get(unit.uri);
+    if (!document) {
+      return;
+    }
+    await this.process(
+      unit,
+      document.getText(),
+      this.connection,
+      cancellationToken,
+    );
+    unit.requestCaches.revalidateAll({ connection: this.connection, unit });
+  }
+
   /**
    * Process a unit by running it through the lifecycle and generating diagnostics to report back.
    * @param unit The compilation unit
    * @param text Program content to use for the lifecycle
    * @param connection The connection to send diagnostics to
    */
-  private process(
+  private async process(
     unit: CompilationUnit,
     text: string,
     connection: Connection,
-  ): void {
-    lifecycle(unit, text);
-    for (const file of unit.files) {
-      this.compilationUnits.set(file.toString(), unit);
-    }
-    const allDiagnostics = diagnosticsToLSP(collectDiagnostics(unit));
-    for (const file of unit.files) {
-      const fileDiagnostics = allDiagnostics.get(file.toString());
-      connection.sendDiagnostics({
-        uri: file.toString(),
-        diagnostics: fileDiagnostics ?? [],
-      });
+    cancellationToken: CancellationToken,
+  ): Promise<void> {
+    try {
+      await lifecycle(unit, text, cancellationToken);
+      for (const file of unit.files) {
+        this.compilationUnits.set(file.toString(), unit);
+      }
+      const allDiagnostics = diagnosticsToLSP(collectDiagnostics(unit));
+      for (const file of unit.files) {
+        const fileDiagnostics = allDiagnostics.get(file.toString());
+        connection.sendDiagnostics({
+          uri: file.toString(),
+          diagnostics: fileDiagnostics ?? [],
+        });
+      }
+    } catch (err) {
+      if (isOperationCancelled(err)) {
+        return;
+      }
+      throw err;
     }
   }
 
@@ -287,11 +310,19 @@ export class CompilationUnitHandler {
    * Reachable as in the units w/ associated docs that are currently open in the editor.
    * @param connection The connection to send diagnostics to
    */
-  reindex(connection: Connection): void {
+  reindex(connection: Connection, cancellationToken: CancellationToken): void {
     for (const unit of this.getAllCompilationUnits()) {
+      if (cancellationToken.isCancellationRequested) {
+        return;
+      }
       const textDocument = TextDocuments.get(unit.uri.toString());
       if (textDocument) {
-        this.process(unit, textDocument.getText(), connection);
+        this.process(
+          unit,
+          textDocument.getText(),
+          connection,
+          cancellationToken,
+        );
       }
     }
   }

--- a/packages/language/src/workspace/lifecycle.ts
+++ b/packages/language/src/workspace/lifecycle.ts
@@ -25,19 +25,28 @@ import { LexerResult, PliLexer } from "../preprocessor/pli-lexer";
 import { URI } from "../utils/uri";
 import { assignDebugKinds } from "../utils/debug-kinds";
 import { getDefaultCompilerOptions } from "../preprocessor/compiler-options/options";
+import { CancellationToken } from "vscode-languageserver";
+import { interruptAndCheck } from "../utils/promises";
 
-export function lifecycle(
+export async function lifecycle(
   compilationUnit: CompilationUnit,
   text: string,
-): void {
+  cancellation: CancellationToken,
+): Promise<void> {
   compilationUnit.statementOrderCache.clear();
   compilationUnit.referencesCache.clear();
   compilationUnit.scopeCaches.clear();
+  await interruptAndCheck(cancellation);
   tokenize(compilationUnit, text);
+  await interruptAndCheck(cancellation);
   parse(compilationUnit);
+  await interruptAndCheck(cancellation);
   generateSymbolTable(compilationUnit);
+  await interruptAndCheck(cancellation);
   link(compilationUnit);
+  await interruptAndCheck(cancellation);
   validate(compilationUnit);
+  await interruptAndCheck(cancellation);
 }
 
 const lexer = new PliLexer();

--- a/packages/language/src/workspace/mutex.ts
+++ b/packages/language/src/workspace/mutex.ts
@@ -1,0 +1,63 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import {
+  CancellationToken,
+  CancellationTokenSource,
+} from "vscode-languageserver";
+import { Deferred } from "../utils/promises";
+
+export type MutexFunc = (cancellation: CancellationToken) => Promise<void>;
+
+class MutexImpl {
+  private current: Promise<void> = Promise.resolve();
+  private source = new CancellationTokenSource();
+
+  cancel() {
+    try {
+      this.source.cancel();
+    } catch {
+      // Sometimes cancellation randomly fails, this seems to be a `vscode-languageserver` issue.
+    }
+  }
+
+  run(func: MutexFunc, cancel = true): Promise<void> {
+    const deferred = new Deferred<void>();
+    if (cancel) {
+      this.cancel();
+    }
+    const newSource = new CancellationTokenSource();
+    this.source = newSource;
+    this.current = this.current.finally(async () => {
+      if (newSource.token.isCancellationRequested) {
+        return;
+      }
+      try {
+        await func(newSource.token);
+        deferred.resolve();
+      } catch (err) {
+        deferred.reject(err);
+      }
+    });
+    return deferred.promise;
+  }
+
+  /**
+   * Returns a promise that indicates when the mutex is done and ready for the next operation.
+   *
+   * Note that this will prevent cancellation of the current operation!
+   */
+  ready(): Promise<void> {
+    return this.run(() => Promise.resolve(), false);
+  }
+}
+
+export const Mutex = new MutexImpl();

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -144,14 +144,14 @@ export class PluginConfigurationProvider {
    * @param filePath The file path to check for library membership
    * @returns true if the file path matches any library file pattern, false otherwise
    */
-  public isLibFileCandidate(filePath: string): boolean {
+  public isLibFileCandidate(uri: URI): boolean {
     if (!this.libFileGlobPatterns) {
       this.buildLibFileGlobPatterns();
     }
+    // normalize a bit
+    const filePath = uri.toString(true).replace(/[\\/]+$/, "");
     const patterns = this.libFileGlobPatterns || [];
     for (const pattern of patterns) {
-      // normalize a bit
-      filePath = filePath.replace(/[\\/]+$/, "");
       if (minimatch(filePath, pattern, { nocase: true })) {
         return true;
       }

--- a/packages/language/test/compiler/lexing.test.ts
+++ b/packages/language/test/compiler/lexing.test.ts
@@ -13,9 +13,9 @@ import { describe, test } from "vitest";
 import { assertNoParseErrors, parse, parseStmts } from "../utils";
 
 describe("CompilerOptions parser", () => {
-  test("Should lex correct NOT without compiler option", () => {
+  test("Should lex correct NOT without compiler option", async () => {
     // Allow both ^ and ¬ as NOT operators by default
-    const doc = parseStmts(`
+    const doc = await parseStmts(`
   DECLARE VAR FIXED;
   VAR = ^VAR;
   VAR = ¬VAR;
@@ -27,8 +27,8 @@ describe("CompilerOptions parser", () => {
     assertNoParseErrors(doc);
   });
 
-  test("Should lex correct NOT compiler option", () => {
-    const doc = parse(`*PROCESS NOT("~");
+  test("Should lex correct NOT compiler option", async () => {
+    const doc = await parse(`*PROCESS NOT("~");
  MAIN: PROC;
    DECLARE VAR FIXED;
    VAR = ~VAR;
@@ -40,8 +40,8 @@ describe("CompilerOptions parser", () => {
     assertNoParseErrors(doc);
   });
 
-  test("Should lex correct OR without compiler option", () => {
-    const doc = parseStmts(`
+  test("Should lex correct OR without compiler option", async () => {
+    const doc = await parseStmts(`
   DECLARE VAR FIXED;
   VAR = 1 | 2;
   VAR |= 2;
@@ -51,8 +51,8 @@ describe("CompilerOptions parser", () => {
     assertNoParseErrors(doc);
   });
 
-  test("Should lex correct OR compiler option", () => {
-    const doc = parse(`*PROCESS OR('!');
+  test("Should lex correct OR compiler option", async () => {
+    const doc = await parse(`*PROCESS OR('!');
  MAIN: PROC;
    DECLARE VAR FIXED;
    VAR = 1 ! 2;

--- a/packages/language/test/compiler/options-parser.test.ts
+++ b/packages/language/test/compiler/options-parser.test.ts
@@ -21,9 +21,9 @@ import {
 import { CompilerOptions } from "../../src/preprocessor/compiler-options/options";
 import { parse } from "../utils";
 
-describe("CompilerOptions parser", () => {
-  test("simple word based compiler option", () => {
-    const options = parseAbstractCompilerOptions("TERMINAL").options;
+describe("CompilerOptions parser", async () => {
+  test("simple word based compiler option", async () => {
+    const options = await parseAbstractCompilerOptions("TERMINAL").options;
     expect(options).toHaveLength(1);
     expect(options[0].name).toBe("TERMINAL");
     expect(options[0].token.startOffset).toBe(0);
@@ -31,8 +31,9 @@ describe("CompilerOptions parser", () => {
     expect(options[0].values).toHaveLength(0);
   });
 
-  test("compiler option with parameter", () => {
-    const options = parseAbstractCompilerOptions("AGGREGATE(DECIMAL)").options;
+  test("compiler option with parameter", async () => {
+    const options =
+      await parseAbstractCompilerOptions("AGGREGATE(DECIMAL)").options;
     expect(options).toHaveLength(1);
     expect(options[0].name).toBe("AGGREGATE");
     expect(options[0].values).toHaveLength(1);
@@ -41,8 +42,9 @@ describe("CompilerOptions parser", () => {
     expect(parameter.value).toBe("DECIMAL");
   });
 
-  test("compiler option with string parameter", () => {
-    const options = parseAbstractCompilerOptions("BRACKETS('[]')").options;
+  test("compiler option with string parameter", async () => {
+    const options =
+      await parseAbstractCompilerOptions("BRACKETS('[]')").options;
     expect(options).toHaveLength(1);
     expect(options[0].name).toBe("BRACKETS");
     expect(options[0].values).toHaveLength(1);
@@ -51,8 +53,8 @@ describe("CompilerOptions parser", () => {
     expect(parameter.value).toBe("[]");
   });
 
-  test("compiler option with number parameter", () => {
-    const options = parseAbstractCompilerOptions("ARCH(10)").options;
+  test("compiler option with number parameter", async () => {
+    const options = await parseAbstractCompilerOptions("ARCH(10)").options;
     expect(options).toHaveLength(1);
     expect(options[0].name).toBe("ARCH");
     expect(options[0].values).toHaveLength(1);
@@ -61,8 +63,8 @@ describe("CompilerOptions parser", () => {
     expect(parameter.value).toBe("10");
   });
 
-  test("compiler option with nested parameter", () => {
-    const options = parseAbstractCompilerOptions(
+  test("compiler option with nested parameter", async () => {
+    const options = await parseAbstractCompilerOptions(
       "DISPLAY(WTO(ROUTCDE(2)))",
     ).options;
     expect(options).toHaveLength(1);
@@ -81,76 +83,77 @@ describe("CompilerOptions parser", () => {
     expect(nestedParameter.value).toBe("2");
   });
 
-  test("multiple compiler options", () => {
-    const options = parseAbstractCompilerOptions("COMPILE,TERMINAL").options;
+  test("multiple compiler options", async () => {
+    const options =
+      await parseAbstractCompilerOptions("COMPILE,TERMINAL").options;
     expect(options).toHaveLength(2);
     expect(options[0].name).toBe("COMPILE");
     expect(options[1].name).toBe("TERMINAL");
   });
 });
 
-describe("CompilerOptions translator", () => {
-  test("Translates MARGINS with values", () => {
-    const options = parseAbstractCompilerOptions("MARGINS(4, 80)");
+describe("CompilerOptions translator", async () => {
+  test("Translates MARGINS with values", async () => {
+    const options = await parseAbstractCompilerOptions("MARGINS(4, 80)");
     const translated = translateCompilerOptions(options).options;
     expect(translated.margins).toEqual({ m: 4, n: 80 });
   });
 
-  test("Translates MARGINS with short identifier", () => {
-    const options = parseAbstractCompilerOptions("MAR(4, 80)");
+  test("Translates MARGINS with short identifier", async () => {
+    const options = await parseAbstractCompilerOptions("MAR(4, 80)");
     const translated = translateCompilerOptions(options).options;
     expect(translated.margins).toEqual({ m: 4, n: 80 });
   });
 
-  test("Translates MARGINS default value", () => {
-    const options = parseAbstractCompilerOptions("MARGINS(4,)");
+  test("Translates MARGINS default value", async () => {
+    const options = await parseAbstractCompilerOptions("MARGINS(4,)");
     const translated = translateCompilerOptions(options).options;
     expect(translated.margins).toEqual({ m: 4, n: 72 });
   });
 
-  test("Translates MARGINS - negative", () => {
+  test("Translates MARGINS - negative", async () => {
     // Margins requires two or three arguments
-    const options = parseAbstractCompilerOptions("MARGINS(4)");
+    const options = await parseAbstractCompilerOptions("MARGINS(4)");
     const translated = translateCompilerOptions(options).options;
     // If the parsing fails, the option is not set
     expect(translated.margins).toBeUndefined();
   });
 
-  test("Translates MARGINS with c", () => {
-    const options = parseAbstractCompilerOptions("MARGINS(0, 14,)");
+  test("Translates MARGINS with c", async () => {
+    const options = await parseAbstractCompilerOptions("MARGINS(0, 14,)");
     const translated = translateCompilerOptions(options).options;
     expect(translated.margins).toEqual({ m: 0, n: 14, c: "" });
   });
 
-  test("Translates NOMARGINS", () => {
-    const options = parseAbstractCompilerOptions("NOMARGINS");
+  test("Translates NOMARGINS", async () => {
+    const options = await parseAbstractCompilerOptions("NOMARGINS");
     const translated = translateCompilerOptions(options).options;
     expect(translated.margins).toEqual(false);
   });
 
-  test("Produce issue for text value in MARGINS m", () => {
-    const options = parseAbstractCompilerOptions("MARGINS(M,444)");
+  test("Produce issue for text value in MARGINS m", async () => {
+    const options = await parseAbstractCompilerOptions("MARGINS(M,444)");
     const issues = translateCompilerOptions(options).issues;
     expect(issues).toHaveLength(1);
     expect(issues[0].message).toBe("Expected a number.");
   });
 
-  test("Produce issue for text value in MARGINS n", () => {
-    const options = parseAbstractCompilerOptions("MARGINS(112, R)");
+  test("Produce issue for text value in MARGINS n", async () => {
+    const options = await parseAbstractCompilerOptions("MARGINS(112, R)");
     const issues = translateCompilerOptions(options).issues;
     expect(issues).toHaveLength(1);
     expect(issues[0].message).toBe("Expected a number.");
   });
 
-  test("Produce issue for text value when string is expected", () => {
-    const options = parseAbstractCompilerOptions("BRACKETS(TEST)");
+  test("Produce issue for text value when string is expected", async () => {
+    const options = await parseAbstractCompilerOptions("BRACKETS(TEST)");
     const issues = translateCompilerOptions(options).issues;
     expect(issues).toHaveLength(1);
     expect(issues[0].message).toBe("Expected a string value.");
   });
 
-  test("Produce issue for text value when enum is expected", () => {
-    const options = parseAbstractCompilerOptions("CASE(TEST)");
+  test("Produce issue for text value when enum is expected", async () => {
+    const options = await parseAbstractCompilerOptions("CASE(TEST)");
     const issues = translateCompilerOptions(options).issues;
     expect(issues).toHaveLength(1);
     expect(issues[0].message).toBe(
@@ -158,8 +161,8 @@ describe("CompilerOptions translator", () => {
     );
   });
 
-  test("Produce issue for text value when option is expected in CASERULES", () => {
-    const options = parseAbstractCompilerOptions("CASERULES(TEST)");
+  test("Produce issue for text value when option is expected in CASERULES", async () => {
+    const options = await parseAbstractCompilerOptions("CASERULES(TEST)");
     const issues = translateCompilerOptions(options).issues;
     expect(issues).toHaveLength(1);
     expect(issues[0].message).toBe(
@@ -167,8 +170,8 @@ describe("CompilerOptions translator", () => {
     );
   });
 
-  test("Produce issue for wrong option in CASERULES", () => {
-    const options = parseAbstractCompilerOptions("CASERULES(TEST())");
+  test("Produce issue for wrong option in CASERULES", async () => {
+    const options = await parseAbstractCompilerOptions("CASERULES(TEST())");
     const issues = translateCompilerOptions(options).issues;
     expect(issues).toHaveLength(1);
     expect(issues[0].message).toBe(
@@ -176,8 +179,10 @@ describe("CompilerOptions translator", () => {
     );
   });
 
-  test("Produce issue for wrong option in KEYWORD in CASERULES", () => {
-    const options = parseAbstractCompilerOptions("CASERULES(KEYWORD(TEST))");
+  test("Produce issue for wrong option in KEYWORD in CASERULES", async () => {
+    const options = await parseAbstractCompilerOptions(
+      "CASERULES(KEYWORD(TEST))",
+    );
     const issues = translateCompilerOptions(options).issues;
     expect(issues).toHaveLength(1);
     expect(issues[0].message).toBe(
@@ -185,20 +190,20 @@ describe("CompilerOptions translator", () => {
     );
   });
 
-  test("Accept multiple same options on CHECK", () => {
-    const options = parseAbstractCompilerOptions("CHECK(storage, stg)");
+  test("Accept multiple same options on CHECK", async () => {
+    const options = await parseAbstractCompilerOptions("CHECK(storage, stg)");
     const issues = translateCompilerOptions(options).issues;
     expect(issues).toHaveLength(0);
   });
 
-  test("Accept multiple same options on CHECK without comma", () => {
-    const options = parseAbstractCompilerOptions("CHECK(storage stg)");
+  test("Accept multiple same options on CHECK without comma", async () => {
+    const options = await parseAbstractCompilerOptions("CHECK(storage stg)");
     const issues = translateCompilerOptions(options).issues;
     expect(issues).toHaveLength(0);
   });
 
-  test("Produce issue for empty DDSQL", () => {
-    const options = parseAbstractCompilerOptions("DDSQL()");
+  test("Produce issue for empty DDSQL", async () => {
+    const options = await parseAbstractCompilerOptions("DDSQL()");
     const issues = translateCompilerOptions(options).issues;
     expect(issues).toHaveLength(1);
     expect(issues[0].message).toBe(
@@ -206,14 +211,14 @@ describe("CompilerOptions translator", () => {
     );
   });
 
-  test("Accept DDSQL with empty string", () => {
-    const options = parseAbstractCompilerOptions("DDSQL('')");
+  test("Accept DDSQL with empty string", async () => {
+    const options = await parseAbstractCompilerOptions("DDSQL('')");
     const issues = translateCompilerOptions(options).issues;
     expect(issues).toHaveLength(0);
   });
 
-  test("Produce issue for unknown compiler option", () => {
-    const options = parseAbstractCompilerOptions("UNKNOWNOPTION");
+  test("Produce issue for unknown compiler option", async () => {
+    const options = await parseAbstractCompilerOptions("UNKNOWNOPTION");
     const issues = translateCompilerOptions(options).issues;
     expect(issues).toHaveLength(1);
     expect(issues[0].message).toMatch(
@@ -221,22 +226,22 @@ describe("CompilerOptions translator", () => {
     );
   });
 
-  test("Produce issue for arguments at COMPILE", () => {
-    const options = parseAbstractCompilerOptions("COMPILE(E)");
+  test("Produce issue for arguments at COMPILE", async () => {
+    const options = await parseAbstractCompilerOptions("COMPILE(E)");
     const issues = translateCompilerOptions(options).issues;
     expect(issues).toHaveLength(1);
     expect(issues[0].message).toBe("Expected 0 arguments, but received 1.");
   });
 
-  test("Produce issue for arguments at NOCOPYRIGHT", () => {
-    const options = parseAbstractCompilerOptions("NOCOPYRIGHT(E)");
+  test("Produce issue for arguments at NOCOPYRIGHT", async () => {
+    const options = await parseAbstractCompilerOptions("NOCOPYRIGHT(E)");
     const issues = translateCompilerOptions(options).issues;
     expect(issues).toHaveLength(1);
     expect(issues[0].message).toBe("Expected 0 arguments, but received 1.");
   });
 
-  test("Produce issue for text value when option is expected in DEPRECATE", () => {
-    const options = parseAbstractCompilerOptions("DEPRECATE(BUILTIN)");
+  test("Produce issue for text value when option is expected in DEPRECATE", async () => {
+    const options = await parseAbstractCompilerOptions("DEPRECATE(BUILTIN)");
     const issues = translateCompilerOptions(options).issues;
     expect(issues).toHaveLength(1);
     expect(issues[0].message).toBe(
@@ -244,10 +249,10 @@ describe("CompilerOptions translator", () => {
     );
   });
 
-  test("Test compiler option abbreviations", () => {
+  test("Test compiler option abbreviations", async () => {
     const abbreviations = ["CURR", "CP", "CSE", "NOCSE", "DEC", "DFT"];
     for (const abbr of abbreviations) {
-      const options = parseAbstractCompilerOptions(abbr);
+      const options = await parseAbstractCompilerOptions(abbr);
       const issues = translateCompilerOptions(options).issues;
       if (
         issues.some((issue) =>
@@ -261,8 +266,8 @@ describe("CompilerOptions translator", () => {
     }
   });
 
-  test("Test BLANK validation, disallowed characters", () => {
-    const options = parseAbstractCompilerOptions("BLANK('D')");
+  test("Test BLANK validation, disallowed characters", async () => {
+    const options = await parseAbstractCompilerOptions("BLANK('D')");
     const issues = translateCompilerOptions(options).issues;
     expect(issues).toHaveLength(1);
     expect(issues[0].message).toBe(
@@ -270,8 +275,8 @@ describe("CompilerOptions translator", () => {
     );
   });
 
-  test("Test BLANK validation, single character", () => {
-    const options = parseAbstractCompilerOptions("BLANK('$$$##')");
+  test("Test BLANK validation, single character", async () => {
+    const options = await parseAbstractCompilerOptions("BLANK('$$$##')");
     const issues = translateCompilerOptions(options).issues;
     expect(issues).toHaveLength(1);
     expect(issues[0].message).toBe(
@@ -279,8 +284,8 @@ describe("CompilerOptions translator", () => {
     );
   });
 
-  test("Test BRACKETS validation, double character", () => {
-    const options = parseAbstractCompilerOptions("BRACKETS('D')");
+  test("Test BRACKETS validation, double character", async () => {
+    const options = await parseAbstractCompilerOptions("BRACKETS('D')");
     const issues = translateCompilerOptions(options).issues;
     expect(issues).toHaveLength(1);
     expect(issues[0].message).toBe(
@@ -288,8 +293,8 @@ describe("CompilerOptions translator", () => {
     );
   });
 
-  test("Test BRACKETS validation, disallowed characters", () => {
-    const options = parseAbstractCompilerOptions("BRACKETS('  ')");
+  test("Test BRACKETS validation, disallowed characters", async () => {
+    const options = await parseAbstractCompilerOptions("BRACKETS('  ')");
     const issues = translateCompilerOptions(options).issues;
     expect(issues).toHaveLength(1);
     expect(issues[0].message).toBe(
@@ -297,8 +302,8 @@ describe("CompilerOptions translator", () => {
     );
   });
 
-  test("Test BRACKETS validation, same character", () => {
-    const options = parseAbstractCompilerOptions("BRACKETS('[[')");
+  test("Test BRACKETS validation, same character", async () => {
+    const options = await parseAbstractCompilerOptions("BRACKETS('[[')");
     const issues = translateCompilerOptions(options).issues;
     expect(issues).toHaveLength(1);
     expect(issues[0].message).toBe(
@@ -306,21 +311,23 @@ describe("CompilerOptions translator", () => {
     );
   });
 
-  test("Test DEFAULT SHORT validation", () => {
-    const options = parseAbstractCompilerOptions("DEFAULT(SHORT(IEEEp98))");
+  test("Test DEFAULT SHORT validation", async () => {
+    const options = await parseAbstractCompilerOptions(
+      "DEFAULT(SHORT(IEEEp98))",
+    );
     const issues = translateCompilerOptions(options).issues;
     expect(issues).toHaveLength(1);
     expect(issues[0].message).toBe("Invalid default option value: IEEEP98");
   });
 
-  test("Test DEFAULT RETURNS validation", () => {
-    const options = parseAbstractCompilerOptions("DEFAULT(RETURNS())");
+  test("Test DEFAULT RETURNS validation", async () => {
+    const options = await parseAbstractCompilerOptions("DEFAULT(RETURNS())");
     const translated = translateCompilerOptions(options).options;
     expect(translated.default?.returns).toEqual({ type: "BYADDR" });
   });
 
-  test("Test CODEPAGE validation", () => {
-    const options = parseAbstractCompilerOptions("CODEPAGE(0114dd0)");
+  test("Test CODEPAGE validation", async () => {
+    const options = await parseAbstractCompilerOptions("CODEPAGE(0114dd0)");
     const issues = translateCompilerOptions(options).issues;
     expect(issues).toHaveLength(1);
     expect(issues[0].message).toBe(
@@ -328,8 +335,8 @@ describe("CompilerOptions translator", () => {
     );
   });
 
-  test("Test DECIMAL validation, mandatory argument", () => {
-    const options = parseAbstractCompilerOptions("DECIMAL");
+  test("Test DECIMAL validation, mandatory argument", async () => {
+    const options = await parseAbstractCompilerOptions("DECIMAL");
     const issues = translateCompilerOptions(options).issues;
     expect(issues).toHaveLength(1);
     expect(issues[0].message).toBe(
@@ -337,8 +344,8 @@ describe("CompilerOptions translator", () => {
     );
   });
 
-  test("Test DECIMAL validation, mandatory argument #2", () => {
-    const options = parseAbstractCompilerOptions("DECIMAL()");
+  test("Test DECIMAL validation, mandatory argument #2", async () => {
+    const options = await parseAbstractCompilerOptions("DECIMAL()");
     const issues = translateCompilerOptions(options).issues;
     expect(issues).toHaveLength(1);
     expect(issues[0].message).toBe(
@@ -346,8 +353,8 @@ describe("CompilerOptions translator", () => {
     );
   });
 
-  test("Test PP validation", () => {
-    const options = parseAbstractCompilerOptions(
+  test("Test PP validation", async () => {
+    const options = await parseAbstractCompilerOptions(
       "PP(INCLUDE('ID(++INCLUDE)'))",
     );
     const result = translateCompilerOptions(options);
@@ -460,8 +467,8 @@ describe("CompilerOptions translator", () => {
   ];
 
   for (const testCase of testCasesSensitivity) {
-    test(`Translates option with parameter case-insensitively: ${testCase.input}`, () => {
-      const parsed = parseAbstractCompilerOptions(testCase.input);
+    test(`Translates option with parameter case-insensitively: ${testCase.input}`, async () => {
+      const parsed = await parseAbstractCompilerOptions(testCase.input);
       const options = translateCompilerOptions(parsed).options;
       expect(testCase.toTest(options)).toEqual(testCase.expected);
     });
@@ -566,15 +573,15 @@ describe("CompilerOptions translator", () => {
 
   for (const testCase of testCasesDefaultOptions) {
     for (const [index, input] of testCase.input.entries()) {
-      test(`Translates default option: ${input}`, () => {
+      test(`Translates default option: ${input}`, async () => {
         const defaultOption = `DEFAULT(${input})`;
-        const parsed = parseAbstractCompilerOptions(defaultOption);
+        const parsed = await parseAbstractCompilerOptions(defaultOption);
         const options = translateCompilerOptions(parsed).options;
         expect(testCase.toTest(options)).toEqual(testCase.expected[index]);
       });
-      test(`Translates default option with conflicts: ${input}`, () => {
+      test(`Translates default option with conflicts: ${input}`, async () => {
         const defaultOption = `DEFAULT(${input}, ${testCase.input.join(", ")})`;
-        const parsed = parseAbstractCompilerOptions(defaultOption);
+        const parsed = await parseAbstractCompilerOptions(defaultOption);
         const issues = translateCompilerOptions(parsed).issues;
         expect(issues).toHaveLength(1);
         expect(issues[0].message).toMatch(
@@ -584,23 +591,23 @@ describe("CompilerOptions translator", () => {
     }
   }
 
-  test('Test "SYSPARM" default option', () => {
+  test('Test "SYSPARM" default option', async () => {
     // parse any compiler option, we should still expect the default SYSPARM in the complete options object
-    const options = parseAbstractCompilerOptions("AG");
+    const options = await parseAbstractCompilerOptions("AG");
     const translated = translateCompilerOptions(options).options;
     expect(translated.sysParm).toBeDefined();
     expect(translated.sysParm).toBe("");
   });
 
-  test('Test "SYSPARM" option', () => {
-    const options = parseAbstractCompilerOptions("SYSPARM('PLIVERSION')");
+  test('Test "SYSPARM" option', async () => {
+    const options = await parseAbstractCompilerOptions("SYSPARM('PLIVERSION')");
     const translated = translateCompilerOptions(options).options;
     expect(translated.sysParm).toBe("PLIVERSION");
   });
 
-  test('Test "SYSPARM" error on excessive length', () => {
+  test('Test "SYSPARM" error on excessive length', async () => {
     // >= 1023 is an issue
-    const options = parseAbstractCompilerOptions(
+    const options = await parseAbstractCompilerOptions(
       `SYSPARM('${"i".repeat(1024)}')`,
     );
     const issues = translateCompilerOptions(options).issues;
@@ -610,25 +617,28 @@ describe("CompilerOptions translator", () => {
     );
   });
 
-  test('Test "SYSTEM" option default, should be MVS', () => {
-    const options = parseAbstractCompilerOptions("SYSTEM");
+  test('Test "SYSTEM" option default, should be MVS', async () => {
+    const options = await parseAbstractCompilerOptions("SYSTEM");
     const translated = translateCompilerOptions(options).options;
     expect(translated.system).toBe("MVS");
   });
 
   for (const systemValue of ["MVS", "CICS", "IMS", "OS", "TSO"]) {
-    test('Test "SYSTEM" option with expected value ' + systemValue, () => {
-      const options = parseAbstractCompilerOptions(
-        "SYSTEM(" + systemValue + ")",
-      );
-      const translated = translateCompilerOptions(options).options;
-      expect(translated.system).toBe(systemValue);
-    });
+    test(
+      'Test "SYSTEM" option with expected value ' + systemValue,
+      async () => {
+        const options = await parseAbstractCompilerOptions(
+          "SYSTEM(" + systemValue + ")",
+        );
+        const translated = translateCompilerOptions(options).options;
+        expect(translated.system).toBe(systemValue);
+      },
+    );
   }
 });
 
-describe("Process directives", () => {
-  test("should parse multiple process directives", () => {
+describe("Process directives", async () => {
+  test("should parse multiple process directives", async () => {
     const code = `
 %PROCESS F(I) AG A(F); 
 *PROCESS MARGINS(2,75);
@@ -636,14 +646,14 @@ describe("Process directives", () => {
  DECLARE LIBREF FIXED;
  LIBREF = 44;`;
 
-    const doc = parse(code, { validate: true });
+    const doc = await parse(code, { validate: true });
     expect(doc.compilerOptions.flag).toBe("I");
     expect(doc.compilerOptions.aggregate).toBeDefined();
     expect(doc.compilerOptions.attributes?.identifiers).toBe("FULL");
     expect(doc.compilerOptions.margins).toEqual({ m: 2, n: 75 });
   });
 
-  test("should parse multiple process directives with comments", () => {
+  test("should parse multiple process directives with comments", async () => {
     const code = `
 %PROCESS F(I) AG A(F); /* XX */
 *PROCESS MARGINS(2,75); // test
@@ -651,7 +661,7 @@ describe("Process directives", () => {
  DECLARE LIBREF FIXED;
  LIBREF = 44;`;
 
-    const doc = parse(code, { validate: true });
+    const doc = await parse(code, { validate: true });
     expect(doc.compilerOptions.flag).toBe("I");
     expect(doc.compilerOptions.aggregate).toBeDefined();
     expect(doc.compilerOptions.attributes?.identifiers).toBe("FULL");
@@ -659,7 +669,7 @@ describe("Process directives", () => {
     expect(doc.compilerOptions.default?.returns).toEqual({ type: "BYADDR" });
   });
 
-  test("should parse multiple process directives with comments inbetween", () => {
+  test("should parse multiple process directives with comments inbetween", async () => {
     const code = `
 %PROCESS F(I) AG A(F); /* XX */
 *PROCESS MARGINS(2,75); // test
@@ -674,7 +684,7 @@ describe("Process directives", () => {
  DECLARE LIBREF FIXED;
  LIBREF = 44;`;
 
-    const doc = parse(code, { validate: true });
+    const doc = await parse(code, { validate: true });
     expect(doc.compilerOptions.flag).toBe("I");
     expect(doc.compilerOptions.aggregate).toBeDefined();
     expect(doc.compilerOptions.attributes?.identifiers).toBe("FULL");
@@ -682,7 +692,7 @@ describe("Process directives", () => {
     expect(doc.compilerOptions.default?.returns).toEqual({ type: "BYADDR" });
   });
 
-  test("should parse multiple process directives with windows line endings", () => {
+  test("should parse multiple process directives with windows line endings", async () => {
     const code = `
 %PROCESS F(I) AG A(F); \r
 *PROCESS MARGINS(2,75); 
@@ -690,7 +700,7 @@ describe("Process directives", () => {
  DECLARE LIBREF FIXED;
  LIBREF = 44;`;
 
-    const doc = parse(code, { validate: true });
+    const doc = await parse(code, { validate: true });
     expect(doc.compilerOptions.flag).toBe("I");
     expect(doc.compilerOptions.aggregate).toBeDefined();
     expect(doc.compilerOptions.attributes?.identifiers).toBe("FULL");

--- a/packages/language/test/extracted-doc-cases.test.ts
+++ b/packages/language/test/extracted-doc-cases.test.ts
@@ -27,7 +27,7 @@ import {
   parseStmts,
 } from "./utils";
 
-test("Block block-492.pli", () => {
+test("Block block-492.pli", async () => {
   // Context:
   //
   // control. It allows multiple ON-units to get control for the same condition.
@@ -43,7 +43,7 @@ test("Block block-492.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.398 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.398 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -55,7 +55,7 @@ test("Block block-492.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-508.pli", () => {
+test("Block block-508.pli", async () => {
   // Context:
   //
   // Example
@@ -71,7 +71,7 @@ test("Block block-508.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.459 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.459 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -90,7 +90,7 @@ test("Block block-508.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-400.pli", () => {
+test("Block block-400.pli", async () => {
   // Context:
   //
   // both specify null ON-units for the same file.
@@ -106,7 +106,7 @@ test("Block block-400.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.331 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.331 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -121,7 +121,7 @@ test("Block block-400.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-204.pli", () => {
+test("Block block-204.pli", async () => {
   // Context:
   //
   // "would be the same as this longer declare:
@@ -137,7 +137,7 @@ test("Block block-204.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.232 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.232 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -148,7 +148,7 @@ test("Block block-204.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-658.pli", () => {
+test("Block block-658.pli", async () => {
   // Context:
   //
   // which is a structure declaration:
@@ -164,7 +164,7 @@ test("Block block-658.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.670 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.670 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -182,7 +182,7 @@ test("Block block-658.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-297.pli", () => {
+test("Block block-297.pli", async () => {
   // Context:
   //
   // is encountered or until a %POP directive that restores the previous %PRINT directive is encountered.
@@ -198,7 +198,7 @@ test("Block block-297.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.278 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.278 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -210,7 +210,7 @@ test("Block block-297.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-477.pli", () => {
+test("Block block-477.pli", async () => {
   // Context:
   //
   // Consider the following example:
@@ -226,7 +226,7 @@ test("Block block-477.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.386 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.386 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -238,7 +238,7 @@ test("Block block-477.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-610.pli", () => {
+test("Block block-610.pli", async () => {
   // Context:
   //
   // Example
@@ -254,7 +254,7 @@ test("Block block-610.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.603 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.603 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -273,7 +273,7 @@ test("Block block-610.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-278.pli", () => {
+test("Block block-278.pli", async () => {
   // Context:
   //
   // UPTHRU and DOWNTHRU are particularly useful with ordinals. Consider the following example:
@@ -289,7 +289,7 @@ test("Block block-278.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.270 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.270 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -306,7 +306,7 @@ test("Block block-278.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-184.pli", () => {
+test("Block block-184.pli", async () => {
   // Context:
   //
   // precision:
@@ -322,7 +322,7 @@ test("Block block-184.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.222 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.222 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -333,7 +333,7 @@ test("Block block-184.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-129.pli", () => {
+test("Block block-129.pli", async () => {
   // Context:
   //
   // To return from a subroutine, the RETURN statement syntax is as follows:
@@ -349,7 +349,7 @@ test("Block block-129.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.175 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.175 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -361,7 +361,7 @@ test("Block block-129.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-689.pli", () => {
+test("Block block-689.pli", async () => {
   // Context:
   //
   // Upper limits
@@ -377,7 +377,7 @@ test("Block block-689.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.684 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.684 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -489,7 +489,7 @@ test("Block block-689.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-688.pli", () => {
+test("Block block-688.pli", async () => {
   // Context:
   //
   // Upper limits
@@ -505,7 +505,7 @@ test("Block block-688.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.683 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.683 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -615,7 +615,7 @@ test("Block block-688.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-68.pli", () => {
+test("Block block-68.pli", async () => {
   // Context:
   //
   // them separately. Consider the following example:
@@ -631,7 +631,7 @@ test("Block block-68.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.127 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.127 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -644,7 +644,7 @@ test("Block block-68.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-142.pli", () => {
+test("Block block-142.pli", async () => {
   // Context:
   //
   // the parent structure.
@@ -660,7 +660,7 @@ test("Block block-142.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.192 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.192 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -680,7 +680,7 @@ test("Block block-142.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-21.pli", () => {
+test("Block block-21.pli", async () => {
   // Context:
   //
   // of 16 binary digits.
@@ -696,7 +696,7 @@ test("Block block-21.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.78 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.78 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -707,7 +707,7 @@ test("Block block-21.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-20.pli", () => {
+test("Block block-20.pli", async () => {
   // Context:
   //
   //  represents fixed-point data of 3 digits, 2 of which are fractional.
@@ -723,7 +723,7 @@ test("Block block-20.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.78 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.78 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -734,7 +734,7 @@ test("Block block-20.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-389.pli", () => {
+test("Block block-389.pli", async () => {
   // Context:
   //
   // Combined with DIMACROSS, it can become even easier to add elements to this declaration:
@@ -750,7 +750,7 @@ test("Block block-389.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.322 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.322 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -769,7 +769,7 @@ test("Block block-389.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-212.pli", () => {
+test("Block block-212.pli", async () => {
   // Context:
   //
   // This example is based on the following declaration:
@@ -785,7 +785,7 @@ test("Block block-212.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.234 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.234 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -796,7 +796,7 @@ test("Block block-212.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-149.pli", () => {
+test("Block block-149.pli", async () => {
   // Context:
   //
   //  is not.
@@ -812,7 +812,7 @@ test("Block block-149.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.195 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.195 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -830,7 +830,7 @@ test("Block block-149.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-192.pli", () => {
+test("Block block-192.pli", async () => {
   // Context:
   //
   // Consider the following example:
@@ -846,7 +846,7 @@ test("Block block-192.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.225 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.225 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -857,7 +857,7 @@ test("Block block-192.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-633.pli", () => {
+test("Block block-633.pli", async () => {
   // Context:
   //
   // Example
@@ -873,7 +873,7 @@ test("Block block-633.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.642 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.642 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -891,7 +891,7 @@ test("Block block-633.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-383.pli", () => {
+test("Block block-383.pli", async () => {
   // Context:
   //
   // consists of the elements '9.99' of the picture E.
@@ -907,7 +907,7 @@ test("Block block-383.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.318 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.318 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -919,7 +919,7 @@ test("Block block-383.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-382.pli", () => {
+test("Block block-382.pli", async () => {
   // Context:
   //
   // X is a bit string that consists of 40 elements of C, starting at the 20th element.
@@ -935,7 +935,7 @@ test("Block block-382.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.318 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.318 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -949,7 +949,7 @@ test("Block block-382.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-177.pli", () => {
+test("Block block-177.pli", async () => {
   // Context:
   //
   // Consider the following example:
@@ -965,7 +965,7 @@ test("Block block-177.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.220 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.220 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -977,7 +977,7 @@ test("Block block-177.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-87.pli", () => {
+test("Block block-87.pli", async () => {
   // Context:
   //
   // The ENTRY statement can define a secondary entry point to a procedure. Consider the following example:
@@ -993,7 +993,7 @@ test("Block block-87.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.145 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.145 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -1006,7 +1006,7 @@ test("Block block-87.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-562.pli", () => {
+test("Block block-562.pli", async () => {
   // Context:
   //
   // Example
@@ -1022,7 +1022,7 @@ test("Block block-562.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.541 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.541 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -1039,7 +1039,7 @@ test("Block block-562.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-563.pli", () => {
+test("Block block-563.pli", async () => {
   // Context:
   //
   // Example
@@ -1055,7 +1055,7 @@ test("Block block-563.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.542 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.542 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -1076,7 +1076,7 @@ test("Block block-563.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-27.pli", () => {
+test("Block block-27.pli", async () => {
   // Context:
   //
   //  in this example do compare as equal:
@@ -1092,7 +1092,7 @@ test("Block block-27.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.83 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.83 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -1104,7 +1104,7 @@ test("Block block-27.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-692.pli", () => {
+test("Block block-692.pli", async () => {
   // Context:
   //
   // Upper limits
@@ -1120,7 +1120,7 @@ test("Block block-692.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.687 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.687 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -1170,7 +1170,7 @@ test("Block block-692.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-214.pli", () => {
+test("Block block-214.pli", async () => {
   // Context:
   //
   // twentieth and the twenty-first centuries, it might be declared as follows:
@@ -1186,7 +1186,7 @@ test("Block block-214.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.237 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.237 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -1208,7 +1208,7 @@ test("Block block-214.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-215.pli", () => {
+test("Block block-215.pli", async () => {
   // Context:
   //
   //  are structures:
@@ -1224,7 +1224,7 @@ test("Block block-215.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.237 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.237 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -1240,7 +1240,7 @@ test("Block block-215.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-286.pli", () => {
+test("Block block-286.pli", async () => {
   // Context:
   //
   // The EXIT statement stops the current thread.
@@ -1256,7 +1256,7 @@ test("Block block-286.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.272 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.272 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -1268,7 +1268,7 @@ test("Block block-286.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-329.pli", () => {
+test("Block block-329.pli", async () => {
   // Context:
   //
   // Consider the following example:
@@ -1284,7 +1284,7 @@ test("Block block-329.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.294 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.294 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -1299,7 +1299,7 @@ test("Block block-329.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-194.pli", () => {
+test("Block block-194.pli", async () => {
   // Context:
   //
   // its associated name. For example, the items of a payroll record could be declared as follows:
@@ -1315,7 +1315,7 @@ test("Block block-194.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.228 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.228 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -1335,7 +1335,7 @@ test("Block block-194.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-317.pli", () => {
+test("Block block-317.pli", async () => {
   // Context:
   //
   // interpreted as fixed-point binary.
@@ -1351,7 +1351,7 @@ test("Block block-317.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.288 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.288 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -1362,7 +1362,7 @@ test("Block block-317.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-12.pli", () => {
+test("Block block-12.pli", async () => {
   // Context:
   //
   // DECIMAL with a PRECISION of five digits, four to the right of the decimal point:
@@ -1378,7 +1378,7 @@ test("Block block-12.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.70 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.70 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -1389,7 +1389,7 @@ test("Block block-12.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-385.pli", () => {
+test("Block block-385.pli", async () => {
   // Context:
   //
   // containing the names of the weekdays.
@@ -1405,7 +1405,7 @@ test("Block block-385.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.321 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.321 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -1423,7 +1423,7 @@ test("Block block-385.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-153.pli", () => {
+test("Block block-153.pli", async () => {
   // Context:
   //
   //  is valid.
@@ -1439,7 +1439,7 @@ test("Block block-153.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.196 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.196 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -1454,7 +1454,7 @@ test("Block block-153.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-152.pli", () => {
+test("Block block-152.pli", async () => {
   // Context:
   //
   // Consider the following example:
@@ -1470,7 +1470,7 @@ test("Block block-152.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.196 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.196 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -1483,7 +1483,7 @@ test("Block block-152.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-31.pli", () => {
+test("Block block-31.pli", async () => {
   // Context:
   //
   // false. However, if the window started at 1950, the comparison would return true.
@@ -1499,7 +1499,7 @@ test("Block block-31.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.93 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.93 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -1517,7 +1517,7 @@ test("Block block-31.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-629.pli", () => {
+test("Block block-629.pli", async () => {
   // Context:
   //
   // This example is based on the following code fragment:
@@ -1533,7 +1533,7 @@ test("Block block-629.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.634 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.634 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -1564,7 +1564,7 @@ test("Block block-629.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-291.pli", () => {
+test("Block block-291.pli", async () => {
   // Context:
   //
   // This example is based on the following declarations.
@@ -1580,7 +1580,7 @@ test("Block block-291.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.276 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.276 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -1596,7 +1596,7 @@ test("Block block-291.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-530.pli", () => {
+test("Block block-530.pli", async () => {
   // Context:
   //
   // Example 1
@@ -1612,7 +1612,7 @@ test("Block block-530.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.500 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.500 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -1634,7 +1634,7 @@ test("Block block-530.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-399.pli", () => {
+test("Block block-399.pli", async () => {
   // Context:
   //
   // file constants. The file constants can subsequently be assigned to the file variable.
@@ -1650,7 +1650,7 @@ test("Block block-399.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.331 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.331 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -1663,7 +1663,7 @@ test("Block block-399.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-471.pli", () => {
+test("Block block-471.pli", async () => {
   // Context:
   //
   // 329
@@ -1679,7 +1679,7 @@ test("Block block-471.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.381 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.381 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -1692,7 +1692,7 @@ test("Block block-471.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-183.pli", () => {
+test("Block block-183.pli", async () => {
   // Context:
   //
   // BINARY:
@@ -1708,7 +1708,7 @@ test("Block block-183.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.222 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.222 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -1719,7 +1719,7 @@ test("Block block-183.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-236.pli", () => {
+test("Block block-236.pli", async () => {
   // Context:
   //
   // This code sums up all the row elements:
@@ -1735,7 +1735,7 @@ test("Block block-236.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.257 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.257 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -1757,7 +1757,7 @@ test("Block block-236.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-209.pli", () => {
+test("Block block-209.pli", async () => {
   // Context:
   //
   //  would be ambiguous:
@@ -1773,7 +1773,7 @@ test("Block block-209.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.233 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.233 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -1795,7 +1795,7 @@ test("Block block-209.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-208.pli", () => {
+test("Block block-208.pli", async () => {
   // Context:
   //
   // :
@@ -1811,7 +1811,7 @@ test("Block block-208.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.232 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.232 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -1827,7 +1827,7 @@ test("Block block-208.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-393.pli", () => {
+test("Block block-393.pli", async () => {
   // Context:
   //
   // .
@@ -1843,7 +1843,7 @@ test("Block block-393.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.324 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.324 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -1854,7 +1854,7 @@ test("Block block-393.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-392.pli", () => {
+test("Block block-392.pli", async () => {
   // Context:
   //
   // (padded on the right to 10 characters) is assigned to it.
@@ -1870,7 +1870,7 @@ test("Block block-392.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.324 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.324 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -1881,7 +1881,7 @@ test("Block block-392.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-300.pli", () => {
+test("Block block-300.pli", async () => {
   // Context:
   //
   // The %PAGE directive allows you to start a new page in the compiler source listings.
@@ -1897,7 +1897,7 @@ test("Block block-300.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.279 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.279 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -1909,7 +1909,7 @@ test("Block block-300.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-166.pli", () => {
+test("Block block-166.pli", async () => {
   // Context:
   //
   // See the following example:
@@ -1925,7 +1925,7 @@ test("Block block-166.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.206 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.206 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -1936,7 +1936,7 @@ test("Block block-166.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-28.pli", () => {
+test("Block block-28.pli", async () => {
   // Context:
   //
   // Consider the following example:
@@ -1952,7 +1952,7 @@ test("Block block-28.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.91 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.91 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -1963,7 +1963,7 @@ test("Block block-28.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-29.pli", () => {
+test("Block block-29.pli", async () => {
   // Context:
   //
   // digits, signs, and the location of the assumed decimal point are assigned. Consider the following example:
@@ -1979,7 +1979,7 @@ test("Block block-29.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.91 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.91 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -1994,7 +1994,7 @@ test("Block block-29.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-516.pli", () => {
+test("Block block-516.pli", async () => {
   // Context:
   //
   //  is too short to contain the result.
@@ -2010,7 +2010,7 @@ test("Block block-516.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.472 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.472 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2023,7 +2023,7 @@ test("Block block-516.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-679.pli", () => {
+test("Block block-679.pli", async () => {
   // Context:
   //
   // preprocessor output generated is as follows:
@@ -2039,7 +2039,7 @@ test("Block block-679.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.676 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.676 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2051,7 +2051,7 @@ test("Block block-679.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-191.pli", () => {
+test("Block block-191.pli", async () => {
   // Context:
   //
   // Consider the following declaration:
@@ -2067,7 +2067,7 @@ test("Block block-191.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.225 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.225 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2078,7 +2078,7 @@ test("Block block-191.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-380.pli", () => {
+test("Block block-380.pli", async () => {
   // Context:
   //
   // V is a two-dimensional array that consists of all the elements in the character string A.
@@ -2094,7 +2094,7 @@ test("Block block-380.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.317 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.317 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2106,7 +2106,7 @@ test("Block block-380.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-528.pli", () => {
+test("Block block-528.pli", async () => {
   // Context:
   //
   // contain the result.
@@ -2122,7 +2122,7 @@ test("Block block-528.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.498 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.498 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2135,7 +2135,7 @@ test("Block block-528.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-486.pli", () => {
+test("Block block-486.pli", async () => {
   // Context:
   //
   // Example 1
@@ -2151,7 +2151,7 @@ test("Block block-486.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.396 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.396 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2166,7 +2166,7 @@ test("Block block-486.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-22.pli", () => {
+test("Block block-22.pli", async () => {
   // Context:
   //
   // Consider this example:
@@ -2182,7 +2182,7 @@ test("Block block-22.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.79 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.79 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2193,7 +2193,7 @@ test("Block block-22.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-23.pli", () => {
+test("Block block-23.pli", async () => {
   // Context:
   //
   // 15:
@@ -2209,7 +2209,7 @@ test("Block block-23.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.82 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.82 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2220,7 +2220,7 @@ test("Block block-23.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-115.pli", () => {
+test("Block block-115.pli", async () => {
   // Context:
   //
   // applied only for the second parameter.
@@ -2236,7 +2236,7 @@ test("Block block-115.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.167 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.167 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2247,7 +2247,7 @@ test("Block block-115.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-548.pli", () => {
+test("Block block-548.pli", async () => {
   // Context:
   //
   // Example
@@ -2263,7 +2263,7 @@ test("Block block-548.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.525 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.525 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2277,7 +2277,7 @@ test("Block block-548.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-549.pli", () => {
+test("Block block-549.pli", async () => {
   // Context:
   //
   // Example
@@ -2293,7 +2293,7 @@ test("Block block-549.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.526 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.526 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2325,7 +2325,7 @@ test("Block block-549.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-436.pli", () => {
+test("Block block-436.pli", async () => {
   // Context:
   //
   // list. Consider the following example:
@@ -2341,7 +2341,7 @@ test("Block block-436.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.354 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.354 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2357,7 +2357,7 @@ test("Block block-436.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-305.pli", () => {
+test("Block block-305.pli", async () => {
   // Context:
   //
   // A common use of %PUSH and %POP directives is in included files and macros.
@@ -2373,7 +2373,7 @@ test("Block block-305.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.281 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.281 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2385,7 +2385,7 @@ test("Block block-305.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-239.pli", () => {
+test("Block block-239.pli", async () => {
   // Context:
   //
   // :
@@ -2401,7 +2401,7 @@ test("Block block-239.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.258 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.258 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2423,7 +2423,7 @@ test("Block block-239.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-403.pli", () => {
+test("Block block-403.pli", async () => {
   // Context:
   //
   // This example illustrates attribute merging for an explicit opening of a file by using a file variable.
@@ -2439,7 +2439,7 @@ test("Block block-403.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.336 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.336 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2456,7 +2456,7 @@ test("Block block-403.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-402.pli", () => {
+test("Block block-402.pli", async () => {
   // Context:
   //
   // constant.
@@ -2472,7 +2472,7 @@ test("Block block-402.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.336 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.336 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2484,7 +2484,7 @@ test("Block block-402.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-379.pli", () => {
+test("Block block-379.pli", async () => {
   // Context:
   //
   // Examples
@@ -2500,7 +2500,7 @@ test("Block block-379.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.317 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.317 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2512,7 +2512,7 @@ test("Block block-379.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-475.pli", () => {
+test("Block block-475.pli", async () => {
   // Context:
   //
   // .
@@ -2528,7 +2528,7 @@ test("Block block-475.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.384 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.384 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2540,7 +2540,7 @@ test("Block block-475.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-613.pli", () => {
+test("Block block-613.pli", async () => {
   // Context:
   //
   // The following are invalid STRING targets:
@@ -2556,7 +2556,7 @@ test("Block block-613.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.606 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.606 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2571,7 +2571,7 @@ test("Block block-613.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-181.pli", () => {
+test("Block block-181.pli", async () => {
   // Context:
   //
   // These statements are equivalent to the following declaration:
@@ -2587,7 +2587,7 @@ test("Block block-181.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.221 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.221 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2600,7 +2600,7 @@ test("Block block-181.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-180.pli", () => {
+test("Block block-180.pli", async () => {
   // Context:
   //
   // Consider the following example:
@@ -2616,7 +2616,7 @@ test("Block block-180.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.221 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.221 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2633,7 +2633,7 @@ test("Block block-180.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-375.pli", () => {
+test("Block block-375.pli", async () => {
   // Context:
   //
   // Y is a character string that consists of the first 5 characters of B.
@@ -2649,7 +2649,7 @@ test("Block block-375.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.316 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.316 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2661,7 +2661,7 @@ test("Block block-375.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-374.pli", () => {
+test("Block block-374.pli", async () => {
   // Context:
   //
   // element identified by the subscript expressions L, M, and N.
@@ -2677,7 +2677,7 @@ test("Block block-374.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.316 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.316 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2689,7 +2689,7 @@ test("Block block-374.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-506.pli", () => {
+test("Block block-506.pli", async () => {
   // Context:
   //
   // The following example is not a multiple declaration:
@@ -2705,7 +2705,7 @@ test("Block block-506.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.452 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.452 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2716,7 +2716,7 @@ test("Block block-506.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-594.pli", () => {
+test("Block block-594.pli", async () => {
   // Context:
   //
   //   Enterprise PL/I for z/OS: Enterprise PL/I for z/OS Language Reference
@@ -2732,7 +2732,7 @@ test("Block block-594.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.590 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.590 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2750,7 +2750,7 @@ test("Block block-594.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-479.pli", () => {
+test("Block block-479.pli", async () => {
   // Context:
   //
   // Consider the following example:
@@ -2766,7 +2766,7 @@ test("Block block-479.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.389 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.389 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2777,7 +2777,7 @@ test("Block block-479.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-478.pli", () => {
+test("Block block-478.pli", async () => {
   // Context:
   //
   // Consider the following example:
@@ -2793,7 +2793,7 @@ test("Block block-478.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.386 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.386 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2804,7 +2804,7 @@ test("Block block-478.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-94.pli", () => {
+test("Block block-94.pli", async () => {
   // Context:
   //
   // entry variable that is used in a procedure reference, as in the following example:
@@ -2820,7 +2820,7 @@ test("Block block-94.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.151 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.151 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2835,7 +2835,7 @@ test("Block block-94.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-299.pli", () => {
+test("Block block-299.pli", async () => {
   // Context:
   //
   // OTHERWISE statements.
@@ -2851,7 +2851,7 @@ test("Block block-299.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.279 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.279 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2862,7 +2862,7 @@ test("Block block-299.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-302.pli", () => {
+test("Block block-302.pli", async () => {
   // Context:
   //
   // The %PRINT directive causes printing of the source listings to be resumed.
@@ -2878,7 +2878,7 @@ test("Block block-302.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.280 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.280 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2890,7 +2890,7 @@ test("Block block-302.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-165.pli", () => {
+test("Block block-165.pli", async () => {
   // Context:
   //
   // .
@@ -2906,7 +2906,7 @@ test("Block block-165.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.204 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.204 */
 
 
    X: proc options(main);
@@ -2925,7 +2925,7 @@ test("Block block-165.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-150.pli", () => {
+test("Block block-150.pli", async () => {
   // Context:
   //
   // a type as a variable name as well.
@@ -2941,7 +2941,7 @@ test("Block block-150.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.195 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.195 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2953,7 +2953,7 @@ test("Block block-150.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-309.pli", () => {
+test("Block block-309.pli", async () => {
   // Context:
   //
   // Qualify blocks can also be nested. For example, you can nest a qualify block inside the block above:
@@ -2969,7 +2969,7 @@ test("Block block-309.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.282 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.282 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -2985,7 +2985,7 @@ test("Block block-309.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-532.pli", () => {
+test("Block block-532.pli", async () => {
   // Context:
   //
   // Example 1
@@ -3001,7 +3001,7 @@ test("Block block-532.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.501 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.501 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -3023,7 +3023,7 @@ test("Block block-532.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-473.pli", () => {
+test("Block block-473.pli", async () => {
   // Context:
   //
   // Consider the following example:
@@ -3039,7 +3039,7 @@ test("Block block-473.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.381 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.381 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -3053,7 +3053,7 @@ test("Block block-473.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-687.pli", () => {
+test("Block block-687.pli", async () => {
   // Context:
   //
   // Upper limits
@@ -3069,7 +3069,7 @@ test("Block block-687.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.682 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.682 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -3159,7 +3159,7 @@ test("Block block-687.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-222.pli", () => {
+test("Block block-222.pli", async () => {
   // Context:
   //
   // Example: The usage of the ASSERT COMPARE statement
@@ -3175,7 +3175,7 @@ test("Block block-222.pli", () => {
   //
 
   const doc =
-    parse(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.249 */
+    await parse(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.249 */
 
 
  asserts: package;                                                             
@@ -3241,7 +3241,7 @@ test("Block block-222.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-450.pli", () => {
+test("Block block-450.pli", async () => {
   // Context:
   //
   // Example 2
@@ -3257,7 +3257,7 @@ test("Block block-450.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.358 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.358 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -3274,7 +3274,7 @@ test("Block block-450.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-637.pli", () => {
+test("Block block-637.pli", async () => {
   // Context:
   //
   // The preprocessor would produce the output text:
@@ -3290,7 +3290,7 @@ test("Block block-637.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.647 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.647 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -3301,7 +3301,7 @@ test("Block block-637.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-196.pli", () => {
+test("Block block-196.pli", async () => {
   // Context:
   //
   // and variant parts. For example, records in a client file can be declared as follows:
@@ -3317,7 +3317,7 @@ test("Block block-196.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.229 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.229 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -3339,7 +3339,7 @@ test("Block block-196.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-67.pli", () => {
+test("Block block-67.pli", async () => {
   // Context:
   //
   // Examples
@@ -3355,7 +3355,7 @@ test("Block block-67.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.124 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.124 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -3382,7 +3382,7 @@ test("Block block-67.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-315.pli", () => {
+test("Block block-315.pli", async () => {
   // Context:
   //
   // The STOP statement stops the current application.
@@ -3398,7 +3398,7 @@ test("Block block-315.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.285 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.285 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -3410,7 +3410,7 @@ test("Block block-315.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-172.pli", () => {
+test("Block block-172.pli", async () => {
   // Context:
   //
   // declaration:
@@ -3426,7 +3426,7 @@ test("Block block-172.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.218 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.218 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -3438,7 +3438,7 @@ test("Block block-172.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-387.pli", () => {
+test("Block block-387.pli", async () => {
   // Context:
   //
   // For example, consider the declaration:
@@ -3454,7 +3454,7 @@ test("Block block-387.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.321 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.321 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -3471,7 +3471,7 @@ test("Block block-387.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-25.pli", () => {
+test("Block block-25.pli", async () => {
   // Context:
   //
   // .
@@ -3487,7 +3487,7 @@ test("Block block-25.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.82 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.82 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -3499,7 +3499,7 @@ test("Block block-25.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-480.pli", () => {
+test("Block block-480.pli", async () => {
   // Context:
   //
   // the following example:
@@ -3515,7 +3515,7 @@ test("Block block-480.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.389 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.389 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -3527,7 +3527,7 @@ test("Block block-480.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-24.pli", () => {
+test("Block block-24.pli", async () => {
   // Context:
   //
   // The following example shows the declaration of a bit variable:
@@ -3543,7 +3543,7 @@ test("Block block-24.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.82 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.82 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -3554,7 +3554,7 @@ test("Block block-24.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-589.pli", () => {
+test("Block block-589.pli", async () => {
   // Context:
   //
   // substring f in the string x will be replaced by the substring t.
@@ -3570,7 +3570,7 @@ test("Block block-589.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.587 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.587 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -3599,7 +3599,7 @@ test("Block block-589.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-147.pli", () => {
+test("Block block-147.pli", async () => {
   // Context:
   //
   // that gets a handle to this typed structure:
@@ -3615,7 +3615,7 @@ test("Block block-147.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.194 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.194 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -3645,7 +3645,7 @@ test("Block block-147.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-321.pli", () => {
+test("Block block-321.pli", async () => {
   // Context:
   //
   // . PL/I does not resolve this type of declaration dependency.
@@ -3661,7 +3661,7 @@ test("Block block-321.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.290 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.290 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -3675,7 +3675,7 @@ test("Block block-321.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-146.pli", () => {
+test("Block block-146.pli", async () => {
   // Context:
   //
   // previous DEFINE ALIAS statement. See the following example:
@@ -3691,7 +3691,7 @@ test("Block block-146.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.194 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.194 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -3703,7 +3703,7 @@ test("Block block-146.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-52.pli", () => {
+test("Block block-52.pli", async () => {
   // Context:
   //
   // Consider the following example:
@@ -3719,7 +3719,7 @@ test("Block block-52.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.105 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.105 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -3732,7 +3732,7 @@ test("Block block-52.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-690.pli", () => {
+test("Block block-690.pli", async () => {
   // Context:
   //
   // Upper limits
@@ -3748,7 +3748,7 @@ test("Block block-690.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.685 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.685 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -3878,7 +3878,7 @@ test("Block block-690.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-691.pli", () => {
+test("Block block-691.pli", async () => {
   // Context:
   //
   // Upper limits
@@ -3894,7 +3894,7 @@ test("Block block-691.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.686 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.686 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -4024,7 +4024,7 @@ test("Block block-691.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-216.pli", () => {
+test("Block block-216.pli", async () => {
   // Context:
   //
   // Consider the following union:
@@ -4040,7 +4040,7 @@ test("Block block-216.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.238 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.238 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -4059,7 +4059,7 @@ test("Block block-216.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-179.pli", () => {
+test("Block block-179.pli", async () => {
   // Context:
   //
   // an attribute specification. Consider the following example:
@@ -4075,7 +4075,7 @@ test("Block block-179.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.221 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.221 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -4086,7 +4086,7 @@ test("Block block-179.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-178.pli", () => {
+test("Block block-178.pli", async () => {
   // Context:
   //
   // following example:
@@ -4102,7 +4102,7 @@ test("Block block-178.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.221 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Language Reference v6.1, pg.221 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -4114,7 +4114,7 @@ test("Block block-178.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-271.pli", () => {
+test("Block block-271.pli", async () => {
   // Context:
   //
   // The following example shows a procedure-specific message filter control block:
@@ -4130,7 +4130,7 @@ test("Block block-271.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.518 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.518 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -4161,7 +4161,7 @@ test("Block block-271.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-169.pli", () => {
+test("Block block-169.pli", async () => {
   // Context:
   //
   // Table 94. PL/I equivalent for a C file
@@ -4177,7 +4177,7 @@ test("Block block-169.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.400 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.400 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -4189,7 +4189,7 @@ test("Block block-169.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-48.pli", () => {
+test("Block block-48.pli", async () => {
   // Context:
   //
   // positions.
@@ -4205,7 +4205,7 @@ test("Block block-48.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.223 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.223 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -4229,7 +4229,7 @@ test("Block block-48.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-187.pli", () => {
+test("Block block-187.pli", async () => {
   // Context:
   //
   // Table 113. Incorrect declaration of qsort
@@ -4245,7 +4245,7 @@ test("Block block-187.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.405 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.405 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -4262,7 +4262,7 @@ test("Block block-187.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-2.pli", () => {
+test("Block block-2.pli", async () => {
   // Context:
   //
   // Consider the following example:
@@ -4278,7 +4278,7 @@ test("Block block-2.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.81 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.81 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -4292,7 +4292,7 @@ test("Block block-2.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-267.pli", () => {
+test("Block block-267.pli", async () => {
   // Context:
   //
   // must execute the statement:
@@ -4308,7 +4308,7 @@ test("Block block-267.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.512 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.512 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -4319,7 +4319,7 @@ test("Block block-267.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-283.pli", () => {
+test("Block block-283.pli", async () => {
   // Context:
   //
   // The declare for a CMPAT(V3) array descriptor is as follows:
@@ -4335,7 +4335,7 @@ test("Block block-283.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.525 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.525 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -4352,7 +4352,7 @@ test("Block block-283.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-137.pli", () => {
+test("Block block-137.pli", async () => {
   // Context:
   //
   // string:
@@ -4368,7 +4368,7 @@ test("Block block-137.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.369 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.369 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -4382,7 +4382,7 @@ test("Block block-137.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-102.pli", () => {
+test("Block block-102.pli", async () => {
   // Context:
   //
   // preceded by a PUT statement as follows:
@@ -4398,7 +4398,7 @@ test("Block block-102.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.298 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.298 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -4409,7 +4409,7 @@ test("Block block-102.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-8.pli", () => {
+test("Block block-8.pli", async () => {
   // Context:
   //
   //   Enterprise PL/I for z/OS: Enterprise PL/I for z/OS Programming Guide
@@ -4425,7 +4425,7 @@ test("Block block-8.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.130 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.130 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -4439,7 +4439,7 @@ test("Block block-8.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-289.pli", () => {
+test("Block block-289.pli", async () => {
   // Context:
   //
   // Table 144. Record types encoded as an ordinal value
@@ -4455,7 +4455,7 @@ test("Block block-289.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.529 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.529 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -4480,7 +4480,7 @@ test("Block block-289.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-55.pli", () => {
+test("Block block-55.pli", async () => {
   // Context:
   //
   // Here is the sample of the PL/I fetched MAIN program:
@@ -4496,7 +4496,7 @@ test("Block block-55.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.231 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.231 */
 
 
     FMAIN: proc(parm) options(main,noexecops );
@@ -4512,7 +4512,7 @@ test("Block block-55.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-285.pli", () => {
+test("Block block-285.pli", async () => {
   // Context:
   //
   // These are possible values for the dsc_Type field:
@@ -4528,7 +4528,7 @@ test("Block block-285.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.525 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.525 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -4544,7 +4544,7 @@ test("Block block-285.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-284.pli", () => {
+test("Block block-284.pli", async () => {
   // Context:
   //
   // The declare for a descriptor header is as follows:
@@ -4560,7 +4560,7 @@ test("Block block-284.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.525 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.525 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -4576,7 +4576,7 @@ test("Block block-284.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-131.pli", () => {
+test("Block block-131.pli", async () => {
   // Context:
   //
   // For instance, under RULES(LAXCTL), you can declare a structure as follows:
@@ -4592,7 +4592,7 @@ test("Block block-131.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.364 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.364 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -4606,7 +4606,7 @@ test("Block block-131.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-11.pli", () => {
+test("Block block-11.pli", async () => {
   // Context:
   //
   // members that are not level 1 and are not dot qualified. Consider the following example:
@@ -4622,7 +4622,7 @@ test("Block block-11.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.133 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.133 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -4640,7 +4640,7 @@ test("Block block-11.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-276.pli", () => {
+test("Block block-276.pli", async () => {
   // Context:
   //
   //  is declared as follows:
@@ -4656,7 +4656,7 @@ test("Block block-276.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.523 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.523 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -4668,7 +4668,7 @@ test("Block block-276.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-249.pli", () => {
+test("Block block-249.pli", async () => {
   // Context:
   //
   //  OSRIN is an zFS file, use the following JCL statement instead:
@@ -4684,7 +4684,7 @@ test("Block block-249.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.486 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.486 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -4696,7 +4696,7 @@ test("Block block-249.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-94.pli", () => {
+test("Block block-94.pli", async () => {
   // Context:
   //
   // Table 43. Creating a library member in a PL/I program
@@ -4712,7 +4712,7 @@ test("Block block-94.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.283 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.283 */
 
 
   //OPT10#3  JOB
@@ -4744,7 +4744,7 @@ test("Block block-94.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-309.pli", () => {
+test("Block block-309.pli", async () => {
   // Context:
   //
   // Table 162. Declare for the expression kind
@@ -4760,7 +4760,7 @@ test("Block block-309.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.542 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.542 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -4788,7 +4788,7 @@ test("Block block-309.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-303.pli", () => {
+test("Block block-303.pli", async () => {
   // Context:
   //
   // Table 157. Declare for the token record kind
@@ -4804,7 +4804,7 @@ test("Block block-303.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.538 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.538 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -4824,7 +4824,7 @@ test("Block block-303.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-298.pli", () => {
+test("Block block-298.pli", async () => {
   // Context:
   //
   // Consider the following structure:
@@ -4840,7 +4840,7 @@ test("Block block-298.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.534 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.534 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -4858,7 +4858,7 @@ test("Block block-298.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-299.pli", () => {
+test("Block block-299.pli", async () => {
   // Context:
   //
   // Table 154. Data type of a variable
@@ -4874,7 +4874,7 @@ test("Block block-299.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.536 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.536 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -4914,7 +4914,7 @@ test("Block block-299.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-101.pli", () => {
+test("Block block-101.pli", async () => {
   // Context:
   //
   // Table 49. PL/I structure PLITABS for modifying the preset tab settings
@@ -4930,7 +4930,7 @@ test("Block block-101.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.297 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.297 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -4952,7 +4952,7 @@ test("Block block-101.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-21.pli", () => {
+test("Block block-21.pli", async () => {
   // Context:
   //
   //  declared as follows:
@@ -4968,7 +4968,7 @@ test("Block block-21.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.163 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.163 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -4982,7 +4982,7 @@ test("Block block-21.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-311.pli", () => {
+test("Block block-311.pli", async () => {
   // Context:
   //
   // Table 164. Declare for the lexeme kind
@@ -4998,7 +4998,7 @@ test("Block block-311.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.543 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.543 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -5048,7 +5048,7 @@ test("Block block-311.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-310.pli", () => {
+test("Block block-310.pli", async () => {
   // Context:
   //
   // Table 163. Declare for the number kind
@@ -5064,7 +5064,7 @@ test("Block block-310.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.543 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.543 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -5087,7 +5087,7 @@ test("Block block-310.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-56.pli", () => {
+test("Block block-56.pli", async () => {
   // Context:
   //
   // Here is the sample of the PL/I MAIN program that fetches another PL/I MAIN program:
@@ -5103,7 +5103,7 @@ test("Block block-56.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.231 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.231 */
 
 
     MainFet: Proc Options(main);
@@ -5123,7 +5123,7 @@ test("Block block-56.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-143.pli", () => {
+test("Block block-143.pli", async () => {
   // Context:
   //
   // compiler generates more optimal code for the pair in the union.
@@ -5139,7 +5139,7 @@ test("Block block-143.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.372 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.372 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -5155,7 +5155,7 @@ test("Block block-143.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-281.pli", () => {
+test("Block block-281.pli", async () => {
   // Context:
   //
   // The declare for a CMPAT(V1) array descriptor is as follows:
@@ -5171,7 +5171,7 @@ test("Block block-281.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.524 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.524 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -5188,7 +5188,7 @@ test("Block block-281.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-280.pli", () => {
+test("Block block-280.pli", async () => {
   // Context:
   //
   // The possible values for the codepage encoding are defined as follows:
@@ -5204,7 +5204,7 @@ test("Block block-280.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.524 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.524 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -5243,7 +5243,7 @@ test("Block block-280.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-135.pli", () => {
+test("Block block-135.pli", async () => {
   // Context:
   //
   // For example, under the DEFAULT( NOOVERLAP ) option, the assignment in this example is invalid:
@@ -5259,7 +5259,7 @@ test("Block block-135.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.367 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.367 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -5271,7 +5271,7 @@ test("Block block-135.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-307.pli", () => {
+test("Block block-307.pli", async () => {
   // Context:
   //
   // Table 160. Declare for the syntax record kind
@@ -5287,7 +5287,7 @@ test("Block block-307.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.541 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.541 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -5333,7 +5333,7 @@ test("Block block-307.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-128.pli", () => {
+test("Block block-128.pli", async () => {
   // Context:
   //
   // .
@@ -5349,7 +5349,7 @@ test("Block block-128.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.363 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.363 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -5369,7 +5369,7 @@ test("Block block-128.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-273.pli", () => {
+test("Block block-273.pli", async () => {
   // Context:
   //
   // Code the termination procedure-specific control block as follows:
@@ -5385,7 +5385,7 @@ test("Block block-273.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.520 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.520 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -5397,7 +5397,7 @@ test("Block block-273.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-272.pli", () => {
+test("Block block-272.pli", async () => {
   // Context:
   //
   // 463
@@ -5413,7 +5413,7 @@ test("Block block-272.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.519 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.519 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -5427,7 +5427,7 @@ test("Block block-272.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-74.pli", () => {
+test("Block block-74.pli", async () => {
   // Context:
   //
   // how a DD statement should be associated with the value of a file variable:
@@ -5443,7 +5443,7 @@ test("Block block-74.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.250 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.250 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -5457,7 +5457,7 @@ test("Block block-74.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-91.pli", () => {
+test("Block block-91.pli", async () => {
   // Context:
   //
   // For example, you can use redirection in the following program:
@@ -5473,7 +5473,7 @@ test("Block block-91.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.279 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.279 */
 
 
  Hello2: proc options(main);
@@ -5484,7 +5484,7 @@ test("Block block-91.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-300.pli", () => {
+test("Block block-300.pli", async () => {
   // Context:
   //
   // The type of the extent is encoded by the values:
@@ -5500,7 +5500,7 @@ test("Block block-300.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.536 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.536 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -5518,7 +5518,7 @@ test("Block block-300.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-274.pli", () => {
+test("Block block-274.pli", async () => {
   // Context:
   //
   //  is declared as follows:
@@ -5534,7 +5534,7 @@ test("Block block-274.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.522 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.522 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -5546,7 +5546,7 @@ test("Block block-274.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-188.pli", () => {
+test("Block block-188.pli", async () => {
   // Context:
   //
   // Table 114. Correct declaration of qsort
@@ -5562,7 +5562,7 @@ test("Block block-188.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.405 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.405 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -5580,7 +5580,7 @@ test("Block block-188.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-220.pli", () => {
+test("Block block-220.pli", async () => {
   // Context:
   //
   // as follows:
@@ -5596,7 +5596,7 @@ test("Block block-220.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.433 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.433 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -5610,7 +5610,7 @@ test("Block block-220.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-171.pli", () => {
+test("Block block-171.pli", async () => {
   // Context:
   //
   // Table 96. Declarations for filedump program
@@ -5626,7 +5626,7 @@ test("Block block-171.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.401 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.401 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -5644,7 +5644,7 @@ test("Block block-171.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-287.pli", () => {
+test("Block block-287.pli", async () => {
   // Context:
   //
   // These are the possible values for the dsc_String_Type field:
@@ -5660,7 +5660,7 @@ test("Block block-287.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.526 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.526 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -5691,7 +5691,7 @@ test("Block block-287.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-215.pli", () => {
+test("Block block-215.pli", async () => {
   // Context:
   //
   // PLIXOPT variable as follows:
@@ -5707,7 +5707,7 @@ test("Block block-215.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.424 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.424 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 
@@ -5718,7 +5718,7 @@ test("Block block-215.pli", () => {
   generateAndAssertValidSymbolTable(doc);
 });
 
-test("Block block-12.pli", () => {
+test("Block block-12.pli", async () => {
   // Context:
   //
   // members that do not include the level-1 name. Consider the following example:
@@ -5734,7 +5734,7 @@ test("Block block-12.pli", () => {
   //
 
   const doc =
-    parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.133 */
+    await parseStmts(` /* Enterprise PL/I for z/OS Programming Guide v6.1, pg.133 */
 
  MAINTP: PROCEDURE OPTIONS (MAIN);
 

--- a/packages/language/test/fourslash-harness/harness-runner.ts
+++ b/packages/language/test/fourslash-harness/harness-runner.ts
@@ -11,8 +11,7 @@
 
 import { HarnessTesterInterface } from "./harness-interface";
 import { HarnessTest } from "./types";
-
-const vm = require("vm");
+import vm from "vm";
 
 /**
  * Run a harness test.

--- a/packages/language/test/fourslash-harness/types.ts
+++ b/packages/language/test/fourslash-harness/types.ts
@@ -31,5 +31,5 @@ export interface HarnessFile {
 export interface HarnessTest {
   fileName: string;
   files: Map<string | UnnamedFile, HarnessFile>;
-  commands: string | undefined;
+  commands: string;
 }

--- a/packages/language/test/lsp/document-symbol-request.test.ts
+++ b/packages/language/test/lsp/document-symbol-request.test.ts
@@ -31,7 +31,7 @@ const documentSymbolKindString = (symbolKind: SymbolKind): string =>
     (key) => SymbolKind[key as keyof typeof SymbolKind] === symbolKind,
   ) ?? "";
 
-function expectDocumentSymbols(annotatedCode: string): void {
+async function expectDocumentSymbols(annotatedCode: string): Promise<void> {
   const { output, ranges } = replaceNamedIndices(formatTestPLI(annotatedCode));
   const textDocument = TextDocument.create(
     URI.file("/test.pli").toString(),
@@ -41,7 +41,7 @@ function expectDocumentSymbols(annotatedCode: string): void {
   );
 
   EditorDocuments.set(textDocument);
-  const unit = parse(output, { validate: true });
+  const unit = await parse(output, { validate: true });
   const documentSymbols = documentSymbolRequest(URI.file("/test.pli"), unit);
 
   const totalRanges = Object.values(ranges).reduce(
@@ -84,7 +84,7 @@ function expectDocumentSymbols(annotatedCode: string): void {
 }
 
 describe("Document Symbol Request", () => {
-  test("should retrieve symbols for basic function and variable declarations", () => {
+  test("should retrieve symbols for basic function and variable declarations", async () => {
     const code = `
  <|Function_0:IGNO|>: PROCEDURE OPTIONS (MAIN);
    dcl <|Variable_1:A|> fixed bin(31);
@@ -92,20 +92,20 @@ describe("Document Symbol Request", () => {
    WHAT = 123;
  END;`;
 
-    expectDocumentSymbols(code);
+    await await expectDocumentSymbols(code);
   });
 
-  test("should retrieve symbols for function, variable, and constant declarations", () => {
+  test("should retrieve symbols for function, variable, and constant declarations", async () => {
     const code = `
  <|Function_0:IGNO|>: PROCEDURE OPTIONS (MAIN);
    dcl <|Variable_1:A|> fixed bin(31);
    dcl <|Constant_1:PI|> constant(3.14159);
  END;`;
 
-    expectDocumentSymbols(code);
+    await expectDocumentSymbols(code);
   });
 
-  test("should retrieve symbols for basic struct declarations", () => {
+  test("should retrieve symbols for basic struct declarations", async () => {
     const code = `
  <|Function_0:IGNO|>: PROCEDURE OPTIONS (MAIN);
    dcl 1 <|Struct_1:myStruct|>,
@@ -113,10 +113,10 @@ describe("Document Symbol Request", () => {
            3 <|Variable_3:myField2|> char(10);
  END;`;
 
-    expectDocumentSymbols(code);
+    await expectDocumentSymbols(code);
   });
 
-  test("should retrieve symbols for complex nested struct declarations with multiple levels", () => {
+  test("should retrieve symbols for complex nested struct declarations with multiple levels", async () => {
     const code = `
  <|Function_0:IGNO|>: PROCEDURE OPTIONS (MAIN);
    dcl <|Variable_1:A|> fixed bin(31);
@@ -131,17 +131,17 @@ describe("Document Symbol Request", () => {
          2 <|Variable_2:myField5|> char(10);
  END;`;
 
-    expectDocumentSymbols(code);
+    await expectDocumentSymbols(code);
   });
 
-  test("should retrieve symbols for procedure, labels, variables, and constants", () => {
+  test("should retrieve symbols for procedure, labels, variables, and constants", async () => {
     const code = `
  <|Function_0:IGNO|>: PROCEDURE OPTIONS (MAIN);
    <|Key_1:L1004|>: dcl <|Variable_1:A|> fixed bin(31);
    <|Key_1:L1005|>: dcl <|Constant_1:PI|> constant(3.14159);
  END;`;
 
-    expectDocumentSymbols(code);
+    await expectDocumentSymbols(code);
   });
 });
 

--- a/packages/language/test/lsp/workspace-symbol-request.test.ts
+++ b/packages/language/test/lsp/workspace-symbol-request.test.ts
@@ -17,11 +17,12 @@ import { CompilationUnitHandler } from "../../src/workspace/compilation-unit";
 import * as lifecycle from "../../src/workspace/lifecycle";
 import { workspaceSymbolRequest } from "../../src/language-server/workspace-symbol-request";
 import { EditorDocuments } from "../../src/language-server/text-documents";
+import { CancellationToken } from "vscode-languageserver";
 
 const formatTestPLI = (code: string): string =>
   code.startsWith("\n") ? code.slice(1) : code;
 
-function expectWorkspaceSymbols(annotatedCode: string[]): void {
+async function expectWorkspaceSymbols(annotatedCode: string[]): Promise<void> {
   const outputs: string[] = [];
   const allRanges: {
     fileIndex: number;
@@ -45,19 +46,21 @@ function expectWorkspaceSymbols(annotatedCode: string[]): void {
 
   const handler = new CompilationUnitHandler();
   textDocuments.forEach((doc) => EditorDocuments.set(doc));
-  outputs.map((output, i) => {
-    const unit = handler.createAndStoreCompilationUnit(
-      URI.file(`/test${i}.pli`),
-    );
+  await Promise.all(
+    outputs.map(async (output, i) => {
+      const unit = handler.createAndStoreCompilationUnit(
+        URI.file(`/test${i}.pli`),
+      );
 
-    if (!unit) {
-      // standalone library files do not synthesize new compilation units
+      if (!unit) {
+        // standalone library files do not synthesize new compilation units
+        return unit;
+      }
+
+      await lifecycle.lifecycle(unit, output, CancellationToken.None);
       return unit;
-    }
-
-    lifecycle.lifecycle(unit, output);
-    return unit;
-  });
+    }),
+  );
 
   const rangesWithSameName: Record<
     string,
@@ -106,7 +109,7 @@ function expectWorkspaceSymbols(annotatedCode: string[]): void {
 }
 
 describe("Workspace Symbol Request", () => {
-  test("should retrieve symbols for basic function and variable declarations", () => {
+  test("should retrieve symbols for basic function and variable declarations", async () => {
     const code0 = `
  <|IG:IGNO|>: PROCEDURE OPTIONS (MAIN);
    dcl <|A:A|> fixed bin(31);
@@ -120,6 +123,6 @@ describe("Workspace Symbol Request", () => {
    dcl PI constant(3.14159);
  END;`;
 
-    expectWorkspaceSymbols([code0, code1]);
+    await expectWorkspaceSymbols([code0, code1]);
   });
 });

--- a/packages/language/test/parsing.test.ts
+++ b/packages/language/test/parsing.test.ts
@@ -21,7 +21,7 @@ import {
 import { PreprocessorTokens } from "../src/preprocessor/pli-preprocessor-tokens";
 import { Lexer } from "chevrotain";
 
-test("PL/I tokens are all using sticky regex", () => {
+test("PL/I tokens are all using sticky regex", async () => {
   for (const token of tokens.all) {
     if (token.PATTERN instanceof RegExp && token.PATTERN !== Lexer.NA) {
       expect(token.PATTERN.sticky).toBe(true);
@@ -35,29 +35,29 @@ test("PL/I tokens are all using sticky regex", () => {
 });
 
 describe("PL/I Parsing tests", () => {
-  test("empty program parses as valid", () => {
+  test("empty program parses as valid", async () => {
     // no parse error, but...
     // triggers IBM1917IS on the compiler (source has no statements or all stmts are invalid)
     // later for validation
-    const doc = parse("");
+    const doc = await parse("");
     assertNoParseErrors(doc);
     generateAndAssertValidSymbolTable(doc);
   });
 
-  test("empty program w/ null statement", () => {
-    const doc = parseStmts(` ;`);
+  test("empty program w/ null statement", async () => {
+    const doc = await parseStmts(` ;`);
     assertNoParseErrors(doc);
     generateAndAssertValidSymbolTable(doc);
   });
 
-  test("empty program w/ null %statement", () => {
-    const doc = parseStmts(` %;`);
+  test("empty program w/ null %statement", async () => {
+    const doc = await parseStmts(` %;`);
     assertNoParseErrors(doc);
     generateAndAssertValidSymbolTable(doc);
   });
 
-  test("Hello World Program", () => {
-    const doc = parse(`
+  test("Hello World Program", async () => {
+    const doc = await parse(`
  AVERAGE: PROCEDURE OPTIONS (MAIN);
    /* Test characters: ^[] € */
    /* AVERAGE_GRADE = SUM / 5; */
@@ -67,17 +67,17 @@ describe("PL/I Parsing tests", () => {
     generateAndAssertValidSymbolTable(doc);
   });
 
-  describe("Procedures", () => {
-    test("Simple procedure", () => {
-      const doc = parse(`
+  describe("Procedures", async () => {
+    test("Simple procedure", async () => {
+      const doc = await parse(`
     P1: procedure;
     end P1;`);
       assertNoParseErrors(doc);
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("Procedure w/ alternate entry point", () => {
-      const doc = parseStmts(`
+    test("Procedure w/ alternate entry point", async () => {
+      const doc = await parseStmts(`
     P1: procedure;
     B: entry; // secondary entry point into this procedure
     end P1;`);
@@ -85,8 +85,8 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("Procedure with call", () => {
-      const doc = parse(`
+    test("Procedure with call", async () => {
+      const doc = await parse(`
  Control: procedure options(main);
   call A('ok'); // invoke the 'A' subroutine
  end Control;
@@ -98,8 +98,8 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("Simple recursive procedure w/ recursive stated before returns", () => {
-      const doc = parseStmts(`
+    test("Simple recursive procedure w/ recursive stated before returns", async () => {
+      const doc = await parseStmts(`
  Fact: proc (Input) recursive returns (fixed bin(31));
   dcl Input fixed bin(15);
   if Input <= 1 then
@@ -111,8 +111,8 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("Simple recursive procedure w/ recursive stated after returns", () => {
-      const doc = parseStmts(`
+    test("Simple recursive procedure w/ recursive stated after returns", async () => {
+      const doc = await parseStmts(`
  Fact: proc (Input) returns (fixed bin(31)) recursive;
   dcl Input fixed bin(15);
   if Input <= 1 then
@@ -124,8 +124,8 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("Procedures w/ Order & Reorder options", () => {
-      const doc = parseStmts(`
+    test("Procedures w/ Order & Reorder options", async () => {
+      const doc = await parseStmts(`
  P1: proc Options(Order);
  end P1;
  P2: proc Options( Reorder );
@@ -136,8 +136,8 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("Procedure w/ Reorder option & Returns", () => {
-      const doc = parseStmts(`
+    test("Procedure w/ Reorder option & Returns", async () => {
+      const doc = await parseStmts(`
  Double: proc (Input) Options(Reorder) returns(fixed bin(31));
   declare Input fixed bin(15);
   return( Input * 2);
@@ -148,8 +148,8 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("Recursive - Returns - Options for a Procedure in various permutations", () => {
-      const doc = parseStmts(`
+    test("Recursive - Returns - Options for a Procedure in various permutations", async () => {
+      const doc = await parseStmts(`
  // returns - options - recursive
  F1: proc (Input) returns (fixed bin(31)) Options(Order) recursive;
   dcl Input fixed bin(15);
@@ -199,9 +199,9 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("Unassigned closing end is OK", () => {
+    test("Unassigned closing end is OK", async () => {
       // validating that an 'end' which implcitly closes the prior procedure is valid
-      const doc = parseStmts(`
+      const doc = await parseStmts(`
   MYPROC: PROCEDURE OPTIONS (MAIN);
   DCL TRUE BIT(1) INIT(1);
   DCL FALSE BIT(1) INIT(0);
@@ -214,8 +214,8 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("Options Separate by Commas & Spaces", () => {
-      const doc = parseStmts(`
+    test("Options Separate by Commas & Spaces", async () => {
+      const doc = await parseStmts(`
     P1: proc Options( Order, Reorder, Recursive );
     end P1;
     P2: proc Options( Order Reorder Recursive);
@@ -228,8 +228,8 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("Complex recursive procedure", () => {
-      const doc = parse(`
+    test("Complex recursive procedure", async () => {
+      const doc = await parse(`
  START: procedure options (main);
  dcl I fixed bin(15);
  I=1; call A;
@@ -252,21 +252,21 @@ describe("PL/I Parsing tests", () => {
   });
 
   // tests for labels
-  describe("Label Tests", () => {
-    test("empty label, null statement", () => {
-      const doc = parseStmts(` main:;`);
+  describe("Label Tests", async () => {
+    test("empty label, null statement", async () => {
+      const doc = await parseStmts(` main:;`);
       assertNoParseErrors(doc);
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("Declared label", () => {
-      const doc = parseStmts(` declare Label_x label;`);
+    test("Declared label", async () => {
+      const doc = await parseStmts(` declare Label_x label;`);
       assertNoParseErrors(doc);
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("Label assignment", () => {
-      const doc = parseStmts(`
+    test("Label assignment", async () => {
+      const doc = await parseStmts(`
  declare Label_x label;
  Label_a:;
  Label_x = Label_a; // label assignments
@@ -278,9 +278,9 @@ describe("PL/I Parsing tests", () => {
   });
 
   // tests fro declarations
-  describe("Declaration tests", () => {
-    test("simple char declarations", () => {
-      const doc = parseStmts(`*PROCESS MARGINS(2,200)
+  describe("Declaration tests", async () => {
+    test("simple char declarations", async () => {
+      const doc = await parseStmts(`*PROCESS MARGINS(2,200)
  declare UserA character (15); // 15 character var
  declare UserB character (15) varying; // varying
  declare UserC character (15) varyingz; // varying w/ null termination
@@ -292,8 +292,8 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("char declaration w/ overflow assignment", () => {
-      const doc = parseStmts(`*PROCESS MARGINS(2,200)
+    test("char declaration w/ overflow assignment", async () => {
+      const doc = await parseStmts(`*PROCESS MARGINS(2,200)
  declare Subject char(10);
  Subject = 'Transformations'; // will truncate the last 5 chars, emitting a warning (but valid nonetheless)
 `);
@@ -301,16 +301,16 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("arbitrary length char decl", () => {
-      const doc = parseStmts(`
+    test("arbitrary length char decl", async () => {
+      const doc = await parseStmts(`
  dcl VAL char(*) value('Some text that runs on and on');
 `);
       assertNoParseErrors(doc);
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("nested quotes char decl", () => {
-      const doc = parseStmts(`
+    test("nested quotes char decl", async () => {
+      const doc = await parseStmts(`
  declare User1 character (30) init('Shakespeare''s "Hamlet"');
  declare User2 character (30) init("Shakespeare's ""Hamlet""");
  declare User3 character (30) init('/* blah */');
@@ -319,8 +319,8 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("Bit declarations", () => {
-      const doc = parseStmts(`
+    test("Bit declarations", async () => {
+      const doc = await parseStmts(`
  declare S bit (64); // 64 bit var
  declare Code bit(10);
  Code = '110011'B;
@@ -330,8 +330,8 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("Format constants", () => {
-      const doc = parseStmts(`
+    test("Format constants", async () => {
+      const doc = await parseStmts(`
  Prntexe: format
     ( column(20),A(15), column(40),A(15), column(60),A(15) );
  Prntstf: format
@@ -341,8 +341,8 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("Attribute declarations", () => {
-      const doc = parseStmts(`
+    test("Attribute declarations", async () => {
+      const doc = await parseStmts(`
  declare Account1 file variable, // file var
  Account2 file automatic, // file var too
  File1 file, // file constant
@@ -352,8 +352,8 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("Value List declaration", () => {
-      const doc = parseStmts(`
+    test("Value List declaration", async () => {
+      const doc = await parseStmts(`
  dcl cmonth char(3)
             valuelist( 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
                          'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec' );
@@ -362,8 +362,8 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("value list from declaration", () => {
-      const doc = parseStmts(`
+    test("value list from declaration", async () => {
+      const doc = await parseStmts(`
  dcl 1 a,
     2 b fixed bin value(31),
     2 c fixed bin value(28),
@@ -375,8 +375,8 @@ describe("PL/I Parsing tests", () => {
     });
 
     // Handle as validation error
-    //         test.fails('fails with duplicate value in value list', () => {
-    //             const doc = parseStmts(`
+    //         test.fails('fails with duplicate value in value list', async () => {
+    //             const doc = await parseStmts(`
     //  dcl 1 a,
     //     2 b fixed bin value(31),
     //     2 d fixed bin value(31);
@@ -386,17 +386,20 @@ describe("PL/I Parsing tests", () => {
     //             expect(doc.parseResult.parserErrors).toHaveLength(0);
     //         });
 
-    test.fails("value list is too long to handle in compiler correctly", () => {
-      const doc = parseStmts(`
+    test.fails(
+      "value list is too long to handle in compiler correctly",
+      async () => {
+        const doc = await parseStmts(`
  dcl 1 a, 2 b fixed bin value(31), 2 c fixed bin value(28), 2 d fixed bin value(31);
  dcl x fixed bin valuelistfrom a;
 `);
-      assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
-    });
+        assertNoParseErrors(doc);
+        generateAndAssertValidSymbolTable(doc);
+      },
+    );
 
-    test("value range declaration", () => {
-      const doc = parseStmts(`
+    test("value range declaration", async () => {
+      const doc = await parseStmts(`
  define alias numeric_month fixed bin(7) valuerange(1,12);
  dcl imonth type numeric_month; // must hold a val between 1 & 12 inclusive
  dcl cmonth char(3) // must be one of the 12 months listed
@@ -407,8 +410,8 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("multi-declaration", () => {
-      const doc = parseStmts(`*PROCESS MARGINS(2,200)
+    test("multi-declaration", async () => {
+      const doc = await parseStmts(`*PROCESS MARGINS(2,200)
     declare Result bit(3),
         A fixed decimal(1),
         B fixed binary (15), // precison lower than 15 will trigger a compiler warning, less than storage allows
@@ -419,9 +422,9 @@ describe("PL/I Parsing tests", () => {
     });
   });
 
-  test("pseduovariables", () => {
+  test("pseduovariables", async () => {
     // assigns into a sub-section of A from a sub-string of B
-    const doc = parseStmts(`
+    const doc = await parseStmts(`
  declare A character(10),
         B character(30);
  substr(A,6,5) = substr(B,20,5);
@@ -430,8 +433,8 @@ describe("PL/I Parsing tests", () => {
     generateAndAssertValidSymbolTable(doc);
   });
 
-  test("assignment from multi-declaration", () => {
-    const doc = parseStmts(`
+  test("assignment from multi-declaration", async () => {
+    const doc = await parseStmts(`
  declare Result bit(4),
     A fixed decimal(1),
     B fixed binary (15),
@@ -446,9 +449,9 @@ describe("PL/I Parsing tests", () => {
     generateAndAssertValidSymbolTable(doc);
   });
 
-  describe("Expressions", () => {
-    test("Assorted restricted expressions", () => {
-      const doc = parseStmts(`
+  describe("Expressions", async () => {
+    test("Assorted restricted expressions", async () => {
+      const doc = await parseStmts(`
  // from pg. 73
  dcl Max_names fixed bin value (1000),
     Name_size fixed bin value (30),
@@ -472,8 +475,8 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("Simple arithmetic expressions", () => {
-      const doc = parseStmts(`
+    test("Simple arithmetic expressions", async () => {
+      const doc = await parseStmts(`
  dcl A fixed bin(15), B fixed bin(15), C fixed bin(15);
  A = 5;
  B = 10;
@@ -487,8 +490,8 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("Function invocation", () => {
-      const doc = parseStmts(`
+    test("Function invocation", async () => {
+      const doc = await parseStmts(`
  dcl A fixed bin(15), B fixed bin(15), Y fixed bin(15), X fixed bin(15);
  A = 5;
  B = 10;
@@ -505,8 +508,8 @@ describe("PL/I Parsing tests", () => {
     });
   });
 
-  test("Basic branching", () => {
-    const doc = parseStmts(`
+  test("Basic branching", async () => {
+    const doc = await parseStmts(`
  dcl A bit(4),
     D bit(5);
  A=1;
@@ -520,9 +523,9 @@ describe("PL/I Parsing tests", () => {
     generateAndAssertValidSymbolTable(doc);
   });
 
-  describe("Packages", () => {
-    test("Package with main routine", () => {
-      const doc = parse(`
+  describe("Packages", async () => {
+    test("Package with main routine", async () => {
+      const doc = await parse(`
  Package_Demo: Package exports (T);
  T: PROCEDURE OPTIONS (MAIN);
  END T;
@@ -533,16 +536,16 @@ describe("PL/I Parsing tests", () => {
     });
   });
 
-  test("simple PUT", () => {
+  test("simple PUT", async () => {
     // output a string to the stdout
-    const doc = parseStmts(` put skip list('Hello ' || 'World');`);
+    const doc = await parseStmts(` put skip list('Hello ' || 'World');`);
     assertNoParseErrors(doc);
     generateAndAssertValidSymbolTable(doc);
   });
 
-  test("simple GET", () => {
+  test("simple GET", async () => {
     // read a string into a variable 'var'
-    const doc = parseStmts(`
+    const doc = await parseStmts(`
  dcl VAR fixed bin(15);
  get list(var);
 `);
@@ -550,8 +553,8 @@ describe("PL/I Parsing tests", () => {
     generateAndAssertValidSymbolTable(doc);
   });
 
-  test("fetch", () => {
-    const doc = parseStmts(`
+  test("fetch", async () => {
+    const doc = await parseStmts(`
  dcl A entry;
  fetch A title('X');
  fetch A;
@@ -566,8 +569,8 @@ describe("PL/I Parsing tests", () => {
     generateAndAssertValidSymbolTable(doc);
   });
 
-  test("BEGIN block", () => {
-    const doc = parseStmts(`
+  test("BEGIN block", async () => {
+    const doc = await parseStmts(`
  B: begin;
  declare A fixed bin(15);
  end B;`);
@@ -575,8 +578,8 @@ describe("PL/I Parsing tests", () => {
     generateAndAssertValidSymbolTable(doc);
   });
 
-  test("Subscripted entry invocation", () => {
-    const doc = parseStmts(`
+  test("Subscripted entry invocation", async () => {
+    const doc = await parseStmts(`
  declare (A,B,C,D,E) entry;
  declare F(5) entry variable initial (A,B,C,D,E);
  declare I fixed bin(15),
@@ -590,8 +593,8 @@ describe("PL/I Parsing tests", () => {
     generateAndAssertValidSymbolTable(doc);
   });
 
-  test("Optional args", () => {
-    const doc = parseStmts(`
+  test("Optional args", async () => {
+    const doc = await parseStmts(`
  dcl Vrtn entry (
     fixed bin,
     ptr optional,
@@ -610,8 +613,8 @@ describe("PL/I Parsing tests", () => {
     generateAndAssertValidSymbolTable(doc);
   });
 
-  test("Block 27", () => {
-    const doc = parseStmts(`
+  test("Block 27", async () => {
+    const doc = await parseStmts(`
     /* Enterprise PL/I for z/OS Language Reference v6.1, pg.59 */
     A = '/* This is a constant, not a comment */' ;
     `);
@@ -619,12 +622,12 @@ describe("PL/I Parsing tests", () => {
     generateAndAssertValidSymbolTable(doc);
   });
 
-  describe("Ordinal Tests", () => {
+  describe("Ordinal Tests", async () => {
     /**
      * Verifies we can parse 'returns(ordinal `type` byvalue)` cases
      */
     test("parse returns ordinal by value", async () => {
-      const doc = parseStmts(`
+      const doc = await parseStmts(`
       define ordinal day (
           Monday,
           Tuesday,
@@ -646,7 +649,7 @@ describe("PL/I Parsing tests", () => {
 
     test("parses ordinals w/ multiple unsigned/signed attributes", async () => {
       // silly example, but this parses as valid on the compiler
-      const doc = parseStmts(`
+      const doc = await parseStmts(`
       define ordinal day (
         Monday
       ) prec(15) signed signed unsigned signed unsigned signed prec(15);
@@ -659,7 +662,7 @@ describe("PL/I Parsing tests", () => {
      * Ensure we can't accidentally add precision onto signed, should be in separate alternatives
      */
     test("Cannot specify precision on sign", async () => {
-      const doc = parseStmts(`
+      const doc = await parseStmts(`
       define ordinal day (
         Monday
       ) signed(15);
@@ -669,7 +672,7 @@ describe("PL/I Parsing tests", () => {
     });
 
     test("Can specify value on ordinal definition", async () => {
-      const doc = parseStmts(`
+      const doc = await parseStmts(`
       define ordinal day (
         Monday VALUE(1)
       );
@@ -679,7 +682,7 @@ describe("PL/I Parsing tests", () => {
     });
 
     test("Can specify negative value on ordinal definition", async () => {
-      const doc = parseStmts(`
+      const doc = await parseStmts(`
       define ordinal day (
         Monday VALUE(-1)
       );
@@ -688,10 +691,10 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("Can use non-UNION attributes in DEFINE STRUCTURE statement", () => {
+    test("Can use non-UNION attributes in DEFINE STRUCTURE statement", async () => {
       // The Enterprise PL/I for z/OS Language Reference specifies that UNION is the only allowed attribute for the first structure item
       // However, this is not true, we can use non-UNION attributes as well, the compiler will accept it
-      const doc = parse(`
+      const doc = await parse(`
        DEFINE STRUCTURE
         01 MEMORY_USAGE       UNALIGNED
           ,05 TOT_24B_BYT_CT      BIN FIXED(31)
@@ -713,7 +716,7 @@ describe("PL/I Parsing tests", () => {
      * Ensure both forms of precision are parsable
      */
     test("PREC & PRECISION are parsable", async () => {
-      const doc = parseStmts(`
+      const doc = await parseStmts(`
       define ordinal D1 (
         Day1
       ) precision(15) prec(15);
@@ -727,9 +730,9 @@ describe("PL/I Parsing tests", () => {
     });
   });
 
-  describe("PL/I Constants", () => {
-    test("xn binary fixed point constants", () => {
-      const doc = parseStmts(`
+  describe("PL/I Constants", async () => {
+    test("xn binary fixed point constants", async () => {
+      const doc = await parseStmts(`
    MAINPR: procedure options (main);
       dcl x fixed bin(31) init(0);
       x = '0000ffff'xn;
@@ -739,8 +742,8 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("xu binary fixed point constants", () => {
-      const doc = parseStmts(`
+    test("xu binary fixed point constants", async () => {
+      const doc = await parseStmts(`
    MAINPR: procedure options (main);
       dcl x fixed bin(31) init(0);
       x = '0000ffff'xu;
@@ -750,8 +753,8 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("x character constants", () => {
-      const doc = parseStmts(`
+    test("x character constants", async () => {
+      const doc = await parseStmts(`
    MAINPR: procedure options (main);
       dcl x char(8) init('0000ffff'x);
    end MAINPR;
@@ -760,8 +763,8 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("a character constants", () => {
-      const doc = parseStmts(`
+    test("a character constants", async () => {
+      const doc = await parseStmts(`
    MAINPR: procedure options (main);
       dcl x char(8) init('Hello'a);
    end MAINPR;
@@ -770,8 +773,8 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("e character constants", () => {
-      const doc = parseStmts(`
+    test("e character constants", async () => {
+      const doc = await parseStmts(`
    MAINPR: procedure options (main);
       dcl x char(8) init('Hello'e);
    end MAINPR;
@@ -780,8 +783,8 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("b3 octal constants", () => {
-      const doc = parseStmts(`
+    test("b3 octal constants", async () => {
+      const doc = await parseStmts(`
    MAINPR: procedure options (main);
       dcl x fixed bin(31) init('377'b3);
    end MAINPR;
@@ -790,8 +793,8 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("b4 hex bit constants", () => {
-      const doc = parseStmts(`
+    test("b4 hex bit constants", async () => {
+      const doc = await parseStmts(`
    MAINPR: procedure options (main);
       dcl x bit(16) init('ffff'b4);
    end MAINPR;
@@ -800,8 +803,8 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("bx hex bit constants", () => {
-      const doc = parseStmts(`
+    test("bx hex bit constants", async () => {
+      const doc = await parseStmts(`
    MAINPR: procedure options (main);
       dcl x bit(16) init('ffff'bx);
    end MAINPR;
@@ -810,8 +813,8 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("b bit constants", () => {
-      const doc = parseStmts(`
+    test("b bit constants", async () => {
+      const doc = await parseStmts(`
    MAINPR: procedure options (main);
       dcl x bit(8) init('10101010'b);
    end MAINPR;
@@ -820,8 +823,8 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("gx hex graphic constants", () => {
-      const doc = parseStmts(`
+    test("gx hex graphic constants", async () => {
+      const doc = await parseStmts(`
    MAINPR: procedure options (main);
       dcl x graphic(4) init('81a1'gx);
    end MAINPR;
@@ -830,9 +833,9 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("g graphic constants", () => {
+    test("g graphic constants", async () => {
       // TODO @montymxb Feb. 21st, 2025: This one won't take SBCS on the mainframe, still needs work
-      const doc = parseStmts(`
+      const doc = await parseStmts(`
    MAINPR: procedure options (main);
       dcl x graphic(4) init('<.I.B.M>'g);
    end MAINPR;
@@ -841,8 +844,8 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("ux hex uchar constants", () => {
-      const doc = parseStmts(`
+    test("ux hex uchar constants", async () => {
+      const doc = await parseStmts(`
    MAINPR: procedure options (main);
       dcl x uchar(4) init('F48FBFBF'ux);
    end MAINPR;
@@ -851,8 +854,8 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("wx hex widechar constants", () => {
-      const doc = parseStmts(`
+    test("wx hex widechar constants", async () => {
+      const doc = await parseStmts(`
    MAINPR: procedure options (main);
       dcl x WIDECHAR(4) init('0000ffff'wx);
    end MAINPR;
@@ -861,8 +864,8 @@ describe("PL/I Parsing tests", () => {
       generateAndAssertValidSymbolTable(doc);
     });
 
-    test("m mixed character constants", () => {
-      const doc = parseStmts(`
+    test("m mixed character constants", async () => {
+      const doc = await parseStmts(`
    MAINPR: procedure options (main);
       dcl x char(8) init('<.I.B.M>'m);
    end MAINPR;
@@ -872,8 +875,8 @@ describe("PL/I Parsing tests", () => {
     });
   });
 
-  test("External declaration with returns 'byvalue fixed type'", () => {
-    const doc = parseStmts(`
+  test("External declaration with returns 'byvalue fixed type'", async () => {
+    const doc = await parseStmts(`
  dcl my_external ext('my_external')
         entry( 
             pointer byvalue,
@@ -885,8 +888,8 @@ describe("PL/I Parsing tests", () => {
     generateAndAssertValidSymbolTable(doc);
   });
 
-  test("parses GET LIST w/ file", () => {
-    const doc = parseStmts(`
+  test("parses GET LIST w/ file", async () => {
+    const doc = await parseStmts(`
     H: PROC OPTIONS (MAIN);
     DECLARE N BINARY FIXED (31);
     GET LIST (N) FILE(SYSIN);
@@ -896,9 +899,9 @@ describe("PL/I Parsing tests", () => {
     generateAndAssertValidSymbolTable(doc);
   });
 
-  test("Procedures w/ aligned & unaligned attributes", () => {
+  test("Procedures w/ aligned & unaligned attributes", async () => {
     // regular parseStmts but with a body that has a procedure w/ align & unaligned attributes
-    const doc = parseStmts(`
+    const doc = await parseStmts(`
  P1: proc returns( bit(4) aligned );
  return(0);
  end P1;
@@ -922,8 +925,8 @@ describe("PL/I Parsing tests", () => {
     generateAndAssertValidSymbolTable(doc);
   });
 
-  test("align in returns attributes is valid as well", () => {
-    const doc = parseStmts(`
+  test("align in returns attributes is valid as well", async () => {
+    const doc = await parseStmts(`
       dcl my_external ext('my_external')
         entry( 
             returns ( aligned byvalue bin(7) fixed )
@@ -933,9 +936,9 @@ describe("PL/I Parsing tests", () => {
     generateAndAssertValidSymbolTable(doc);
   });
 
-  test("Supports GENERIC attribute", () => {
+  test("Supports GENERIC attribute", async () => {
     // From page 122 of the Enterprise PL/I for z/OS Language Reference
-    const doc = parseStmts(`
+    const doc = await parseStmts(`
       declare Calc generic (
         Fxdcal when (fixed,fixed),
         Flocal when (float,float),

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -16,7 +16,7 @@ import {
 } from "../src/workspace/compilation-unit";
 import { URI } from "vscode-uri";
 import { Diagnostic, Range, Severity } from "../src/language-server/types";
-import { parse, parseAndLink, replaceNamedIndices } from "./utils";
+import { parseAndLink, replaceNamedIndices } from "./utils";
 import { expect } from "vitest";
 import { FileSystemProvider } from "../src/workspace/file-system-provider";
 import { completionRequest } from "../src/language-server/completion/completion-request";
@@ -38,6 +38,7 @@ import {
 } from "../src/workspace/plugin-configuration-provider";
 import { InternalCodes } from "../src/validation/messages";
 import { CompilerOptions } from "../src/preprocessor/compiler-options/options";
+import { tokenize } from "../src/parser/tokenizer";
 
 export type Label = string | number | string[] | number[];
 
@@ -294,8 +295,9 @@ export class TestBuilder {
     if (Array.isArray(textOrTokens)) {
       expectedTokens = textOrTokens;
     } else {
-      const expectedUnit = parse(textOrTokens);
-      expectedTokens = expectedUnit.tokens.all.map((e) => e.image);
+      expectedTokens = tokenize(textOrTokens, undefined).tokens.map(
+        (e) => e.image,
+      );
     }
     expect(actualTokens).toEqual(expectedTokens);
   }

--- a/packages/language/test/utils.ts
+++ b/packages/language/test/utils.ts
@@ -24,6 +24,7 @@ import { IntermediateBinaryExpression } from "../src/parser/abstract-parser";
 import { escapeRegExp, Token } from "../src/parser/tokens";
 import { referencesRequest } from "../src/language-server/references-request";
 import { completionRequest } from "../src/language-server/completion/completion-request";
+import { CancellationToken } from "vscode-languageserver";
 
 interface AssertNoDiagnosticsOptions {
   ignoreSeverity?: Severity[];
@@ -109,10 +110,10 @@ export function assertDiagnostic(
  * @param text PL/I text to parse
  * @param options Options for parsing, chiefly to enable additional validation
  */
-export function parse(
+export async function parse(
   text: string,
   options?: { validate?: boolean; uri?: URI },
-): CompilationUnit {
+): Promise<CompilationUnit> {
   const sourceFile = createCompilationUnit(
     options?.uri ?? URI.file("test.pli"),
   );
@@ -120,7 +121,7 @@ export function parse(
     lifecycle.tokenize(sourceFile, text);
     lifecycle.parse(sourceFile);
   } else {
-    lifecycle.lifecycle(sourceFile, text);
+    await lifecycle.lifecycle(sourceFile, text, CancellationToken.None);
   }
   return sourceFile;
 }
@@ -132,7 +133,7 @@ export function parse(
 export function parseStmts(
   text: string,
   options?: { validate: boolean },
-): CompilationUnit {
+): Promise<CompilationUnit> {
   // TODO ssmifi: Currently, process directives must start at the beginning of the file.
   let prefix = "";
   while (text.startsWith("*PROCESS") || text.startsWith("%PROCESS")) {

--- a/packages/language/test/validating.test.ts
+++ b/packages/language/test/validating.test.ts
@@ -35,7 +35,7 @@ function parseWithValidations(text: string) {
 
 describe("Validating", () => {
   test("check simple program", async () => {
-    const doc = parseWithValidations(`
+    const doc = await parseWithValidations(`
         H: PROC OPTIONS (MAIN);
         DCL ABC BIT(1) INIT(1);
         END H;
@@ -44,7 +44,7 @@ describe("Validating", () => {
   });
 
   test("check empty program", async () => {
-    const doc = parseWithValidations(`;`);
+    const doc = await parseWithValidations(`;`);
     assertDiagnostic(doc, {
       code: PLICodes.Severe.IBM1917I.fullCode,
       severity: Severity.S,
@@ -52,7 +52,7 @@ describe("Validating", () => {
   });
 
   test("check IBM2462I, unaligned & aligned conflict", async () => {
-    const doc = parseWithValidations(`
+    const doc = await parseWithValidations(`
         H: PROC OPTIONS (MAIN);
         xyz: proc returns ( optional aligned unaligned bit(4) ); // <-- conflicting attributes, second one should be ignored
         return(0);
@@ -67,7 +67,7 @@ describe("Validating", () => {
   });
 
   test("check mismatched end label", async () => {
-    const doc = parseWithValidations(`
+    const doc = await parseWithValidations(`
         MYPROC: PROCEDURE OPTIONS (MAIN);
         DCL TRUE BIT(1) INIT(1);
         DCL FALSE BIT(1) INIT(0);
@@ -96,7 +96,7 @@ describe("Validating", () => {
   });
 
   test("package end label validates", async () => {
-    const doc = parseWithValidations(`
+    const doc = await parseWithValidations(`
         baseline: package;
         end baseline;`);
     assertNoDiagnostics(doc, {
@@ -106,7 +106,7 @@ describe("Validating", () => {
 
   // TODO @montymxb Mar. 28th, 2025: Pending a fix to linking + scoping
   test.fails("validates ordinal reference", async () => {
-    const doc = parseWithValidations(`
+    const doc = await parseWithValidations(`
         define ordinal day (
             Monday,
             Tuesday,
@@ -128,7 +128,7 @@ describe("Validating", () => {
   test.fails.skip(
     "Reference to alias types __SIGNED_INT & __UNSIGNED_INT",
     async () => {
-      const doc = parseWithValidations(`
+      const doc = await parseWithValidations(`
         mypackage: package;
         DCL x type __SIGNED_INT;
         DCL y type __UNSIGNED_INT;
@@ -140,7 +140,7 @@ describe("Validating", () => {
 
   describe("Call validations", () => {
     test("can call function declared by procedure", async () => {
-      const doc = parseWithValidations(
+      const doc = await parseWithValidations(
         `
            MAINPR: procedure options( main );
            b: proc() returns( OPTIONAL byvalue fixed bin(31) );
@@ -154,7 +154,7 @@ describe("Validating", () => {
     });
 
     test("can call function declared by entry statement", async () => {
-      const doc = parseWithValidations(
+      const doc = await parseWithValidations(
         `
             MAINPR: procedure options( main );
             // calling 'a'
@@ -168,7 +168,7 @@ describe("Validating", () => {
     });
 
     test("cannot invoke function from declaration w/out entry (no args)", async () => {
-      const doc = parseWithValidations(
+      const doc = await parseWithValidations(
         `
             MAINPR: procedure options( main );
             dcl a fixed bin(31); // not callable
@@ -185,7 +185,7 @@ describe("Validating", () => {
     });
 
     test("cannot invoke function from declaration w/out entry (w/ args)", async () => {
-      const doc = parseWithValidations(
+      const doc = await parseWithValidations(
         `
               MAINPR: procedure options( main );
               // calling 'a'
@@ -211,7 +211,7 @@ describe("Validating", () => {
   describe("Ordinal validations", async () => {
     test("Signed & unsigned are mutually exclusive", async () => {
       // ensure that only one set of signed/unsigned & precision is specified
-      const doc = parseWithValidations(`
+      const doc = await parseWithValidations(`
       define ordinal day (
         Monday
       ) prec(15) signed unsigned;`);
@@ -221,7 +221,7 @@ describe("Validating", () => {
 
     test("Valid to have signed before precision", async () => {
       // ensure that only one set of signed/unsigned & precision is specified
-      const doc = parseWithValidations(`
+      const doc = await parseWithValidations(`
       define ordinal day (
         Monday
       ) signed prec(15);`);
@@ -231,7 +231,7 @@ describe("Validating", () => {
 
     test("Don't allow multiple precisions", async () => {
       // ensure that only one set of signed/unsigned & precision is specified
-      const doc = parseWithValidations(`
+      const doc = await parseWithValidations(`
       define ordinal day (
         Monday
       ) precision(15) prec(15);`);
@@ -241,7 +241,7 @@ describe("Validating", () => {
 
     test("Double signed/unsigned is ok (redundant)", async () => {
       // ensure that only one set of signed/unsigned & precision is specified
-      const doc = parseWithValidations(`
+      const doc = await parseWithValidations(`
       define ordinal D1 (
         Day1
       ) unsigned unsigned;
@@ -268,7 +268,7 @@ describe("Validating", () => {
 
   describe("*PROCESS Validations", () => {
     test("No options valid", async () => {
-      const doc = parseWithValidations(`*PROCESS;
+      const doc = await parseWithValidations(`*PROCESS;
         EP: PROC OPTIONS (MAIN);
         END EP;
         `);
@@ -276,7 +276,7 @@ describe("Validating", () => {
     });
 
     test("Single option is valid", async () => {
-      const doc = parseWithValidations(`*PROCESS NOEXIT;
+      const doc = await parseWithValidations(`*PROCESS NOEXIT;
         EP: PROC OPTIONS (MAIN);
         END EP;
         `);
@@ -284,7 +284,7 @@ describe("Validating", () => {
     });
 
     test("Warn on mutex opts", async () => {
-      const doc = parseWithValidations(`*PROCESS NOAGGREGATE, AGGREGATE;
+      const doc = await parseWithValidations(`*PROCESS NOAGGREGATE, AGGREGATE;
         EP: PROC OPTIONS (MAIN);
         END EP;
         `);
@@ -296,7 +296,7 @@ describe("Validating", () => {
     });
 
     test("Warn on duplicate opts", async () => {
-      const doc = parseWithValidations(`*PROCESS AGGREGATE, AGGREGATE;
+      const doc = await parseWithValidations(`*PROCESS AGGREGATE, AGGREGATE;
         EP: PROC OPTIONS (MAIN);
         END EP;
         `);
@@ -307,7 +307,7 @@ describe("Validating", () => {
     });
 
     test("Warn on unrecognized compiler option", async () => {
-      const doc = parseWithValidations(`*PROCESS TYPEFOXOPT;
+      const doc = await parseWithValidations(`*PROCESS TYPEFOXOPT;
         EP: PROC OPTIONS (MAIN);
         END EP;
         `);
@@ -319,7 +319,7 @@ describe("Validating", () => {
 
     test("Warn on complex case w/ mutex opt", async () => {
       const doc =
-        parseWithValidations(`*PROCESS NODBRMLIB, COMPILE, AGGREGATE, NOCOMPILE;
+        await parseWithValidations(`*PROCESS NODBRMLIB, COMPILE, AGGREGATE, NOCOMPILE;
         EP: PROC OPTIONS (MAIN);
         END EP;
         `);
@@ -331,7 +331,7 @@ describe("Validating", () => {
     });
 
     test("Warn on duplicate w/ aliased form", async () => {
-      const doc = parseWithValidations(`*PROCESS AG, AGGREGATE;
+      const doc = await parseWithValidations(`*PROCESS AG, AGGREGATE;
         EP: PROC OPTIONS (MAIN);
         END EP;
         `);
@@ -342,7 +342,7 @@ describe("Validating", () => {
     });
 
     test("Warn on mutex case w/ aliased form", async () => {
-      const doc = parseWithValidations(`*PROCESS NAG, AGGREGATE;
+      const doc = await parseWithValidations(`*PROCESS NAG, AGGREGATE;
         EP: PROC OPTIONS (MAIN);
         END EP;
         `);
@@ -355,7 +355,7 @@ describe("Validating", () => {
 
     test("Valid on complex case w/ no issues", async () => {
       const doc =
-        parseWithValidations(`*PROCESS COMPILE, NODBRMLIB, AGGREGATE, MARGINS(2,72);
+        await parseWithValidations(`*PROCESS COMPILE, NODBRMLIB, AGGREGATE, MARGINS(2,72);
         EP: PROC OPTIONS (MAIN);
         END EP;
         `);
@@ -363,7 +363,7 @@ describe("Validating", () => {
     });
 
     test("Error on invalid %INCLUDE directive", async () => {
-      const doc = parseWithValidations(` %INCLUDE 'nonexistent.pli';
+      const doc = await parseWithValidations(` %INCLUDE 'nonexistent.pli';
         EP: PROC OPTIONS (MAIN);
         END EP;
       `);
@@ -373,48 +373,4 @@ describe("Validating", () => {
       });
     });
   });
-
-  //
-  //     test('check no errors', async () => {
-  //         document = await parseWithValidations(`
-  //             person Langium
-  //         `);
-  //
-  //         expect(
-  //             // here we first check for validity of the parsed document object by means of the reusable function
-  //             //  'checkDocumentValid()' to sort out (critical) typos first,
-  //             // and then evaluate the diagnostics by converting them into human readable strings;
-  //             // note that 'toHaveLength()' works for arrays and strings alike ;-)
-  //             checkDocumentValid(document) || document?.diagnostics?.map(diagnosticToString)?.join('\n')
-  //         ).toHaveLength(0);
-  //     });
-  //
-  //     test('check capital letter validation', async () => {
-  //         document = await parseWithValidations(`
-  //             person langium
-  //         `);
-  //
-  //         expect(
-  //             checkDocumentValid(document) || document?.diagnostics?.map(diagnosticToString)?.join('\n')
-  //         ).toEqual(
-  //             // 'expect.stringContaining()' makes our test robust against future additions of further validation rules
-  //             expect.stringContaining(s`
-  //                 [1:19..1:26]: Person name should start with a capital.
-  //             `)
-  //         );
-  //     });
 });
-
-// function checkDocumentValid(document: LangiumDocument): string | undefined {
-//     return document.parseResult.parserErrors.length && s`
-//         Parser errors:
-//           ${document.parseResult.parserErrors.map(e => e.message).join('\n  ')}
-//     `
-//         || document.parseResult.value === undefined && `ParseResult is 'undefined'.`
-//         || !isPliProgram(document.parseResult.value) && `Root AST object is a ${document.parseResult.value.$type}, expected a 'Model'.`
-//         || undefined;
-// }
-
-// function diagnosticToString(d: Diagnostic) {
-//     return `[${d.range.start.line}:${d.range.start.character}..${d.range.end.line}:${d.range.end.character}]: ${d.message}`;
-// }


### PR DESCRIPTION
There are two main reasons to make the lifecycle async:
1. With a sync lifecycle, we always need to wait until the previous lifecycle is completed until we can start with a new one. This can quickly accumulate and essentially prevent the language server from catching up to the current state of the document.
2. Eventually, we want to perform async file operations in the preprocessor code (i.e. lookups of files on remote filesystems, etc.). This requires us to make the preprocessor async, which in turn requires the lifecycle to already be async.

This fixes the first issue, as it will abort the mutex when the compilation unit is changed. The second part will come when necessary. Most of the changes in here are related to the tests, which all needed to be updated to be async.