### PR TITLE
Update Web Extension 

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -116,7 +116,8 @@
     "pli-language": "workspace:*",
     "util": "^0.12.5",
     "vscode-languageclient": "~9.0.1",
-    "vscode-languageserver": "~9.0.1"
+    "vscode-languageserver": "~9.0.1",
+    "vscode-uri": "~3.0.8"
   },
   "devDependencies": {
     "@types/vscode": "~1.67.0",

--- a/packages/vscode-extension/src/extension/main-browser.ts
+++ b/packages/vscode-extension/src/extension/main-browser.ts
@@ -9,33 +9,140 @@
  *
  */
 
-import type { LanguageClientOptions } from "vscode-languageclient/browser.js";
+import { WorkspaceDidChangePlipluginConfigNotification } from "pli-language";
 import * as vscode from "vscode";
+import type { LanguageClientOptions } from "vscode-languageclient/browser.js";
 import { LanguageClient } from "vscode-languageclient/browser.js";
 import { BuiltinFileSystemProvider } from "./builtin-files";
+import {
+  notifyWorker,
+  readAndNotifyWorker,
+  syncExistingFiles,
+} from "./workspace-sync";
+import { LSFileAction, PLIPLUGIN_CONFIG_FILES } from "../utils";
 
 let client: LanguageClient;
 
-// This function is called when the extension is activated.
-export function activate(context: vscode.ExtensionContext): void {
-  BuiltinFileSystemProvider.register(context);
-  client = startLanguageClient(context);
+/**
+ * Web Worker instance for the language server
+ * Held here to allow file system watchers to notify it of changes
+ */
+let worker: Worker;
+
+/**
+ * Helper to setup file system watchers and notify the language server of changes
+ * @param context Extension context for registering subscriptions
+ */
+function setupFileSystemWatchers(context: vscode.ExtensionContext): void {
+  // watch for file creation
+  const createWatcher = vscode.workspace.onDidCreateFiles(async (event) => {
+    for (const uri of event.files) {
+      if (uri.scheme === "file") {
+        await readAndNotifyWorker(worker, uri, LSFileAction.Add);
+      }
+    }
+  });
+
+  // watch for file deletion
+  const deleteWatcher = vscode.workspace.onDidDeleteFiles((event) => {
+    for (const file of event.files) {
+      if (file.scheme === "file") {
+        notifyWorker(worker, file, LSFileAction.Delete);
+      }
+    }
+  });
+
+  // watch for file renaming
+  const renameWatcher = vscode.workspace.onDidRenameFiles(async (event) => {
+    for (const rename of event.files) {
+      if (rename.oldUri.scheme === "file" && rename.newUri.scheme === "file") {
+        notifyWorker(worker, rename.oldUri, LSFileAction.Delete);
+        await readAndNotifyWorker(worker, rename.newUri, LSFileAction.Add);
+      }
+    }
+  });
+
+  // Watch for text document changes
+  const changeWatcher = vscode.workspace.onDidChangeTextDocument((event) => {
+    const uri = event.document.uri;
+    if (uri.scheme === "file") {
+      notifyWorker(worker, uri, LSFileAction.Add, event.document.getText());
+    }
+  });
+
+  context.subscriptions.push(
+    createWatcher,
+    deleteWatcher,
+    renameWatcher,
+    changeWatcher,
+  );
 }
 
-// This function is called when the extension is deactivated.
+/**
+ * Watch for changes to .pliplugin configuration files and notify the language server
+ * @param client LanguageClient instance to send notifications
+ */
+function watchPlipluginConfigChanges(client: LanguageClient): void {
+  // get the workspace path
+  const workspacePath = vscode.workspace.workspaceFolders?.[0]?.uri;
+
+  if (!workspacePath) {
+    return;
+  }
+
+  const configFilePaths = new Set(
+    PLIPLUGIN_CONFIG_FILES.map(
+      (file) => vscode.Uri.joinPath(workspacePath, file).path,
+    ),
+  );
+
+  vscode.workspace.onDidChangeTextDocument((event) => {
+    const uriPath = event.document.uri.path;
+    if (configFilePaths.has(uriPath)) {
+      client.sendNotification(WorkspaceDidChangePlipluginConfigNotification);
+    }
+  });
+}
+
+/**
+ * Invoked when the extension is activated
+ * @param context
+ */
+export async function activate(
+  context: vscode.ExtensionContext,
+): Promise<void> {
+  BuiltinFileSystemProvider.register(context);
+  client = startLanguageClient(context);
+  setupFileSystemWatchers(context);
+  watchPlipluginConfigChanges(client);
+  syncExistingFiles(client, worker);
+}
+
+/**
+ * Invoked when the extension is deactivated
+ * @returns
+ */
 export function deactivate(): Thenable<void> | undefined {
   if (client) {
     return client.stop();
   }
+  if (worker) {
+    worker.terminate();
+  }
   return undefined;
 }
 
+/**
+ * Starts the language client in a web worker
+ * @param context
+ * @returns
+ */
 function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
   const serverModule = vscode.Uri.joinPath(
     context.extensionUri,
     "out/language/main-browser.js",
   );
-  const worker = new Worker(serverModule.toString(true));
+  worker = new Worker(serverModule.toString(true));
 
   // Options to control the language client
   const clientOptions: LanguageClientOptions = {
@@ -44,8 +151,6 @@ function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
 
   // Create the language client and start the client.
   const client = new LanguageClient("pli", "PL/I", clientOptions, worker);
-
-  // Start the client. This will also launch the server
   client.start();
   return client;
 }

--- a/packages/vscode-extension/src/extension/main.ts
+++ b/packages/vscode-extension/src/extension/main.ts
@@ -9,19 +9,19 @@
  *
  */
 
+import TelemetryReporter from "@vscode/extension-telemetry";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { WorkspaceDidChangePlipluginConfigNotification } from "pli-language";
+import * as vscode from "vscode";
 import type {
   LanguageClientOptions,
   ServerOptions,
 } from "vscode-languageclient/node.js";
-import * as vscode from "vscode";
-import * as path from "node:path";
-import * as fs from "node:fs";
 import { LanguageClient, TransportKind } from "vscode-languageclient/node.js";
 import { BuiltinFileSystemProvider } from "./builtin-files";
-import { Settings } from "./settings";
 import { registerCustomDecorators } from "./decorators";
-import { WorkspaceDidChangePlipluginConfigNotification } from "pli-language";
-import TelemetryReporter from "@vscode/extension-telemetry";
+import { Settings } from "./settings";
 
 let client: LanguageClient;
 let settings: Settings;

--- a/packages/vscode-extension/src/extension/workspace-sync.ts
+++ b/packages/vscode-extension/src/extension/workspace-sync.ts
@@ -1,0 +1,193 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import * as vscode from "vscode";
+import { ProcessGroup } from "../../../language/src/workspace/plugin-configuration-provider";
+import { LanguageClient } from "vscode-languageclient/browser.js";
+import { WorkspaceDidChangePlipluginConfigNotification } from "pli-language";
+import {
+  FILE_SYSTEM_NAMESPACE,
+  FileSystemMessage,
+  LSFileAction,
+  PLIPLUGIN_CONFIG_FILES,
+} from "../utils";
+
+/**
+ * Generic glob pattern for common PL/I source files
+ */
+const FILE_PATTERNS = "*.{pli,pl1,inc,mac}";
+
+/**
+ * Helper to read files and notify the ls worker of their content
+ * @param worker Web Worker instance for the language server
+ * @param uri URI of the file to read
+ * @param action Action performed on the file
+ * @returns Promise<void>
+ */
+export async function readAndNotifyWorker(
+  worker: Worker,
+  uri: vscode.Uri,
+  action: LSFileAction,
+): Promise<void> {
+  try {
+    const content = await vscode.workspace.fs.readFile(uri);
+    const contentStr = new TextDecoder().decode(content);
+    notifyWorker(worker, uri, action, contentStr);
+  } catch (error) {
+    console.error(`Error reading file ${uri.toString()}:`, error);
+  }
+}
+
+/**
+ * Helper to notify the language server worker of file system changes
+ * @param worker Web Worker instance for the language server
+ * @param uri URI of the file that changed
+ * @param action Action performed on the file
+ * @param content Changed content of the file, if applicable
+ */
+export function notifyWorker(
+  worker: Worker,
+  uri: vscode.Uri,
+  action: LSFileAction,
+  content?: string,
+): void {
+  if (worker) {
+    const message: FileSystemMessage = {
+      namespace: FILE_SYSTEM_NAMESPACE,
+      type: action,
+      uri: uri.toString(),
+      content: content,
+    };
+    worker.postMessage(message);
+  }
+}
+
+/**
+ * Synchronizes existing files in the workspace to the language server,
+ * to populate its Virtual File System
+ * @param client LanguageClient instance to notify of config changes
+ * @param worker Web Worker instance for the language server
+ */
+export async function syncExistingFiles(
+  client: LanguageClient,
+  worker: Worker,
+): Promise<void> {
+  const workspaceFolders = vscode.workspace.workspaceFolders;
+  if (!workspaceFolders) {
+    return;
+  }
+
+  for (const folder of workspaceFolders) {
+    await syncWorkspaceFolder(worker, folder);
+  }
+
+  try {
+    client.sendNotification(WorkspaceDidChangePlipluginConfigNotification);
+  } catch (error) {
+    console.error("Error sending configuration reload notification:", error);
+  }
+}
+
+/**
+ * Syncs a single workspace folder's relevant files to the language server
+ * @param worker Web Worker instance for the language server
+ * @param folder Workspace folder to sync
+ * @returns Promise<void>
+ */
+async function syncWorkspaceFolder(
+  worker: Worker,
+  folder: vscode.WorkspaceFolder,
+): Promise<void> {
+  try {
+    // Sync top-level PL/I program files using FILE_PATTERNS
+    const programFiles = await vscode.workspace.findFiles(
+      new vscode.RelativePattern(folder, FILE_PATTERNS),
+    );
+    for (const fileUri of programFiles) {
+      await readAndNotifyWorker(worker, fileUri, LSFileAction.Add);
+    }
+
+    // add in the pli plugin config files
+    for (const configFile of PLIPLUGIN_CONFIG_FILES) {
+      const configFiles = await vscode.workspace.findFiles(
+        new vscode.RelativePattern(folder, configFile),
+      );
+      for (const fileUri of configFiles) {
+        await readAndNotifyWorker(worker, fileUri, LSFileAction.Add);
+      }
+    }
+
+    // Find the proc_grps.json config file in the workspace
+    const procGrpsFiles = await vscode.workspace.findFiles(
+      new vscode.RelativePattern(folder, ".pliplugin/proc_grps.json"),
+    );
+
+    if (procGrpsFiles.length === 0) {
+      console.warn("No proc_grps.json found in workspace");
+      return;
+    }
+
+    // Read and parse the first proc_grps.json file
+    const procGrpsContent = await vscode.workspace.fs.readFile(
+      procGrpsFiles[0],
+    );
+    const procGrpsJson = JSON.parse(new TextDecoder().decode(procGrpsContent));
+    const pgroups = procGrpsJson.pgroups || [];
+
+    // load library files
+    for (const pgroup of pgroups) {
+      await syncLibraryFilesForProcGroup(worker, folder, pgroup);
+    }
+  } catch (error) {
+    console.error("Error finding library files:", error);
+  }
+}
+
+/**
+ * Loads library files for a given program group (pgroup) based on its configuration.
+ * @param worker Web Worker instance for the language server
+ * @param folder Workspace folder
+ * @param pgroup Process group configuration object, w/ valid libs & extensions properties
+ */
+async function syncLibraryFilesForProcGroup(
+  worker: Worker,
+  folder: vscode.WorkspaceFolder,
+  pgroup: ProcessGroup,
+) {
+  const libs = pgroup.libs || [];
+  const extensions: string[] = pgroup["include-extensions"] || [
+    ".pli",
+    ".pl1",
+    ".inc",
+    ".mac",
+  ];
+  for (const lib of libs) {
+    // construct a glob pattern for the lib, e.g. "cpy/**/*.pli"
+    const pattern = `${lib}/**/*.{${extensions.map((ext) => ext.slice(1)).join(",")}}`;
+
+    // find libs with these extensions
+    const libFiles = await vscode.workspace.findFiles(
+      new vscode.RelativePattern(folder, pattern),
+    );
+    for (const fileUri of libFiles) {
+      await readAndNotifyWorker(worker, fileUri, LSFileAction.Add);
+    }
+
+    // find libs w/out any extensions , e.g. "cpy/LIB"
+    const noExtPattern = `${lib}/**/[^.]*`;
+    const libFilesNoExt = await vscode.workspace.findFiles(
+      new vscode.RelativePattern(folder, noExtPattern),
+    );
+    for (const fileUri of libFilesNoExt) {
+      await readAndNotifyWorker(worker, fileUri, LSFileAction.Add);
+    }
+  }
+}

--- a/packages/vscode-extension/src/language/main-browser.ts
+++ b/packages/vscode-extension/src/language/main-browser.ts
@@ -10,11 +10,48 @@
  */
 
 import {
+  setFileSystemProvider,
+  startLanguageServer,
+  VirtualFileSystemProvider,
+} from "pli-language";
+import {
   BrowserMessageReader,
   BrowserMessageWriter,
   createConnection,
 } from "vscode-languageserver/browser.js";
-import { startLanguageServer } from "pli-language";
+import { URI } from "vscode-uri";
+import {
+  FILE_SYSTEM_NAMESPACE,
+  FileSystemMessage,
+  LSFileAction,
+} from "../utils";
+
+class LSFileSystemProvider extends VirtualFileSystemProvider {
+  constructor() {
+    super();
+    self.addEventListener("message", (event) => {
+      if (event.data?.namespace === FILE_SYSTEM_NAMESPACE) {
+        const message = event.data as FileSystemMessage;
+        switch (message.type) {
+          case LSFileAction.Add:
+            this.writeFileSync(URI.parse(message.uri), message.content || "");
+            break;
+          case LSFileAction.Delete:
+            this.deleteFileSync(URI.parse(event.data.uri));
+            break;
+          case LSFileAction.Rename:
+            const content = this.readFileSync(URI.parse(event.data.uri));
+            this.deleteFileSync(URI.parse(event.data.uri));
+            this.writeFileSync(URI.parse(event.data.content), content || "");
+            break;
+          default:
+            console.log("Unsupported file action: ", event.data.type);
+            break;
+        }
+      }
+    });
+  }
+}
 
 /* browser specific setup code */
 const messageReader = new BrowserMessageReader(self);
@@ -23,4 +60,5 @@ const messageWriter = new BrowserMessageWriter(self);
 const connection = createConnection(messageReader, messageWriter);
 
 // Start the language server with the shared services
+setFileSystemProvider(new LSFileSystemProvider());
 startLanguageServer(connection);

--- a/packages/vscode-extension/src/language/main-browser.ts
+++ b/packages/vscode-extension/src/language/main-browser.ts
@@ -29,20 +29,20 @@ import {
 class LSFileSystemProvider extends VirtualFileSystemProvider {
   constructor() {
     super();
-    self.addEventListener("message", (event) => {
+    self.addEventListener("message", async (event) => {
       if (event.data?.namespace === FILE_SYSTEM_NAMESPACE) {
         const message = event.data as FileSystemMessage;
         switch (message.type) {
           case LSFileAction.Add:
-            this.writeFileSync(URI.parse(message.uri), message.content || "");
+            await this.writeFile(URI.parse(message.uri), message.content || "");
             break;
           case LSFileAction.Delete:
-            this.deleteFileSync(URI.parse(event.data.uri));
+            await this.deleteFile(URI.parse(event.data.uri));
             break;
           case LSFileAction.Rename:
-            const content = this.readFileSync(URI.parse(event.data.uri));
-            this.deleteFileSync(URI.parse(event.data.uri));
-            this.writeFileSync(URI.parse(event.data.content), content || "");
+            const content = await this.readFile(URI.parse(event.data.uri));
+            await this.deleteFile(URI.parse(event.data.uri));
+            await this.writeFile(URI.parse(event.data.content), content || "");
             break;
           default:
             console.log("Unsupported file action: ", event.data.type);

--- a/packages/vscode-extension/src/utils.ts
+++ b/packages/vscode-extension/src/utils.ts
@@ -1,0 +1,38 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { PluginConfigurationProvider } from "../../language/src/workspace/plugin-configuration-provider";
+
+/**
+ * File actions that can be communicated to the language server
+ */
+export enum LSFileAction {
+  Add = "add",
+  Delete = "delete",
+  Rename = "rename",
+}
+
+export const FILE_SYSTEM_NAMESPACE = "file-system";
+
+export const PLIPLUGIN_CONFIG_FILES = [
+  PluginConfigurationProvider.PROGRAM_CONFIG_FILE,
+  PluginConfigurationProvider.PROCESS_GROUP_CONFIG_FILE,
+];
+
+/**
+ * Message format for file system changes
+ */
+export interface FileSystemMessage {
+  namespace: typeof FILE_SYSTEM_NAMESPACE;
+  type: LSFileAction;
+  uri: string;
+  content?: string;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,6 +178,9 @@ importers:
       vscode-languageserver:
         specifier: ~9.0.1
         version: 9.0.1
+      vscode-uri:
+        specifier: ~3.0.8
+        version: 3.0.8
     devDependencies:
       '@types/vscode':
         specifier: ~1.67.0


### PR DESCRIPTION
Closes #317 by bringing the web extension up to parity with regards to the existing playground state.

Points that I'm still thinking of:
- This more or less mimics the approach in the playground, where we're pre-emptively loading most of the workspace (ex. all proc groups are iterated over and loaded). This won't work for larger workspaces. I had a thought about adding a notification that the LS can send back to the LC to 'request' for documents to be looked for & added lazily on demand to avoid this, but nothing in that area has been put into place here.
- main-browser changes are a bit large, especially all the traversal logic for loading the workspace into the VFS, open for suggestions on improving that
- Ran into timing issues w/ regards to the LC starting while we were still sending files to the LS worker, that's been resolved here, but larger workspaces could trigger strange diagnostics for a currently opened file while we're still populating the workspace on the LS side. Especially before the plugin configuration is reloaded.
- This doesn't replace the playground implementation _yet_, but it mirrors several parts. Ideally either this PR is pushed up to subsume those duplicate parts, or a subsequent one should bring those together
    - could be either directly incorporating the web-extension, or directly replacing & reusing this LS & LC setup there


This looks to also resolves a recent bug in the playground where case-insensitivity of imports leads to Go To Def requests jumping to non-existent files whenever the actual file is not fully lower-cased. So `%INCLUDE abc` fails when the file is actually `ABC`. Although the fixed state is just in the web-extension here. I've opened up #359 to track that separately, especially since this doesn't modify the playground yet. Note that although the jumped to file may not be there, the import still resolves correctly as expected.