### PR TITLE
Initial support for preprocessor procedures

### DIFF
--- a/packages/language/src/preprocessor/instruction-cache.ts
+++ b/packages/language/src/preprocessor/instruction-cache.ts
@@ -16,7 +16,7 @@ import {
   CompilerOptions,
   getDefaultCompilerOptions,
 } from "./compiler-options/options";
-import * as inst from "./instructions";
+import { InstructionGeneratorResult } from "./instruction-generator";
 import { LexingIssue } from "./pli-lexer";
 
 interface CachedInstructions {
@@ -28,7 +28,7 @@ export interface FileInstructionResult {
   tokens: Token[];
   issues: LexingIssue[];
   statements: Statement[];
-  node: inst.InstructionNode;
+  result: InstructionGeneratorResult;
 }
 
 export class InstructionCache {

--- a/packages/language/src/preprocessor/instruction-generator.ts
+++ b/packages/language/src/preprocessor/instruction-generator.ts
@@ -16,16 +16,23 @@ import { getAttributes } from "./util";
 interface GenerateInstructionContext {
   labels: Map<string, inst.InstructionNode>;
   nodes: Map<ast.SyntaxNode | null, inst.InstructionNode>;
+  procedures: Map<string, inst.ProcedureInstructionContainer>;
   onFinish: (callback: () => void) => void;
+}
+
+export interface InstructionGeneratorResult {
+  entryNode: inst.InstructionNode;
+  procedures: Map<string, inst.ProcedureInstructionContainer>;
 }
 
 export function generateInstructions(
   statements: ast.Statement[],
-): inst.InstructionNode {
+): InstructionGeneratorResult {
   const callbacks: (() => void)[] = [];
   const context: GenerateInstructionContext = {
     labels: new Map(),
     nodes: new Map(),
+    procedures: new Map(),
     onFinish: (callback) => {
       callbacks.push(callback);
     },
@@ -42,7 +49,10 @@ export function generateInstructions(
   for (let i = callbacks.length - 1; i >= 0; i--) {
     callbacks[i]();
   }
-  return list.head ?? inst.createHaltNode();
+  return {
+    entryNode: list.head ?? inst.createHaltNode(),
+    procedures: context.procedures,
+  };
 }
 
 function generateInstructionList(
@@ -51,12 +61,46 @@ function generateInstructionList(
 ): inst.LinkedInstructionList {
   const list = new inst.LinkedInstructionList();
   for (const statement of statements) {
-    const node = generateInstructionForStatement(statement, context);
-    if (node) {
-      list.append(node);
+    if (statement.value?.kind === ast.SyntaxKind.ProcedureStatement) {
+      const procedure = generateProcedureInstructionContainer(statement);
+      for (const name of procedure.names) {
+        context.procedures.set(name, procedure);
+      }
+    } else {
+      const node = generateInstructionForStatement(statement, context);
+      if (node) {
+        list.append(node);
+      }
     }
   }
   return list;
+}
+
+function generateProcedureInstructionContainer(
+  statement: ast.Statement,
+): inst.ProcedureInstructionContainer {
+  const names: string[] = [];
+  const args: string[] = [];
+  for (const label of statement.labels) {
+    if (label.name) {
+      names.push(label.name);
+    }
+  }
+  const procedure = statement.value as ast.ProcedureStatement;
+  for (const arg of procedure.parameters) {
+    const name = arg.ref?.text;
+    if (name) {
+      args.push(name);
+    }
+  }
+  const statements = procedure.statements;
+  const instructionList = generateInstructions(statements);
+  return {
+    names,
+    parameters: args,
+    node: instructionList.entryNode,
+    localProcedures: instructionList.procedures,
+  };
 }
 
 function generateInstructionForStatement(
@@ -80,6 +124,9 @@ function generateInstructionForStatement(
   switch (value.kind) {
     case ast.SyntaxKind.DeclareStatement:
       instruction = generateDeclareInstruction(value);
+      break;
+    case ast.SyntaxKind.ReturnStatement:
+      instruction = generateReturnInstruction(value);
       break;
     case ast.SyntaxKind.IfStatement:
       instruction = generateIfInstruction(value, context);
@@ -132,7 +179,16 @@ function generateInstructionForStatement(
   return node;
 }
 
-export function generateTokenInstruction(
+function generateReturnInstruction(
+  node: ast.ReturnStatement,
+): inst.HaltInstruction {
+  return {
+    kind: inst.InstructionKind.Halt,
+    value: generateExpressionInstruction(node.expression),
+  };
+}
+
+function generateTokenInstruction(
   node: ast.TokenStatement,
 ): inst.TokensInstruction {
   return {

--- a/packages/language/src/preprocessor/instruction-generator.ts
+++ b/packages/language/src/preprocessor/instruction-generator.ts
@@ -99,7 +99,6 @@ function generateProcedureInstructionContainer(
     names,
     parameters: args,
     node: instructionList.entryNode,
-    localProcedures: instructionList.procedures,
   };
 }
 

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -19,7 +19,10 @@ import {
 import { FileSystemProviderInstance } from "../workspace/file-system-provider";
 import { PluginConfigurationProviderInstance } from "../workspace/plugin-configuration-provider";
 import { CompilerOptionResult } from "./compiler-options/options";
-import { generateInstructions } from "./instruction-generator";
+import {
+  generateInstructions,
+  InstructionGeneratorResult,
+} from "./instruction-generator";
 import * as inst from "./instructions";
 import * as ast from "../syntax-tree/ast";
 import { LexingIssue } from "./pli-lexer";
@@ -165,16 +168,26 @@ interface InterpreterContext {
   unit: CompilationUnit;
   currentUri?: URI;
   entryUri?: URI;
+  /**
+   * These are global variables that are defined on the root level of the preprocessor
+   */
   variables: Map<string, Variable>;
+  /**
+   * Local variables only exist within the scope of a procedure. Set to `undefined` when not in a procedure.
+   */
+  localVariables?: Map<string, Variable>;
   statements: ast.Statement[];
   result: CompilationUnitTokens;
   errors: LexingIssue[];
+  procedures: Map<string, inst.ProcedureInstructionContainer>;
+  activeProcedures: Set<string>;
   counter: Map<inst.InstructionNode, number>;
   references: ast.Reference[];
   evaluations: EvaluationResults;
   xIncludes: Set<string>;
   uris: string[];
   options: InterpreterOptions;
+  returnValue: Value;
 }
 
 export type InstructionInterpreterResult = CompilationUnitTokens & {
@@ -195,7 +208,7 @@ export interface InterpreterOptions {
 export function runInstructions(
   unit: CompilationUnit,
   uri: URI,
-  start: inst.InstructionNode,
+  instruction: InstructionGeneratorResult,
   options: InterpreterOptions,
 ): InstructionInterpreterResult {
   const context: InterpreterContext = {
@@ -207,6 +220,8 @@ export function runInstructions(
     statements: [],
     xIncludes: new Set(),
     variables: new Map(),
+    procedures: new Map(),
+    activeProcedures: new Set(),
     references: [],
     evaluations: {
       ifStatements: new Map(),
@@ -217,9 +232,13 @@ export function runInstructions(
     },
     options,
     counter: new Map(),
+    returnValue: defaultEmptyValue,
   };
+  for (const [key, value] of instruction.procedures.entries()) {
+    context.procedures.set(key, value);
+  }
 
-  const tokenResult = doRunInstructions(context, start);
+  const tokenResult = doRunInstructions(context, instruction.entryNode);
   return {
     ...tokenResult,
     evaluationResults: context.evaluations,
@@ -256,15 +275,15 @@ function runInstructionNode(
   const instruction = node.instruction;
   let result = node.next;
   try {
-    if (node.instruction.kind === inst.InstructionKind.Halt) {
-      return undefined; // Stop execution
-    }
     const instructionResult = runInstruction(instruction, context);
     if (instructionResult) {
       result = instructionResult;
     }
   } catch (err) {
     handleInstructionError(err, context);
+  }
+  if (node.instruction.kind === inst.InstructionKind.Halt) {
+    return undefined; // Stop execution
   }
   return result;
 }
@@ -312,8 +331,23 @@ function runInstruction(
     case inst.InstructionKind.Deactivate:
       runDeactivateInstruction(instruction, context);
       break;
+    case inst.InstructionKind.Halt:
+      runHaltInstruction(instruction, context);
+      break;
   }
   return undefined;
+}
+
+function runHaltInstruction(
+  instruction: inst.HaltInstruction,
+  context: InterpreterContext,
+): void {
+  // Every return statement in a procedure generates a halt statement with a `value`
+  // Simply evaluate it and set it as the return value of the current context
+  if (instruction.value) {
+    const value = evaluateExpression(instruction.value, context);
+    context.returnValue = value;
+  }
 }
 
 function runDoInstruction(
@@ -359,7 +393,9 @@ function runAssignmentInstruction(
 ): void {
   const value = evaluateExpression(instruction.value, context);
   for (const ref of instruction.refs) {
-    let variable = context.variables.get(ref.variable);
+    let variable =
+      context.localVariables?.get(ref.variable) ??
+      context.variables.get(ref.variable);
     if (!variable) {
       if (ref.args.length > 0) {
         // This seems to write into an undeclared array variable
@@ -374,7 +410,7 @@ function runAssignmentInstruction(
         active: false, // Implicitly declared variables are inactive by default
         mode: inst.ScanMode.Scan,
       };
-      context.variables.set(ref.variable, variable);
+      (context.localVariables ?? context.variables).set(ref.variable, variable);
     } else {
       evaluateValueAccess(variable, ref.args, context).setter(value);
     }
@@ -548,9 +584,15 @@ function evaluateReferenceExpression(
   expression: inst.ReferenceItemInstruction,
   context: InterpreterContext,
 ): Value {
-  const variable = context.variables.get(expression.variable);
+  const variable =
+    context.localVariables?.get(expression.variable) ||
+    context.variables.get(expression.variable);
   if (!variable) {
-    return defaultEmptyValue;
+    const procedure = context.procedures.get(expression.variable);
+    if (!procedure) {
+      return defaultEmptyValue;
+    }
+    return evaluateProcedure(procedure, expression.args, context);
   }
   return evaluateValueAccess(variable, expression.args, context).getter();
 }
@@ -631,6 +673,53 @@ function evaluateValueAccess(
   }
 }
 
+function evaluateProcedure(
+  procedure: inst.ProcedureInstructionContainer,
+  args: inst.ExpressionInstruction[],
+  context: InterpreterContext,
+): Value {
+  const procArgs = args.map((e) => evaluateExpression(e, context));
+  const localContext = createLocalContext(context);
+  return runProcedure(procedure, procArgs, localContext);
+}
+
+function createLocalContext(context: InterpreterContext): InterpreterContext {
+  return {
+    ...context,
+    localVariables: new Map(),
+  };
+}
+
+function runProcedure(
+  procedure: inst.ProcedureInstructionContainer,
+  args: Value[],
+  context: InterpreterContext,
+): Value {
+  if (!context.localVariables) {
+    throw new Error("Local variables map is not initialized!");
+  }
+  if (args.length !== procedure.parameters.length) {
+    // The type system should report this error
+    return defaultEmptyValue;
+  }
+  for (let i = 0; i < procedure.parameters.length; i++) {
+    const param = procedure.parameters[i];
+    const arg = args[i];
+    const variable: Variable = {
+      name: param,
+      value: arg,
+      active: false,
+      mode: inst.ScanMode.NoScan,
+      declarationNode: null,
+    };
+    context.localVariables.set(param, variable);
+  }
+  doRunInstructions(context, procedure.node);
+  const returnValue = context.returnValue;
+  context.returnValue = defaultEmptyValue;
+  return returnValue;
+}
+
 function evaluateLiteralExpression(
   expression: inst.NumberInstruction | inst.StringInstruction,
   context: InterpreterContext,
@@ -682,21 +771,34 @@ function runDeclareInstruction(
   instruction: inst.DeclareInstruction,
   context: InterpreterContext,
 ): void {
-  const variable = generateVariable(instruction, context);
-  context.variables.set(variable.name, variable);
+  // If a declaration like `DCL PROC_NAME ENTRY` appears, simply activate the procedure
+  if (context.procedures.has(instruction.name)) {
+    context.activeProcedures.add(instruction.name);
+    return;
+  }
+  // If the local variables are defined, that means we are in a procedure
+  const variables = context.localVariables ?? context.variables;
+  // Don't override existing variables
+  if (!variables.has(instruction.name)) {
+    const variable = generateVariable(instruction, context);
+    variables.set(variable.name, variable);
+  }
 }
 
 function runActivateInstruction(
   instruction: inst.ActivateInstruction,
   context: InterpreterContext,
 ): void {
-  const variable = context.variables.get(instruction.variable.variable);
+  const name = instruction.variable.variable;
+  const variable = context.variables.get(name);
   if (variable) {
     if (instruction.scanMode !== undefined) {
       variable.mode = instruction.scanMode;
     }
     // TODO: Report IBM3530I if the variable is an array
     variable.active = true;
+  } else if (context.procedures.has(name)) {
+    context.activeProcedures.add(name);
   }
 }
 
@@ -704,7 +806,9 @@ function runDeactivateInstruction(
   instruction: inst.DeactivateInstruction,
   context: InterpreterContext,
 ): void {
-  const variable = context.variables.get(instruction.variable.variable);
+  const name = instruction.variable.variable;
+  const variable = context.variables.get(name);
+  context.activeProcedures.delete(name);
   if (variable) {
     variable.active = false;
   }
@@ -931,23 +1035,26 @@ function runInclude(item: IncludeItem, context: InterpreterContext): void {
         uri,
       );
       const subProgram = context.options.parser.parse(subState);
-      const instruction = generateInstructions(subProgram.statements);
+      const result = generateInstructions(subProgram.statements);
       return {
         tokens: subProgram.tokens,
         issues: subProgram.errors,
         statements: subProgram.statements,
-        node: instruction,
+        result,
       };
     });
     context.statements.push(...cachedResult.statements);
     context.result.fileTokens.set(uri.toString(), cachedResult.tokens);
     context.errors.push(...cachedResult.issues);
+    for (const [key, value] of Object.entries(cachedResult.result.procedures)) {
+      context.procedures.set(key, value);
+    }
     const newContext: InterpreterContext = {
       ...context,
       currentUri: uri,
       uris: [uri.toString(), ...context.uris],
     };
-    doRunInstructions(newContext, cachedResult.node);
+    doRunInstructions(newContext, cachedResult.result.entryNode);
   } catch (err) {
     failToResolve(err);
   }

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -696,15 +696,15 @@ function runProcedure(
   context: InterpreterContext,
 ): Value {
   if (!context.localVariables) {
-    throw new Error("Local variables map is not initialized!");
+    throw new Error(
+      "Local variables map is not initialized! Use the createLocalContext function before calling runProcedure!",
+    );
   }
-  if (args.length !== procedure.parameters.length) {
-    // The type system should report this error
-    return defaultEmptyValue;
-  }
+  // Note that in case a procedure has received too many arguments, the excess ones are ignored
   for (let i = 0; i < procedure.parameters.length; i++) {
     const param = procedure.parameters[i];
-    const arg = args[i];
+    // In case a variable hasn't been supplied, the default value is used
+    const arg = args[i] ?? defaultEmptyValue;
     const variable: Variable = {
       name: param,
       value: arg,

--- a/packages/language/src/preprocessor/instructions.ts
+++ b/packages/language/src/preprocessor/instructions.ts
@@ -104,8 +104,16 @@ export type Instruction =
   | DeactivateInstruction
   | DeclareInstruction;
 
+export interface ProcedureInstructionContainer {
+  names: string[];
+  parameters: string[];
+  localProcedures: Map<string, ProcedureInstructionContainer>;
+  node: InstructionNode;
+}
+
 export interface HaltInstruction {
   kind: InstructionKind.Halt;
+  value?: ExpressionInstruction;
 }
 
 export const Halt: HaltInstruction = {

--- a/packages/language/src/preprocessor/instructions.ts
+++ b/packages/language/src/preprocessor/instructions.ts
@@ -107,7 +107,6 @@ export type Instruction =
 export interface ProcedureInstructionContainer {
   names: string[];
   parameters: string[];
-  localProcedures: Map<string, ProcedureInstructionContainer>;
   node: InstructionNode;
 }
 

--- a/packages/language/src/preprocessor/pli-lexer.ts
+++ b/packages/language/src/preprocessor/pli-lexer.ts
@@ -86,12 +86,12 @@ export class PliLexer {
         errors,
         tokens: fileTokens,
       } = this.preprocessorParser.parse(state);
-      const instructionNode = generateInstructions(statements);
+      const result = generateInstructions(statements);
       return {
         tokens: fileTokens,
-        node: instructionNode,
         issues: errors,
         statements: statements,
+        result,
       };
     });
     allErrors.push(...instruction.issues);
@@ -99,12 +99,15 @@ export class PliLexer {
 
     const incAfter = compilerOptionsResult.result?.options.incAfter;
     if (incAfter?.process) {
-      instruction.node = generateIncAfterInstruction(
-        instruction.node,
-        incAfter,
-      );
+      instruction.result = {
+        entryNode: generateIncAfterInstruction(
+          instruction.result.entryNode,
+          incAfter,
+        ),
+        procedures: instruction.result.procedures,
+      };
     }
-    const output = runInstructions(unit, uri, instruction.node, {
+    const output = runInstructions(unit, uri, instruction.result, {
       compilerOptions: compilerOptionsResult.result,
       marginsProcessor: this.marginsProcessor,
       parser: this.preprocessorParser,

--- a/packages/language/src/preprocessor/pli-preprocessor-parser-state.ts
+++ b/packages/language/src/preprocessor/pli-preprocessor-parser-state.ts
@@ -18,7 +18,10 @@ import { URI } from "../utils/uri";
 import { Token } from "../parser/tokens";
 import { tokenize } from "../parser/tokenizer";
 
-type ParserLocation = "in-statement" | "in-procedure";
+export enum ParserLocation {
+  Statement,
+  Procedure,
+}
 
 export interface PreprocessorParserState {
   index: number;
@@ -58,8 +61,6 @@ export interface PreprocessorParserState {
   isOnlyInStatement(): boolean;
   isInProcedure(): boolean;
   lookahead(la: number): Token | undefined;
-  addInclude(uri: URI): void;
-  hasInclude(uri: URI): boolean;
 }
 
 const nl = "\n".charCodeAt(0);
@@ -70,7 +71,7 @@ export class PliPreprocessorParserState implements PreprocessorParserState {
   public uri: URI;
   private text: string;
   private location: ParserLocation[] = [];
-  private includes: Set<string> = new Set();
+  private inProcedure: boolean = false;
 
   constructor(text: string, uri: URI) {
     this.text = text;
@@ -120,6 +121,9 @@ export class PliPreprocessorParserState implements PreprocessorParserState {
   }
   push(location: ParserLocation): void {
     this.location.push(location);
+    if (location === ParserLocation.Procedure) {
+      this.inProcedure = true;
+    }
   }
   top(): ParserLocation | undefined {
     if (this.location.length > 0) {
@@ -129,6 +133,9 @@ export class PliPreprocessorParserState implements PreprocessorParserState {
   }
   pop(): void {
     this.location.pop();
+    this.inProcedure = this.location.some(
+      (l) => l === ParserLocation.Procedure,
+    );
   }
 
   get current() {
@@ -164,14 +171,11 @@ export class PliPreprocessorParserState implements PreprocessorParserState {
   }
 
   isOnlyInStatement() {
-    return (
-      this.location.length === 0 ||
-      this.location.every((l) => l === "in-statement")
-    );
+    return !this.inProcedure;
   }
 
   isInProcedure() {
-    return this.location.some((l) => l === "in-procedure");
+    return this.inProcedure;
   }
 
   tryConsume(
@@ -211,7 +215,11 @@ export class PliPreprocessorParserState implements PreprocessorParserState {
   }
 
   canConsumeKeyword(...tokenTypes: TokenType[]): boolean {
-    if (!this.isInProcedure()) {
+    // Always add percentage sign for the end keyword, even if in a procedure
+    if (
+      !this.isInProcedure() ||
+      tokenTypes[0].tokenTypeIdx === PreprocessorTokens.End.tokenTypeIdx
+    ) {
       tokenTypes = [PreprocessorTokens.Percentage, ...tokenTypes];
     }
     return this.canConsume(...tokenTypes);
@@ -228,6 +236,7 @@ export class PliPreprocessorParserState implements PreprocessorParserState {
       if (!this.canConsume(PreprocessorTokens.Percentage)) {
         return false;
       }
+      // Increment, so the next canConsume operates on the actual requested token type
       this.index++;
     }
     if (!this.canConsume(tokenType)) {
@@ -259,13 +268,5 @@ export class PliPreprocessorParserState implements PreprocessorParserState {
       );
     }
     return this.consume(element, kind, tokenType);
-  }
-
-  addInclude(uri: URI): void {
-    this.includes.add(uri.toString());
-  }
-
-  hasInclude(uri: URI): boolean {
-    return this.includes.has(uri.toString());
   }
 }

--- a/packages/language/src/preprocessor/pli-preprocessor-parser-state.ts
+++ b/packages/language/src/preprocessor/pli-preprocessor-parser-state.ts
@@ -18,11 +18,6 @@ import { URI } from "../utils/uri";
 import { Token } from "../parser/tokens";
 import { tokenize } from "../parser/tokenizer";
 
-export enum ParserLocation {
-  Statement,
-  Procedure,
-}
-
 export interface PreprocessorParserState {
   index: number;
   uri: URI;
@@ -56,9 +51,8 @@ export interface PreprocessorParserState {
   ): Token;
 
   advanceLines(lineCount: number): void;
-  push(location: ParserLocation): void;
-  pop(): void;
-  isOnlyInStatement(): boolean;
+  pushProcedure(): void;
+  popProcedure(): void;
   isInProcedure(): boolean;
   lookahead(la: number): Token | undefined;
 }
@@ -70,7 +64,6 @@ export class PliPreprocessorParserState implements PreprocessorParserState {
   public index: number;
   public uri: URI;
   private text: string;
-  private location: ParserLocation[] = [];
   private inProcedure: boolean = false;
 
   constructor(text: string, uri: URI) {
@@ -78,6 +71,13 @@ export class PliPreprocessorParserState implements PreprocessorParserState {
     this.tokens = tokenize(this.text, uri).tokens;
     this.index = 0;
     this.uri = uri;
+  }
+
+  pushProcedure(): void {
+    this.inProcedure = true;
+  }
+  popProcedure(): void {
+    this.inProcedure = false;
   }
 
   lookahead(la: number): Token | undefined {
@@ -119,24 +119,6 @@ export class PliPreprocessorParserState implements PreprocessorParserState {
       offset++;
     }
   }
-  push(location: ParserLocation): void {
-    this.location.push(location);
-    if (location === ParserLocation.Procedure) {
-      this.inProcedure = true;
-    }
-  }
-  top(): ParserLocation | undefined {
-    if (this.location.length > 0) {
-      return this.location[this.location.length - 1];
-    }
-    return undefined;
-  }
-  pop(): void {
-    this.location.pop();
-    this.inProcedure = this.location.some(
-      (l) => l === ParserLocation.Procedure,
-    );
-  }
 
   get current() {
     return this.tokens[this.index];
@@ -168,10 +150,6 @@ export class PliPreprocessorParserState implements PreprocessorParserState {
       }
     }
     return true;
-  }
-
-  isOnlyInStatement() {
-    return !this.inProcedure;
   }
 
   isInProcedure() {
@@ -215,11 +193,7 @@ export class PliPreprocessorParserState implements PreprocessorParserState {
   }
 
   canConsumeKeyword(...tokenTypes: TokenType[]): boolean {
-    // Always add percentage sign for the end keyword, even if in a procedure
-    if (
-      !this.isInProcedure() ||
-      tokenTypes[0].tokenTypeIdx === PreprocessorTokens.End.tokenTypeIdx
-    ) {
+    if (!this.isInProcedure()) {
       tokenTypes = [PreprocessorTokens.Percentage, ...tokenTypes];
     }
     return this.canConsume(...tokenTypes);

--- a/packages/language/src/preprocessor/pli-preprocessor-parser.ts
+++ b/packages/language/src/preprocessor/pli-preprocessor-parser.ts
@@ -14,6 +14,7 @@ import {
   PreprocessorTokens,
 } from "./pli-preprocessor-tokens";
 import {
+  ParserLocation,
   PliPreprocessorParserState,
   PreprocessorParserState,
 } from "./pli-preprocessor-parser-state";
@@ -112,7 +113,7 @@ export class PliPreprocessorParser {
           PreprocessorTokens.Percentage,
         )
       ) {
-        state.push("in-statement");
+        state.push(ParserLocation.Statement);
         try {
           return this.commonStatement(state);
         } finally {
@@ -202,40 +203,17 @@ export class PliPreprocessorParser {
         case PreprocessorTokens.Iterate.tokenTypeIdx:
           unit = this.iterateStatement(state);
           break;
-        default:
-          if (state.isOnlyInStatement()) {
-            if (state.current?.tokenType === PreprocessorTokens.Procedure) {
-              unit = this.procedureStatement(state);
-            }
-          } else {
-            //state.isInProcedure()
-            const returnStatement = ast.createReturnStatement();
-            if (
-              state.tryConsume(
-                returnStatement,
-                CstNodeKind.ReturnStatement_RETURN,
-                PreprocessorTokens.Return,
-              )
-            ) {
-              state.consume(
-                returnStatement,
-                CstNodeKind.ReturnStatement_OpenParen,
-                PreprocessorTokens.LParen,
-              );
-              returnStatement.expression = this.expression(state);
-              unit = returnStatement;
-              state.consume(
-                returnStatement,
-                CstNodeKind.ReturnStatement_CloseParen,
-                PreprocessorTokens.RParen,
-              );
-              state.consume(
-                returnStatement,
-                CstNodeKind.ReturnStatement_Semicolon,
-                PreprocessorTokens.Semicolon,
-              );
-            }
+        case PreprocessorTokens.Procedure.tokenTypeIdx:
+          try {
+            state.push(ParserLocation.Procedure);
+            unit = this.procedureStatement(state);
+          } finally {
+            state.pop();
           }
+          break;
+        case PreprocessorTokens.Return.tokenTypeIdx:
+          unit = this.returnStatement(state);
+          break;
       }
     }
 
@@ -260,7 +238,6 @@ export class PliPreprocessorParser {
 
   procedureStatement(state: PreprocessorParserState): ast.ProcedureStatement {
     const statement = ast.createProcedureStatement();
-    state.push("in-procedure");
     state.consume(
       statement,
       CstNodeKind.ProcedureStatement_PROCEDURE,
@@ -273,22 +250,24 @@ export class PliPreprocessorParser {
         PreprocessorTokens.LParen,
       )
     ) {
-      do {
-        const parameter = ast.createProcedureParameter();
-        const nameToken = state.consume(
-          parameter,
-          CstNodeKind.ProcedureParameter_Id,
-          PreprocessorTokens.Id,
+      if (state.canConsume(PreprocessorTokens.Id)) {
+        do {
+          const parameter = ast.createProcedureParameter();
+          const nameToken = state.consume(
+            parameter,
+            CstNodeKind.ProcedureParameter_Id,
+            PreprocessorTokens.Id,
+          );
+          parameter.ref = ast.createReference(parameter, nameToken);
+          statement.parameters.push(parameter);
+        } while (
+          state.tryConsume(
+            statement,
+            CstNodeKind.ProcedureStatement_Comma,
+            PreprocessorTokens.Comma,
+          )
         );
-        parameter.ref = ast.createReference(parameter, nameToken);
-        statement.parameters.push(parameter);
-      } while (
-        state.tryConsume(
-          statement,
-          CstNodeKind.ProcedureStatement_Comma,
-          PreprocessorTokens.Comma,
-        )
-      );
+      }
       state.consume(
         statement,
         CstNodeKind.ProcedureStatement_CloseParenParams,
@@ -322,7 +301,7 @@ export class PliPreprocessorParser {
           PreprocessorTokens.Character,
         )
       ) {
-        returnType = "character";
+        returnType = "CHARACTER";
       } else if (
         state.tryConsume(
           dataAttribute,
@@ -330,7 +309,7 @@ export class PliPreprocessorParser {
           PreprocessorTokens.Fixed,
         )
       ) {
-        returnType = "fixed";
+        returnType = "FIXED";
       }
       if (returnType) {
         dataAttribute.type = returnType as ast.DefaultAttribute;
@@ -350,6 +329,12 @@ export class PliPreprocessorParser {
     );
     const body = this.statements(state);
     statement.statements = body;
+    // Manually consume the percentage sign before the end
+    state.consume(
+      statement,
+      CstNodeKind.Percentage,
+      PreprocessorTokens.Percentage,
+    );
     state.consume(
       statement,
       CstNodeKind.ProcedureStatement_PROCEDURE_END,
@@ -361,6 +346,32 @@ export class PliPreprocessorParser {
       PreprocessorTokens.Semicolon,
     );
     state.pop();
+    return statement;
+  }
+
+  returnStatement(state: PreprocessorParserState): ast.ReturnStatement {
+    const statement = ast.createReturnStatement();
+    state.consume(
+      statement,
+      CstNodeKind.ReturnStatement_RETURN,
+      PreprocessorTokens.Return,
+    );
+    state.consume(
+      statement,
+      CstNodeKind.ReturnStatement_OpenParen,
+      PreprocessorTokens.LParen,
+    );
+    statement.expression = this.expression(state);
+    state.consume(
+      statement,
+      CstNodeKind.ReturnStatement_CloseParen,
+      PreprocessorTokens.RParen,
+    );
+    state.consume(
+      statement,
+      CstNodeKind.ReturnStatement_Semicolon,
+      PreprocessorTokens.Semicolon,
+    );
     return statement;
   }
 
@@ -1237,6 +1248,16 @@ export class PliPreprocessorParser {
       CstNodeKind.Dimensions_OpenParen,
       PreprocessorTokens.LParen,
     );
+    if (
+      state.tryConsume(
+        dimensions,
+        CstNodeKind.Dimensions_CloseParen,
+        PreprocessorTokens.RParen,
+      )
+    ) {
+      // Return early if we found a close parenthesis immediately after open
+      return dimensions;
+    }
     dimensions.dimensions.push(this.parseBound(state));
     while (
       state.tryConsume(

--- a/packages/language/src/preprocessor/pli-preprocessor-parser.ts
+++ b/packages/language/src/preprocessor/pli-preprocessor-parser.ts
@@ -14,7 +14,6 @@ import {
   PreprocessorTokens,
 } from "./pli-preprocessor-tokens";
 import {
-  ParserLocation,
   PliPreprocessorParserState,
   PreprocessorParserState,
 } from "./pli-preprocessor-parser-state";
@@ -105,7 +104,7 @@ export class PliPreprocessorParser {
   }
 
   statement(state: PreprocessorParserState): ast.Statement {
-    if (state.isOnlyInStatement()) {
+    if (!state.isInProcedure()) {
       if (
         state.tryConsume(
           undefined,
@@ -113,12 +112,7 @@ export class PliPreprocessorParser {
           PreprocessorTokens.Percentage,
         )
       ) {
-        state.push(ParserLocation.Statement);
-        try {
-          return this.commonStatement(state);
-        } finally {
-          state.pop();
-        }
+        return this.commonStatement(state);
       } else {
         return this.consumeTokenStatement(state);
       }
@@ -149,7 +143,36 @@ export class PliPreprocessorParser {
     let unit: ast.Unit | undefined = undefined;
     if (performAssignmentLookahead((la) => state.lookahead(la))) {
       unit = this.assignmentStatement(state);
+    } else if (state.isInProcedure()) {
+      // TODO: Handle missing preprocessor procedure statements: ANSWER, CALL, NOTE, SELECT
+      switch (state.current?.tokenTypeIdx) {
+        case PreprocessorTokens.Declare.tokenTypeIdx:
+          unit = this.declareStatement(state);
+          break;
+        case PreprocessorTokens.Do.tokenTypeIdx:
+          unit = this.doStatement(state);
+          break;
+        case PreprocessorTokens.Go.tokenTypeIdx:
+        case PreprocessorTokens.Goto.tokenTypeIdx:
+          unit = this.goToStatement(state);
+          break;
+        case PreprocessorTokens.If.tokenTypeIdx:
+          unit = this.ifStatement(state);
+          break;
+        case PreprocessorTokens.Leave.tokenTypeIdx:
+          unit = this.leaveStatement(state);
+          break;
+        case PreprocessorTokens.Iterate.tokenTypeIdx:
+          unit = this.iterateStatement(state);
+          break;
+        case PreprocessorTokens.Return.tokenTypeIdx:
+          unit = this.returnStatement(state);
+          break;
+        case PreprocessorTokens.Semicolon.tokenTypeIdx:
+          unit = this.nullStatement(state);
+      }
     } else {
+      // TODO: Handle missing preprocessor statements: NOTE, REPLACE, SELECT
       switch (state.current?.tokenTypeIdx) {
         case PreprocessorTokens.Semicolon.tokenTypeIdx:
           unit = this.nullStatement(state);
@@ -205,10 +228,10 @@ export class PliPreprocessorParser {
           break;
         case PreprocessorTokens.Procedure.tokenTypeIdx:
           try {
-            state.push(ParserLocation.Procedure);
+            state.pushProcedure();
             unit = this.procedureStatement(state);
           } finally {
-            state.pop();
+            state.popProcedure();
           }
           break;
         case PreprocessorTokens.Return.tokenTypeIdx:
@@ -345,7 +368,6 @@ export class PliPreprocessorParser {
       CstNodeKind.ProcedureStatement_Semicolon1,
       PreprocessorTokens.Semicolon,
     );
-    state.pop();
     return statement;
   }
 
@@ -881,6 +903,14 @@ export class PliPreprocessorParser {
   private statements(state: PreprocessorParserState): ast.Statement[] {
     const statements: ast.Statement[] = [];
     while (!state.eof && !state.canConsumeKeyword(PreprocessorTokens.End)) {
+      if (
+        state.isInProcedure() &&
+        state.canConsume(PreprocessorTokens.Percentage, PreprocessorTokens.End)
+      ) {
+        // Even though the %END; statement is technically part of the procedure, it still has a % prefix.
+        // We need special handling for it here. End statements list if we encounter it.
+        break;
+      }
       const statement = this.statement(state);
       statements.push(statement);
     }

--- a/packages/language/test/fourslash/preprocessor/procedures/interpreter-does-not-leak-procedure-variables.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/interpreter-does-not-leak-procedure-variables.ts
@@ -1,0 +1,25 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %TEST: PROC (VAR) RETURNS (CHAR);
+////   DCL TEST_VAR CHAR;
+////   TEST_VAR = VAR;
+////   RETURN (TEST_VAR);
+//// %END;
+//// %DCL (X, Y) CHAR;
+//// %Y = TEST("HELLO_WORLD");
+//// %X = TEST_VAR; // Attempt to grab procedure local variable
+//// X
+
+/* Actually expect no tokens here, X is empty due to access to an undefined variable */
+preprocessor.expectTokens([]);

--- a/packages/language/test/fourslash/preprocessor/procedures/procedure-with-do.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/procedure-with-do.ts
@@ -1,0 +1,25 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %TEST: PROC (VAR) RETURNS (FIXED);
+////   DCL I FIXED;
+////   DO WHILE (I < 10);
+////    I = I + 1;
+////   END;
+////   RETURN (I);
+//// %END;
+//// %DCL X FIXED;
+//// %X = TEST(5);
+//// X
+
+preprocessor.expectTokens("10");

--- a/packages/language/test/fourslash/preprocessor/procedures/procedure-with-if.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/procedure-with-if.ts
@@ -1,0 +1,27 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %TEST: PROC (VAR) RETURNS (FIXED);
+////   IF (VAR < 10) THEN
+////     RETURN ("A");
+////   ELSE
+////     RETURN ("B");
+////   // Should never be reached
+////   RETURN ("C");
+//// %END;
+//// %DCL (X, Y) FIXED;
+//// %X = TEST(15);
+//// %Y = TEST(5);
+//// X Y
+
+preprocessor.expectTokens("B A");

--- a/packages/language/test/fourslash/preprocessor/procedures/simple-procedure-concat-self.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/simple-procedure-concat-self.ts
@@ -1,0 +1,25 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %TEST: PROC (VAR) RETURNS (CHAR);
+////   RETURN (VAR || " TEST " || VAR);
+//// %END;
+//// %DCL X CHAR;
+//// %DCL Y CHAR;
+//// %X = "HELLO_WORLD";
+//// %Y = TEST(X);
+//// Y
+
+preprocessor.expectTokens(`
+  HELLO_WORLD TEST HELLO_WORLD
+`);

--- a/packages/language/test/fourslash/preprocessor/procedures/simple-procedure-input-output-with-declare.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/simple-procedure-input-output-with-declare.ts
@@ -1,0 +1,27 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %TEST: PROC (VAR) RETURNS (CHAR);
+////   DCL VAR CHAR; // Should have no impact on the interpreter
+////   RETURN (VAR);
+//// %END;
+//// %DCL X CHAR;
+//// %DCL Y CHAR;
+//// %X = "HELLO_WORLD";
+//// // Test should immediately return with its input variable
+//// %Y = TEST(X);
+//// Y
+
+preprocessor.expectTokens(`
+  HELLO_WORLD
+`);

--- a/packages/language/test/fourslash/preprocessor/procedures/simple-procedure-input-output.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/simple-procedure-input-output.ts
@@ -1,0 +1,26 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %TEST: PROC (VAR) RETURNS (CHAR);
+////   RETURN (VAR);
+//// %END;
+//// %DCL X CHAR;
+//// %DCL Y CHAR;
+//// %X = "HELLO_WORLD";
+//// // Test should immediately return with its input variable
+//// %Y = TEST(X);
+//// Y
+
+preprocessor.expectTokens(`
+  HELLO_WORLD
+`);

--- a/packages/language/test/fourslash/preprocessor/procedures/simple-procedure-invalid-args.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/simple-procedure-invalid-args.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %TEST: PROC (VAR) RETURNS (CHAR);
+////   RETURN (VAR);
+//// %END;
+//// %DCL Y CHAR;
+//// // No arguments received, should simply yield no tokens
+//// %Y = TEST();
+//// Y
+
+/* Actually expect no tokens here, all the text is preprocessor code */
+preprocessor.expectTokens([]);

--- a/packages/language/test/fourslash/preprocessor/procedures/simple-procedure-missing-args.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/simple-procedure-missing-args.ts
@@ -1,0 +1,22 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %TEST: PROC (VAR) RETURNS (CHAR);
+////   RETURN (VAR || " HELLO");
+//// %END;
+//// %DCL Y CHAR;
+//// // No arguments received, the interpreter will use the default for VAR
+//// %Y = TEST();
+//// Y
+
+preprocessor.expectTokens(`HELLO`);

--- a/packages/language/test/fourslash/preprocessor/procedures/simple-procedure-too-many-args.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/simple-procedure-too-many-args.ts
@@ -11,13 +11,11 @@
 
 /// <reference path="../../framework.ts" />
 
-//// %TEST: PROC (VAR) RETURNS (CHAR);
-////   RETURN (VAR);
+//// %TEST: PROC (A, B) RETURNS (CHAR);
+////   RETURN (A || B);
 //// %END;
 //// %DCL Y CHAR;
-//// // No arguments received, should simply yield no tokens
-//// %Y = TEST();
+//// %Y = TEST("HELLO", " WORLD", "HOW", "ARE", "YOU?");
 //// Y
 
-/* Actually expect no tokens here, all the text is preprocessor code */
-preprocessor.expectTokens([]);
+preprocessor.expectTokens(`HELLO WORLD`);


### PR DESCRIPTION
Related to https://github.com/zowe/zowe-pli-language-support/issues/297. Adds support for preprocessor procedures in preprocessor code. I.e. you can now call a (locally) defined preprocessor procedure:

```
%TEST_PROC: PROC (...) RETURNS (CHAR);
  // DO SOMETHING
%END;
%VAR = TEST_PROC(...);
```

And expect that the correct value is now attached to `VAR`.

Out of scope for this PR: Use preprocessor procedures outside of preprocessor code. This requires some tricky behavior, due to the `STATEMENT` keyword:

<img width="802" height="394" alt="grafik" src="https://github.com/user-attachments/assets/68218983-a27a-4513-926d-2d59faf6f852" />


