### PR TITLE
Adds Do-Type 3 support to preprocessor interpreter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,8 @@ out/
 *.tsbuildinfo
 *.vsix
 **/*.DS_Store
-scripts/*.html
+scripts/*
+!scripts/*.mts
 coverage/
 !img/*
 **/pli.merged.json

--- a/code_samples/preprocessor/do-type3.pli
+++ b/code_samples/preprocessor/do-type3.pli
@@ -1,74 +1,138 @@
- /* DO Type 3 - Loop Control Variable Examples */
+ /* DO Type 3 Examples */
  
- /* Basic DO i = 1 TO 10 */
- %DCL I FIXED;
- %DO I = 1 TO 10;
-   PUT LIST('Iteration: ' || I);
+ /* Basic DO i = 1 TO 2 */
+ %DCL I1 FIXED;
+ %DO I1 = 1 TO 2;
+   DCL BasicVar%;I1 FIXED;
  %END;
+ /* Evaluates to:
+   DCL BasicVar1 FIXED;
+   DCL BasicVar2 FIXED;
+ */
  
  /* DO with BY clause */
- %DCL J FIXED;
- %DO J = 2 TO 20 BY 2;
-   PUT LIST('Even number: ' || J);
+ %DCL I2 FIXED;
+ %DO I2 = 2 TO 4 BY 2;
+   DCL ByVar%;I2 FIXED;
  %END;
+ /* Evaluates to:
+   DCL ByVar2 FIXED;
+   DCL ByVar4 FIXED;
+ */
  
  /* DO with BY before TO */
- %DCL T FIXED;
- %DO T = 5 BY 5 TO 25;
-   PUT LIST('BY before TO: ' || T);
+ %DCL I3 FIXED;
+ %DO I3 = 5 BY 5 TO 10;
+   DCL ByToVar%;I3 FIXED;
  %END;
+ /* Evaluates to:
+   DCL ByToVar5 FIXED;
+   DCL ByToVar10 FIXED;
+ */
  
  /* DO with multiple specifications */
- %DCL K FIXED;
- %DCL L FIXED;
- %DO K = 1 TO 5, L = 10 TO 50 BY 10;
-   PUT LIST('K=' || K || ', L=' || L);
+ %DCL I4 FIXED;
+ %DO I4 = 1 TO 2, 2 TO 4 BY 2;
+   DCL MultiVar%;I4 FIXED;
  %END;
+ /* Evaluates to:
+   DCL MultiVar1 FIXED;
+   DCL MultiVar2 FIXED;
+   DCL MultiVar2 FIXED;
+   DCL MultiVar4 FIXED;
+ */
  
  /* DO with UPTHRU */
- %DCL M FIXED;
- %DO M = 1 UPTHRU 5;
-   PUT LIST('UPTHRU: ' || M);
+ %DCL I5 FIXED;
+ %DO I5 = 1 UPTHRU 3;
+   DCL UpthruVar%;I5 FIXED;
  %END;
+ /* Evaluates to:
+   DCL UpthruVar1 FIXED;
+   DCL UpthruVar2 FIXED;
+   DCL UpthruVar3 FIXED;
+ */
  
  /* DO with DOWNTHRU */
- %DCL N FIXED;
- %DO N = 10 DOWNTHRU 1;
-   PUT LIST('DOWNTHRU: ' || N);
+ %DCL I6 FIXED;
+ %DO I6 = 3 DOWNTHRU 1;
+   DCL DownthruVar%;I6 FIXED;
  %END;
+ /* Evaluates to:
+   DCL DownthruVar3 FIXED;
+   DCL DownthruVar2 FIXED;
+   DCL DownthruVar1 FIXED;
+ */
  
  /* DO with REPEAT */
- %DCL P FIXED;
- %DO P = 1 REPEAT 3;
-   PUT LIST('REPEAT: ' || P);
+ %DCL I7 FIXED;
+ %DO I7 = 1 REPEAT 2*I7 UNTIL(I7 > 6);
+   DCL RepeatVar%;I7 FIXED;
  %END;
+ /* Evaluates to:
+   DCL RepeatVar1 FIXED;
+   DCL RepeatVar2 FIXED;
+   DCL RepeatVar4 FIXED;
+   DCL RepeatVar8 FIXED;
+ */
  
  /* DO with WHILE condition */
- %DCL Q FIXED;
- %DO Q = 1 TO 10 WHILE(Q < 5);
-   PUT LIST('WHILE condition: ' || Q);
+ %DCL I8 FIXED;
+ %DO I8 = 1 TO 10 WHILE(I8 < 4);
+   DCL WhileVar%;I8 FIXED;
  %END;
+ /* Evaluates to:
+   DCL WhileVar1 FIXED;
+   DCL WhileVar2 FIXED;
+   DCL WhileVar3 FIXED;
+ */
  
  /* DO with UNTIL condition */
- %DCL R FIXED;
- %DO R = 1 TO 10 UNTIL(R >= 3);
-   PUT LIST('UNTIL condition: ' || R);
+ %DCL I9 FIXED;
+ %DO I9 = 1 TO 10 UNTIL(I9 >= 3);
+   DCL UntilVar%;I9 FIXED;
  %END;
+ /* Evaluates to:
+   DCL UntilVar1 FIXED;
+   DCL UntilVar2 FIXED;
+   DCL UntilVar3 FIXED;
+ */
  
  /* Complex DO with BY and WHILE */
- %DCL S FIXED;
- %DO S = 10 TO 100 BY 10 WHILE(S <= 50);
-   PUT LIST('Complex: ' || S);
+ %DCL I10 FIXED;
+ %DO I10 = 10 TO 30 BY 10 WHILE(I10 < 25);
+   DCL ComplexVar%;I10 FIXED;
  %END;
+ /* Evaluates to:
+   DCL ComplexVar10 FIXED;
+   DCL ComplexVar20 FIXED;
+ */
  
  /* DO with WHILE condition followed by UNTIL condition */
  %DCL COUNT FIXED;
  %DCL SUM FIXED;
  %SUM = 0;
- %DO COUNT = 1 TO 20 WHILE(COUNT <= 10) UNTIL(SUM > 25);
+ %DO COUNT = 1 TO 20 WHILE(COUNT <= 10) UNTIL(SUM > 13);
    %SUM = SUM + COUNT;
-   PUT LIST('WHILE then UNTIL: COUNT=' || COUNT || ', SUM=' || SUM);
+   DCL WhileUntilVar%;COUNT FIXED;
+   DCL SumVar%;SUM FIXED;
  %END;
+ /* Evaluates to:
+   DCL WhileUntilVar1 FIXED;
+   DCL SumVar1 FIXED;
+   
+   DCL WhileUntilVar2 FIXED;
+   DCL SumVar3 FIXED;
+   
+   DCL WhileUntilVar3 FIXED;
+   DCL SumVar6 FIXED;
+   
+   DCL WhileUntilVar4 FIXED;
+   DCL SumVar10 FIXED;
+   
+   DCL WhileUntilVar5 FIXED;
+   DCL SumVar15 FIXED;
+ */
  
  /* DO with UNTIL condition followed by WHILE condition */
  %DCL NUM FIXED;
@@ -76,5 +140,22 @@
  %PRODUCT = 1;
  %DO NUM = 1 TO 15 UNTIL(PRODUCT > 50) WHILE(NUM <= 8);
    %PRODUCT = PRODUCT * NUM;
-   PUT LIST('UNTIL then WHILE: NUM=' || NUM || ', PRODUCT=' || PRODUCT);
+   DCL UntilWhileVar%;NUM FIXED;
+   DCL ProductVar%;PRODUCT FIXED;
  %END;
+ /* Evaluates to:
+   DCL UntilWhileVar1 FIXED;
+   DCL ProductVar1 FIXED;
+   
+   DCL UntilWhileVar2 FIXED;
+   DCL ProductVar2 FIXED;
+   
+   DCL UntilWhileVar3 FIXED;
+   DCL ProductVar6 FIXED;
+   
+   DCL UntilWhileVar4 FIXED;
+   DCL ProductVar24 FIXED;
+   
+   DCL UntilWhileVar5 FIXED;
+   DCL ProductVar120 FIXED;
+ */

--- a/code_samples/preprocessor/do-type3.pli
+++ b/code_samples/preprocessor/do-type3.pli
@@ -30,40 +30,6 @@
    DCL ByToVar10 FIXED;
  */
  
- /* DO with multiple specifications */
- %DCL I4 FIXED;
- %DO I4 = 1 TO 2, 2 TO 4 BY 2;
-   DCL MultiVar%;I4 FIXED;
- %END;
- /* Evaluates to:
-   DCL MultiVar1 FIXED;
-   DCL MultiVar2 FIXED;
-   DCL MultiVar2 FIXED;
-   DCL MultiVar4 FIXED;
- */
- 
- /* DO with UPTHRU */
- %DCL I5 FIXED;
- %DO I5 = 1 UPTHRU 3;
-   DCL UpthruVar%;I5 FIXED;
- %END;
- /* Evaluates to:
-   DCL UpthruVar1 FIXED;
-   DCL UpthruVar2 FIXED;
-   DCL UpthruVar3 FIXED;
- */
- 
- /* DO with DOWNTHRU */
- %DCL I6 FIXED;
- %DO I6 = 3 DOWNTHRU 1;
-   DCL DownthruVar%;I6 FIXED;
- %END;
- /* Evaluates to:
-   DCL DownthruVar3 FIXED;
-   DCL DownthruVar2 FIXED;
-   DCL DownthruVar1 FIXED;
- */
- 
  /* DO with REPEAT */
  %DCL I7 FIXED;
  %DO I7 = 1 REPEAT 2*I7 UNTIL(I7 > 6);

--- a/packages/language/src/preprocessor/instruction-generator.ts
+++ b/packages/language/src/preprocessor/instruction-generator.ts
@@ -392,10 +392,12 @@ function generateDoInstruction(
     };
   }
   if (node.doType3) {
-    if (!node.doType3.variable) {
+    if (!node.doType3.variable?.element) {
       return undefined;
     }
-    const variable = generateReferenceItemInstruction(node.doType3.variable);
+    const variable = generateReferenceItemInstruction(
+      node.doType3.variable.element,
+    );
     if (node.doType3.specifications.length !== 1) {
       return undefined; // Preprocessor %DO does require exactly one specification
     }

--- a/packages/language/src/preprocessor/instruction-generator.ts
+++ b/packages/language/src/preprocessor/instruction-generator.ts
@@ -392,7 +392,10 @@ function generateDoInstruction(
     };
   }
   if (node.doType3) {
-    const variable = generateReferenceItemInstruction(node.doType3.variable!);
+    if (!node.doType3.variable) {
+      return undefined;
+    }
+    const variable = generateReferenceItemInstruction(node.doType3.variable);
     if (node.doType3.specifications.length !== 1) {
       return undefined; // Preprocessor %DO does require exactly one specification
     }

--- a/packages/language/src/preprocessor/instruction-generator.ts
+++ b/packages/language/src/preprocessor/instruction-generator.ts
@@ -391,6 +391,31 @@ function generateDoInstruction(
       while: whileCond,
     };
   }
+  if (node.doType3) {
+    const variable = generateReferenceItemInstruction(node.doType3.variable!);
+    const specificationItems: inst.DoType3SpecificationItem[] = [];
+    for (const spec of node.doType3.specifications) {
+      const specItem: inst.DoType3SpecificationItem = {
+        expression: generateExpressionInstruction(spec.expression) ?? null,
+        upthru: generateExpressionInstruction(spec.upthru) ?? null,
+        downthru: generateExpressionInstruction(spec.downthru) ?? null,
+        repeat: generateExpressionInstruction(spec.repeat) ?? null,
+        while: spec.whileOrUntil?.while
+          ? (generateExpressionInstruction(spec.whileOrUntil.while) ?? null)
+          : null,
+        until: spec.whileOrUntil?.until
+          ? (generateExpressionInstruction(spec.whileOrUntil.until) ?? null)
+          : null,
+        to: generateExpressionInstruction(spec.to) ?? null,
+        by: generateExpressionInstruction(spec.by) ?? null,
+      };
+      specificationItems.push(specItem);
+    }
+    doInstruction.doType3 = {
+      variable,
+      specificationItems,
+    };
+  }
   if (node.doType2 || node.doType3 || node.doType4) {
     doType1 = false;
   }

--- a/packages/language/src/preprocessor/instruction-generator.ts
+++ b/packages/language/src/preprocessor/instruction-generator.ts
@@ -393,27 +393,24 @@ function generateDoInstruction(
   }
   if (node.doType3) {
     const variable = generateReferenceItemInstruction(node.doType3.variable!);
-    const specificationItems: inst.DoType3SpecificationItem[] = [];
-    for (const spec of node.doType3.specifications) {
-      const specItem: inst.DoType3SpecificationItem = {
-        expression: generateExpressionInstruction(spec.expression) ?? null,
-        upthru: generateExpressionInstruction(spec.upthru) ?? null,
-        downthru: generateExpressionInstruction(spec.downthru) ?? null,
-        repeat: generateExpressionInstruction(spec.repeat) ?? null,
-        while: spec.whileOrUntil?.while
-          ? (generateExpressionInstruction(spec.whileOrUntil.while) ?? null)
-          : null,
-        until: spec.whileOrUntil?.until
-          ? (generateExpressionInstruction(spec.whileOrUntil.until) ?? null)
-          : null,
-        to: generateExpressionInstruction(spec.to) ?? null,
-        by: generateExpressionInstruction(spec.by) ?? null,
-      };
-      specificationItems.push(specItem);
+    if (node.doType3.specifications.length !== 1) {
+      return undefined; // Preprocessor %DO does require exactly one specification
     }
+    const spec = node.doType3.specifications[0];
+    if (spec.upthru || spec.downthru) {
+      return undefined; // upthru and downthru are not supported
+    }
+    const specification: inst.DoType3Specification = {
+      expression: generateExpressionInstruction(spec.expression) ?? null,
+      repeat: generateExpressionInstruction(spec.repeat) ?? null,
+      while: generateExpressionInstruction(spec.whileOrUntil?.while) ?? null,
+      until: generateExpressionInstruction(spec.whileOrUntil?.until) ?? null,
+      to: generateExpressionInstruction(spec.to) ?? null,
+      by: generateExpressionInstruction(spec.by) ?? null,
+    };
     doInstruction.doType3 = {
       variable,
-      specificationItems,
+      specification,
     };
   }
   if (node.doType2 || node.doType3 || node.doType4) {

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -185,6 +185,8 @@ interface InterpreterContext {
   procedures: Map<string, inst.ProcedureInstructionContainer>;
   activeProcedures: Set<string>;
   counter: Map<inst.InstructionNode, number>;
+  doType3SpecIndex: Map<inst.InstructionNode, number>;
+  doType3NeedsReinit: Map<inst.InstructionNode, boolean>;
   references: ast.Reference[];
   evaluations: EvaluationResults;
   xIncludes: Set<string>;
@@ -235,6 +237,8 @@ export function runInstructions(
     },
     options,
     counter: new Map(),
+    doType3SpecIndex: new Map(),
+    doType3NeedsReinit: new Map(),
     returnValue: defaultEmptyValue,
   };
   for (const [key, value] of instruction.procedures.entries()) {
@@ -409,22 +413,10 @@ function runDoType3Instruction(
   context: InterpreterContext,
   node: inst.InstructionNode,
 ): boolean {
-  let condition = true;
   const { specificationItems, variable } = doType3;
 
   if (specificationItems.length === 0) {
     throw new Error("DoType3 requires at least one specification item!");
-  }
-
-  // TODO(@@dd) --> handle more than one do-type3 spec
-  if (specificationItems.length > 1) {
-    throw new Error("Multiple DoType3 specifications not implemented yet!");
-  }
-  const spec = doType3.specificationItems[0];
-  // <- TODO(@@dd)
-
-  if (!spec.expression) {
-    throw new Error("DoType3 requires initial value!");
   }
 
   const iterationCount = context.counter.get(node);
@@ -433,11 +425,25 @@ function runDoType3Instruction(
   }
   const isFirstIteration = iterationCount === 1;
 
+  // Get current spec index, starting at 0 for first iteration
+  let currentSpecIndex = context.doType3SpecIndex.get(node) ?? 0;
+  const needsReinit = context.doType3NeedsReinit.get(node) ?? false;
+
+  // If we've exhausted all specifications, return false to stop the loop
+  if (currentSpecIndex >= specificationItems.length) {
+    return false;
+  }
+
+  const spec = specificationItems[currentSpecIndex];
+  if (!spec.expression) {
+    throw new Error("DoType3 requires initial value!");
+  }
+
   const varName = variable.variable;
   let loopVar = context.variables.get(varName);
 
-  if (isFirstIteration) {
-    // First iteration - create the loop variable and initialize it
+  // Initialize for first iteration OR when we need to reinitialize for a new spec
+  if (isFirstIteration || needsReinit) {
     const start = evaluateExpression(spec.expression, context);
     if (!isScalarValue(start)) {
       throw new Error("DoType3 initial value must be scalar!");
@@ -456,88 +462,94 @@ function runDoType3Instruction(
       };
       context.variables.set(varName, loopVar);
     } else {
-      // Variable exists, just set the initial value
       loopVar.value = {
         value: start.value,
         type: inst.DeclaredType.Fixed,
       };
     }
+
+    // Clear the reinit flag and update spec index
+    context.doType3NeedsReinit.set(node, false);
+    context.doType3SpecIndex.set(node, currentSpecIndex);
+    return true; // Always continue after initialization
+  }
+
+  // Normal iteration within current spec - update the loop variable
+  if (!loopVar) {
+    throw new Error("DoType3 loop variable not found on subsequent iteration!");
+  }
+
+  let condition = true;
+
+  // Until is evaluated after each repetition of the loop body
+  if (spec.until) {
+    const untilCondition = evaluateExpression(spec.until, context);
+    if (!isScalarValue(untilCondition)) {
+      throw new Error("DoType3 condition must be scalar!");
+    }
+    condition &&= !valueToBool(untilCondition);
+  }
+
+  // Update the variable based on the loop type
+  if (spec.repeat) {
+    const repeatValue = evaluateExpression(spec.repeat, context);
+    if (!isScalarValue(repeatValue)) {
+      throw new Error("DoType3 repeat value must be scalar!");
+    }
+    loopVar.value = {
+      value: repeatValue.value,
+      type: inst.DeclaredType.Fixed,
+    };
   } else {
-    // Subsequent iterations - update the loop variable
-    if (!loopVar) {
+    // TO, UPTHRU, or DOWNTHRU clause
+    let endValue;
+    let stepValue;
+
+    if (spec.to) {
+      endValue = evaluateExpression(spec.to, context);
+      if (spec.by) {
+        stepValue = evaluateExpression(spec.by, context);
+      } else {
+        stepValue = valueToNumber("1");
+      }
+    } else if (spec.upthru) {
+      endValue = evaluateExpression(spec.upthru, context);
+      stepValue = valueToNumber("1");
+    } else if (spec.downthru) {
+      endValue = evaluateExpression(spec.downthru, context);
+      stepValue = valueToNumber("-1");
+    } else {
       throw new Error(
-        "DoType3 loop variable not found on subsequent iteration!",
+        "DoType3 requires a TO, UPTHRU, DOWNTHRU or REPEAT clause!",
       );
     }
 
-    // Until is evaluated after each repetition of the loop body
-    if (spec.until) {
-      const untilCondition = evaluateExpression(spec.until, context);
-      if (!isScalarValue(untilCondition)) {
-        throw new Error("DoType3 condition must be scalar!");
-      }
-      condition &&= !valueToBool(untilCondition);
+    if (!isScalarValue(endValue)) {
+      throw new Error("DoType3 end value must be scalar!");
+    }
+    if (!isScalarValue(stepValue)) {
+      throw new Error("DoType3 step value must be scalar!");
     }
 
-    // Update the variable based on the loop type
-    if (spec.repeat) {
-      // The REPEAT expression is assigned to the loop variable on each loop iteration
-      const repeatValue = evaluateExpression(spec.repeat, context);
-      if (!isScalarValue(repeatValue)) {
-        throw new Error("DoType3 repeat value must be scalar!");
-      }
+    const end = parseInt(endValue.value);
+    const step = parseInt(stepValue.value);
+
+    if (!isScalarValue(loopVar.value)) {
+      throw new Error("DoType3 loop variable must be scalar!");
+    }
+
+    let currentValue = parseInt(loopVar.value.value);
+    // Check if the next value would be within bounds BEFORE updating
+    const nextValue = currentValue + step;
+    condition &&=
+      (step > 0 && nextValue <= end) || (step < 0 && nextValue >= end);
+
+    // Only update the variable if the condition is still true
+    if (condition) {
       loopVar.value = {
-        value: repeatValue.value,
+        value: nextValue.toString(),
         type: inst.DeclaredType.Fixed,
       };
-    } else {
-      // TO, UPTHRU, or DOWNTHRU clause
-      let endValue;
-      let stepValue;
-
-      if (spec.to) {
-        endValue = evaluateExpression(spec.to, context);
-        if (spec.by) {
-          stepValue = evaluateExpression(spec.by, context);
-        } else {
-          stepValue = valueToNumber("1");
-        }
-      } else if (spec.upthru) {
-        endValue = evaluateExpression(spec.upthru, context);
-        stepValue = valueToNumber("1");
-      } else if (spec.downthru) {
-        endValue = evaluateExpression(spec.downthru, context);
-        stepValue = valueToNumber("-1");
-      } else {
-        throw new Error(
-          "DoType3 requires a TO, UPTHRU, DOWNTHRU or REPEAT clause!",
-        );
-      }
-
-      if (!isScalarValue(endValue)) {
-        throw new Error("DoType3 end value must be scalar!");
-      }
-      if (!isScalarValue(stepValue)) {
-        throw new Error("DoType3 step value must be scalar!");
-      }
-
-      const end = parseInt(endValue.value);
-      const step = parseInt(stepValue.value);
-
-      if (!isScalarValue(loopVar.value)) {
-        throw new Error("DoType3 loop variable must be scalar!");
-      }
-
-      let currentValue = parseInt(loopVar.value.value);
-      currentValue = currentValue + step;
-      loopVar.value = {
-        value: currentValue.toString(),
-        type: inst.DeclaredType.Fixed,
-      };
-
-      // Check if we should continue the loop
-      condition &&=
-        (step > 0 && currentValue <= end) || (step < 0 && currentValue >= end);
     }
   }
 
@@ -548,6 +560,33 @@ function runDoType3Instruction(
       throw new Error("DoType3 condition must be scalar!");
     }
     condition &&= valueToBool(whileCondition);
+  }
+
+  // If current spec is done, try to advance to next spec
+  if (!condition && currentSpecIndex < specificationItems.length - 1) {
+    // Advance to next spec immediately and reinitialize
+    const nextSpecIndex = currentSpecIndex + 1;
+    const nextSpec = specificationItems[nextSpecIndex];
+
+    if (!nextSpec.expression) {
+      throw new Error("DoType3 requires initial value!");
+    }
+
+    const start = evaluateExpression(nextSpec.expression, context);
+    if (!isScalarValue(start)) {
+      throw new Error("DoType3 initial value must be scalar!");
+    }
+
+    // Reinitialize with the next spec's initial value
+    loopVar.value = {
+      value: start.value,
+      type: inst.DeclaredType.Fixed,
+    };
+
+    // Update state to reflect the new spec
+    context.doType3SpecIndex.set(node, nextSpecIndex);
+    context.doType3NeedsReinit.set(node, false);
+    return true;
   }
 
   return condition;

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -418,20 +418,20 @@ function runDoType3Instruction(
 
   if (!doType3Context) {
     // Store all expressions that must be evaluated at the start of the loop
-    condition &&= _runDoType3Initialization(doType3, context, node);
+    condition &&= runDoType3Initialization(doType3, context, node);
   } else {
     // Subsequent iterations
-    condition &&= _runDoType3UntilCheck(doType3, context);
-    condition &&= _runDoType3VariableUpdate(doType3, context, node);
+    condition &&= runDoType3UntilCheck(doType3, context);
+    condition &&= runDoType3VariableUpdate(doType3, context, node);
   }
 
   // Check WHILE condition before do-group execution
-  condition &&= _runDoType3WhileCheck(doType3, context);
+  condition &&= runDoType3WhileCheck(doType3, context);
 
   return condition;
 }
 
-function _runDoType3Initialization(
+function runDoType3Initialization(
   doType3: inst.DoType3Instruction,
   context: InterpreterContext,
   node: inst.InstructionNode,
@@ -503,7 +503,7 @@ function _runDoType3Initialization(
   return true;
 }
 
-function _runDoType3WhileCheck(
+function runDoType3WhileCheck(
   doType3: inst.DoType3Instruction,
   context: InterpreterContext,
 ): boolean {
@@ -520,7 +520,7 @@ function _runDoType3WhileCheck(
   return true;
 }
 
-function _runDoType3UntilCheck(
+function runDoType3UntilCheck(
   doType3: inst.DoType3Instruction,
   context: InterpreterContext,
 ): boolean {
@@ -537,7 +537,7 @@ function _runDoType3UntilCheck(
   return true;
 }
 
-function _runDoType3VariableUpdate(
+function runDoType3VariableUpdate(
   doType3: inst.DoType3Instruction,
   context: InterpreterContext,
   node: inst.InstructionNode,

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -411,6 +411,31 @@ function runDoType3Instruction(
   context: InterpreterContext,
   node: inst.InstructionNode,
 ): boolean {
+  let condition = true;
+
+  // Get current do-type3 state
+  const doType3Context = context.doType3.get(node);
+
+  if (!doType3Context) {
+    // Store all expressions that must be evaluated at the start of the loop
+    condition &&= _runDoType3Initialization(doType3, context, node);
+  } else {
+    // Subsequent iterations
+    condition &&= _runDoType3UntilCheck(doType3, context);
+    condition &&= _runDoType3VariableUpdate(doType3, context, node);
+  }
+
+  // Check WHILE condition before do-group execution
+  condition &&= _runDoType3WhileCheck(doType3, context);
+
+  return condition;
+}
+
+function _runDoType3Initialization(
+  doType3: inst.DoType3Instruction,
+  context: InterpreterContext,
+  node: inst.InstructionNode,
+): boolean {
   const { variable } = doType3;
   const varName = variable.variable;
   const spec = doType3.specification;
@@ -424,84 +449,108 @@ function runDoType3Instruction(
     return false;
   }
 
-  // Get current do-type3 state
-  let doType3Context = context.doType3.get(node);
-
   let loopVar = context.variables.get(varName);
 
-  // Initialize the do-type3 context on first iteration
-  if (!doType3Context) {
-    // Implicitly declare the loop variable if it doesn't exist, or update existing variable
-    if (!loopVar) {
-      loopVar = {
-        name: varName,
-        declarationNode: variable.reference?.owner,
-        value: {
-          value: start.value,
-          type: inst.DeclaredType.Fixed,
-        },
-        active: true,
-        mode: inst.ScanMode.Scan,
-      };
-      context.variables.set(varName, loopVar);
-    } else {
-      // Update existing variable to the start value
-      loopVar.value = {
+  // Implicitly declare the loop variable if it doesn't exist, or update existing variable
+  if (!loopVar) {
+    loopVar = {
+      name: varName,
+      declarationNode: variable.reference?.owner,
+      value: {
         value: start.value,
         type: inst.DeclaredType.Fixed,
-      };
-    }
-
-    // Evaluate and save TO and BY expressions at entry to the specification
-    let toValue: ScalarValue | undefined;
-    let byValue: ScalarValue | undefined;
-
-    if (spec.to) {
-      const value = evaluateExpression(spec.to, context);
-      if (!isScalarValue(value)) {
-        return false;
-      }
-      toValue = value;
-    }
-
-    if (spec.by) {
-      const value = evaluateExpression(spec.by, context);
-      if (!isScalarValue(value)) {
-        return false;
-      }
-      byValue = value;
-    } else {
-      byValue = valueToNumber("1");
-    }
-      
-    doType3Context = {
-      toValue,
-      byValue,
+      },
+      active: true,
+      mode: inst.ScanMode.Scan,
     };
-
-    context.doType3.set(node, doType3Context);
-
-    // Always continue after initialization
-    return true;
+    context.variables.set(varName, loopVar);
+  } else {
+    // Update existing variable to the start value
+    loopVar.value = {
+      value: start.value,
+      type: inst.DeclaredType.Fixed,
+    };
   }
 
-  // Ensure loop variable exists for subsequent iterations
-  if (!loopVar) {
-    return false; // Variable should exist by now
+  // Evaluate and save TO and BY expressions at entry to the specification
+  let toValue: ScalarValue | undefined;
+  let byValue: ScalarValue | undefined;
+
+  if (spec.to) {
+    const value = evaluateExpression(spec.to, context);
+    if (!isScalarValue(value)) {
+      return false;
+    }
+    toValue = value;
   }
 
-  let condition = true;
+  if (spec.by) {
+    const value = evaluateExpression(spec.by, context);
+    if (!isScalarValue(value)) {
+      return false;
+    }
+    byValue = value;
+  } else if (spec.to) {
+    byValue = valueToNumber("1");
+  }
 
-  // Until is evaluated after each repetition of the do-group
+  const doType3Context = {
+    toValue,
+    byValue,
+  };
+
+  context.doType3.set(node, doType3Context);
+  return true;
+}
+
+function _runDoType3WhileCheck(
+  doType3: inst.DoType3Instruction,
+  context: InterpreterContext,
+): boolean {
+  const spec = doType3.specification;
+
+  if (spec.while) {
+    const whileCondition = evaluateExpression(spec.while, context);
+    if (!isScalarValue(whileCondition)) {
+      return false;
+    }
+    return valueToBool(whileCondition);
+  }
+
+  return true;
+}
+
+function _runDoType3UntilCheck(
+  doType3: inst.DoType3Instruction,
+  context: InterpreterContext,
+): boolean {
+  const spec = doType3.specification;
+
   if (spec.until) {
     const untilCondition = evaluateExpression(spec.until, context);
     if (!isScalarValue(untilCondition)) {
       return false;
     }
-    condition &&= !valueToBool(untilCondition);
+    return !valueToBool(untilCondition);
   }
 
-  // Update the variable based on the loop type
+  return true;
+}
+
+function _runDoType3VariableUpdate(
+  doType3: inst.DoType3Instruction,
+  context: InterpreterContext,
+  node: inst.InstructionNode,
+): boolean {
+  const { variable } = doType3;
+  const varName = variable.variable;
+  const spec = doType3.specification;
+
+  const loopVar = context.variables.get(varName);
+  if (!loopVar) {
+    return false;
+  }
+
   if (spec.repeat) {
     const repeatValue = evaluateExpression(spec.repeat, context);
     if (!isScalarValue(repeatValue)) {
@@ -511,51 +560,36 @@ function runDoType3Instruction(
       value: repeatValue.value,
       type: inst.DeclaredType.Fixed,
     };
+    // No range check needed for REPEAT-only loops
+    return true;
   } else if (spec.to) {
-
-    const { toValue, byValue } = doType3Context;
-
-    // Sanity check for TypeScript, values must be set
-    if (!toValue || !byValue) {
+    const doType3Context = context.doType3.get(node);
+    if (!doType3Context?.toValue || !doType3Context?.byValue) {
       return false;
     }
 
-    const end = parseInt(toValue.value);
-    const step = parseInt(byValue.value);
+    const end = parseInt(doType3Context.toValue.value);
+    const step = parseInt(doType3Context.byValue.value);
 
-    // Sanity check for TypeScript, the loop variable must be a number
     if (!isScalarValue(loopVar.value)) {
       return false;
     }
 
-    let currentValue = parseInt(loopVar.value.value);
-    // Check if the next value would be within bounds BEFORE updating
+    const currentValue = parseInt(loopVar.value.value);
     const nextValue = currentValue + step;
-    condition &&=
-      (step > 0 && nextValue <= end) || (step < 0 && nextValue >= end);
 
-    // Only update the variable if the condition is still true
-    if (condition) {
-      loopVar.value = {
-        value: nextValue.toString(),
-        type: inst.DeclaredType.Fixed,
-      };
-    }
+    // Update the variable
+    loopVar.value = {
+      value: nextValue.toString(),
+      type: inst.DeclaredType.Fixed,
+    };
+
+    // Check if the updated value is still within range
+    return (step > 0 && nextValue <= end) || (step < 0 && nextValue >= end);
   } else {
-    // unsupported do specification clause
+    // unsupported DO type3 clause
     return false;
   }
-
-  // While is evaluated with the updated value (after increment)
-  if (spec.while) {
-    const whileCondition = evaluateExpression(spec.while, context);
-    if (!isScalarValue(whileCondition)) {
-      return false;
-    }
-    condition &&= valueToBool(whileCondition);
-  }
-
-  return condition;
 }
 
 function runAssignmentInstruction(

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -311,7 +311,7 @@ function handleInstructionError(err: any, context: InterpreterContext): void {
 function runInstruction(
   instruction: inst.Instruction,
   context: InterpreterContext,
-  node?: inst.InstructionNode,
+  node: inst.InstructionNode,
 ): inst.InstructionNode | undefined {
   switch (instruction.kind) {
     case inst.InstructionKind.Assignment:
@@ -321,7 +321,7 @@ function runInstruction(
       runTokenInstruction(instruction, context);
       break;
     case inst.InstructionKind.Compound:
-      runCompoundInstruction(instruction, context);
+      runCompoundInstruction(instruction, context, node);
       break;
     case inst.InstructionKind.Goto:
       return instruction.node;
@@ -366,17 +366,12 @@ function runHaltInstruction(
 function runDoInstruction(
   instruction: inst.DoInstruction,
   context: InterpreterContext,
-  node?: inst.InstructionNode,
+  node: inst.InstructionNode,
 ): inst.InstructionNode | undefined {
   let condition = true;
   if (instruction.doType2) {
     condition = runDoType2Instruction(instruction.doType2, context);
   } else if (instruction.doType3) {
-    if (!node) {
-      throw new Error(
-        "DoType3 instruction requires a node for iteration tracking",
-      );
-    }
     condition = runDoType3Instruction(instruction.doType3, context, node);
   }
   if (condition) {
@@ -1082,10 +1077,11 @@ function runDeactivateInstruction(
 function runCompoundInstruction(
   instruction: inst.CompoundInstruction,
   context: InterpreterContext,
+  node: inst.InstructionNode,
 ): void {
   for (const subInstruction of instruction.instructions) {
     try {
-      const result = runInstruction(subInstruction, context);
+      const result = runInstruction(subInstruction, context, node);
       if (result) {
         throw new Error(
           `Only non-jump instructions are allowed in a compound instruction. Found: ${subInstruction.kind}`,

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -278,7 +278,7 @@ function runInstructionNode(
   const instruction = node.instruction;
   let result = node.next;
   try {
-    const instructionResult = runInstruction(instruction, context);
+    const instructionResult = runInstruction(instruction, context, node);
     if (instructionResult) {
       result = instructionResult;
     }
@@ -302,6 +302,7 @@ function handleInstructionError(err: any, context: InterpreterContext): void {
 function runInstruction(
   instruction: inst.Instruction,
   context: InterpreterContext,
+  node?: inst.InstructionNode,
 ): inst.InstructionNode | undefined {
   switch (instruction.kind) {
     case inst.InstructionKind.Assignment:
@@ -318,7 +319,7 @@ function runInstruction(
     case inst.InstructionKind.If:
       return runIfInstruction(instruction, context);
     case inst.InstructionKind.Do:
-      return runDoInstruction(instruction, context);
+      return runDoInstruction(instruction, context, node);
     case inst.InstructionKind.Include:
       runIncludeInstruction(instruction, context);
       break;
@@ -356,38 +357,200 @@ function runHaltInstruction(
 function runDoInstruction(
   instruction: inst.DoInstruction,
   context: InterpreterContext,
+  node?: inst.InstructionNode,
 ): inst.InstructionNode | undefined {
   let condition = true;
   if (instruction.doType2) {
-    const type2 = instruction.doType2;
-    if (type2.until) {
-      const untilConditionValue = evaluateExpression(type2.until, context);
-      if (!isScalarValue(untilConditionValue)) {
-        // Condition cannot be evaluated, don't run the instruction
-        condition = false;
-      } else {
-        // If UNTIL is specified, we don't run the instruction if it evaluates to true
-        condition &&= !valueToBool(untilConditionValue);
-      }
+    condition = runDoType2Instruction(instruction.doType2, context);
+  } else if (instruction.doType3) {
+    if (!node) {
+      throw new Error(
+        "DoType3 instruction requires a node for iteration tracking",
+      );
     }
-    if (type2.while) {
-      const whileConditionValue = evaluateExpression(type2.while, context);
-      if (!isScalarValue(whileConditionValue)) {
-        // Condition cannot be evaluated, don't run the instruction
-        condition = false;
-      } else {
-        // If WHILE is specified, we only run the instruction if it evaluates to true
-        condition &&= valueToBool(whileConditionValue);
-      }
-    }
-  }
-  if (instruction.doType3) {
-    throw new Error("DoType3 instructions are not implemented yet!");
+    condition = runDoType3Instruction(instruction.doType3, context, node);
   }
   if (condition) {
     return instruction.content;
   }
   return undefined;
+}
+
+function runDoType2Instruction(
+  doType2: inst.DoType2Instruction,
+  context: InterpreterContext,
+): boolean {
+  let condition = true;
+  if (doType2.until) {
+    const untilConditionValue = evaluateExpression(doType2.until, context);
+    if (!isScalarValue(untilConditionValue)) {
+      // Condition cannot be evaluated, don't run the instruction
+      condition = false;
+    } else {
+      // If UNTIL is specified, we don't run the instruction if it evaluates to true
+      condition &&= !valueToBool(untilConditionValue);
+    }
+  }
+  if (doType2.while) {
+    const whileConditionValue = evaluateExpression(doType2.while, context);
+    if (!isScalarValue(whileConditionValue)) {
+      // Condition cannot be evaluated, don't run the instruction
+      condition = false;
+    } else {
+      // If WHILE is specified, we only run the instruction if it evaluates to true
+      condition &&= valueToBool(whileConditionValue);
+    }
+  }
+  return condition;
+}
+
+function runDoType3Instruction(
+  doType3: inst.DoType3Instruction,
+  context: InterpreterContext,
+  node: inst.InstructionNode,
+): boolean {
+  let condition = true;
+  const { specificationItems, variable } = doType3;
+
+  if (specificationItems.length === 0) {
+    throw new Error("DoType3 requires at least one specification item!");
+  }
+
+  // TODO(@@dd) --> handle more than one do-type3 spec
+  if (specificationItems.length > 1) {
+    throw new Error("Multiple DoType3 specifications not implemented yet!");
+  }
+  const spec = doType3.specificationItems[0];
+  // <- TODO(@@dd)
+
+  if (!spec.expression) {
+    throw new Error("DoType3 requires initial value!");
+  }
+
+  const iterationCount = context.counter.get(node);
+  if (iterationCount === undefined || iterationCount < 1) {
+    throw new Error("Interpreter can't determine AST node iteration count");
+  }
+  const isFirstIteration = iterationCount === 1;
+
+  const varName = variable.variable;
+  let loopVar = context.variables.get(varName);
+
+  if (isFirstIteration) {
+    // First iteration - create the loop variable and initialize it
+    const start = evaluateExpression(spec.expression, context);
+    if (!isScalarValue(start)) {
+      throw new Error("DoType3 initial value must be scalar!");
+    }
+
+    if (!loopVar) {
+      loopVar = {
+        name: varName,
+        declarationNode: variable.reference?.owner,
+        value: {
+          value: start.value,
+          type: inst.DeclaredType.Fixed,
+        },
+        active: true,
+        mode: inst.ScanMode.Scan,
+      };
+      context.variables.set(varName, loopVar);
+    } else {
+      // Variable exists, just set the initial value
+      loopVar.value = {
+        value: start.value,
+        type: inst.DeclaredType.Fixed,
+      };
+    }
+  } else {
+    // Subsequent iterations - update the loop variable
+    if (!loopVar) {
+      throw new Error(
+        "DoType3 loop variable not found on subsequent iteration!",
+      );
+    }
+
+    // Until is evaluated after each repetition of the loop body
+    if (spec.until) {
+      const untilCondition = evaluateExpression(spec.until, context);
+      if (!isScalarValue(untilCondition)) {
+        throw new Error("DoType3 condition must be scalar!");
+      }
+      condition &&= !valueToBool(untilCondition);
+    }
+
+    // Update the variable based on the loop type
+    if (spec.repeat) {
+      // The REPEAT expression is assigned to the loop variable on each loop iteration
+      const repeatValue = evaluateExpression(spec.repeat, context);
+      if (!isScalarValue(repeatValue)) {
+        throw new Error("DoType3 repeat value must be scalar!");
+      }
+      loopVar.value = {
+        value: repeatValue.value,
+        type: inst.DeclaredType.Fixed,
+      };
+    } else {
+      // TO, UPTHRU, or DOWNTHRU clause
+      let endValue;
+      let stepValue;
+
+      if (spec.to) {
+        endValue = evaluateExpression(spec.to, context);
+        if (spec.by) {
+          stepValue = evaluateExpression(spec.by, context);
+        } else {
+          stepValue = valueToNumber("1");
+        }
+      } else if (spec.upthru) {
+        endValue = evaluateExpression(spec.upthru, context);
+        stepValue = valueToNumber("1");
+      } else if (spec.downthru) {
+        endValue = evaluateExpression(spec.downthru, context);
+        stepValue = valueToNumber("-1");
+      } else {
+        throw new Error(
+          "DoType3 requires a TO, UPTHRU, DOWNTHRU or REPEAT clause!",
+        );
+      }
+
+      if (!isScalarValue(endValue)) {
+        throw new Error("DoType3 end value must be scalar!");
+      }
+      if (!isScalarValue(stepValue)) {
+        throw new Error("DoType3 step value must be scalar!");
+      }
+
+      const end = parseInt(endValue.value);
+      const step = parseInt(stepValue.value);
+
+      if (!isScalarValue(loopVar.value)) {
+        throw new Error("DoType3 loop variable must be scalar!");
+      }
+
+      let currentValue = parseInt(loopVar.value.value);
+      currentValue = currentValue + step;
+      loopVar.value = {
+        value: currentValue.toString(),
+        type: inst.DeclaredType.Fixed,
+      };
+
+      // Check if we should continue the loop
+      condition &&=
+        (step > 0 && currentValue <= end) || (step < 0 && currentValue >= end);
+    }
+  }
+
+  // While is evaluated before each repetition of the loop body
+  if (spec.while) {
+    const whileCondition = evaluateExpression(spec.while, context);
+    if (!isScalarValue(whileCondition)) {
+      throw new Error("DoType3 condition must be scalar!");
+    }
+    condition &&= valueToBool(whileCondition);
+  }
+
+  return condition;
 }
 
 function runAssignmentInstruction(

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -197,6 +197,8 @@ interface InterpreterContext {
 interface DoType3Store {
   specIndex: number;
   needsReinit: boolean;
+  savedToValue?: ScalarValue;
+  savedByValue?: ScalarValue;
 }
 
 export type InstructionInterpreterResult = CompilationUnitTokens & {
@@ -472,8 +474,49 @@ function runDoType3Instruction(
       };
     }
 
-    // Clear the reinit flag and update spec index
-    context.doType3.set(node, { specIndex: currentSpecIndex, needsReinit: false });
+    // Evaluate and save TO and BY expressions at entry to the specification
+    let savedToValue: ScalarValue | undefined;
+    let savedByValue: ScalarValue | undefined;
+
+    if (spec.to) {
+      const endValue = evaluateExpression(spec.to, context);
+      if (!isScalarValue(endValue)) {
+        throw new Error("DoType3 end value must be scalar!");
+      }
+      savedToValue = endValue;
+
+      if (spec.by) {
+        const stepValue = evaluateExpression(spec.by, context);
+        if (!isScalarValue(stepValue)) {
+          throw new Error("DoType3 step value must be scalar!");
+        }
+        savedByValue = stepValue;
+      } else {
+        savedByValue = valueToNumber("1");
+      }
+    } else if (spec.upthru) {
+      const endValue = evaluateExpression(spec.upthru, context);
+      if (!isScalarValue(endValue)) {
+        throw new Error("DoType3 end value must be scalar!");
+      }
+      savedToValue = endValue;
+      savedByValue = valueToNumber("1");
+    } else if (spec.downthru) {
+      const endValue = evaluateExpression(spec.downthru, context);
+      if (!isScalarValue(endValue)) {
+        throw new Error("DoType3 end value must be scalar!");
+      }
+      savedToValue = endValue;
+      savedByValue = valueToNumber("-1");
+    }
+
+    // Clear the reinit flag and update spec index with saved values
+    context.doType3.set(node, { 
+      specIndex: currentSpecIndex, 
+      needsReinit: false,
+      savedToValue,
+      savedByValue
+    });
     return true; // Always continue after initialization
   }
 
@@ -504,34 +547,14 @@ function runDoType3Instruction(
       type: inst.DeclaredType.Fixed,
     };
   } else {
-    // TO, UPTHRU, or DOWNTHRU clause
-    let endValue;
-    let stepValue;
+    // TO, UPTHRU, or DOWNTHRU clause - use saved values from entry evaluation
+    const endValue = doType3Store.savedToValue;
+    const stepValue = doType3Store.savedByValue;
 
-    if (spec.to) {
-      endValue = evaluateExpression(spec.to, context);
-      if (spec.by) {
-        stepValue = evaluateExpression(spec.by, context);
-      } else {
-        stepValue = valueToNumber("1");
-      }
-    } else if (spec.upthru) {
-      endValue = evaluateExpression(spec.upthru, context);
-      stepValue = valueToNumber("1");
-    } else if (spec.downthru) {
-      endValue = evaluateExpression(spec.downthru, context);
-      stepValue = valueToNumber("-1");
-    } else {
+    if (!endValue || !stepValue) {
       throw new Error(
         "DoType3 requires a TO, UPTHRU, DOWNTHRU or REPEAT clause!",
       );
-    }
-
-    if (!isScalarValue(endValue)) {
-      throw new Error("DoType3 end value must be scalar!");
-    }
-    if (!isScalarValue(stepValue)) {
-      throw new Error("DoType3 step value must be scalar!");
     }
 
     const end = parseInt(endValue.value);
@@ -586,8 +609,49 @@ function runDoType3Instruction(
       type: inst.DeclaredType.Fixed,
     };
 
-    // Update state to reflect the new spec
-    context.doType3.set(node, { specIndex: nextSpecIndex, needsReinit: false });
+    // Evaluate and save TO and BY expressions for the new specification
+    let savedToValue: ScalarValue | undefined;
+    let savedByValue: ScalarValue | undefined;
+
+    if (nextSpec.to) {
+      const endValue = evaluateExpression(nextSpec.to, context);
+      if (!isScalarValue(endValue)) {
+        throw new Error("DoType3 end value must be scalar!");
+      }
+      savedToValue = endValue;
+
+      if (nextSpec.by) {
+        const stepValue = evaluateExpression(nextSpec.by, context);
+        if (!isScalarValue(stepValue)) {
+          throw new Error("DoType3 step value must be scalar!");
+        }
+        savedByValue = stepValue;
+      } else {
+        savedByValue = valueToNumber("1");
+      }
+    } else if (nextSpec.upthru) {
+      const endValue = evaluateExpression(nextSpec.upthru, context);
+      if (!isScalarValue(endValue)) {
+        throw new Error("DoType3 end value must be scalar!");
+      }
+      savedToValue = endValue;
+      savedByValue = valueToNumber("1");
+    } else if (nextSpec.downthru) {
+      const endValue = evaluateExpression(nextSpec.downthru, context);
+      if (!isScalarValue(endValue)) {
+        throw new Error("DoType3 end value must be scalar!");
+      }
+      savedToValue = endValue;
+      savedByValue = valueToNumber("-1");
+    }
+
+    // Update state to reflect the new spec with saved values
+    context.doType3.set(node, { 
+      specIndex: nextSpecIndex, 
+      needsReinit: false,
+      savedToValue,
+      savedByValue
+    });
     return true;
   }
 

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -89,6 +89,12 @@ function copyValue(value: Value): Value {
   }
 }
 
+function variables(context: InterpreterContext): Map<string, Variable> {
+  // Returns the correct variable map for the current scope:
+  // local (in a procedure call), otherwise global
+  return context.localVariables ?? context.variables;
+}
+
 function generateVariable(
   instruction: inst.DeclareInstruction,
   context: InterpreterContext,
@@ -449,7 +455,7 @@ function runDoType3Initialization(
     return false;
   }
 
-  let loopVar = context.variables.get(varName);
+  let loopVar = variables(context).get(varName);
 
   // Implicitly declare the loop variable if it doesn't exist, or update existing variable
   if (!loopVar) {
@@ -463,7 +469,7 @@ function runDoType3Initialization(
       active: true,
       mode: inst.ScanMode.Scan,
     };
-    context.variables.set(varName, loopVar);
+    variables(context).set(varName, loopVar);
   } else {
     // Update existing variable to the start value
     loopVar.value = {
@@ -546,7 +552,7 @@ function runDoType3VariableUpdate(
   const varName = variable.variable;
   const spec = doType3.specification;
 
-  const loopVar = context.variables.get(varName);
+  const loopVar = variables(context).get(varName);
   if (!loopVar) {
     return false;
   }
@@ -598,9 +604,7 @@ function runAssignmentInstruction(
 ): void {
   const value = evaluateExpression(instruction.value, context);
   for (const ref of instruction.refs) {
-    let variable =
-      context.localVariables?.get(ref.variable) ??
-      context.variables.get(ref.variable);
+    let variable = variables(context).get(ref.variable);
     if (!variable) {
       if (ref.args.length > 0) {
         // This seems to write into an undeclared array variable
@@ -615,7 +619,7 @@ function runAssignmentInstruction(
         active: false, // Implicitly declared variables are inactive by default
         mode: inst.ScanMode.Scan,
       };
-      (context.localVariables ?? context.variables).set(ref.variable, variable);
+      variables(context).set(ref.variable, variable);
     } else {
       evaluateValueAccess(variable, ref.args, context).setter(value);
     }
@@ -789,9 +793,7 @@ function evaluateReferenceExpression(
   expression: inst.ReferenceItemInstruction,
   context: InterpreterContext,
 ): Value {
-  const variable =
-    context.localVariables?.get(expression.variable) ||
-    context.variables.get(expression.variable);
+  const variable = variables(context).get(expression.variable);
   if (!variable) {
     const procedure = context.procedures.get(expression.variable);
     if (!procedure) {
@@ -981,12 +983,11 @@ function runDeclareInstruction(
     context.activeProcedures.add(instruction.name);
     return;
   }
-  // If the local variables are defined, that means we are in a procedure
-  const variables = context.localVariables ?? context.variables;
-  // Don't override existing variables
-  if (!variables.has(instruction.name)) {
+  // Consider variables declared in a procedure call
+  // and don't override existing variables
+  if (!variables(context).has(instruction.name)) {
     const variable = generateVariable(instruction, context);
-    variables.set(variable.name, variable);
+    variables(context).set(variable.name, variable);
   }
 }
 
@@ -995,7 +996,7 @@ function runActivateInstruction(
   context: InterpreterContext,
 ): void {
   const name = instruction.variable.variable;
-  const variable = context.variables.get(name);
+  const variable = variables(context).get(name);
   if (variable) {
     if (instruction.scanMode !== undefined) {
       variable.mode = instruction.scanMode;
@@ -1012,7 +1013,7 @@ function runDeactivateInstruction(
   context: InterpreterContext,
 ): void {
   const name = instruction.variable.variable;
-  const variable = context.variables.get(name);
+  const variable = variables(context).get(name);
   context.activeProcedures.delete(name);
   if (variable) {
     variable.active = false;
@@ -1100,7 +1101,7 @@ function performTokenScan(
   context: InterpreterContext,
 ): Token[] | undefined {
   const image = token.image;
-  const variable = context.variables.get(image);
+  const variable = variables(context).get(image);
   // If there is no active variable with that name, return undefined
   // The caller side will simply push the token to the output
   if (!variable?.active) {

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -195,8 +195,6 @@ interface InterpreterContext {
 }
 
 interface DoType3Store {
-  specIndex: number;
-  needsReinit: boolean;
   savedToValue?: ScalarValue;
   savedByValue?: ScalarValue;
 }
@@ -415,35 +413,25 @@ function runDoType3Instruction(
 ): boolean {
   const { specificationItems, variable } = doType3;
 
-  if (specificationItems.length === 0) {
+  // Do specification required, multiple specifications are not supported
+  if (specificationItems.length !== 1) {
     return false;
   }
 
-  // Get current spec index, starting at 0 for first iteration
-  const doType3Store = context.doType3.get(node) ?? {
-    specIndex: 0,
-    needsReinit: true,
-  };
-  let currentSpecIndex = doType3Store.specIndex;
-  const needsReinit = doType3Store.needsReinit;
-
-  // If we've exhausted all specifications, return false to stop the loop
-  if (currentSpecIndex >= specificationItems.length) {
-    return false;
-  }
-
-  const spec = specificationItems[currentSpecIndex];
-  // TODO(@@dd): change this, according to the spec, the initial value is not required
-  if (!spec.expression) {
-    return false;
-  }
+  // Get the single specification
+  const spec = specificationItems[0];
+  
+  // Get current do-type3 state
+  const doType3Store = context.doType3.get(node);
 
   const varName = variable.variable;
   let loopVar = context.variables.get(varName);
 
-  // Initialize when we need to reinitialize for a new spec (including first time)
-  // or when the loop variable doesn't exist (implicit declaration)
-  if (!loopVar || needsReinit) {
+  // Initialize when called the first time)
+  if (!loopVar || !doType3Store) {
+    if (!spec.expression) {
+      return false;
+    }
     const start = evaluateExpression(spec.expression, context);
     if (!isScalarValue(start)) {
       return false;
@@ -506,10 +494,8 @@ function runDoType3Instruction(
       savedByValue = valueToNumber("-1");
     }
 
-    // Clear the reinit flag and update spec index with saved values
+    // Save values that must be evaluated only once
     context.doType3.set(node, {
-      specIndex: currentSpecIndex,
-      needsReinit: false,
       savedToValue,
       savedByValue,
     });
@@ -577,74 +563,6 @@ function runDoType3Instruction(
       return false;
     }
     condition &&= valueToBool(whileCondition);
-  }
-
-  // If current spec is done, try to advance to next spec
-  if (!condition && currentSpecIndex < specificationItems.length - 1) {
-    // Advance to next spec immediately and reinitialize
-    const nextSpecIndex = currentSpecIndex + 1;
-    const nextSpec = specificationItems[nextSpecIndex];
-
-    // TODO(@@dd): change this, according to the spec, the initial value is not required
-    if (!nextSpec.expression) {
-      return false;
-    }
-
-    const start = evaluateExpression(nextSpec.expression, context);
-    if (!isScalarValue(start)) {
-      return false;
-    }
-
-    // Reinitialize with the next spec's initial value
-    loopVar.value = {
-      value: start.value,
-      type: inst.DeclaredType.Fixed,
-    };
-
-    // Evaluate and save TO and BY expressions for the new specification
-    let savedToValue: ScalarValue | undefined;
-    let savedByValue: ScalarValue | undefined;
-
-    if (nextSpec.to) {
-      const endValue = evaluateExpression(nextSpec.to, context);
-      if (!isScalarValue(endValue)) {
-        return false;
-      }
-      savedToValue = endValue;
-
-      if (nextSpec.by) {
-        const stepValue = evaluateExpression(nextSpec.by, context);
-        if (!isScalarValue(stepValue)) {
-          return false;
-        }
-        savedByValue = stepValue;
-      } else {
-        savedByValue = valueToNumber("1");
-      }
-    } else if (nextSpec.upthru) {
-      const endValue = evaluateExpression(nextSpec.upthru, context);
-      if (!isScalarValue(endValue)) {
-        return false;
-      }
-      savedToValue = endValue;
-      savedByValue = valueToNumber("1");
-    } else if (nextSpec.downthru) {
-      const endValue = evaluateExpression(nextSpec.downthru, context);
-      if (!isScalarValue(endValue)) {
-        return false;
-      }
-      savedToValue = endValue;
-      savedByValue = valueToNumber("-1");
-    }
-
-    // Update state to reflect the new spec with saved values
-    context.doType3.set(node, {
-      specIndex: nextSpecIndex,
-      needsReinit: false,
-      savedToValue,
-      savedByValue,
-    });
-    return true;
   }
 
   return condition;

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -185,14 +185,18 @@ interface InterpreterContext {
   procedures: Map<string, inst.ProcedureInstructionContainer>;
   activeProcedures: Set<string>;
   counter: Map<inst.InstructionNode, number>;
-  doType3SpecIndex: Map<inst.InstructionNode, number>;
-  doType3NeedsReinit: Map<inst.InstructionNode, boolean>;
+  doType3: Map<inst.InstructionNode, DoType3Store>;
   references: ast.Reference[];
   evaluations: EvaluationResults;
   xIncludes: Set<string>;
   uris: string[];
   options: InterpreterOptions;
   returnValue: Value;
+}
+
+interface DoType3Store {
+  specIndex: number;
+  needsReinit: boolean;
 }
 
 export type InstructionInterpreterResult = CompilationUnitTokens & {
@@ -237,8 +241,7 @@ export function runInstructions(
     },
     options,
     counter: new Map(),
-    doType3SpecIndex: new Map(),
-    doType3NeedsReinit: new Map(),
+    doType3: new Map(),
     returnValue: defaultEmptyValue,
   };
   for (const [key, value] of instruction.procedures.entries()) {
@@ -426,8 +429,9 @@ function runDoType3Instruction(
   const isFirstIteration = iterationCount === 1;
 
   // Get current spec index, starting at 0 for first iteration
-  let currentSpecIndex = context.doType3SpecIndex.get(node) ?? 0;
-  const needsReinit = context.doType3NeedsReinit.get(node) ?? false;
+  const doType3Store = context.doType3.get(node) ?? { specIndex: 0, needsReinit: false };
+  let currentSpecIndex = doType3Store.specIndex;
+  const needsReinit = doType3Store.needsReinit;
 
   // If we've exhausted all specifications, return false to stop the loop
   if (currentSpecIndex >= specificationItems.length) {
@@ -469,8 +473,7 @@ function runDoType3Instruction(
     }
 
     // Clear the reinit flag and update spec index
-    context.doType3NeedsReinit.set(node, false);
-    context.doType3SpecIndex.set(node, currentSpecIndex);
+    context.doType3.set(node, { specIndex: currentSpecIndex, needsReinit: false });
     return true; // Always continue after initialization
   }
 
@@ -584,8 +587,7 @@ function runDoType3Instruction(
     };
 
     // Update state to reflect the new spec
-    context.doType3SpecIndex.set(node, nextSpecIndex);
-    context.doType3NeedsReinit.set(node, false);
+    context.doType3.set(node, { specIndex: nextSpecIndex, needsReinit: false });
     return true;
   }
 

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -466,7 +466,7 @@ function runDoType3Initialization(
         value: start.value,
         type: inst.DeclaredType.Fixed,
       },
-      active: true,
+      active: false,
       mode: inst.ScanMode.Scan,
     };
     variables(context).set(varName, loopVar);

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -424,14 +424,8 @@ function runDoType3Instruction(
     throw new Error("DoType3 requires at least one specification item!");
   }
 
-  const iterationCount = context.counter.get(node);
-  if (iterationCount === undefined || iterationCount < 1) {
-    throw new Error("Interpreter can't determine AST node iteration count");
-  }
-  const isFirstIteration = iterationCount === 1;
-
   // Get current spec index, starting at 0 for first iteration
-  const doType3Store = context.doType3.get(node) ?? { specIndex: 0, needsReinit: false };
+  const doType3Store = context.doType3.get(node) ?? { specIndex: 0, needsReinit: true };
   let currentSpecIndex = doType3Store.specIndex;
   const needsReinit = doType3Store.needsReinit;
 
@@ -448,8 +442,8 @@ function runDoType3Instruction(
   const varName = variable.variable;
   let loopVar = context.variables.get(varName);
 
-  // Initialize for first iteration OR when we need to reinitialize for a new spec
-  if (isFirstIteration || needsReinit) {
+  // Initialize when we need to reinitialize for a new spec (including first time)
+  if (needsReinit) {
     const start = evaluateExpression(spec.expression, context);
     if (!isScalarValue(start)) {
       throw new Error("DoType3 initial value must be scalar!");

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -420,7 +420,10 @@ function runDoType3Instruction(
   }
 
   // Get current spec index, starting at 0 for first iteration
-  const doType3Store = context.doType3.get(node) ?? { specIndex: 0, needsReinit: true };
+  const doType3Store = context.doType3.get(node) ?? {
+    specIndex: 0,
+    needsReinit: true,
+  };
   let currentSpecIndex = doType3Store.specIndex;
   const needsReinit = doType3Store.needsReinit;
 
@@ -439,13 +442,15 @@ function runDoType3Instruction(
   let loopVar = context.variables.get(varName);
 
   // Initialize when we need to reinitialize for a new spec (including first time)
-  if (needsReinit) {
+  // or when the loop variable doesn't exist (implicit declaration)
+  if (!loopVar || needsReinit) {
     const start = evaluateExpression(spec.expression, context);
     if (!isScalarValue(start)) {
       return false;
     }
 
     if (!loopVar) {
+      // Implicitly declare the loop variable if it doesn't exist
       loopVar = {
         name: varName,
         declarationNode: variable.reference?.owner,
@@ -458,6 +463,7 @@ function runDoType3Instruction(
       };
       context.variables.set(varName, loopVar);
     } else {
+      // Next doSequence, update the loop variable if it already exists
       loopVar.value = {
         value: start.value,
         type: inst.DeclaredType.Fixed,
@@ -501,18 +507,13 @@ function runDoType3Instruction(
     }
 
     // Clear the reinit flag and update spec index with saved values
-    context.doType3.set(node, { 
-      specIndex: currentSpecIndex, 
+    context.doType3.set(node, {
+      specIndex: currentSpecIndex,
       needsReinit: false,
       savedToValue,
-      savedByValue
+      savedByValue,
     });
     return true; // Always continue after initialization
-  }
-
-  // Sanity check (normal iteration within current spec)
-  if (!loopVar) {
-    return false;
   }
 
   let condition = true;
@@ -637,11 +638,11 @@ function runDoType3Instruction(
     }
 
     // Update state to reflect the new spec with saved values
-    context.doType3.set(node, { 
-      specIndex: nextSpecIndex, 
+    context.doType3.set(node, {
+      specIndex: nextSpecIndex,
       needsReinit: false,
       savedToValue,
-      savedByValue
+      savedByValue,
     });
     return true;
   }

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -416,7 +416,7 @@ function runDoType3Instruction(
   const { specificationItems, variable } = doType3;
 
   if (specificationItems.length === 0) {
-    throw new Error("DoType3 requires at least one specification item!");
+    return false;
   }
 
   // Get current spec index, starting at 0 for first iteration
@@ -430,8 +430,9 @@ function runDoType3Instruction(
   }
 
   const spec = specificationItems[currentSpecIndex];
+  // TODO(@@dd): change this, according to the spec, the initial value is not required
   if (!spec.expression) {
-    throw new Error("DoType3 requires initial value!");
+    return false;
   }
 
   const varName = variable.variable;
@@ -441,7 +442,7 @@ function runDoType3Instruction(
   if (needsReinit) {
     const start = evaluateExpression(spec.expression, context);
     if (!isScalarValue(start)) {
-      throw new Error("DoType3 initial value must be scalar!");
+      return false;
     }
 
     if (!loopVar) {
@@ -470,14 +471,14 @@ function runDoType3Instruction(
     if (spec.to) {
       const endValue = evaluateExpression(spec.to, context);
       if (!isScalarValue(endValue)) {
-        throw new Error("DoType3 end value must be scalar!");
+        return false;
       }
       savedToValue = endValue;
 
       if (spec.by) {
         const stepValue = evaluateExpression(spec.by, context);
         if (!isScalarValue(stepValue)) {
-          throw new Error("DoType3 step value must be scalar!");
+          return false;
         }
         savedByValue = stepValue;
       } else {
@@ -486,14 +487,14 @@ function runDoType3Instruction(
     } else if (spec.upthru) {
       const endValue = evaluateExpression(spec.upthru, context);
       if (!isScalarValue(endValue)) {
-        throw new Error("DoType3 end value must be scalar!");
+        return false;
       }
       savedToValue = endValue;
       savedByValue = valueToNumber("1");
     } else if (spec.downthru) {
       const endValue = evaluateExpression(spec.downthru, context);
       if (!isScalarValue(endValue)) {
-        throw new Error("DoType3 end value must be scalar!");
+        return false;
       }
       savedToValue = endValue;
       savedByValue = valueToNumber("-1");
@@ -509,9 +510,9 @@ function runDoType3Instruction(
     return true; // Always continue after initialization
   }
 
-  // Normal iteration within current spec - update the loop variable
+  // Sanity check (normal iteration within current spec)
   if (!loopVar) {
-    throw new Error("DoType3 loop variable not found on subsequent iteration!");
+    return false;
   }
 
   let condition = true;
@@ -520,7 +521,7 @@ function runDoType3Instruction(
   if (spec.until) {
     const untilCondition = evaluateExpression(spec.until, context);
     if (!isScalarValue(untilCondition)) {
-      throw new Error("DoType3 condition must be scalar!");
+      return false;
     }
     condition &&= !valueToBool(untilCondition);
   }
@@ -529,7 +530,7 @@ function runDoType3Instruction(
   if (spec.repeat) {
     const repeatValue = evaluateExpression(spec.repeat, context);
     if (!isScalarValue(repeatValue)) {
-      throw new Error("DoType3 repeat value must be scalar!");
+      return false;
     }
     loopVar.value = {
       value: repeatValue.value,
@@ -540,17 +541,17 @@ function runDoType3Instruction(
     const endValue = doType3Store.savedToValue;
     const stepValue = doType3Store.savedByValue;
 
+    // TODO(@@dd): change this, according to the spec, the initial value is not required
+    // Sanity check (TO, UPTHRU, or DOWNTHRU clause)
     if (!endValue || !stepValue) {
-      throw new Error(
-        "DoType3 requires a TO, UPTHRU, DOWNTHRU or REPEAT clause!",
-      );
+      return false;
     }
 
     const end = parseInt(endValue.value);
     const step = parseInt(stepValue.value);
 
     if (!isScalarValue(loopVar.value)) {
-      throw new Error("DoType3 loop variable must be scalar!");
+      return false;
     }
 
     let currentValue = parseInt(loopVar.value.value);
@@ -572,7 +573,7 @@ function runDoType3Instruction(
   if (spec.while) {
     const whileCondition = evaluateExpression(spec.while, context);
     if (!isScalarValue(whileCondition)) {
-      throw new Error("DoType3 condition must be scalar!");
+      return false;
     }
     condition &&= valueToBool(whileCondition);
   }
@@ -583,13 +584,14 @@ function runDoType3Instruction(
     const nextSpecIndex = currentSpecIndex + 1;
     const nextSpec = specificationItems[nextSpecIndex];
 
+    // TODO(@@dd): change this, according to the spec, the initial value is not required
     if (!nextSpec.expression) {
-      throw new Error("DoType3 requires initial value!");
+      return false;
     }
 
     const start = evaluateExpression(nextSpec.expression, context);
     if (!isScalarValue(start)) {
-      throw new Error("DoType3 initial value must be scalar!");
+      return false;
     }
 
     // Reinitialize with the next spec's initial value
@@ -605,14 +607,14 @@ function runDoType3Instruction(
     if (nextSpec.to) {
       const endValue = evaluateExpression(nextSpec.to, context);
       if (!isScalarValue(endValue)) {
-        throw new Error("DoType3 end value must be scalar!");
+        return false;
       }
       savedToValue = endValue;
 
       if (nextSpec.by) {
         const stepValue = evaluateExpression(nextSpec.by, context);
         if (!isScalarValue(stepValue)) {
-          throw new Error("DoType3 step value must be scalar!");
+          return false;
         }
         savedByValue = stepValue;
       } else {
@@ -621,14 +623,14 @@ function runDoType3Instruction(
     } else if (nextSpec.upthru) {
       const endValue = evaluateExpression(nextSpec.upthru, context);
       if (!isScalarValue(endValue)) {
-        throw new Error("DoType3 end value must be scalar!");
+        return false;
       }
       savedToValue = endValue;
       savedByValue = valueToNumber("1");
     } else if (nextSpec.downthru) {
       const endValue = evaluateExpression(nextSpec.downthru, context);
       if (!isScalarValue(endValue)) {
-        throw new Error("DoType3 end value must be scalar!");
+        return false;
       }
       savedToValue = endValue;
       savedByValue = valueToNumber("-1");

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -428,7 +428,7 @@ function runDoType3Instruction(
   } else {
     // Subsequent iterations
     condition &&= runDoType3UntilCheck(doType3, context);
-    condition &&= runDoType3VariableUpdate(doType3, context, node);
+    condition &&= runDoType3VariableUpdate(doType3, context, doType3Context);
   }
 
   // Check WHILE condition before do-group execution
@@ -546,7 +546,7 @@ function runDoType3UntilCheck(
 function runDoType3VariableUpdate(
   doType3: inst.DoType3Instruction,
   context: InterpreterContext,
-  node: inst.InstructionNode,
+  doType3Context: DoType3Context,
 ): boolean {
   const { variable } = doType3;
   const varName = variable.variable;
@@ -569,7 +569,6 @@ function runDoType3VariableUpdate(
     // No range check needed for REPEAT-only loops
     return true;
   } else if (spec.to) {
-    const doType3Context = context.doType3.get(node);
     if (!doType3Context?.toValue || !doType3Context?.byValue) {
       return false;
     }

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -185,7 +185,7 @@ interface InterpreterContext {
   procedures: Map<string, inst.ProcedureInstructionContainer>;
   activeProcedures: Set<string>;
   counter: Map<inst.InstructionNode, number>;
-  doType3: Map<inst.InstructionNode, DoType3Store>;
+  doType3: Map<inst.InstructionNode, DoType3Context>;
   references: ast.Reference[];
   evaluations: EvaluationResults;
   xIncludes: Set<string>;
@@ -194,9 +194,9 @@ interface InterpreterContext {
   returnValue: Value;
 }
 
-interface DoType3Store {
-  savedToValue?: ScalarValue;
-  savedByValue?: ScalarValue;
+interface DoType3Context {
+  toValue?: ScalarValue;
+  byValue?: ScalarValue;
 }
 
 export type InstructionInterpreterResult = CompilationUnitTokens & {
@@ -411,34 +411,28 @@ function runDoType3Instruction(
   context: InterpreterContext,
   node: inst.InstructionNode,
 ): boolean {
-  const { specificationItems, variable } = doType3;
+  const { variable } = doType3;
+  const varName = variable.variable;
+  const spec = doType3.specification;
 
-  // Do specification required, multiple specifications are not supported
-  if (specificationItems.length !== 1) {
+  // Initial expression is required
+  if (!spec.expression) {
+    return false;
+  }
+  const start = evaluateExpression(spec.expression, context);
+  if (!isScalarValue(start)) {
     return false;
   }
 
-  // Get the single specification
-  const spec = specificationItems[0];
-  
   // Get current do-type3 state
-  const doType3Store = context.doType3.get(node);
+  let doType3Context = context.doType3.get(node);
 
-  const varName = variable.variable;
   let loopVar = context.variables.get(varName);
 
-  // Initialize when called the first time)
-  if (!loopVar || !doType3Store) {
-    if (!spec.expression) {
-      return false;
-    }
-    const start = evaluateExpression(spec.expression, context);
-    if (!isScalarValue(start)) {
-      return false;
-    }
-
+  // Initialize the do-type3 context on first iteration
+  if (!doType3Context) {
+    // Implicitly declare the loop variable if it doesn't exist, or update existing variable
     if (!loopVar) {
-      // Implicitly declare the loop variable if it doesn't exist
       loopVar = {
         name: varName,
         declarationNode: variable.reference?.owner,
@@ -451,7 +445,7 @@ function runDoType3Instruction(
       };
       context.variables.set(varName, loopVar);
     } else {
-      // Next doSequence, update the loop variable if it already exists
+      // Update existing variable to the start value
       loopVar.value = {
         value: start.value,
         type: inst.DeclaredType.Fixed,
@@ -459,52 +453,46 @@ function runDoType3Instruction(
     }
 
     // Evaluate and save TO and BY expressions at entry to the specification
-    let savedToValue: ScalarValue | undefined;
-    let savedByValue: ScalarValue | undefined;
+    let toValue: ScalarValue | undefined;
+    let byValue: ScalarValue | undefined;
 
     if (spec.to) {
-      const endValue = evaluateExpression(spec.to, context);
-      if (!isScalarValue(endValue)) {
+      const value = evaluateExpression(spec.to, context);
+      if (!isScalarValue(value)) {
         return false;
       }
-      savedToValue = endValue;
-
-      if (spec.by) {
-        const stepValue = evaluateExpression(spec.by, context);
-        if (!isScalarValue(stepValue)) {
-          return false;
-        }
-        savedByValue = stepValue;
-      } else {
-        savedByValue = valueToNumber("1");
-      }
-    } else if (spec.upthru) {
-      const endValue = evaluateExpression(spec.upthru, context);
-      if (!isScalarValue(endValue)) {
-        return false;
-      }
-      savedToValue = endValue;
-      savedByValue = valueToNumber("1");
-    } else if (spec.downthru) {
-      const endValue = evaluateExpression(spec.downthru, context);
-      if (!isScalarValue(endValue)) {
-        return false;
-      }
-      savedToValue = endValue;
-      savedByValue = valueToNumber("-1");
+      toValue = value;
     }
 
-    // Save values that must be evaluated only once
-    context.doType3.set(node, {
-      savedToValue,
-      savedByValue,
-    });
-    return true; // Always continue after initialization
+    if (spec.by) {
+      const value = evaluateExpression(spec.by, context);
+      if (!isScalarValue(value)) {
+        return false;
+      }
+      byValue = value;
+    } else {
+      byValue = valueToNumber("1");
+    }
+      
+    doType3Context = {
+      toValue,
+      byValue,
+    };
+
+    context.doType3.set(node, doType3Context);
+
+    // Always continue after initialization
+    return true;
+  }
+
+  // Ensure loop variable exists for subsequent iterations
+  if (!loopVar) {
+    return false; // Variable should exist by now
   }
 
   let condition = true;
 
-  // Until is evaluated after each repetition of the loop body
+  // Until is evaluated after each repetition of the do-group
   if (spec.until) {
     const untilCondition = evaluateExpression(spec.until, context);
     if (!isScalarValue(untilCondition)) {
@@ -523,20 +511,19 @@ function runDoType3Instruction(
       value: repeatValue.value,
       type: inst.DeclaredType.Fixed,
     };
-  } else {
-    // TO, UPTHRU, or DOWNTHRU clause - use saved values from entry evaluation
-    const endValue = doType3Store.savedToValue;
-    const stepValue = doType3Store.savedByValue;
+  } else if (spec.to) {
 
-    // TODO(@@dd): change this, according to the spec, the initial value is not required
-    // Sanity check (TO, UPTHRU, or DOWNTHRU clause)
-    if (!endValue || !stepValue) {
+    const { toValue, byValue } = doType3Context;
+
+    // Sanity check for TypeScript, values must be set
+    if (!toValue || !byValue) {
       return false;
     }
 
-    const end = parseInt(endValue.value);
-    const step = parseInt(stepValue.value);
+    const end = parseInt(toValue.value);
+    const step = parseInt(byValue.value);
 
+    // Sanity check for TypeScript, the loop variable must be a number
     if (!isScalarValue(loopVar.value)) {
       return false;
     }
@@ -554,9 +541,12 @@ function runDoType3Instruction(
         type: inst.DeclaredType.Fixed,
       };
     }
+  } else {
+    // unsupported do specification clause
+    return false;
   }
 
-  // While is evaluated before each repetition of the loop body
+  // While is evaluated with the updated value (after increment)
   if (spec.while) {
     const whileCondition = evaluateExpression(spec.while, context);
     if (!isScalarValue(whileCondition)) {

--- a/packages/language/src/preprocessor/instructions.ts
+++ b/packages/language/src/preprocessor/instructions.ts
@@ -203,13 +203,11 @@ export interface DoType2Instruction {
 
 export interface DoType3Instruction {
   variable: ReferenceItemInstruction;
-  specificationItems: DoType3SpecificationItem[];
+  specification: DoType3Specification;
 }
 
-export interface DoType3SpecificationItem {
+export interface DoType3Specification {
   expression: ExpressionInstruction | null;
-  upthru: ExpressionInstruction | null;
-  downthru: ExpressionInstruction | null;
   repeat: ExpressionInstruction | null;
   while: ExpressionInstruction | null;
   until: ExpressionInstruction | null;

--- a/packages/language/src/preprocessor/instructions.ts
+++ b/packages/language/src/preprocessor/instructions.ts
@@ -211,7 +211,8 @@ export interface DoType3SpecificationItem {
   upthru: ExpressionInstruction | null;
   downthru: ExpressionInstruction | null;
   repeat: ExpressionInstruction | null;
-  whileOrUntil: ExpressionInstruction | null;
+  while: ExpressionInstruction | null;
+  until: ExpressionInstruction | null;
   to: ExpressionInstruction | null;
   by: ExpressionInstruction | null;
 }

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-by-to.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-by-to.ts
@@ -17,10 +17,10 @@
 
 //// %DCL I FIXED;
 //// %DO I = 5 BY 5 TO 10;
-////   DCL Var%;I FIXED;
+////   I
 //// %END;
 
 preprocessor.expectTokens(`
-  DCL Var5 FIXED;
-  DCL Var10 FIXED;
+  5
+  10
 `);

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-by-to.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-by-to.ts
@@ -1,0 +1,26 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+/**
+ * DO Type 3 - DO with BY before TO
+ */
+
+//// %DCL I FIXED;
+//// %DO I = 5 BY 5 TO 10;
+////   DCL Var%;I FIXED;
+//// %END;
+
+preprocessor.expectTokens(`
+  DCL Var5 FIXED;
+  DCL Var10 FIXED;
+`);

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-by-while.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-by-while.ts
@@ -1,0 +1,26 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+/**
+ * DO Type 3 - Complex DO with BY and WHILE
+ */
+
+//// %DCL I FIXED;
+//// %DO I = 10 TO 30 BY 10 WHILE(I < 25);
+////   DCL Var%;I FIXED;
+//// %END;
+
+preprocessor.expectTokens(`
+  DCL Var10 FIXED;
+  DCL Var20 FIXED;
+`);

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-by-while.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-by-while.ts
@@ -17,10 +17,10 @@
 
 //// %DCL I FIXED;
 //// %DO I = 10 TO 30 BY 10 WHILE(I < 25);
-////   DCL Var%;I FIXED;
+////   I
 //// %END;
 
 preprocessor.expectTokens(`
-  DCL Var10 FIXED;
-  DCL Var20 FIXED;
+  10
+  20
 `);

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-downthru.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-downthru.ts
@@ -21,4 +21,4 @@
 //// %END;
 
 // downthru not supported
-preprocessor.expectTokens('');
+preprocessor.expectTokens("");

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-downthru.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-downthru.ts
@@ -17,7 +17,7 @@
 
 //// %DCL I FIXED;
 //// %DO I = 3 DOWNTHRU 1;
-////   DCL Var%;I FIXED;
+////   I
 //// %END;
 
 // downthru not supported

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-downthru.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-downthru.ts
@@ -1,0 +1,27 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+/**
+ * DO Type 3 - DO with DOWNTHRU
+ */
+
+//// %DCL I FIXED;
+//// %DO I = 3 DOWNTHRU 1;
+////   DCL Var%;I FIXED;
+//// %END;
+
+preprocessor.expectTokens(`
+  DCL Var3 FIXED;
+  DCL Var2 FIXED;
+  DCL Var1 FIXED;
+`);

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-downthru.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-downthru.ts
@@ -20,8 +20,5 @@
 ////   DCL Var%;I FIXED;
 //// %END;
 
-preprocessor.expectTokens(`
-  DCL Var3 FIXED;
-  DCL Var2 FIXED;
-  DCL Var1 FIXED;
-`);
+// downthru not supported
+preprocessor.expectTokens('');

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-multiple-specs.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-multiple-specs.ts
@@ -21,4 +21,4 @@
 //// %END;
 
 // multiple specifications not supported
-preprocessor.expectTokens('');
+preprocessor.expectTokens("");

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-multiple-specs.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-multiple-specs.ts
@@ -17,7 +17,7 @@
 
 //// %DCL I FIXED;
 //// %DO I = 1 TO 2, 4 TO 6 BY 2;
-////   DCL VarI%;I FIXED;
+////   I
 //// %END;
 
 // multiple specifications not supported

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-multiple-specs.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-multiple-specs.ts
@@ -20,9 +20,5 @@
 ////   DCL VarI%;I FIXED;
 //// %END;
 
-preprocessor.expectTokens(`
-  DCL VarI1 FIXED;
-  DCL VarI2 FIXED;
-  DCL VarI4 FIXED;
-  DCL VarI6 FIXED;
-`);
+// multiple specifications not supported
+preprocessor.expectTokens('');

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-multiple-specs.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-multiple-specs.ts
@@ -1,0 +1,28 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+/**
+ * DO Type 3 - DO with multiple specifications
+ */
+
+//// %DCL I FIXED;
+//// %DO I = 1 TO 2, 2 TO 4 BY 2;
+////   DCL VarI%;I FIXED;
+//// %END;
+
+preprocessor.expectTokens(`
+  DCL VarI1 FIXED;
+  DCL VarI2 FIXED;
+  DCL VarI2 FIXED;
+  DCL VarI4 FIXED;
+`);

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-repeat.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-repeat.ts
@@ -1,0 +1,28 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+/**
+ * DO Type 3 - DO with REPEAT
+ */
+
+//// %DCL I FIXED;
+//// %DO I = 1 REPEAT 2*I UNTIL(I > 6);
+////   DCL Var%;I FIXED;
+//// %END;
+
+preprocessor.expectTokens(`
+  DCL Var1 FIXED;
+  DCL Var2 FIXED;
+  DCL Var4 FIXED;
+  DCL Var8 FIXED;
+`);

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-repeat.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-repeat.ts
@@ -17,12 +17,12 @@
 
 //// %DCL I FIXED;
 //// %DO I = 1 REPEAT 2*I UNTIL(I > 6);
-////   DCL Var%;I FIXED;
+////   I
 //// %END;
 
 preprocessor.expectTokens(`
-  DCL Var1 FIXED;
-  DCL Var2 FIXED;
-  DCL Var4 FIXED;
-  DCL Var8 FIXED;
+  1
+  2
+  4
+  8
 `);

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-to-by.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-to-by.ts
@@ -16,7 +16,12 @@
  */
 
 //// %DCL I FIXED;
-//// %DO I = 2 TO 4 BY 2;
+//// %DCL X FIXED;
+//// %X = 4;
+//// %Y = 2;
+//// %DO I = 2 TO X BY Y;
+////   %X = X + 1;
+////   %Y = Y + 1;
 ////   DCL Var%;I FIXED;
 //// %END;
 

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-to-by.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-to-by.ts
@@ -1,0 +1,26 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+/**
+ * DO Type 3 - DO with BY clause
+ */
+
+//// %DCL I FIXED;
+//// %DO I = 2 TO 4 BY 2;
+////   DCL Var%;I FIXED;
+//// %END;
+
+preprocessor.expectTokens(`
+  DCL Var2 FIXED;
+  DCL Var4 FIXED;
+`);

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-to-by.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-to-by.ts
@@ -22,10 +22,10 @@
 //// %DO I = 2 TO X BY Y;
 ////   %X = X + 1;
 ////   %Y = Y + 1;
-////   DCL Var%;I FIXED;
+////   I
 //// %END;
 
 preprocessor.expectTokens(`
-  DCL Var2 FIXED;
-  DCL Var4 FIXED;
+  2
+  4
 `);

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-to-by.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-to-by.ts
@@ -13,6 +13,10 @@
 
 /**
  * DO Type 3 - DO with BY clause
+ *
+ * This test verifies that the preprocessor correctly implements the DO Type 3
+ * specification by ensuring that the TO and BY expressions are evaluated only
+ * once at loop entry, not re-evaluated on each iteration.
  */
 
 //// %DCL I FIXED;

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-to.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-to.ts
@@ -16,7 +16,10 @@
  */
 
 //// %DCL I FIXED;
-//// %DO I = 1 TO 2;
+//// %DCL X FIXED;
+//// %X = 2;
+//// %DO I = 1 TO X;
+////   %X = X + 1;
 ////   DCL Var%;I FIXED;
 //// %END;
 

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-to.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-to.ts
@@ -20,10 +20,10 @@
 //// %X = 2;
 //// %DO I = 1 TO X;
 ////   %X = X + 1;
-////   DCL Var%;I FIXED;
+////   I
 //// %END;
 
 preprocessor.expectTokens(`
-  DCL Var1 FIXED;
-  DCL Var2 FIXED;
+  1
+  2
 `);

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-to.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-to.ts
@@ -1,0 +1,26 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+/**
+ * DO Type 3 - Basic DO i = 1 TO 10
+ */
+
+//// %DCL I FIXED;
+//// %DO I = 1 TO 2;
+////   DCL Var%;I FIXED;
+//// %END;
+
+preprocessor.expectTokens(`
+  DCL Var1 FIXED;
+  DCL Var2 FIXED;
+`);

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-to_implicit_loopVar_decl_active.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-to_implicit_loopVar_decl_active.ts
@@ -1,0 +1,29 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+/**
+ * DO Type 3 - DO without explicit loop variable declaration
+ *
+ * This will implicitly declare an incactive loop variable I (and set it to 1).
+ * In this test, we activate the loop variable such that it can be observed.
+ */
+
+//// %DO I = 1 TO 2;
+////   %ACTIVATE I;
+////   I
+//// %END;
+
+preprocessor.expectTokens(`
+  1
+  2
+`);

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-to_implicit_loopVar_decl_non-active.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-to_implicit_loopVar_decl_non-active.ts
@@ -13,6 +13,9 @@
 
 /**
  * DO Type 3 - DO without explicit loop variable declaration
+ *
+ * This will implicitly declare an incactive loop variable I (and set it to 1).
+ * In this test, we don't activate the loop variable such it is not substituted by its value.
  */
 
 //// %DO I = 1 TO 2;
@@ -20,6 +23,6 @@
 //// %END;
 
 preprocessor.expectTokens(`
-  1
-  2
+  I
+  I
 `);

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-to_without_explicit_loopVar_decl.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-to_without_explicit_loopVar_decl.ts
@@ -12,17 +12,14 @@
 /// <reference path="../../framework.ts" />
 
 /**
- * DO Type 3 - DO with multiple specifications
+ * DO Type 3 - DO without explicit loop variable declaration
  */
 
-//// %DCL I FIXED;
-//// %DO I = 1 TO 2, 4 TO 6 BY 2;
-////   DCL VarI%;I FIXED;
+//// %DO I = 1 TO 2;
+////   DCL Var%;I FIXED;
 //// %END;
 
 preprocessor.expectTokens(`
-  DCL VarI1 FIXED;
-  DCL VarI2 FIXED;
-  DCL VarI4 FIXED;
-  DCL VarI6 FIXED;
+  DCL Var1 FIXED;
+  DCL Var2 FIXED;
 `);

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-to_without_explicit_loopVar_decl.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-to_without_explicit_loopVar_decl.ts
@@ -16,10 +16,10 @@
  */
 
 //// %DO I = 1 TO 2;
-////   DCL Var%;I FIXED;
+////   I
 //// %END;
 
 preprocessor.expectTokens(`
-  DCL Var1 FIXED;
-  DCL Var2 FIXED;
+  1
+  2
 `);

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-until-becomes-true.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-until-becomes-true.ts
@@ -12,13 +12,17 @@
 /// <reference path="../../framework.ts" />
 
 /**
- * DO Type 3 - DO with UPTHRU
+ * DO Type 3 - UNTIL condition starts false then becomes true
+ * Tests case where UNTIL condition controls loop termination
  */
 
 //// %DCL I FIXED;
-//// %DO I = 1 UPTHRU 3;
+//// %DO I = 1 TO 10 UNTIL(I >= 3);
 ////   DCL Var%;I FIXED;
 //// %END;
 
-// upthru not supported
-preprocessor.expectTokens("");
+preprocessor.expectTokens(`
+  DCL Var1 FIXED;
+  DCL Var2 FIXED;
+  DCL Var3 FIXED;
+`);

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-until-becomes-true.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-until-becomes-true.ts
@@ -18,11 +18,11 @@
 
 //// %DCL I FIXED;
 //// %DO I = 1 TO 10 UNTIL(I >= 3);
-////   DCL Var%;I FIXED;
+////   I
 //// %END;
 
 preprocessor.expectTokens(`
-  DCL Var1 FIXED;
-  DCL Var2 FIXED;
-  DCL Var3 FIXED;
+  1
+  2
+  3
 `);

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-until-false-single.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-until-false-single.ts
@@ -18,9 +18,9 @@
 
 //// %DCL I FIXED;
 //// %DO I = 1 TO 1 UNTIL(I < 1);
-////   DCL Var%;I FIXED;
+////   I
 //// %END;
 
 preprocessor.expectTokens(`
-  DCL Var1 FIXED;
+  1
 `);

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-until-false-single.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-until-false-single.ts
@@ -12,13 +12,15 @@
 /// <reference path="../../framework.ts" />
 
 /**
- * DO Type 3 - DO with UPTHRU
+ * DO Type 3 - UNTIL condition false (single iteration)
+ * Tests corner case where UNTIL condition is false but range limits to one iteration
  */
 
 //// %DCL I FIXED;
-//// %DO I = 1 UPTHRU 3;
+//// %DO I = 1 TO 1 UNTIL(I < 1);
 ////   DCL Var%;I FIXED;
 //// %END;
 
-// upthru not supported
-preprocessor.expectTokens("");
+preprocessor.expectTokens(`
+  DCL Var1 FIXED;
+`);

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-until-while.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-until-while.ts
@@ -20,23 +20,23 @@
 //// %PRODUCT = 1;
 //// %DO NUM = 1 TO 15 UNTIL(PRODUCT > 50) WHILE(NUM <= 8);
 ////   %PRODUCT = PRODUCT * NUM;
-////   DCL UntilWhileVar%;NUM FIXED;
-////   DCL ProductVar%;PRODUCT FIXED;
+////   NUM
+////   PRODUCT
 //// %END;
 
 preprocessor.expectTokens(`
-  DCL UntilWhileVar1 FIXED;
-  DCL ProductVar1 FIXED;
+  1
+  1
   
-  DCL UntilWhileVar2 FIXED;
-  DCL ProductVar2 FIXED;
+  2
+  2
   
-  DCL UntilWhileVar3 FIXED;
-  DCL ProductVar6 FIXED;
+  3
+  6
   
-  DCL UntilWhileVar4 FIXED;
-  DCL ProductVar24 FIXED;
+  4
+  24
   
-  DCL UntilWhileVar5 FIXED;
-  DCL ProductVar120 FIXED;
+  5
+  120
 `);

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-until-while.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-until-while.ts
@@ -1,0 +1,42 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+/**
+ * DO Type 3 - DO with UNTIL condition followed by WHILE condition
+ */
+
+//// %DCL NUM FIXED;
+//// %DCL PRODUCT FIXED;
+//// %PRODUCT = 1;
+//// %DO NUM = 1 TO 15 UNTIL(PRODUCT > 50) WHILE(NUM <= 8);
+////   %PRODUCT = PRODUCT * NUM;
+////   DCL UntilWhileVar%;NUM FIXED;
+////   DCL ProductVar%;PRODUCT FIXED;
+//// %END;
+
+preprocessor.expectTokens(`
+  DCL UntilWhileVar1 FIXED;
+  DCL ProductVar1 FIXED;
+  
+  DCL UntilWhileVar2 FIXED;
+  DCL ProductVar2 FIXED;
+  
+  DCL UntilWhileVar3 FIXED;
+  DCL ProductVar6 FIXED;
+  
+  DCL UntilWhileVar4 FIXED;
+  DCL ProductVar24 FIXED;
+  
+  DCL UntilWhileVar5 FIXED;
+  DCL ProductVar120 FIXED;
+`);

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-until.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-until.ts
@@ -1,0 +1,27 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+/**
+ * DO Type 3 - DO with UNTIL condition
+ */
+
+//// %DCL I FIXED;
+//// %DO I = 1 TO 10 UNTIL(I >= 3);
+////   DCL Var%;I FIXED;
+//// %END;
+
+preprocessor.expectTokens(`
+  DCL Var1 FIXED;
+  DCL Var2 FIXED;
+  DCL Var3 FIXED;
+`);

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-until.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-until.ts
@@ -17,11 +17,11 @@
 
 //// %DCL I FIXED;
 //// %DO I = 1 TO 10 UNTIL(I >= 3);
-////   DCL Var%;I FIXED;
+////   I
 //// %END;
 
 preprocessor.expectTokens(`
-  DCL Var1 FIXED;
-  DCL Var2 FIXED;
-  DCL Var3 FIXED;
+  1
+  2
+  3
 `);

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-upthru.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-upthru.ts
@@ -20,8 +20,5 @@
 ////   DCL Var%;I FIXED;
 //// %END;
 
-preprocessor.expectTokens(`
-  DCL Var1 FIXED;
-  DCL Var2 FIXED;
-  DCL Var3 FIXED;
-`);
+// upthru not supported
+preprocessor.expectTokens('');

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-upthru.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-upthru.ts
@@ -1,0 +1,27 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+/**
+ * DO Type 3 - DO with UPTHRU
+ */
+
+//// %DCL I FIXED;
+//// %DO I = 1 UPTHRU 3;
+////   DCL Var%;I FIXED;
+//// %END;
+
+preprocessor.expectTokens(`
+  DCL Var1 FIXED;
+  DCL Var2 FIXED;
+  DCL Var3 FIXED;
+`);

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-upthru.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-upthru.ts
@@ -17,7 +17,7 @@
 
 //// %DCL I FIXED;
 //// %DO I = 1 UPTHRU 3;
-////   DCL Var%;I FIXED;
+////   I
 //// %END;
 
 // upthru not supported

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-while-becomes-false.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-while-becomes-false.ts
@@ -12,13 +12,16 @@
 /// <reference path="../../framework.ts" />
 
 /**
- * DO Type 3 - DO with UPTHRU
+ * DO Type 3 - WHILE condition starts true then becomes false
+ * Tests case where WHILE condition controls loop termination
  */
 
 //// %DCL I FIXED;
-//// %DO I = 1 UPTHRU 3;
+//// %DO I = 1 TO 10 WHILE(I <= 2);
 ////   DCL Var%;I FIXED;
 //// %END;
 
-// upthru not supported
-preprocessor.expectTokens("");
+preprocessor.expectTokens(`
+  DCL Var1 FIXED;
+  DCL Var2 FIXED;
+`);

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-while-becomes-false.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-while-becomes-false.ts
@@ -18,10 +18,10 @@
 
 //// %DCL I FIXED;
 //// %DO I = 1 TO 10 WHILE(I <= 2);
-////   DCL Var%;I FIXED;
+////   I
 //// %END;
 
 preprocessor.expectTokens(`
-  DCL Var1 FIXED;
-  DCL Var2 FIXED;
+  1
+  2
 `);

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-while-false-immediate.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-while-false-immediate.ts
@@ -12,13 +12,14 @@
 /// <reference path="../../framework.ts" />
 
 /**
- * DO Type 3 - DO with UPTHRU
+ * DO Type 3 - WHILE condition false immediately (no iterations)
+ * Tests corner case where WHILE condition is false from the start
  */
 
 //// %DCL I FIXED;
-//// %DO I = 1 UPTHRU 3;
+//// %DO I = 1 TO 1 WHILE(I < 1);
 ////   DCL Var%;I FIXED;
 //// %END;
 
-// upthru not supported
-preprocessor.expectTokens("");
+preprocessor.expectTokens(`
+`);

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-while-false-immediate.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-while-false-immediate.ts
@@ -18,7 +18,7 @@
 
 //// %DCL I FIXED;
 //// %DO I = 1 TO 1 WHILE(I < 1);
-////   DCL Var%;I FIXED;
+////   I
 //// %END;
 
 preprocessor.expectTokens(`

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-while-until.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-while-until.ts
@@ -1,0 +1,42 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+/**
+ * DO Type 3 - DO with WHILE condition followed by UNTIL condition
+ */
+
+//// %DCL COUNT FIXED;
+//// %DCL SUM FIXED;
+//// %SUM = 0;
+//// %DO COUNT = 1 TO 20 WHILE(COUNT <= 10) UNTIL(SUM > 13);
+////   %SUM = SUM + COUNT;
+////   DCL WhileUntilVar%;COUNT FIXED;
+////   DCL SumVar%;SUM FIXED;
+//// %END;
+
+preprocessor.expectTokens(`
+  DCL WhileUntilVar1 FIXED;
+  DCL SumVar1 FIXED;
+  
+  DCL WhileUntilVar2 FIXED;
+  DCL SumVar3 FIXED;
+  
+  DCL WhileUntilVar3 FIXED;
+  DCL SumVar6 FIXED;
+  
+  DCL WhileUntilVar4 FIXED;
+  DCL SumVar10 FIXED;
+  
+  DCL WhileUntilVar5 FIXED;
+  DCL SumVar15 FIXED;
+`);

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-while-until.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-while-until.ts
@@ -20,23 +20,23 @@
 //// %SUM = 0;
 //// %DO COUNT = 1 TO 20 WHILE(COUNT <= 10) UNTIL(SUM > 13);
 ////   %SUM = SUM + COUNT;
-////   DCL WhileUntilVar%;COUNT FIXED;
-////   DCL SumVar%;SUM FIXED;
+////   COUNT
+////   SUM
 //// %END;
 
 preprocessor.expectTokens(`
-  DCL WhileUntilVar1 FIXED;
-  DCL SumVar1 FIXED;
+  1
+  1
   
-  DCL WhileUntilVar2 FIXED;
-  DCL SumVar3 FIXED;
+  2
+  3
   
-  DCL WhileUntilVar3 FIXED;
-  DCL SumVar6 FIXED;
+  3
+  6
   
-  DCL WhileUntilVar4 FIXED;
-  DCL SumVar10 FIXED;
+  4
+  10
   
-  DCL WhileUntilVar5 FIXED;
-  DCL SumVar15 FIXED;
+  5
+  15
 `);

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-while.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-while.ts
@@ -1,0 +1,27 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+/**
+ * DO Type 3 - DO with WHILE condition
+ */
+
+//// %DCL I FIXED;
+//// %DO I = 1 TO 10 WHILE(I < 4);
+////   DCL Var%;I FIXED;
+//// %END;
+
+preprocessor.expectTokens(`
+  DCL Var1 FIXED;
+  DCL Var2 FIXED; 
+  DCL Var3 FIXED;
+`);

--- a/packages/language/test/fourslash/preprocessor/do/do-type3-while.ts
+++ b/packages/language/test/fourslash/preprocessor/do/do-type3-while.ts
@@ -17,11 +17,11 @@
 
 //// %DCL I FIXED;
 //// %DO I = 1 TO 10 WHILE(I < 4);
-////   DCL Var%;I FIXED;
+////   I
 //// %END;
 
 preprocessor.expectTokens(`
-  DCL Var1 FIXED;
-  DCL Var2 FIXED; 
-  DCL Var3 FIXED;
+  1
+  2
+  3
 `);


### PR DESCRIPTION
Fixes #316 
Follow-up of PR #343

This PR implements interpreter support for PL/I preprocessor DO Type 3 statements. The semantics are described in the [PL/I language specification](https://www.ibm.com/docs/en/SSY2V3_6.1/pdf/lrm.pdf) on the pages 212-222 ("DO statement").

The corresponding tests can be run by

```bash
npx vitest run packages/language/test/fourslash-harness/execute.test.ts -t "do-type3-"
```
