### PR TITLE
Some npm vs pnpm related fixes

### DIFF
--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -11,7 +11,7 @@
     "build": "vite -c vite.config.ts build",
     "serve": "vite -c vite.config.ts serve",
     "preview": "vite -c vite.config.ts preview",
-    "build:clean": "npm run clean && npm run build",
+    "build:clean": "pnpm clean && pnpm build",
     "dev": "vite -c vite.config.ts",
     "dev:debug": "vite -c vite.config.ts --debug --force"
   },


### PR DESCRIPTION
Consistently using pnpm in favor of npm.

---

Off-topic regarding this PR:

I saw that the `ci.yml` also defines the pnpm version:

```yaml
- name: Install pnpm
  uses: pnpm/action-setup@v4
  with:
    version: 9
```

Though: another way to do it could be (to be consistent with developer environments):

1. (once) run built-in nodejs tool `corepack use pnpm@9` to write `packageManager` property with the correct `pnpm` version to `package.json`
2. Initially run `corepack enable` in the project to enable nodejs shims (`pnpm` proxy command)
3. When `pnpm` is called the first time, the proxy command will read the `packageManager` property, install `pnpm` in the right version and use that version for the project
