### PR TITLE
Extend compiler options and tests #3

### DIFF
--- a/packages/language/src/preprocessor/compiler-options/codes.ts
+++ b/packages/language/src/preprocessor/compiler-options/codes.ts
@@ -10,6 +10,7 @@
  */
 
 import { Severity } from "../../language-server/types";
+import { PLICodes } from "../../validation/messages";
 import { ParametricPLICode } from "../../validation/messages/pli-codes";
 
 export const CompilerOptionsCodes = {
@@ -305,11 +306,107 @@ export const CompilerOptionsCodes = {
 
   MaxInit: {
     InvalidParameter: {
-      code: "COMN01",
+      code: "COMT01",
       severity: Severity.W,
       message: (value: string) =>
         `Expected a number followed by "K", "M" or "G", but received '${value}'.`,
+      fullCode: "COMT01W",
+    } as ParametricPLICode,
+  },
+
+  MaxNest: {
+    InvalidParameter: {
+      code: "COMN01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "BLOCK", "DO" or "IF", but received '${value}'.`,
       fullCode: "COMN01W",
+    } as ParametricPLICode,
+  },
+
+  MaxStmt: {
+    InvalidRange: {
+      code: "COMS01",
+      severity: Severity.W,
+      message: () =>
+        `The m statement count must be less or equal to the n statement count.`,
+      fullCode: "COMS01W",
+    } as ParametricPLICode,
+  },
+
+  MDeck: {
+    InvalidParameter: {
+      code: "COMD01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "AFTERALL" or "AFTERMACRO", but received '${value}'.`,
+      fullCode: "COMD01W",
+    } as ParametricPLICode,
+  },
+
+  MsgSummary: {
+    InvalidParameter: {
+      code: "COMS02",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "XREF" or "NOXREF", but received '${value}'.`,
+      fullCode: "COMS02W",
+    } as ParametricPLICode,
+  },
+
+  NatLang: {
+    InvalidParameter: {
+      code: "COLN01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "ENU" or "UEN", but received '${value}'.`,
+      fullCode: "COLN01W",
+    } as ParametricPLICode,
+  },
+
+  Names: {
+    CharacterAlreadyDefined: PLICodes.Warning.IBM1108I,
+    InvalidParameterLengths: PLICodes.Warning.IBM1205I,
+  },
+
+  OffsetSize: {
+    // [Warning] IBM1161I: The suboption 3 is not valid for the OFFSETSIZE compiler option.
+    InvalidParameter: {
+      code: "COOS01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "4" or "8", but received '${value}'.`,
+      fullCode: "COOS01W",
+    } as ParametricPLICode,
+  },
+
+  OnSnap: {
+    InvalidParameter: {
+      code: "COOS02",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "STRINGRANGE" or "STRINGSIZE", but received '${value}'.`,
+      fullCode: "COOS02W",
+    } as ParametricPLICode,
+  },
+
+  Optimize: {
+    InvalidParameter: {
+      code: "COOP01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "0", "2", "3" or "TIME", but received '${value}'.`,
+      fullCode: "COOP01W",
+    } as ParametricPLICode,
+  },
+
+  Options: {
+    InvalidParameter: {
+      code: "COOP02",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "DOC" or "ALL", but received '${value}'.`,
+      fullCode: "COOP02W",
     } as ParametricPLICode,
   },
 };

--- a/packages/language/src/preprocessor/compiler-options/options.ts
+++ b/packages/language/src/preprocessor/compiler-options/options.ts
@@ -341,7 +341,7 @@ export interface CompilerOptions {
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-maxstatic
    */
-  maxStatic?: string;
+  maxStatic?: number;
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-maxstmt
    */
@@ -353,15 +353,15 @@ export interface CompilerOptions {
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-mdeck
    */
-  mDeck?: CompilerOptions.MDeck;
+  mDeck?: CompilerOptions.MDeck | false;
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-msgsummary
    */
-  msgSummary?: CompilerOptions.MsgSummary;
+  msgSummary?: CompilerOptions.MsgSummary | false;
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-name
    */
-  name?: string | false;
+  name?: string | boolean;
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-names
    */
@@ -799,16 +799,8 @@ export declare namespace CompilerOptions {
      */
     n?: number;
   }
-  export type MDeck =
-    | {
-        type?: "AFTERALL" | "AFTERMACRO";
-      }
-    | false;
-  export type MsgSummary =
-    | {
-        xref?: boolean;
-      }
-    | false;
+  export type MDeck = "AFTERALL" | "AFTERMACRO";
+  export type MsgSummary = "XREF" | "NOXREF";
   export type Names = {
     extralingChar?: string;
     uppExtralingChar?: string;
@@ -825,18 +817,8 @@ export declare namespace CompilerOptions {
         stringSize?: boolean;
       }
     | false;
-  export type Optimize =
-    | {
-        level?: 0 | 2 | 3 | "TIME";
-      }
-    | false;
-  export type Options =
-    | {
-        all?: boolean;
-        doc?: boolean;
-      }
-    | false;
-
+  export type Optimize = 0 | 3;
+  export type Options = "DOC" | "ALL" | false;
   export type PPOption = PP | false;
 
   export type PP = {
@@ -1128,6 +1110,33 @@ const defaultCompilerOptions: CompilerOptions = {
     severity: "W",
     n: 250,
   },
+  maxnest: {
+    block: 17,
+    do: 17,
+    if: 17,
+  },
+  maxRunOnIf: 10,
+  maxStmt: {
+    m: 4 * $1K,
+    n: 8 * $1K,
+  },
+  maxTemp: 50000,
+  mDeck: false,
+  msgSummary: false,
+  name: false,
+  names: {
+    extralingChar: "@#$",
+    uppExtralingChar: "@#$",
+  },
+  natlang: "ENU",
+  nest: false,
+  nullDate: false,
+  object: true,
+  offset: false,
+  offsetSize: 4,
+  onSnap: false,
+  optimize: 0,
+  options: "DOC",
   system: "MVS",
   sysParm: "",
 };

--- a/packages/language/src/preprocessor/compiler-options/translator.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator.ts
@@ -48,7 +48,12 @@ enum RuleAlignment {
   NEGATIVE = -1,
 }
 
-const PLI_CHARACTER_SET = /[A-Za-z0-9 =+\-*/()\.,'"%;:&|<>_¬]/;
+const PLI_CHARACTER_REGEX = /[A-Za-z0-9 =+\-*/()\.,'"%;:&|<>_¬]/;
+const PLI_CHARACTER_SET = new Set(
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 =+-*/().,'\"%;:&|<>_¬".split(
+    "",
+  ),
+);
 
 class Translator {
   options: CompilerOptions = getDefaultCompilerOptions();
@@ -311,7 +316,7 @@ function ensureNumberValue(
 }
 
 function stringToNumber(text: string): number {
-  const numRegex = /^\s*(\-?\d+)([kmg])?\s*$/i;
+  const numRegex = /^\s*(\-?\d+)([km])?\s*$/i;
   const match = numRegex.exec(text);
   if (!match) {
     return NaN;
@@ -319,9 +324,6 @@ function stringToNumber(text: string): number {
   let num = Number(match[1]);
   if (match[2]) {
     switch (match[2]) {
-      case "G":
-      case "g":
-        num *= 1024;
       case "M":
       case "m":
         num *= 1024;
@@ -516,7 +518,7 @@ translator.rule(["BLANK"], (option, options) => {
     );
   }
 
-  if (PLI_CHARACTER_SET.test(value.value)) {
+  if (PLI_CHARACTER_REGEX.test(value.value)) {
     throw new TranslationError(
       value.token,
       "BLANK option value contains disallowed characters. Cannot contain letters, numbers, spaces, or PL/I special characters.",
@@ -545,7 +547,7 @@ translator.rule(
     const start = value.value.charAt(0);
     const end = value.value.charAt(1);
 
-    if (PLI_CHARACTER_SET.test(start) || PLI_CHARACTER_SET.test(end)) {
+    if (PLI_CHARACTER_REGEX.test(start) || PLI_CHARACTER_REGEX.test(end)) {
       throw new TranslationError(
         value.token,
         "BRACKETS option value contains disallowed characters. Cannot contain letters, numbers, spaces, or PL/I special characters.",
@@ -2050,16 +2052,231 @@ translator.rule(["MAXMSG"], (option, options) => {
 });
 
 /** {@link CompilerOptions.maxnest} */
+translator.rule(["MAXNEST"], (option, options) => {
+  ensureArguments(option, 1);
+  if (!options.maxnest) {
+    options.maxnest = getDefaultCompilerOptions().maxnest;
+  }
+  // Suboptions may override previously set values.
+  for (const suboption of option.values) {
+    ensureType(suboption, "option");
+    const name = suboption.name.toLowerCase();
+    if (["block", "do", "if"].includes(name)) {
+      ensureArguments(suboption, 1, 1);
+      const value = suboption.values[0];
+      ensureType(value, "plainNotEmpty");
+      options.maxnest![name as keyof CompilerOptions.MaxNest] =
+        ensureNumberValue(value, 1, 50);
+    } else {
+      throw TranslationError.fromCode(
+        suboption.token,
+        CompilerOptionsCodes.MaxNest.InvalidParameter,
+        suboption.name,
+      );
+    }
+  }
+});
+
 /** {@link CompilerOptions.maxRunOnIf} */
+translator.rule(["MAXRUNONIF"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "plainNotEmpty");
+  // The spec does not specify the minimum and maximum values.
+  // The mainframe testing suggests 2 - 1000.
+  options.maxRunOnIf = ensureNumberValue(value, 2, 1000);
+});
+
 /** {@link CompilerOptions.maxStatic} */
+translator.rule(["MAXSTATIC"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "plainNotEmpty");
+  options.maxStatic = ensureNumberValue(value, 1);
+});
+
 /** {@link CompilerOptions.maxStmt} */
+translator.rule(["MAXSTMT"], (option, options) => {
+  ensureArguments(option, 1, 2);
+  const mValue = option.values[0];
+  ensureType(mValue, "plainNotEmpty");
+  const nValue = option.values.length > 1 ? option.values[1] : mValue;
+  ensureType(nValue, "plainNotEmpty");
+  const m = ensureNumberValue(mValue, 1);
+  const n = ensureNumberValue(nValue, 1);
+  if (m > n) {
+    throw TranslationError.fromCode(
+      mValue.token,
+      CompilerOptionsCodes.MaxStmt.InvalidRange,
+    );
+  }
+  options.maxStmt = {
+    m,
+    n,
+  };
+});
+
 /** {@link CompilerOptions.maxTemp} */
+translator.rule(["MAXTEMP"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "plainNotEmpty");
+  options.maxTemp = ensureNumberValue(value, 1);
+});
+
 /** {@link CompilerOptions.mDeck} */
+translator.rule(
+  ["MDECK", "MD"],
+  (option, options) => {
+    ensureArguments(option, 1);
+    // Only the last value takes effect.
+    for (const value of option.values) {
+      ensureType(value, "plain");
+      const valueName = value.value.toUpperCase();
+      if (["AFTERALL", "AFTERMACRO"].includes(valueName)) {
+        options.mDeck = valueName as CompilerOptions.MDeck;
+      } else {
+        throw TranslationError.fromCode(
+          value.token,
+          CompilerOptionsCodes.MDeck.InvalidParameter,
+          value.value,
+        );
+      }
+    }
+  },
+  ["NOMDECK", "NMD"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.mDeck = false;
+  },
+);
+
 /** {@link CompilerOptions.msgSummary} */
+translator.rule(
+  ["MSGSUMMARY"],
+  (option, options) => {
+    // Actually does not accept multiple or empty values.
+    // *PROCESS MSGSUMMARY; is valid, but *PROCESS MSGSUMMARY(); is not.
+    ensureArguments(option, 0, 1);
+    let valueName = "NOXREF";
+    if (option.values.length === 1) {
+      const value = option.values[0];
+      ensureType(value, "plainNotEmpty");
+      valueName = value.value.toUpperCase();
+    }
+    if (["XREF", "NOXREF"].includes(valueName)) {
+      options.msgSummary = valueName as CompilerOptions.MsgSummary;
+    } else {
+      // Can only be reached if the value is plain.
+      throw TranslationError.fromCode(
+        option.values[0].token,
+        CompilerOptionsCodes.MsgSummary.InvalidParameter,
+        (option.values[0] as CompilerOptionText).value,
+      );
+    }
+  },
+  ["NOMSGSUMMARY"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.msgSummary = false;
+  },
+);
+
 /** {@link CompilerOptions.name} */
+translator.rule(
+  ["NAME", "N"],
+  (option, options) => {
+    ensureArguments(option, 0, 1);
+    if (option.values.length === 1) {
+      const value = option.values[0];
+      ensureType(value, "plainOrString");
+      if (
+        value.kind === SyntaxKind.CompilerOptionText &&
+        value.value.length === 0
+      ) {
+        // If it is just plain text, no text is not recognized.
+        throw TranslationError.fromCode(
+          value.token,
+          CompilerOptionsCodes.ExpectedPlainNotEmpty,
+          value.value,
+        );
+      }
+      options.name = value.value;
+    } else {
+      options.name = true;
+    }
+  },
+  ["NONAME"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.name = false;
+  },
+);
+
 /** {@link CompilerOptions.names} */
+translator.rule(["NAMES"], (option, options) => {
+  const ensureSafeCharacters = (
+    value: CompilerOptionText | CompilerOptionString,
+  ) => {
+    const seen = new Set<string>();
+    for (const char of value.value) {
+      // The character must not be from the character or set nor occur more than once.
+      if (PLI_CHARACTER_SET.has(char) || seen.has(char)) {
+        throw TranslationError.fromCode(
+          value.token,
+          CompilerOptionsCodes.Names.CharacterAlreadyDefined,
+          char,
+          "NAMES",
+        );
+      }
+      seen.add(char);
+    }
+  };
+
+  ensureArguments(option, 1, 2);
+  const firstValue = option.values[0];
+  // TODO ssmifi: The mainframe accepts plain and string tokens.
+  // However, the options parser does not support special characters in plain tokens currently.
+  ensureType(firstValue, "plainOrString");
+  ensureSafeCharacters(firstValue);
+  options.names = {
+    extralingChar: firstValue.value,
+    uppExtralingChar: firstValue.value,
+  };
+  if (option.values.length > 1) {
+    const secondValue = option.values[1];
+    ensureType(secondValue, "plainOrString");
+    ensureSafeCharacters(secondValue);
+    if (firstValue.value.length !== secondValue.value.length) {
+      throw TranslationError.fromCode(
+        secondValue.token,
+        CompilerOptionsCodes.Names.InvalidParameterLengths,
+        "NAMES",
+      );
+    }
+    options.names!.uppExtralingChar = secondValue.value;
+  }
+});
+
 /** {@link CompilerOptions.natlang} */
+translator.rule(["NATLANG"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "plainNotEmpty");
+  const lang = value.value.toUpperCase();
+  if (["ENU", "UEN"].includes(lang)) {
+    options.natlang = lang as CompilerOptions.NatLang;
+  } else {
+    throw TranslationError.fromCode(
+      value.token,
+      CompilerOptionsCodes.NatLang.InvalidParameter,
+      value.value,
+    );
+  }
+});
+
 /** {@link CompilerOptions.nest} */
+translator.flag("nest", ["NEST"], ["NONEST"]);
 
 /** {@link CompilerOptions.not} */
 translator.rule(
@@ -2070,12 +2287,136 @@ translator.rule(
 );
 
 /** {@link CompilerOptions.nullDate} */
+translator.flag("nullDate", ["NULLDATE"], ["NONULLDATE"]);
+
 /** {@link CompilerOptions.object} */
+translator.flag("object", ["OBJECT", "OBJ"], ["NOOBJECT", "NOBJ"]);
+
 /** {@link CompilerOptions.offset} */
+translator.flag("offset", ["OFFSET"], ["NOOFFSET"]);
+
 /** {@link CompilerOptions.offsetSize} */
+translator.rule(["OFFSETSIZE"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "plainNotEmpty");
+  const offsetSize = ensureNumberValue(value);
+  if (offsetSize !== 4 && offsetSize !== 8) {
+    throw TranslationError.fromCode(
+      value.token,
+      CompilerOptionsCodes.OffsetSize.InvalidParameter,
+      value.value,
+    );
+  }
+  options.offsetSize = offsetSize;
+});
+
 /** {@link CompilerOptions.onSnap} */
+translator.rule(
+  ["ONSNAP"],
+  (option, options) => {
+    ensureArguments(option, 1);
+    if (!options.onSnap) {
+      options.onSnap = {
+        stringRange: false,
+        stringSize: false,
+      };
+    }
+    for (const value of option.values) {
+      ensureType(value, "plain");
+      if (value.value.length === 0) {
+        continue;
+      }
+      const onSnapValue = value.value.toUpperCase();
+      if (onSnapValue === "STRINGRANGE") {
+        options.onSnap.stringRange = true;
+      } else if (onSnapValue === "STRINGSIZE") {
+        options.onSnap.stringSize = true;
+      } else {
+        throw TranslationError.fromCode(
+          value.token,
+          CompilerOptionsCodes.OnSnap.InvalidParameter,
+          value.value,
+        );
+      }
+    }
+    if (!options.onSnap.stringRange && !options.onSnap.stringSize) {
+      // Special case: If both stringRange and stringSize are false, the onSnap option is disabled.
+      options.onSnap = false;
+    }
+  },
+  ["NOONSNAP"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.onSnap = false;
+  },
+);
+
 /** {@link CompilerOptions.optimize} */
+translator.rule(
+  ["OPTIMIZE", "OPT"],
+  (option, options) => {
+    // Verified 0 and more than 1 argument. The last one takes effect.
+    ensureArguments(option, 0);
+    if (option.values.length === 0) {
+      // *PROCESS OPTIMIZE; enables level 3, whereas *PROCESS OPTIMIZE(); toggles level 0.
+      options.optimize = 3;
+      return;
+    }
+    for (const value of option.values) {
+      ensureType(value, "plain");
+      const valueName = value.value.toUpperCase();
+      if (valueName.length === 0 || valueName === "0") {
+        options.optimize = 0;
+      } else if (
+        valueName === "2" ||
+        valueName === "3" ||
+        valueName === "TIME"
+      ) {
+        options.optimize = 3;
+      } else {
+        throw TranslationError.fromCode(
+          value.token,
+          CompilerOptionsCodes.Optimize.InvalidParameter,
+          value.value,
+        );
+      }
+    }
+  },
+  ["NOOPTIMIZE", "NOPT"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.optimize = 0;
+  },
+);
+
 /** {@link CompilerOptions.options} */
+translator.rule(
+  ["OPTIONS", "OP"],
+  (option, options) => {
+    ensureArguments(option, 0, 1);
+    if (option.values.length === 0) {
+      options.options = "DOC";
+      return;
+    }
+    ensureType(option.values[0], "plainNotEmpty");
+    const valueName = option.values[0].value.toUpperCase();
+    if (["DOC", "ALL"].includes(valueName)) {
+      options.options = valueName as CompilerOptions.Options;
+    } else {
+      throw TranslationError.fromCode(
+        option.values[0].token,
+        CompilerOptionsCodes.Options.InvalidParameter,
+        valueName,
+      );
+    }
+  },
+  ["NOOPTIONS", "NOP"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.options = false;
+  },
+);
 
 /** {@link CompilerOptions.or} */
 translator.rule(

--- a/packages/language/test/fourslash-harness/harness-interface.ts
+++ b/packages/language/test/fourslash-harness/harness-interface.ts
@@ -77,6 +77,7 @@ export interface HarnessTesterInterface {
      * @param regexes The regexes to expect no diagnostics apart from.
      */
     noDiagnosticsExcept(regexes: RegExp[]): void;
+    noDiagnosticsExceptAt(label: Label, regexes: RegExp[]): void;
 
     /**
      * Expect that the given function throws an error.

--- a/packages/language/test/fourslash-harness/harness.test.ts
+++ b/packages/language/test/fourslash-harness/harness.test.ts
@@ -56,6 +56,7 @@ function createTestingHarnessImplementation(
       expectDiagnosticsAt: listen("verify.expectDiagnosticsAt"),
       noDiagnostics: listen("verify.noDiagnostics"),
       noDiagnosticsExcept: listen("verify.noDiagnosticsExcept"),
+      noDiagnosticsExceptAt: listen("verify.noDiagnosticsExceptAt"),
       expectToThrow: listen("verify.expectToThrow"),
       expectCompilerOptions: listen("verify.expectCompilerOptions"),
     },

--- a/packages/language/test/fourslash-harness/implementation/test-builder.ts
+++ b/packages/language/test/fourslash-harness/implementation/test-builder.ts
@@ -50,6 +50,8 @@ export function createTestBuilderHarnessImplementation(
           : testBuilder.expectNoDiagnostics(),
       noDiagnosticsExcept: (regex: RegExp[]) =>
         testBuilder.noDiagnosticsExcept(regex),
+      noDiagnosticsExceptAt: (label, regexes) =>
+        testBuilder.noDiagnosticsExcept(regexes, label),
       expectToThrow: (fn, messageToThrow) =>
         testBuilder.expectToThrow(fn, messageToThrow),
       expectCompilerOptions: (expectedOptions) =>

--- a/packages/language/test/fourslash/preprocessor/compiler-options/maxnest.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/maxnest.ts
@@ -1,0 +1,45 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:MAXNEST|>;
+////*PROCESS <|2:MAXNEST|>(<|3:)|>;
+////*PROCESS <|4:MAXNEST|>(<|5:INVALID|>);
+////*PROCESS <|6:MAXNEST|>(DO(<|7:100|>));
+////*PROCESS <|8:MAXNEST|>(IF(<|9:0|>));
+////*PROCESS <|12:MAXNEST|>(<|13:BLOCK(50), DO(50), IF(50)|>);
+////*PROCESS <|14:MAXNEST|>(<|15:BLOCK(40) DO(40) IF (40)|>);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1),
+});
+verify.expectDiagnosticsAt([2, 4, 6, 8, 12, 14], {
+  message: code.CompilerOptions.DupeOptionIssue.message("MAXNEST"),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.ExpectedOption.message("INVALID"),
+});
+verify.expectDiagnosticsAt(7, {
+  message: code.CompilerOptions.ExpectedNumberRange.message(100, 1, 50),
+});
+verify.expectDiagnosticsAt(9, {
+  message: code.CompilerOptions.ExpectedNumberRange.message(0, 1, 50),
+});
+verify.noDiagnostics([13, 15]);
+verify.expectCompilerOptions({
+  maxnest: {
+    block: 40,
+    do: 40,
+    if: 40,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/maxrunonif.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/maxrunonif.ts
@@ -1,0 +1,42 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:MAXRUNONIF|>;
+////*PROCESS <|2:MAXRUNONIF|>(<|3:)|>;
+////*PROCESS <|4:MAXRUNONIF|>(<|5:INVALID|>);
+////*PROCESS <|6:MAXRUNONIF|>(<|7:-5|>);
+////*PROCESS <|8:MAXRUNONIF|>(<|9:1001|>);
+////*PROCESS <|10:MAXRUNONIF|>(12);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
+});
+verify.expectDiagnosticsAt([2, 4, 6, 8, 10], {
+  message: code.CompilerOptions.DupeOptionIssue.message("MAXRUNONIF"),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.ExpectedNumber.message("INVALID"),
+});
+verify.expectDiagnosticsAt(7, {
+  message: code.CompilerOptions.ExpectedNumberRange.message(-5, 2, 1000),
+});
+verify.expectDiagnosticsAt(9, {
+  message: code.CompilerOptions.ExpectedNumberRange.message(1001, 2, 1000),
+});
+verify.expectCompilerOptions({
+  maxRunOnIf: 12,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/maxstatic.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/maxstatic.ts
@@ -1,0 +1,38 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:MAXSTATIC|>;
+////*PROCESS <|2:MAXSTATIC|>(<|3:)|>;
+////*PROCESS <|4:MAXSTATIC|>(<|5:INVALID|>);
+////*PROCESS <|6:MAXSTATIC|>(<|7:-5|>);
+////*PROCESS <|8:MAXSTATIC|>(100M);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
+});
+verify.expectDiagnosticsAt([2, 4, 6, 8], {
+  message: code.CompilerOptions.DupeOptionIssue.message("MAXSTATIC"),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.ExpectedNumber.message("INVALID"),
+});
+verify.expectDiagnosticsAt(7, {
+  message: code.CompilerOptions.ExpectedNumberRange.message(-5, 1),
+});
+verify.expectCompilerOptions({
+  maxStatic: 100 * 1024 * 1024,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/maxstmt.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/maxstmt.ts
@@ -1,0 +1,48 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:MAXSTMT|>;
+////*PROCESS <|2:MAXSTMT|>(<|3:)|>;
+////*PROCESS <|4:MAXSTMT|>(<|5:INVALID|>);
+////*PROCESS <|6:MAXSTMT|>(<|7:0|>);
+////*PROCESS <|8:MAXSTMT|>(<|9:4K|>, 2K);
+////*PROCESS <|10:MAXSTMT|>(<|11:4K, 4K|>);
+////*PROCESS <|12:MAXSTMT|>(8K);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 2),
+});
+verify.expectDiagnosticsAt([2, 4, 6, 8, 10, 12], {
+  message: code.CompilerOptions.DupeOptionIssue.message("MAXSTMT"),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.ExpectedNumber.message("INVALID"),
+});
+verify.expectDiagnosticsAt(7, {
+  message: code.CompilerOptions.ExpectedNumberRange.message(0, 1),
+});
+verify.expectDiagnosticsAt(9, {
+  message: code.CompilerOptions.MaxStmt.InvalidRange.message(),
+});
+// TODO ssmifi: This is actually invalid. The options must be changed to prohibit plain nummeric values without comma.
+verify.noDiagnostics(11);
+verify.expectCompilerOptions({
+  maxStmt: {
+    m: 8 * 1024,
+    n: 8 * 1024,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/maxtemp.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/maxtemp.ts
@@ -1,0 +1,38 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:MAXTEMP|>;
+////*PROCESS <|2:MAXTEMP|>(<|3:)|>;
+////*PROCESS <|4:MAXTEMP|>(<|5:INVALID|>);
+////*PROCESS <|6:MAXTEMP|>(<|7:-5|>);
+////*PROCESS <|8:MAXTEMP|>(8M);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
+});
+verify.expectDiagnosticsAt([2, 4, 6, 8], {
+  message: code.CompilerOptions.DupeOptionIssue.message("MAXTEMP"),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.ExpectedNumber.message("INVALID"),
+});
+verify.expectDiagnosticsAt(7, {
+  message: code.CompilerOptions.ExpectedNumberRange.message(-5, 1),
+});
+verify.expectCompilerOptions({
+  maxTemp: 8 * 1024 * 1024,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/mdeck.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/mdeck.ts
@@ -1,0 +1,44 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NOMDECK;
+////*PROCESS <|1:MDECK|>;
+////*PROCESS <|2:MDECK|>(<|3:)|>;
+////*PROCESS <|4:MDECK|>(<|5:INVALID|>);
+////*PROCESS <|6:MDECK|>(<|7:AFTERALL|> AFTERMACRO);
+////*PROCESS <|8:NMD|>;
+////*PROCESS <|9:MD|>(AFTERMACRO, AFTERALL);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.MDeck.InvalidParameter.message(""),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.MDeck.InvalidParameter.message("INVALID"),
+});
+verify.noDiagnostics(7); // Verified.
+verify.expectDiagnosticsAt([1, 2, 4, 6], {
+  message: code.CompilerOptions.MutexOptionIssue.message("MDECK"),
+});
+verify.expectDiagnosticsAt(8, {
+  message: code.CompilerOptions.DupeOptionIssue.message("NMD"),
+});
+verify.expectDiagnosticsAt(9, {
+  message: code.CompilerOptions.MutexOptionIssue.message("MD"),
+});
+verify.expectCompilerOptions({
+  mDeck: "AFTERALL",
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/msgsummary.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/msgsummary.ts
@@ -1,0 +1,40 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NOMSGSUMMARY;
+////*PROCESS <|1:MSGSUMMARY|>;
+////*PROCESS <|2:MSGSUMMARY|>(<|3:)|>;
+////*PROCESS <|4:MSGSUMMARY|>(<|5:INVALID|>);
+////*PROCESS <|6:MSGSUMMARY|>(<|7:NOXREF|> XREF);
+////*PROCESS <|8:MSGSUMMARY|>(XREF);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.MutexOptionIssue.message("MSGSUMMARY"),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.MsgSummary.InvalidParameter.message("INVALID"),
+});
+verify.noDiagnostics(7);
+verify.expectDiagnosticsAt([1, 2, 4, 6], {
+  message: code.CompilerOptions.MutexOptionIssue.message("MSGSUMMARY"),
+});
+verify.expectDiagnosticsAt(8, {
+  message: code.CompilerOptions.MutexOptionIssue.message("MSGSUMMARY"),
+});
+verify.expectCompilerOptions({
+  msgSummary: "XREF",
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/name.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/name.ts
@@ -1,0 +1,31 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NONAME;
+////*PROCESS <|1:NAME|>;
+////*PROCESS <|2:NAME|>(<|3:)|>;
+////*PROCESS <|4:N|>('XY');
+
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(""),
+});
+verify.expectDiagnosticsAt([1, 2], {
+  message: code.CompilerOptions.MutexOptionIssue.message("NAME"),
+});
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.MutexOptionIssue.message("N"),
+});
+verify.expectCompilerOptions({
+  name: "XY",
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/names.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/names.ts
@@ -1,0 +1,44 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NAMES(<|1:'@#$%'|>);
+////*PROCESS <|2:NAMES|>('@#$!', <|3:'@#$%'|>);
+////*PROCESS <|4:NAMES|>('@#$!', <|5:'@#$!!'|>);
+////*PROCESS <|6:NAMES|>('@#$!', <|7:'@#$!`'|>);
+////*PROCESS <|8:NAMES|>('@#$!', @#$!);
+
+verify.expectDiagnosticsAt([1, 3], {
+  message: code.CompilerOptions.Names.CharacterAlreadyDefined.message(
+    "%",
+    "NAMES",
+  ),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.Names.CharacterAlreadyDefined.message(
+    "!",
+    "NAMES",
+  ),
+});
+verify.expectDiagnosticsAt(7, {
+  message: code.CompilerOptions.Names.InvalidParameterLengths.message("NAMES"),
+});
+verify.expectDiagnosticsAt([2, 4, 6, 8], {
+  message: code.CompilerOptions.DupeOptionIssue.message("NAMES"),
+});
+verify.expectCompilerOptions({
+  names: {
+    extralingChar: "@#$!",
+    uppExtralingChar: "@#$!",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/natlang.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/natlang.ts
@@ -1,0 +1,34 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:NATLANG|>;
+////*PROCESS <|2:NATLANG|>(<|3:)|>;
+////*PROCESS <|4:NATLANG|>(<|5:INVALID|>);
+////*PROCESS <|6:NATLANG|>(UEN);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(""),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.NatLang.InvalidParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt([2, 4, 6], {
+  message: code.CompilerOptions.DupeOptionIssue.message("NATLANG"),
+});
+verify.expectCompilerOptions({
+  natlang: "UEN",
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/nest.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/nest.ts
@@ -1,0 +1,27 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NONEST;
+////*PROCESS <|1:NEST|>();
+////*PROCESS <|2:NEST|>;
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(1, 0, 0),
+});
+verify.expectDiagnosticsAt([1, 2], {
+  message: code.CompilerOptions.MutexOptionIssue.message("NEST"),
+});
+verify.expectCompilerOptions({
+  nest: true,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/nulldate.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/nulldate.ts
@@ -1,0 +1,27 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NONULLDATE;
+////*PROCESS <|1:NULLDATE|>();
+////*PROCESS <|2:NULLDATE|>;
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(1, 0, 0),
+});
+verify.expectDiagnosticsAt([1, 2], {
+  message: code.CompilerOptions.MutexOptionIssue.message("NULLDATE"),
+});
+verify.expectCompilerOptions({
+  nullDate: true,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/object.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/object.ts
@@ -1,0 +1,34 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NOOBJECT;
+////*PROCESS <|1:OBJECT|>();
+////*PROCESS <|2:OBJ|>;
+////*PROCESS <|3:NOBJ|>;
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(1, 0, 0),
+});
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.MutexOptionIssue.message("OBJECT"),
+});
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.MutexOptionIssue.message("OBJ"),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.DupeOptionIssue.message("NOBJ"),
+});
+verify.expectCompilerOptions({
+  object: false,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/offset.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/offset.ts
@@ -1,0 +1,27 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NOOFFSET;
+////*PROCESS <|1:OFFSET|>();
+////*PROCESS <|2:OFFSET|>;
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(1, 0, 0),
+});
+verify.expectDiagnosticsAt([1, 2], {
+  message: code.CompilerOptions.MutexOptionIssue.message("OFFSET"),
+});
+verify.expectCompilerOptions({
+  offset: true,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/offsetsize.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/offsetsize.ts
@@ -1,0 +1,34 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:OFFSETSIZE|>;
+////*PROCESS <|2:OFFSETSIZE|>(<|3:)|>;
+////*PROCESS <|4:OFFSETSIZE|>(<|5:200|>);
+////*PROCESS <|6:OFFSETSIZE|>(8);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(""),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.OffsetSize.InvalidParameter.message("200"),
+});
+verify.expectDiagnosticsAt([2, 4, 6], {
+  message: code.CompilerOptions.DupeOptionIssue.message("OFFSETSIZE"),
+});
+verify.expectCompilerOptions({
+  offsetSize: 8,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/onsnap-disable.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/onsnap-disable.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS ONSNAP();
+
+verify.noDiagnostics();
+verify.expectCompilerOptions({
+  onSnap: false,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/onsnap.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/onsnap.ts
@@ -1,0 +1,34 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NOONSNAP;
+////*PROCESS <|1:ONSNAP|>;
+////*PROCESS <|2:ONSNAP|>(<|3:INVALID|>);
+////*PROCESS <|4:ONSNAP|>(STRINGRANGE);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.OnSnap.InvalidParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt([1, 2, 4], {
+  message: code.CompilerOptions.MutexOptionIssue.message("ONSNAP"),
+});
+verify.expectCompilerOptions({
+  onSnap: {
+    stringRange: true,
+    stringSize: false,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/optimize.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/optimize.ts
@@ -1,0 +1,33 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NOOPTIMIZE;
+////*PROCESS <|1:OPTIMIZE|>;
+////*PROCESS <|2:OPTIMIZE|>(<|3:INVALID|>);
+////*PROCESS <|4:OPTIMIZE|>(0, 3, TIME);
+
+verify.noDiagnosticsExceptAt(1, [
+  new RegExp(
+    code.CompilerOptions.MutexOptionIssue.message("").substring(0, 20),
+  ),
+]);
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.Optimize.InvalidParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt([1, 2, 4], {
+  message: code.CompilerOptions.MutexOptionIssue.message("OPTIMIZE"),
+});
+verify.expectCompilerOptions({
+  optimize: 3,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options.ts
@@ -1,0 +1,39 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NOOPTIONS;
+////*PROCESS <|1:NOP|>;
+////*PROCESS <|2:OP|>;
+////*PROCESS <|4:OPTIONS|>(<|5:)|>;
+////*PROCESS <|6:OPTIONS|>(<|7:INVALID|>);
+////*PROCESS <|8:OPTIONS|>(ALL);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.DupeOptionIssue.message("NOP"),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(""),
+});
+verify.expectDiagnosticsAt(7, {
+  message: code.CompilerOptions.Options.InvalidParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.MutexOptionIssue.message("OP"),
+});
+verify.expectDiagnosticsAt([4, 6, 8], {
+  message: code.CompilerOptions.MutexOptionIssue.message("OPTIONS"),
+});
+verify.expectCompilerOptions({
+  options: "ALL",
+});

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -484,8 +484,11 @@ export class TestBuilder {
     return this;
   }
 
-  noDiagnosticsExcept(regex: RegExp[]): TestBuilder {
-    const remainingDiagnostics = this.diagnostics.filter((diagnostic) => {
+  noDiagnosticsExcept(regex: RegExp[], label?: Label): TestBuilder {
+    const diagnostics = label
+      ? this.getMatchingDiagnostics(label.toString()).exactMatches
+      : this.diagnostics;
+    const remainingDiagnostics = diagnostics.filter((diagnostic) => {
       const message = this.createDiagnosticMessage(diagnostic);
       return !regex.some((r) => r.test(message));
     });


### PR DESCRIPTION
Part of https://github.com/zowe/zowe-pli-language-support/issues/296
Based on https://github.com/zowe/zowe-pli-language-support/pull/318

- Implemented compiler options `maxNest`, `include`, `maxRunOnIf`, `maxStatic`, `maxStmt`, `maxTemp`, `mDeck`, `msgSummary`, `name`, `names`, `natLang`, `nest`, `nullDate`, `object`, `offset`, `offsetSize`, `onSnap`, `optimize`, and `option`.
- Added `noDiagnosticsExceptAt` to also only test at specific labels.