### PR TITLE
Extend compiler options and tests #4

### DIFF
--- a/packages/language/src/preprocessor/compiler-options-processor.ts
+++ b/packages/language/src/preprocessor/compiler-options-processor.ts
@@ -149,7 +149,7 @@ export class CompilerOptionsProcessor {
     // *PROCESS MARGINS(2, 72) ; MARGINS(1, 72); is valid, but everything after the first ; is ignored.
     // Just extract the complete line and let the parser decide what is valid.
     // We still need the whole line to preserve original positions for diagnostics.
-    const processRegex = /([%*]PROCESS[^\n]*(?:(?:\r?\n)|$))/iy;
+    const processRegex = /([%*]PROCESS[^\n\r]*)(?:\r?\n|$)/iy;
     let match: RegExpExecArray | null;
     let currentPosition = 0;
 

--- a/packages/language/src/preprocessor/compiler-options/codes.ts
+++ b/packages/language/src/preprocessor/compiler-options/codes.ts
@@ -409,4 +409,128 @@ export const CompilerOptionsCodes = {
       fullCode: "COOP02W",
     } as ParametricPLICode,
   },
+
+  PrecType: {
+    InvalidParameter: {
+      code: "COPT01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "ANS", "DECDIGIT" or "DECRESULT", but received '${value}'.`,
+      fullCode: "COPT01W",
+    } as ParametricPLICode,
+  },
+
+  Proceed: {
+    InvalidParameter: {
+      code: "COPR01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "S", "E" or "W", but received '${value}'.`,
+      fullCode: "COPR01W",
+    } as ParametricPLICode,
+  },
+
+  Process: {
+    InvalidParameter: {
+      code: "COPR02",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "DELETE" or "KEEP", but received '${value}'.`,
+      fullCode: "COPR02W",
+    } as ParametricPLICode,
+  },
+
+  Quote: {
+    InvalidParameterLength: {
+      code: "COQT01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected a single character, but received '${value}'.`,
+      fullCode: "COQT01W",
+    } as ParametricPLICode,
+    InvalidParameterCharacter: {
+      code: "COQT02",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected a valid quote character, but received '${value}'.`,
+      fullCode: "COQT02W",
+    } as ParametricPLICode,
+  },
+
+  Respect: {
+    InvalidParameter: {
+      code: "CORE01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "DATE" or an empty value, but received '${value}'.`,
+      fullCode: "CORE01W",
+    } as ParametricPLICode,
+  },
+
+  RtCheck: {
+    InvalidParameter: {
+      code: "CORT01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "NONULLPTR", "NULLPTR" or "NULL370", but received '${value}'.`,
+      fullCode: "CORT01W",
+    } as ParametricPLICode,
+  },
+
+  Semantic: {
+    InvalidParameter: {
+      code: "COSE01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "S", "E" or "W", but received '${value}'.`,
+      fullCode: "COSE01W",
+    } as ParametricPLICode,
+  },
+
+  Service: {
+    InvalidParameterLength: {
+      code: "COSR01",
+      severity: Severity.W,
+      message: (length: string) =>
+        `Expected a maximum length of 64 characters, but received '${length}'.`,
+      fullCode: "COSR01W",
+    } as ParametricPLICode,
+    InvalidEmptyPlainParameter: {
+      code: "COSR02",
+      severity: Severity.W,
+      message: () =>
+        `Expected a non-empty plain value. Use a string for empty text.`,
+      fullCode: "COSR02W",
+    } as ParametricPLICode,
+  },
+
+  Static: {
+    InvalidParameter: {
+      code: "COST01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "SHORT" or "FULL", but received '${value}'.`,
+      fullCode: "COST01W",
+    } as ParametricPLICode,
+  },
+
+  StringOfGraphic: {
+    InvalidParameter: {
+      code: "COSG01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "GRAPHIC" or "CHARACTER", but received '${value}'.`,
+      fullCode: "COSG01W",
+    } as ParametricPLICode,
+  },
+
+  Syntax: {
+    InvalidParameter: {
+      code: "COSY01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "S", "E" or "W", but received '${value}'.`,
+      fullCode: "COSY01W",
+    } as ParametricPLICode,
+  },
 };

--- a/packages/language/src/preprocessor/compiler-options/options.ts
+++ b/packages/language/src/preprocessor/compiler-options/options.ts
@@ -441,7 +441,7 @@ export interface CompilerOptions {
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-prectype
    */
-  precType?: "ANS" | "DECDIGIT" | "DECRESULT";
+  precType?: CompilerOptions.PrecType;
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-prefix
    */
@@ -453,7 +453,7 @@ export interface CompilerOptions {
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-process
    */
-  process?: "DELETE" | "KEEP" | false;
+  process?: CompilerOptions.Process | false;
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-quote
    */
@@ -477,7 +477,7 @@ export interface CompilerOptions {
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-rtcheck
    */
-  rtCheck?: "NONULLPTR" | "NULLPTR" | "NULL370";
+  rtCheck?: CompilerOptions.RtCheck;
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-rules
    */
@@ -497,7 +497,7 @@ export interface CompilerOptions {
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-spill
    */
-  spill?: string;
+  spill?: number;
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-static
    */
@@ -517,7 +517,7 @@ export interface CompilerOptions {
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-stringofgraphic
    */
-  stringOfGraphic?: "GRAPHIC" | "CHARACTER";
+  stringOfGraphic?: CompilerOptions.StringOfGraphic;
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-syntax
    */
@@ -838,14 +838,17 @@ export declare namespace CompilerOptions {
     name: string;
     value?: string;
   }
-  export type Proceed =
-    | {
-        flag?: Flag;
-      }
-    | true;
+  export type PrecType = "ANS" | "DECDIGIT" | "DECRESULT";
+  export type Proceed = {
+    // *PROCESS NOPROCEED; actually results in NOPROCEED( I ); which stops
+    // compilation after the preprocessors.
+    noProceed: Flag;
+  };
+  export type Process = "DELETE" | "KEEP";
   export type Respect = {
     date?: boolean;
   };
+  export type RtCheck = "NONULLPTR" | "NULLPTR" | "NULL370";
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-rules
    */
@@ -1016,16 +1019,15 @@ export declare namespace CompilerOptions {
           source?: "ALL" | "SOURCE";
         };
   };
-  export type Semantic =
-    | true
-    | {
-        flag?: CompilerOptions.Flag;
-      };
-  export type Syntax =
-    | true
-    | {
-        flag?: CompilerOptions.Flag;
-      };
+  export type Semantic = {
+    // *PROCESS NOSEMANTIC; actually results in NOSEMANTIC( I );
+    noSemantic: Flag;
+  };
+  export type StringOfGraphic = "GRAPHIC" | "CHARACTER";
+  export type Syntax = {
+    // *PROCESS NOSYNTAX; actually results in NOSYNTAX( I );
+    noSyntax: Flag;
+  };
   export type System = "MVS" | "CICS" | "IMS" | "OS" | "TSO";
   export type Test =
     | false
@@ -1137,6 +1139,24 @@ const defaultCompilerOptions: CompilerOptions = {
   onSnap: false,
   optimize: 0,
   options: "DOC",
+  precType: "ANS",
+  proceed: { noProceed: "S" },
+  process: "DELETE",
+  quote: '"',
+  reduce: true,
+  rent: false,
+  resExp: true,
+  respect: { date: false },
+  rtCheck: "NONULLPTR",
+  service: "",
+  source: true,
+  spill: 512,
+  static: "SHORT",
+  stdsys: false,
+  stmt: false,
+  storage: false,
+  stringOfGraphic: "GRAPHIC",
+  syntax: { noSyntax: "S" },
   system: "MVS",
   sysParm: "",
 };

--- a/packages/language/src/preprocessor/compiler-options/translator.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator.ts
@@ -2574,26 +2574,299 @@ translator.rule(
 );
 
 /** {@link CompilerOptions.precType} */
+translator.rule(["PRECTYPE"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "plainNotEmpty");
+  const name = value.value.toUpperCase();
+  if (["AND", "DECDIGIT", "DECRESULT"].includes(name)) {
+    options.precType = name as CompilerOptions.PrecType;
+  } else {
+    throw TranslationError.fromCode(
+      value.token,
+      CompilerOptionsCodes.PrecType.InvalidParameter,
+      name,
+    );
+  }
+});
+
 /** {@link CompilerOptions.prefix} */
 /** {@link CompilerOptions.proceed} */
+translator.rule(
+  ["PROCEED", "PRO"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.proceed = { noProceed: "S" };
+  },
+  ["NOPROCEED", "NPRO"],
+  (option, options) => {
+    ensureArguments(option, 0, 1);
+    if (option.values.length === 0) {
+      options.proceed = { noProceed: "I" };
+      return;
+    }
+    const value = option.values[0];
+    ensureType(value, "plainNotEmpty");
+    const name = value.value.toUpperCase();
+    if (["S", "E", "W"].includes(name)) {
+      options.proceed = { noProceed: name as CompilerOptions.Flag };
+    } else {
+      throw TranslationError.fromCode(
+        value.token,
+        CompilerOptionsCodes.Proceed.InvalidParameter,
+        name,
+      );
+    }
+  },
+);
+
 /** {@link CompilerOptions.process} */
+translator.rule(
+  ["PROCESS"],
+  (option, options) => {
+    ensureArguments(option, 0, 1);
+    if (option.values.length === 0) {
+      options.process = "DELETE";
+      return;
+    }
+    const value = option.values[0];
+    ensureType(value, "plainNotEmpty");
+    const name = value.value.toUpperCase();
+    if (["DELETE", "KEEP"].includes(name)) {
+      options.process = name as CompilerOptions.Process;
+    } else {
+      throw TranslationError.fromCode(
+        value.token,
+        CompilerOptionsCodes.Process.InvalidParameter,
+        name,
+      );
+    }
+  },
+  ["NOPROCESS"],
+  (option, options) => {
+    options.process = false;
+    ensureArguments(option, 0, 0);
+  },
+);
+
 /** {@link CompilerOptions.quote} */
+translator.rule(["QUOTE"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  // TODO ssmifi: The directive does not allow to use " as string delimiter. It must be set via '.
+  ensureType(value, "string");
+  if (value.value.length !== 1) {
+    throw TranslationError.fromCode(
+      value.token,
+      CompilerOptionsCodes.Quote.InvalidParameterLength,
+      value.value,
+    );
+  }
+  if (PLI_CHARACTER_REGEX.test(value.value)) {
+    throw TranslationError.fromCode(
+      value.token,
+      CompilerOptionsCodes.Quote.InvalidParameterCharacter,
+      value.value,
+    );
+  }
+  options.quote = value.value;
+});
+
 /** {@link CompilerOptions.reduce} */
+translator.flag("reduce", ["REDUCE"], ["NOREDUCE"]);
+
 /** {@link CompilerOptions.rent} */
+translator.flag("rent", ["RENT"], ["NORENT"]);
+
 /** {@link CompilerOptions.resExp} */
+translator.flag("resExp", ["RESEXP"], ["NORESEXP"]);
+
 /** {@link CompilerOptions.respect} */
+translator.rule(["RESPECT"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "plain");
+  if (value.value.length === 0) {
+    options.respect = { date: false };
+    return;
+  }
+  if (value.value.toUpperCase() === "DATE") {
+    options.respect = { date: true };
+  } else {
+    throw TranslationError.fromCode(
+      value.token,
+      CompilerOptionsCodes.Respect.InvalidParameter,
+      value.value,
+    );
+  }
+});
+
 /** {@link CompilerOptions.rtCheck} */
+translator.rule(["RTCHECK"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "plain");
+  if (value.value.length === 0) {
+    options.rtCheck = getDefaultCompilerOptions().rtCheck;
+    return;
+  }
+  const name = value.value.toUpperCase();
+  if (["NONULLPTR", "NULLPTR", "NULL370"].includes(name)) {
+    options.rtCheck = name as CompilerOptions.RtCheck;
+  } else {
+    throw TranslationError.fromCode(
+      value.token,
+      CompilerOptionsCodes.RtCheck.InvalidParameter,
+      value.value,
+    );
+  }
+});
+
 /** {@link CompilerOptions.rules} */
 /** {@link CompilerOptions.semantic} */
+translator.rule(
+  ["SEMANTIC", "SEM"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.semantic = { noSemantic: "S" };
+  },
+  ["NOSEMANTIC", "NSEM"],
+  (option, options) => {
+    ensureArguments(option, 0, 1);
+    if (option.values.length === 0) {
+      options.semantic = { noSemantic: "I" };
+      return;
+    }
+    const value = option.values[0];
+    ensureType(value, "plainNotEmpty");
+    const name = value.value.toUpperCase();
+    if (["S", "E", "W"].includes(name)) {
+      options.semantic = { noSemantic: name as CompilerOptions.Flag };
+    } else {
+      throw TranslationError.fromCode(
+        value.token,
+        CompilerOptionsCodes.Semantic.InvalidParameter,
+        name,
+      );
+    }
+  },
+);
+
 /** {@link CompilerOptions.service} */
+translator.rule(
+  ["SERVICE"],
+  (option, options) => {
+    ensureArguments(option, 1, 1);
+    const value = option.values[0];
+    ensureType(value, "plainOrString");
+    if (
+      value.kind === SyntaxKind.CompilerOptionText &&
+      value.value.length === 0
+    ) {
+      throw TranslationError.fromCode(
+        value.token,
+        CompilerOptionsCodes.Service.InvalidEmptyPlainParameter,
+        value.value,
+      );
+    }
+    if (value.value.length > 64) {
+      throw TranslationError.fromCode(
+        value.token,
+        CompilerOptionsCodes.Service.InvalidParameterLength,
+        value.value.length,
+      );
+    }
+    options.service = value.value;
+  },
+  ["NOSERVICE"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.service = false;
+  },
+);
+
 /** {@link CompilerOptions.source} */
+translator.flag("source", ["SOURCE", "S"], ["NOSOURCE", "NS"]);
+
 /** {@link CompilerOptions.spill} */
+translator.rule(["SPILL", "SP"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  ensureType(option.values[0], "plainNotEmpty");
+  options.spill = ensureNumberValue(option.values[0], 0, 3900);
+});
+
 /** {@link CompilerOptions.static} */
+translator.rule(["STATIC"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "plainNotEmpty");
+  const name = value.value.toUpperCase();
+  if (["SHORT", "FULL"].includes(name)) {
+    options.static = name as CompilerOptions.Length;
+  } else {
+    throw TranslationError.fromCode(
+      value.token,
+      CompilerOptionsCodes.Static.InvalidParameter,
+      name,
+    );
+  }
+});
+
 /** {@link CompilerOptions.stdsys} */
+translator.flag("stdsys", ["STDSYS"], ["NOSTDSYS"]);
+
 /** {@link CompilerOptions.stmt} */
+translator.flag("stmt", ["STMT"], ["NOSTMT"]);
+
 /** {@link CompilerOptions.storage} */
+translator.flag("storage", ["STORAGE", "STG"], ["NOSTORAGE", "NSTG"]);
+
 /** {@link CompilerOptions.stringOfGraphic} */
+translator.rule(["STRINGOFGRAPHIC", "CHAR", "G"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "plainNotEmpty");
+  const name = value.value.toUpperCase();
+  if (["CHARACTER", "GRAPHIC"].includes(name)) {
+    options.stringOfGraphic = name as CompilerOptions.StringOfGraphic;
+  } else {
+    throw TranslationError.fromCode(
+      value.token,
+      CompilerOptionsCodes.StringOfGraphic.InvalidParameter,
+      name,
+    );
+  }
+});
+
 /** {@link CompilerOptions.syntax} */
+translator.rule(
+  ["SYNTAX", "SYN"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.syntax = { noSyntax: "S" };
+  },
+  ["NOSYNTAX", "NSYN"],
+  (option, options) => {
+    ensureArguments(option, 0, 1);
+    if (option.values.length === 0) {
+      options.syntax = { noSyntax: "I" };
+      return;
+    }
+    const value = option.values[0];
+    ensureType(value, "plainNotEmpty");
+    const name = value.value.toUpperCase();
+    if (["S", "E", "W"].includes(name)) {
+      options.syntax = { noSyntax: name as CompilerOptions.Flag };
+    } else {
+      throw TranslationError.fromCode(
+        value.token,
+        CompilerOptionsCodes.Syntax.InvalidParameter,
+        name,
+      );
+    }
+  },
+);
+
 /** {@link CompilerOptions.sysParm} */
 translator.rule(
   ["SYSPARM"],

--- a/packages/language/test/fourslash-harness/harness-parser.ts
+++ b/packages/language/test/fourslash-harness/harness-parser.ts
@@ -167,6 +167,7 @@ class HarnessTestParser {
       fileName,
       wrap,
       content,
+      tags: Object.keys(tags),
       lineOffset,
       characterOffset,
     };
@@ -223,10 +224,15 @@ class HarnessTestParser {
       this.next();
     }
 
+    // Get tags from the last parsed file, if any
+    const lastFile = Array.from(files.values()).at(-1);
+    const tags = lastFile ? lastFile.tags : [];
+
     return {
       fileName: this.fileName,
       files,
       commands: this.text,
+      tags,
     };
   }
 }

--- a/packages/language/test/fourslash-harness/harness.test.ts
+++ b/packages/language/test/fourslash-harness/harness.test.ts
@@ -91,6 +91,7 @@ describe("Harness test framework tests", () => {
       commands,
       fileName: "test.pli",
       files: new Map(),
+      tags: [],
     };
 
     runHarnessTest(file, implementation);
@@ -129,6 +130,7 @@ describe("Harness test framework tests", () => {
       commands,
       fileName: "test.pli",
       files: new Map(),
+      tags: [],
     };
 
     runHarnessTest(file, implementation);

--- a/packages/language/test/fourslash-harness/types.ts
+++ b/packages/language/test/fourslash-harness/types.ts
@@ -16,6 +16,7 @@ export interface HarnessFile {
   fileName: string | undefined;
   wrap: string | undefined;
   content: string;
+  tags: string[];
 
   /**
    * The line offset of the file, e.g. the number of lines to skip before the file content
@@ -32,4 +33,5 @@ export interface HarnessTest {
   fileName: string;
   files: Map<string | UnnamedFile, HarnessFile>;
   commands: string;
+  tags: string[];
 }

--- a/packages/language/test/fourslash-harness/wrapper.ts
+++ b/packages/language/test/fourslash-harness/wrapper.ts
@@ -38,7 +38,7 @@ export function parseWrapperFile(content: string): Wrapper {
     .map((v) => v.substring(HARNESS_FILE_PREFIX.length));
   const wrapperContent = wrapperLines.join("\n");
   const wrapperFunction = (content: string) =>
-    wrapperContent.replace(WRAPPER_CONTENT_TAG, content);
+    wrapperContent.replace(WRAPPER_CONTENT_TAG, () => content);
 
   const headerLength = wrapperLines.findIndex((v) =>
     v.includes(WRAPPER_CONTENT_TAG),

--- a/packages/language/test/fourslash-harness/wrappers/main.ts
+++ b/packages/language/test/fourslash-harness/wrappers/main.ts
@@ -1,3 +1,3 @@
 //// STARTPR: PROCEDURE OPTIONS (MAIN);
 ////<...>
-//// END STARTPR;`;
+//// END STARTPR;

--- a/packages/language/test/fourslash-harness/wrappers/process.ts
+++ b/packages/language/test/fourslash-harness/wrappers/process.ts
@@ -1,3 +1,3 @@
 ////<...>
 //// STARTPR: PROCEDURE OPTIONS (MAIN);
-//// END STARTPR;`;
+//// END STARTPR;

--- a/packages/language/test/fourslash/preprocessor/compiler-options/prectype.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/prectype.ts
@@ -1,0 +1,38 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:PRECTYPE|>;
+////*PROCESS <|2:PRECTYPE|>(<|3:)|>;
+////*PROCESS <|4:PRECTYPE|>(<|5:INVALID|>);
+////*PROCESS <|6:PRECTYPE|>(ANS, DECDIGIT);
+////*PROCESS <|8:PRECTYPE|>(DECDIGIT);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
+});
+verify.expectDiagnosticsAt([2, 2, 6, 8], {
+  message: code.CompilerOptions.DupeOptionIssue.message("PRECTYPE"),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(""),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.PrecType.InvalidParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt(6, {
+  message: code.CompilerOptions.InvalidParameterCount.message(2, 1, 1),
+});
+verify.expectCompilerOptions({
+  precType: "DECDIGIT",
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/proceed.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/proceed.ts
@@ -1,0 +1,46 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:PRO|>;
+////*PROCESS <|2:PROCEED|>();
+////*PROCESS <|4:NOPROCEED|>(<|5:)|>;
+////*PROCESS <|6:NOPROCEED|>(<|7:INVALID|>);
+////*PROCESS <|8:NPRO|>(S, W);
+////*PROCESS <|10:NOPROCEED|>;
+
+verify.noDiagnostics(1);
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.DupeOptionIssue.message("PROCEED"),
+});
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.InvalidParameterCount.message(1, 0, 0),
+});
+verify.expectDiagnosticsAt([4, 6, 10], {
+  message: code.CompilerOptions.MutexOptionIssue.message("NOPROCEED"),
+});
+verify.expectDiagnosticsAt(8, {
+  message: code.CompilerOptions.MutexOptionIssue.message("NPRO"),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(""),
+});
+verify.expectDiagnosticsAt(7, {
+  message: code.CompilerOptions.Proceed.InvalidParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt(8, {
+  message: code.CompilerOptions.InvalidParameterCount.message(2, 0, 1),
+});
+verify.expectCompilerOptions({
+  proceed: { noProceed: "I" },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/process.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/process.ts
@@ -1,0 +1,36 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NOPROCESS;
+////*PROCESS <|2:PROCESS|>;
+////*PROCESS <|4:PROCESS|>(<|5:)|>;
+////*PROCESS <|6:PROCESS|>(<|7:INVALID|>);
+////*PROCESS <|8:PROCESS|>(KEEP DELETE);
+////*PROCESS <|10:PROCESS|>(KEEP);
+
+verify.expectDiagnosticsAt([2, 4, 6, 8, 10], {
+  message: code.CompilerOptions.MutexOptionIssue.message("PROCESS"),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(""),
+});
+verify.expectDiagnosticsAt(7, {
+  message: code.CompilerOptions.Process.InvalidParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt(8, {
+  message: code.CompilerOptions.InvalidParameterCount.message(2, 0, 1),
+});
+verify.expectCompilerOptions({
+  process: "KEEP",
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/quote.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/quote.ts
@@ -1,0 +1,42 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|2:QUOTE|>;
+////*PROCESS <|4:QUOTE|>(<|5:)|>;
+////*PROCESS <|6:QUOTE|>(<|7:INVALID|>);
+////*PROCESS <|8:QUOTE|>(<|9:'##'|>);
+////*PROCESS <|10:QUOTE|>(<|11:'z'|>);
+////*PROCESS <|12:QUOTE|>('$');
+
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
+});
+// verify.expectDiagnosticsAt([4, 6, 8, 10, 12], {
+//   message: code.CompilerOptions.DupeOptionIssue.message("QUOTE"),
+// });
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.ExpectedString.message(),
+});
+verify.expectDiagnosticsAt(7, {
+  message: code.CompilerOptions.ExpectedString.message(),
+});
+verify.expectDiagnosticsAt(9, {
+  message: code.CompilerOptions.Quote.InvalidParameterLength.message("##"),
+});
+verify.expectDiagnosticsAt(11, {
+  message: code.CompilerOptions.Quote.InvalidParameterCharacter.message("z"),
+});
+verify.expectCompilerOptions({
+  quote: "$",
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/reduce.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/reduce.ts
@@ -1,0 +1,27 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NOREDUCE;
+////*PROCESS <|1:REDUCE|>();
+////*PROCESS <|2:REDUCE|>;
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(1, 0, 0),
+});
+verify.expectDiagnosticsAt([1, 2], {
+  message: code.CompilerOptions.MutexOptionIssue.message("REDUCE"),
+});
+verify.expectCompilerOptions({
+  reduce: true,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rent.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rent.ts
@@ -1,0 +1,27 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NORENT;
+////*PROCESS <|1:RENT|>();
+////*PROCESS <|2:RENT|>;
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(1, 0, 0),
+});
+verify.expectDiagnosticsAt([1, 2], {
+  message: code.CompilerOptions.MutexOptionIssue.message("RENT"),
+});
+verify.expectCompilerOptions({
+  rent: true,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/resexp.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/resexp.ts
@@ -1,0 +1,27 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NORESEXP;
+////*PROCESS <|1:RESEXP|>();
+////*PROCESS <|2:RESEXP|>;
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(1, 0, 0),
+});
+verify.expectDiagnosticsAt([1, 2], {
+  message: code.CompilerOptions.MutexOptionIssue.message("RESEXP"),
+});
+verify.expectCompilerOptions({
+  resExp: true,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/respect.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/respect.ts
@@ -1,0 +1,27 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:RESPECT|>;
+////*PROCESS <|2:RESPECT|>();
+////*PROCESS <|3:RESPECT|>(DATE);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
+});
+verify.expectDiagnosticsAt([2, 3], {
+  message: code.CompilerOptions.DupeOptionIssue.message("RESPECT"),
+});
+verify.expectCompilerOptions({
+  respect: { date: true },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rtcheck.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rtcheck.ts
@@ -1,0 +1,30 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:RTCHECK|>;
+////*PROCESS <|2:RTCHECK|>(<|3:INVALID|>);
+////*PROCESS <|4:RTCHECK|>(NULL370);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
+});
+verify.expectDiagnosticsAt([2, 4], {
+  message: code.CompilerOptions.DupeOptionIssue.message("RTCHECK"),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.RtCheck.InvalidParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  rtCheck: "NULL370",
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/semantic.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/semantic.ts
@@ -1,0 +1,46 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:SEM|>;
+////*PROCESS <|2:SEMANTIC|>();
+////*PROCESS <|4:NOSEMANTIC|>(<|5:)|>;
+////*PROCESS <|6:NOSEMANTIC|>(<|7:INVALID|>);
+////*PROCESS <|8:NSEM|>(S, W);
+////*PROCESS <|10:NOSEMANTIC|>;
+
+verify.noDiagnostics(1);
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.DupeOptionIssue.message("SEMANTIC"),
+});
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.InvalidParameterCount.message(1, 0, 0),
+});
+verify.expectDiagnosticsAt([4, 6, 10], {
+  message: code.CompilerOptions.MutexOptionIssue.message("NOSEMANTIC"),
+});
+verify.expectDiagnosticsAt(8, {
+  message: code.CompilerOptions.MutexOptionIssue.message("NSEM"),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(""),
+});
+verify.expectDiagnosticsAt(7, {
+  message: code.CompilerOptions.Semantic.InvalidParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt(8, {
+  message: code.CompilerOptions.InvalidParameterCount.message(2, 0, 1),
+});
+verify.expectCompilerOptions({
+  semantic: { noSemantic: "I" },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/service.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/service.ts
@@ -1,0 +1,38 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:NOSERVICE|>;
+////*PROCESS <|2:SERVICE|>;
+////*PROCESS <|4:SERVICE|>(<|5:)|>;
+////*PROCESS <|6:SERVICE|>(<|7:"xXx"|>);
+////*PROCESS <|8:SERVICE|>(<|9:'yYy'|>);
+////*PROCESS <|10:SERVICE|>(<|11:xxxxxxxxx1xxxxxxxxx2xxxxxxxxx3xxxxxxxxx4xxxxxxxxx5xxxxxxxxx6xxxxxxxxx7xxxxxxxxx8|>);
+////*PROCESS <|12:SERVICE|>(xYz);
+
+verify.noDiagnostics([1, 7, 9]);
+verify.expectDiagnosticsAt([2, 4, 6, 8, 10], {
+  message: code.CompilerOptions.MutexOptionIssue.message("SERVICE"),
+});
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.Service.InvalidEmptyPlainParameter.message(),
+});
+verify.expectDiagnosticsAt(11, {
+  message: code.CompilerOptions.Service.InvalidParameterLength.message("80"),
+});
+verify.expectCompilerOptions({
+  service: "xYz",
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/source.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/source.ts
@@ -1,0 +1,34 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NOSOURCE;
+////*PROCESS <|1:NS|>;
+////*PROCESS <|2:SOURCE|>();
+////*PROCESS <|3:S|>;
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.DupeOptionIssue.message("NS"),
+});
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.InvalidParameterCount.message(1, 0, 0),
+});
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.MutexOptionIssue.message("SOURCE"),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.MutexOptionIssue.message("S"),
+});
+verify.expectCompilerOptions({
+  source: true,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/spill.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/spill.ts
@@ -1,0 +1,45 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:SPILL|>;
+////*PROCESS <|2:SPILL|>(<|3:)|>;
+////*PROCESS <|4:SPILL|>(<|5:INVALID|>);
+////*PROCESS <|6:SPILL|>(<|7:-5|>);
+////*PROCESS <|8:SP|>(<|9:5k|>);
+////*PROCESS <|10:SP|>(1024);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
+});
+verify.expectDiagnosticsAt([2, 4, 6], {
+  message: code.CompilerOptions.DupeOptionIssue.message("SPILL"),
+});
+verify.expectDiagnosticsAt([8, 10], {
+  message: code.CompilerOptions.DupeOptionIssue.message("SP"),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.ExpectedNumber.message("INVALID"),
+});
+verify.expectDiagnosticsAt(7, {
+  message: code.CompilerOptions.ExpectedNumberRange.message(-5, 0, 3900),
+});
+verify.expectDiagnosticsAt(9, {
+  message: code.CompilerOptions.ExpectedNumberRange.message(5 * 1024, 0, 3900),
+});
+verify.expectCompilerOptions({
+  spill: 1024,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/static.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/static.ts
@@ -1,0 +1,34 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:STATIC|>;
+////*PROCESS <|2:STATIC|>(<|3:)|>;
+////*PROCESS <|4:STATIC|>(<|5:INVALID|>);
+////*PROCESS <|6:STATIC|>(FULL);
+
+verify.expectDiagnosticsAt([2, 4, 6], {
+  message: code.CompilerOptions.DupeOptionIssue.message("STATIC"),
+});
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.Static.InvalidParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  static: "FULL",
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/stdsys.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/stdsys.ts
@@ -1,0 +1,27 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NOSTDSYS;
+////*PROCESS <|2:STDSYS|>();
+////*PROCESS <|3:STDSYS|>;
+
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.InvalidParameterCount.message(1, 0, 0),
+});
+verify.expectDiagnosticsAt([2, 3], {
+  message: code.CompilerOptions.MutexOptionIssue.message("STDSYS"),
+});
+verify.expectCompilerOptions({
+  stdsys: true,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/stmt.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/stmt.ts
@@ -1,0 +1,27 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NOSTMT;
+////*PROCESS <|2:STMT|>();
+////*PROCESS <|3:STMT|>;
+
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.InvalidParameterCount.message(1, 0, 0),
+});
+verify.expectDiagnosticsAt([2, 3], {
+  message: code.CompilerOptions.MutexOptionIssue.message("STMT"),
+});
+verify.expectCompilerOptions({
+  stmt: true,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/storage.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/storage.ts
@@ -1,0 +1,34 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NOSTORAGE;
+////*PROCESS <|1:NSTG|>;
+////*PROCESS <|2:STORAGE|>();
+////*PROCESS <|3:STG|>;
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.DupeOptionIssue.message("NSTG"),
+});
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.InvalidParameterCount.message(1, 0, 0),
+});
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.MutexOptionIssue.message("STORAGE"),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.MutexOptionIssue.message("STG"),
+});
+verify.expectCompilerOptions({
+  storage: true,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/stringofgraphic.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/stringofgraphic.ts
@@ -1,0 +1,41 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:STRINGOFGRAPHIC|>;
+////*PROCESS <|2:STRINGOFGRAPHIC|>(<|3:)|>;
+////*PROCESS <|4:CHAR|>(<|5:INVALID|>);
+////*PROCESS <|6:G|>(CHARACTER);
+
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.DupeOptionIssue.message("STRINGOFGRAPHIC"),
+});
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.DupeOptionIssue.message("CHAR"),
+});
+verify.expectDiagnosticsAt(6, {
+  message: code.CompilerOptions.DupeOptionIssue.message("G"),
+});
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message:
+    code.CompilerOptions.StringOfGraphic.InvalidParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  stringOfGraphic: "CHARACTER",
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/syntax.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/syntax.ts
@@ -1,0 +1,46 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:SYN|>;
+////*PROCESS <|2:SYNTAX|>();
+////*PROCESS <|4:NOSYNTAX|>(<|5:)|>;
+////*PROCESS <|6:NOSYNTAX|>(<|7:INVALID|>);
+////*PROCESS <|8:NSYN|>(S, W);
+////*PROCESS <|10:NOSYNTAX|>;
+
+verify.noDiagnostics(1);
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.DupeOptionIssue.message("SYNTAX"),
+});
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.InvalidParameterCount.message(1, 0, 0),
+});
+verify.expectDiagnosticsAt([4, 6, 10], {
+  message: code.CompilerOptions.MutexOptionIssue.message("NOSYNTAX"),
+});
+verify.expectDiagnosticsAt(8, {
+  message: code.CompilerOptions.MutexOptionIssue.message("NSYN"),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(""),
+});
+verify.expectDiagnosticsAt(7, {
+  message: code.CompilerOptions.Semantic.InvalidParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt(8, {
+  message: code.CompilerOptions.InvalidParameterCount.message(2, 0, 1),
+});
+verify.expectCompilerOptions({
+  syntax: { noSyntax: "I" },
+});

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -175,18 +175,14 @@ export class TestBuilder {
     this.configurePluginConfigurationProvider();
 
     const [[firstFileUri, firstFile]] = this.files.entries();
-    const output = firstFile.output;
-    const indices = firstFile.indices;
-    const ranges = firstFile.ranges;
+    this.output = firstFile.output;
+    this.indices = firstFile.indices;
+    this.ranges = firstFile.ranges;
 
-    this.unit = parseAndLink(output, {
+    this.unit = parseAndLink(this.output, {
       validate: options?.validate,
       uri: URI.parse(firstFileUri),
     });
-
-    this.output = output;
-    this.indices = indices;
-    this.ranges = ranges;
     this.diagnostics = collectDiagnostics(this.unit);
     this.checkDiagnosticsURIs();
 


### PR DESCRIPTION
Part of https://github.com/zowe/zowe-pli-language-support/issues/296
Based on https://github.com/zowe/zowe-pli-language-support/pull/342

- Implemented compiler options `precType`, `proceed`, `process`, `quote`, `reduce`, `rent`, `resExp`, `respect`, `rtCheck`, `semantic`, `service`, `source`, `stdsys`, `stmt`, `storage`, `stringOfGraphic`, and `syntax`.
- Fixed a bug that prevented the harness wrapper to wrap strings like `'$'`.
- Extended the harness API such that individual indices can be replaced by generated strings and tests can be executed manually, see `service.ts` test for an example.