### PR TITLE
Improve support for includes within copybooks

### DIFF
--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -17,7 +17,10 @@ import {
   CompilationUnitTokens,
 } from "../workspace/compilation-unit";
 import { FileSystemProviderInstance } from "../workspace/file-system-provider";
-import { PluginConfigurationProviderInstance } from "../workspace/plugin-configuration-provider";
+import {
+  PluginConfigurationProviderInstance,
+  ProcessGroup,
+} from "../workspace/plugin-configuration-provider";
 import { CompilerOptionResult } from "./compiler-options/options";
 import { generateInstructions } from "./instruction-generator";
 import * as inst from "./instructions";
@@ -976,15 +979,19 @@ function resolveIncludeFileUri(
   const programConfig = PluginConfigurationProviderInstance.getProgramConfig(
     context.entryUri,
   );
-  const pgroup = programConfig
-    ? PluginConfigurationProviderInstance.getProcessGroupConfig(
-        programConfig.pgroup,
-      )
-    : undefined;
+  let pgroup: ProcessGroup | undefined = undefined;
+  if (programConfig) {
+    pgroup = PluginConfigurationProviderInstance.getProcessGroupConfig(
+      programConfig.pgroup,
+    );
+  } else if (context.currentUri) {
+    pgroup = PluginConfigurationProviderInstance.getProcessGroupConfigFromLib(
+      context.currentUri,
+    );
+  }
   const ext = UriUtils.extname(URI.parse(item.fileName));
   if (
     ext !== "" &&
-    programConfig &&
     pgroup &&
     (!pgroup["include-extensions"]?.includes(ext) ||
       !pgroup["include-extensions"])
@@ -1012,7 +1019,7 @@ function resolveIncludeFileUri(
   } else ....
   */
 
-  if (programConfig && pgroup) {
+  if (pgroup) {
     // lib file as either a string or a member from a known process group
     for (const lib of pgroup.libs ?? []) {
       const libFileUri = UriUtils.joinPath(

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -402,6 +402,22 @@ export class PluginConfigurationProvider {
   }
 
   /**
+   * Returns the process group config for the given URI. This is used to find the
+   * process group associated with a library file. It is rather fuzzy and might not be 100% accurate.
+   * @param libUri URI of the including file (likely a library file)
+   * @returns Associated process group config, or undefined if not found
+   */
+  public getProcessGroupConfigFromLib(libUri: URI): ProcessGroup | undefined {
+    const dirname = UriUtils.basename(UriUtils.dirname(libUri));
+    for (const config of this.processGroupConfigs.values()) {
+      if (config.libs?.includes(dirname)) {
+        return config;
+      }
+    }
+    return undefined;
+  }
+
+  /**
    * Extracts & converts the merged pli-options for a given program config & associated process group to a compiler option string
    * Program config pli-options override process group pli-options.
    * @param programConfig Program config entry to retrieve options for, factoring in process group options too

--- a/packages/language/test/fourslash/preprocessor/include/include-within-copybook.ts
+++ b/packages/language/test/fourslash/preprocessor/include/include-within-copybook.ts
@@ -1,0 +1,37 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////             "name": "default",
+////             "libs": [
+////                 "cpy"
+////             ],
+////             "include-extensions": [
+////                 ".pli"
+////             ]
+////         }
+////     ]
+//// }
+
+// @filename: cpy/lib.pli
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: cpy/including.pli
+//// %INCLUDE lib;
+
+preprocessor.expectTokens(`
+  DECLARE LIB_VAR FIXED;
+`);


### PR DESCRIPTION
Fixes point 4 of https://github.com/zowe/zowe-pli-language-support/issues/335.

The issue can be explained as follows: Imagine you have opened your IDE, and are currently looking through the copybook (without having opened an entry file of the compilation unit). This means, the traditional way to lookup process configs doesn't work anymore, since we don't know what the actual entry point of a file is.

This PR attempts to circumvent this issue a bit, by adding a new method to the process config provider that uses the current file URI to see whether it's within one of the copybooks of the registered process configs. If it is, then it should actually return the corresponding process config. This allows the currently open file to perform includes, etc.