### PR TITLE
[Validation] Implement support for IBM1219I

### DIFF
--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -4549,6 +4549,7 @@ export class PliParser extends AbstractParser {
       kind: ast.SyntaxKind.LeaveStatement,
       container: null,
       label: null,
+      leaveToken: null,
     };
   }
 
@@ -4557,6 +4558,7 @@ export class PliParser extends AbstractParser {
 
     this.CONSUME_ASSIGN1(tokens.LEAVE, (token) => {
       this.tokenPayload(token, element, CstNodeKind.LeaveStatement_LEAVE);
+      element.leaveToken = token;
     });
     this.OPTION1(() => {
       this.SUBRULE_ASSIGN1(this.LabelReference, {

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -1635,12 +1635,14 @@ export function createLabelReference(): LabelReference {
 export interface LeaveStatement extends AstNode {
   kind: SyntaxKind.LeaveStatement;
   label: LabelReference | null;
+  leaveToken: Token | null;
 }
 export function createLeaveStatement(): LeaveStatement {
   return {
     kind: SyntaxKind.LeaveStatement,
     container: null,
     label: null,
+    leaveToken: null,
   };
 }
 export interface LFormatItem extends AstNode {

--- a/packages/language/src/validation/messages/IBM1219I-leave-exits-noniterative-do.ts
+++ b/packages/language/src/validation/messages/IBM1219I-leave-exits-noniterative-do.ts
@@ -1,0 +1,60 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import {
+  Severity,
+  tokenToRange,
+  tokenToUri,
+} from "../../language-server/types";
+import * as AST from "../../syntax-tree/ast";
+import { ValidationAcceptor } from "../validator";
+import * as PLICodes from "./pli-codes";
+
+/**
+ * IBM1219I – LEAVE will exit noniterative DO.
+ *
+ * Warn when an unlabeled LEAVE sits inside a non-iterative DO.
+ */
+export function IBM1219I_leave_exits_noniterative_do(
+  node: AST.LeaveStatement,
+  acceptor: ValidationAcceptor,
+): void {
+  const leaveToken = node.leaveToken;
+
+  // If LEAVE has a label, rule does not apply. If no token is found - return
+  if (node.label || !leaveToken) return;
+
+  // Find nearest enclosing DO
+  let ancestor: AST.SyntaxNode | null = node.container;
+  let nearestDo: AST.DoStatement | undefined;
+  while (ancestor) {
+    if (ancestor.kind === AST.SyntaxKind.DoStatement) {
+      nearestDo = ancestor;
+      break;
+    }
+    ancestor = ancestor.container;
+  }
+  if (!nearestDo) return;
+
+  // Nearest DO must be a non-iterative DO-group
+  if (nearestDo.doType2 || nearestDo.doType3 || nearestDo.doType4) return;
+
+  // Generate range and uri based on token
+  const warningRange = tokenToRange(leaveToken);
+  const warningUri = tokenToUri(leaveToken);
+  if (!warningRange || !warningUri) return;
+
+  acceptor(Severity.W, PLICodes.Warning.IBM1219I.message, {
+    code: PLICodes.Warning.IBM1219I.fullCode,
+    range: warningRange,
+    uri: warningUri,
+  });
+}

--- a/packages/language/src/validation/pli-validator.ts
+++ b/packages/language/src/validation/pli-validator.ts
@@ -24,6 +24,7 @@ import {
   ProcessGroup,
   ProgramConfig,
 } from "../workspace/plugin-configuration-provider";
+import { IBM1219I_leave_exits_noniterative_do } from "./messages/IBM1219I-leave-exits-noniterative-do";
 import { IBM1324IE_name_occurs_more_than_once_within_exports_clause } from "./messages/IBM1324IE-name-occurs-more-than-once-within-exports-clause.js";
 import { IBM1388IE_NODESCRIPTOR_attribute_is_invalid_when_any_parameter_has_NONCONNECTED_attribute } from "./messages/IBM1388IE-NODESCRIPTOR-attribute-is-invalid-when-any-parameter-has-NONCONNECTED-attribute.js";
 import * as PLICodes from "./messages/pli-codes";
@@ -53,6 +54,7 @@ export function registerPliValidationChecks(unit: CompilationUnit): Validator {
     DefineOrdinalStatement: [validator.checkDefineOrdinalStatement],
     DeclareStatement: [validator.checkDeclareStatement],
     ReferenceItem: [validator.checkImplicitBuiltins.bind(validator)],
+    LeaveStatement: [IBM1219I_leave_exits_noniterative_do],
   });
 
   return validator;

--- a/packages/language/test/fourslash/validate/IBM1219I/do-leave-has-label.ts
+++ b/packages/language/test/fourslash/validate/IBM1219I/do-leave-has-label.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+/**
+ * LEAVE has a label – should NOT trigger IBM1219I
+ */
+
+// @wrap: main
+//// DO;
+////   <|1:LEAVE foo|>;
+//// END;
+
+verify.noDiagnostics(1);

--- a/packages/language/test/fourslash/validate/IBM1219I/do-leave-inside-iterative-type3.ts
+++ b/packages/language/test/fourslash/validate/IBM1219I/do-leave-inside-iterative-type3.ts
@@ -1,0 +1,24 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+/**
+ * LEAVE inside iterative DO (TO/BY) – should NOT trigger IBM1219I
+ */
+
+// @wrap: main
+//// DCL I FIXED BIN(31);
+//// DO I = 1 TO 10;
+////   <|1:LEAVE|>;
+//// END;
+
+verify.noDiagnostics(1);

--- a/packages/language/test/fourslash/validate/IBM1219I/do-leave-inside-type2.ts
+++ b/packages/language/test/fourslash/validate/IBM1219I/do-leave-inside-type2.ts
@@ -1,0 +1,24 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+/**
+ * LEAVE inside DO WHILE (doType2) – should NOT trigger IBM1219I
+ */
+// @wrap: main
+//// DCL X FIXED BIN(31);
+//// DO WHILE (X > 0);
+////   <|1:LEAVE|>;
+////   X = X - 1;
+//// END;
+
+verify.noDiagnostics(1);

--- a/packages/language/test/fourslash/validate/IBM1219I/do-leave-noniterative-basic.ts
+++ b/packages/language/test/fourslash/validate/IBM1219I/do-leave-noniterative-basic.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+/**
+ * A bare non-iterative DO containing only LEAVE should also trigger IBM1219I
+ */
+
+// @wrap: main
+//// DO;
+////   <|1:LEAVE|>;
+//// END;
+
+verify.expectExclusiveErrorCodesAt(1, code.Warning.IBM1219I.fullCode);

--- a/packages/language/test/fourslash/validate/IBM1219I/leave-in-noiterative-do-must-warn.ts
+++ b/packages/language/test/fourslash/validate/IBM1219I/leave-in-noiterative-do-must-warn.ts
@@ -1,0 +1,32 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+/**
+ * LEAVE inside non-iterative DO-group nested in an iterative DO should warn (IBM1219I)
+ */
+
+// @wrap: main
+//// dcl n fixed bin(31);
+//// dcl i fixed bin(31);
+//// dcl a(32) fixed bin(31);
+////
+//// DO I = 1 TO N;
+////   IF A(I) > 0 THEN
+////     DO;
+////       CALL F;
+////       <|1:LEAVE|>;
+////     END;
+////   ELSE;
+//// END;
+////
+verify.expectExclusiveErrorCodesAt(1, code.Warning.IBM1219I.fullCode);

--- a/packages/language/test/fourslash/validate/IBM1219I/leave-inside-do-forever.ts
+++ b/packages/language/test/fourslash/validate/IBM1219I/leave-inside-do-forever.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+/**
+ * LEAVE inside DO FOREVER (doType4) – should NOT trigger IBM1219I
+ */
+
+// @wrap: main
+//// DO FOREVER;
+////   <|1:LEAVE|>;
+//// END;
+
+verify.noDiagnostics(1);

--- a/packages/language/test/fourslash/validate/IBM1219I/leave-outside-do.ts
+++ b/packages/language/test/fourslash/validate/IBM1219I/leave-outside-do.ts
@@ -1,0 +1,22 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+/**
+ * LEAVE outside of any DO block – should NOT trigger IBM1219I
+ */
+
+// @wrap: main
+//// DCL X FIXED BIN(31);
+//// <|1:LEAVE|>;
+
+verify.noDiagnostics(1);


### PR DESCRIPTION
### **Add validation for IBM1219I – LEAVE exits non-iterative DO-groups**

**Summary**

Warn when an unlabeled LEAVE sits inside a non-iterative DO that itself is nested within an iterative DO-loop. In this case the LEAVE exits only the group, not the loop, which is often not what the author intended. Now, in this scenario, we issue a warning.

**Implementation**

1. Skips LEAVE with an explicit label (intended behavior).
2. Walks up the AST to find the nearest enclosing DO.
3. Checks if the nearest DO is non-iterative (doType2/doType3 absent).
4. Searches further up to detect if there is an outer iterative DO.
5. If conditions match, emits warning IBM1219IW at the LEAVE token.

**Changes**

- Added validator IBM1219I_leave_exits_noniterative_do in validation/messages/...
- Parser/Ast: attach leaveToken to LeaveStatement for range/uri resolution
- Added tests: test/fourslash/validate/leave-in-noiterative-do-must-warn.ts and a passing test

**Notes**

- Should I provide more tests?
- I'm still understanding the doType4. Should I include it in the validation?