### PR TITLE
Support member calls on DoType3

### DIFF
--- a/packages/language/src/linking/symbol-table.ts
+++ b/packages/language/src/linking/symbol-table.ts
@@ -400,9 +400,11 @@ const iterateSymbolTable = (
       break;
     // E.g. `DO I = 1 TO 300 BY 100; END DO;`
     case SyntaxKind.DoType3:
-      if (node.variable?.ref) {
+      // Only add the implicit declaration in case it points to a non-nested variable
+      const ref = node.variable?.element?.ref;
+      if (!node.variable?.previous && ref) {
         parentScope.symbolTable.addImplicitDeclarationByReference(
-          node.variable.ref,
+          ref,
           context.reporter,
         );
       }

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -2755,7 +2755,6 @@ export class PliParser extends AbstractParser {
     this.OPTION1(() => {
       this.OR1([
         {
-          GATE: () => this.LA(2).tokenTypeIdx !== tokens.Equals.tokenTypeIdx,
           ALT: () => {
             this.SUBRULE_ASSIGN1(this.DoType2, {
               assign: (result) => {
@@ -2765,7 +2764,6 @@ export class PliParser extends AbstractParser {
           },
         },
         {
-          GATE: () => this.LA(2).tokenTypeIdx === tokens.Equals.tokenTypeIdx,
           ALT: () => {
             this.SUBRULE_ASSIGN1(this.DoType3, {
               assign: (result) => {
@@ -2888,7 +2886,7 @@ export class PliParser extends AbstractParser {
   DoType3 = this.RULE("DoType3", () => {
     let element = this.push(ast.createDoType3());
 
-    this.SUBRULE_ASSIGN1(this.ReferenceItem, {
+    this.SUBRULE_ASSIGN1(this.MemberCall, {
       assign: (result) => {
         element.variable = result;
       },

--- a/packages/language/src/preprocessor/pli-preprocessor-parser.ts
+++ b/packages/language/src/preprocessor/pli-preprocessor-parser.ts
@@ -760,16 +760,7 @@ export class PliPreprocessorParser {
 
   private doType3(state: PreprocessorParserState): ast.DoType3 {
     const doType3 = ast.createDoType3();
-
-    // Consume the ID token to create the ReferenceItem
-    const referenceItem = ast.createReferenceItem();
-    const idToken = state.consume(
-      referenceItem,
-      CstNodeKind.ReferenceItem_Ref,
-      PreprocessorTokens.Id,
-    );
-    referenceItem.ref = ast.createReference(referenceItem, idToken, true);
-    doType3.variable = referenceItem;
+    doType3.variable = this.memberCall(state, true);
 
     // Consume the "=" token
     state.consume(doType3, CstNodeKind.DoType3_Equals, PreprocessorTokens.Eq);

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -1237,7 +1237,7 @@ export function createDoStatement(): DoStatement {
 }
 export interface DoType3 extends AstNode {
   kind: SyntaxKind.DoType3;
-  variable: ReferenceItem | null;
+  variable: MemberCall | null;
   specifications: DoSpecification[];
 }
 export function createDoType3(): DoType3 {

--- a/packages/language/test/parsing.test.ts
+++ b/packages/language/test/parsing.test.ts
@@ -949,4 +949,15 @@ describe("PL/I Parsing tests", () => {
     assertNoParseErrors(doc);
     generateAndAssertValidSymbolTable(doc);
   });
+
+  test("Supports Member Call syntax on DoType3", async () => {
+    const doc = await parseStmts(`
+      DCL 1 A, 2 B FIXED;
+      DO A.B = 1 TO 10;
+        PUT(A.B);
+      END;
+    `);
+    assertNoParseErrors(doc);
+    generateAndAssertValidSymbolTable(doc);
+  });
 });


### PR DESCRIPTION
Fixes an issue related to https://github.com/zowe/zowe-pli-language-support/issues/347.

Currently, we only support "flat" references on the DoType3 parser. This is not correct, as the compiler actually allows to use member calls (i.e. `A.B.C...`) there as well.