### PR TITLE
Fix margin warnings at CR

### DIFF
--- a/packages/language/src/preprocessor/compiler-options-processor.ts
+++ b/packages/language/src/preprocessor/compiler-options-processor.ts
@@ -44,7 +44,8 @@ export class CompilerOptionsProcessor {
     let sourceCompilerOptions: string[] = [];
     let newText = text;
     for (const range of ranges) {
-      // newText should recognize the line break for the margins in the first line after the process directive.
+      // newText should recognize the line break for the margins in the first line after the process directive,
+      // because removing the linebreaks could position the first line of the program outside the margins.
       const offset =
         range.start + CompilerOptionsProcessor.PROCESS_TOKEN_LENGTH;
       sourceCompilerOptions.push(text.substring(offset, range.end));
@@ -144,7 +145,11 @@ export class CompilerOptionsProcessor {
     uri: URI,
   ): (Range & { token: Token })[] {
     const ranges: (Range & { token: Token })[] = [];
-    const processRegex = /([%*]PROCESS[^;\n]*[;\n])/iy;
+    // The PROCESS directive actually allows for further characters after the ;.
+    // *PROCESS MARGINS(2, 72) ; MARGINS(1, 72); is valid, but everything after the first ; is ignored.
+    // Just extract the complete line and let the parser decide what is valid.
+    // We still need the whole line to preserve original positions for diagnostics.
+    const processRegex = /([%*]PROCESS[^\n]*(?:(?:\r?\n)|$))/iy;
     let match: RegExpExecArray | null;
     let currentPosition = 0;
 

--- a/packages/language/src/preprocessor/compiler-options/parser.ts
+++ b/packages/language/src/preprocessor/compiler-options/parser.ts
@@ -29,6 +29,7 @@ import {
 import { Token } from "../../parser/tokens";
 
 const commaToken = createToken({ name: "comma", pattern: "," });
+const semicolonToken = createToken({ name: "semicolon", pattern: ";" });
 const stringToken = createToken({
   name: "string",
   pattern: /("(""|\\.|[^"\\])*"|'(''|\\.|[^'\\])*')/,
@@ -40,6 +41,7 @@ const ws = createToken({ name: "ws", pattern: /\s+/, group: Lexer.SKIPPED });
 const tokenTypes = [
   ws,
   commaToken,
+  semicolonToken,
   stringToken,
   parenOpen,
   parenClose,
@@ -261,10 +263,16 @@ export function parseAbstractCompilerOptions(
   input: string,
   offset?: number,
 ): AbstractCompilerOptions {
-  const lexerResult = lexer.tokenize(
-    " ".repeat(offset ?? 0) + input.replace(/;$/, ""),
+  // Remove everything after the first ;.
+  // *PROCESS MARGINS(2, 72) ; MARGINS(1, 72); is valid, but everything after the first ; is ignored.
+  const lexerResult = lexer.tokenize(" ".repeat(offset ?? 0) + input);
+  const semicolonTokenPosition = lexerResult.tokens.findIndex(
+    (token) => token.tokenTypeIdx === semicolonToken.tokenTypeIdx,
   );
-  const tokens = lexerResult.tokens as Token[];
+  const tokens = lexerResult.tokens.slice(
+    0,
+    semicolonTokenPosition === -1 ? undefined : semicolonTokenPosition,
+  ) as Token[];
   parser.input = tokens;
   const compilerOptions = parser.compilerOptions();
   const issues: CompilerOptionIssue[] = [];

--- a/packages/language/src/preprocessor/pli-margins-processor.ts
+++ b/packages/language/src/preprocessor/pli-margins-processor.ts
@@ -18,7 +18,7 @@ import { PluginConfigurationProviderInstance } from "../workspace/plugin-configu
 
 const NEWLINE = "\n".charCodeAt(0);
 const SPACE = " ".charCodeAt(0);
-const PREFIX_PATTERN = /^[0-9\+\- ]+$/;
+const PREFIX_PATTERN = /^[0-9\+\- \r\t]+$/;
 const SEQUENCE_PATTERN = /^\s*[A-Z0-9]*\r?\n?$/;
 
 export interface MarginsProcessor {

--- a/packages/language/test/fourslash-harness/harness-parser.ts
+++ b/packages/language/test/fourslash-harness/harness-parser.ts
@@ -29,6 +29,11 @@ const HARNESS_TAG_PREFIX = "//";
 export const HARNESS_FILE_PREFIX = "////";
 const REFERENCE_PATH_PREFIX = "/// <reference path=";
 const HARNESS_TAG_PATTERN = /^\/\/\s*@(?<name>\w+)\s*(?<value>:.*)?$/;
+const HARNESS_ESCAPE_CHARACTERS = [
+  ["\\n", "\n"],
+  ["\\r", "\r"],
+  ["\\t", "\t"],
+];
 
 type Context = {
   wrappers: Record<string, Wrapper>;
@@ -140,8 +145,11 @@ class HarnessTestParser {
 
       this.next();
 
-      // Remove the prefix
-      const content = line.substring(HARNESS_FILE_PREFIX.length);
+      // Remove the prefix and escape characters.
+      let content = line.substring(HARNESS_FILE_PREFIX.length);
+      for (const [escapeChar, replacement] of HARNESS_ESCAPE_CHARACTERS) {
+        content = content.replaceAll(escapeChar, replacement);
+      }
       lines.push(content);
     }
 

--- a/packages/language/test/fourslash/lexer/margins-error-left-margin-crlf.ts
+++ b/packages/language/test/fourslash/lexer/margins-error-left-margin-crlf.ts
@@ -1,0 +1,32 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////         "name": "default",
+////         "lsp-options": {
+////             "check-margins": true
+////         }
+////         }
+////     ]
+//// }
+
+// @filename: main.pli
+// @wrap: main
+//// DECLARE LIBREF FIXED;
+////\r
+//// LIBREF = 44;
+
+verify.noDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/compiler-options/option-parser-correct-skip-crlf.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/option-parser-correct-skip-crlf.ts
@@ -1,0 +1,39 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////         "name": "default",
+////         "lsp-options": {
+////             "check-margins": true
+////         }
+////         }
+////     ]
+//// }
+
+// @filename: main.pli
+////*PROCESS GRAPHIC;
+////*PROCESS NOGRAPHIC;
+////*PROCESS NGR;
+////*PROCESS GR;\r
+//// STARTPR: PROCEDURE OPTIONS (MAIN);
+//// END STARTPR;`;
+
+verify.noDiagnosticsExcept([
+  new RegExp(code.CompilerOptions.DupeOptionIssue.message("").substring(0, 20)),
+  new RegExp(
+    code.CompilerOptions.MutexOptionIssue.message("").substring(0, 20),
+  ),
+]);

--- a/packages/language/test/fourslash/preprocessor/compiler-options/option-parser-correct-skip-standalone-crlf.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/option-parser-correct-skip-standalone-crlf.ts
@@ -1,0 +1,40 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////         "name": "default",
+////         "lsp-options": {
+////             "check-margins": true
+////         }
+////         }
+////     ]
+//// }
+
+// @filename: main.pli
+////*PROCESS GRAPHIC;
+////*PROCESS NOGRAPHIC;
+////*PROCESS NGR;
+////*PROCESS GR;\r\n
+
+verify.noDiagnosticsExcept([
+  new RegExp(code.CompilerOptions.DupeOptionIssue.message("").substring(0, 20)),
+  new RegExp(
+    code.CompilerOptions.MutexOptionIssue.message("").substring(0, 20),
+  ),
+  new RegExp(
+    code.Severe.IBM1917I.message, // no program, but the options parser should work nonetheless
+  ),
+]);

--- a/packages/language/test/fourslash/preprocessor/compiler-options/option-parser-correct-skip-standalone.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/option-parser-correct-skip-standalone.ts
@@ -1,0 +1,40 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////         "name": "default",
+////         "lsp-options": {
+////             "check-margins": true
+////         }
+////         }
+////     ]
+//// }
+
+// @filename: main.pli
+////*PROCESS GRAPHIC;
+////*PROCESS NOGRAPHIC;
+////*PROCESS NGR;
+////*PROCESS GR;
+
+verify.noDiagnosticsExcept([
+  new RegExp(code.CompilerOptions.DupeOptionIssue.message("").substring(0, 20)),
+  new RegExp(
+    code.CompilerOptions.MutexOptionIssue.message("").substring(0, 20),
+  ),
+  new RegExp(
+    code.Severe.IBM1917I.message, // no program, but the options parser should work nonetheless
+  ),
+]);

--- a/packages/language/test/fourslash/preprocessor/compiler-options/option-parser-correct-skip.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/option-parser-correct-skip.ts
@@ -1,0 +1,39 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////         "name": "default",
+////         "lsp-options": {
+////             "check-margins": true
+////         }
+////         }
+////     ]
+//// }
+
+// @filename: main.pli
+////*PROCESS GRAPHIC;
+////*PROCESS NOGRAPHIC;
+////*PROCESS NGR;
+////*PROCESS GR;
+//// STARTPR: PROCEDURE OPTIONS (MAIN);
+//// END STARTPR;`;
+
+verify.noDiagnosticsExcept([
+  new RegExp(code.CompilerOptions.DupeOptionIssue.message("").substring(0, 20)),
+  new RegExp(
+    code.CompilerOptions.MutexOptionIssue.message("").substring(0, 20),
+  ),
+]);

--- a/packages/language/test/fourslash/preprocessor/compiler-options/option-parser-right-clutter.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/option-parser-right-clutter.ts
@@ -1,0 +1,36 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////         "name": "default",
+////         "lsp-options": {
+////             "check-margins": true
+////         }
+////         }
+////     ]
+//// }
+
+// @filename: main.pli
+// @wrap: process
+////*PROCESS MARGINS(1, 72); xxx
+
+verify.noDiagnostics();
+verify.expectCompilerOptions({
+  margins: {
+    m: 1,
+    n: 72,
+  },
+});

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -771,7 +771,7 @@ export class TestBuilder {
 
   private createDiagnosticMessage(diagnostic: Diagnostic): string {
     const position = this.createPositionMessage(
-      diagnostic.range?.start ?? -1, // range may not be present in some cases
+      diagnostic.range?.start,
       diagnostic.uri,
     );
     const severity = Severity[diagnostic.severity];


### PR DESCRIPTION
Fix for https://github.com/zowe/zowe-pli-language-support/issues/335 3

- Empty lines with CRLF are now ignored.
- Adjusted the process directive extraction to be in line with the mainframe. The semicolon is not yet mandatory in our version though (https://github.com/zowe/zowe-pli-language-support/issues/301).
- Extended the harness to test for \n \r \t.