### PR TITLE
Support multiple INCAFTER & FLAG Options

### DIFF
--- a/packages/language/src/preprocessor/compiler-options/options.ts
+++ b/packages/language/src/preprocessor/compiler-options/options.ts
@@ -700,8 +700,7 @@ export declare namespace CompilerOptions {
     items?: ("ASSERT" | "DISPLAY" | "PUT")[];
   }
   export interface IncAfter {
-    process?: string;
-    token?: Token;
+    includes: Array<{ process: string; token?: Token }>;
   }
   export interface IncDir {
     directories: string[];

--- a/packages/language/src/preprocessor/compiler-options/translator.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator.ts
@@ -36,6 +36,7 @@ interface TranslatorRule {
   negative?: string[];
   positiveTranslate?: Translate;
   negativeTranslate?: Translate;
+  multipleAllowed?: boolean;
 }
 
 type Translate = (option: CompilerOption, options: CompilerOptions) => void;
@@ -67,17 +68,27 @@ class Translator {
 
   private rules: TranslatorRule[] = [];
 
+  /**
+   * Adds a rule to the translator.
+   * @param positive Positive option names that trigger this rule.
+   * @param positiveTranslate Translation function for positive option.
+   * @param negative Negative option names that trigger this rule.
+   * @param negativeTranslate Negative translation function for negative option.
+   * @param multipleAllowed Whether this rule supports multiple occurrences. Duplicate validations are skipped in this case.
+   */
   rule(
     positive: string[],
     positiveTranslate: Translate,
     negative?: string[],
     negativeTranslate?: Translate,
+    multipleAllowed?: boolean,
   ) {
     this.rules.push({
       positive,
       negative,
       positiveTranslate,
       negativeTranslate,
+      multipleAllowed: multipleAllowed,
     });
   }
 
@@ -145,7 +156,9 @@ class Translator {
       if (!this.isRuleApplied(rule)) {
         this.appliedRules.set(rule, alignment);
       } else if (this.isRuleAlignedWith(rule, alignment)) {
-        this.reportDupeOptIssue(option, name);
+        if (!rule.multipleAllowed) {
+          this.reportDupeOptIssue(option, name);
+        }
       } else {
         this.reportMutexOptIssue(option, name);
       }
@@ -1368,23 +1381,29 @@ translator.rule(
 );
 
 /** {@link CompilerOptions.flag} */
-translator.rule(["FLAG", "F"], (option, options) => {
-  ensureArguments(option, 0, 1);
-  const value = option.values[0];
-  if (value) {
-    ensureType(value, "plain");
-    const flag = value.value.toUpperCase();
-    if (flag === "S" || flag === "E" || flag === "I" || flag === "W") {
-      options.flag = flag;
-    } else {
-      throw new TranslationError(
-        value.token,
-        `Invalid flag value. Expected S, E, I or W, but received '${flag}'.`,
-        1,
-      );
+translator.rule(
+  ["FLAG", "F"],
+  (option, options) => {
+    ensureArguments(option, 0, 1);
+    const value = option.values[0];
+    if (value) {
+      ensureType(value, "plain");
+      const flag = value.value.toUpperCase();
+      if (flag === "S" || flag === "E" || flag === "I" || flag === "W") {
+        options.flag = flag;
+      } else {
+        throw new TranslationError(
+          value.token,
+          `Invalid flag value. Expected S, E, I or W, but received '${flag}'.`,
+          1,
+        );
+      }
     }
-  }
-});
+  },
+  undefined,
+  undefined,
+  true,
+);
 
 /** {@link CompilerOptions.float} */
 translator.rule(
@@ -1519,29 +1538,40 @@ translator.rule(
 );
 
 /** {@link CompilerOptions.incAfter} */
-translator.rule(["INCAFTER"], (option, options) => {
-  ensureArguments(option, 1, 1);
-  const value = option.values[0];
-  if (value.kind === SyntaxKind.CompilerOption) {
-    if (value.name.toUpperCase() !== "PROCESS") {
-      throw new TranslationError(
-        value.token,
-        `Expected "PROCESS", but received '${value.name}'.`,
-        1,
-      );
+translator.rule(
+  ["INCAFTER"],
+  (option, options) => {
+    ensureArguments(option, 1, 1);
+    const value = option.values[0];
+    if (value.kind === SyntaxKind.CompilerOption) {
+      if (value.name.toUpperCase() !== "PROCESS") {
+        throw new TranslationError(
+          value.token,
+          `Expected "PROCESS", but received '${value.name}'.`,
+          1,
+        );
+      }
+      ensureArguments(value, 1, 1);
+      const processValue = value.values[0];
+      ensureType(processValue, "plain");
+
+      if (!options.incAfter) {
+        options.incAfter = { includes: [] };
+      }
+
+      options.incAfter.includes.push({
+        process: processValue.value,
+        token: processValue.token,
+      });
+    } else {
+      ensureType(value, "plain");
+      options.incAfter = undefined;
     }
-    ensureArguments(value, 1, 1);
-    const processValue = value.values[0];
-    ensureType(processValue, "plain");
-    options.incAfter = {
-      process: processValue.value,
-      token: processValue.token,
-    };
-  } else {
-    ensureType(value, "plain");
-    options.incAfter = undefined;
-  }
-});
+  },
+  undefined,
+  undefined,
+  true,
+);
 
 /** {@link CompilerOptions.incDir} */
 translator.rule(

--- a/packages/language/src/preprocessor/pli-lexer.ts
+++ b/packages/language/src/preprocessor/pli-lexer.ts
@@ -98,7 +98,7 @@ export class PliLexer {
     allErrors.push(...this.marginsProcessor.issues);
 
     const incAfter = compilerOptionsResult.result?.options.incAfter;
-    if (incAfter?.process) {
+    if (incAfter?.includes && incAfter.includes.length > 0) {
       instruction.result = {
         entryNode: generateIncAfterInstruction(
           instruction.result.entryNode,
@@ -135,30 +135,41 @@ function generateIncAfterInstruction(
   existingNode: InstructionNode,
   incAfter: CompilerOptions.IncAfter | undefined,
 ): InstructionNode {
-  if (!incAfter || !incAfter.process) {
+  if (!incAfter || !incAfter.includes || incAfter.includes.length === 0) {
     return existingNode;
   }
-  // Generate a synthetic include item here
-  // This allows us to perform LSP operations to jump to the included file
-  const includeItem = ast.createIncludeItem();
-  includeItem.fileName = incAfter.process;
-  includeItem.token = incAfter.token || null;
-  if (incAfter.token) {
-    includeItem.token = incAfter.token;
-    incAfter.token.element = includeItem;
-    incAfter.token.kind = CstNodeKind.IncludeItem_FileID;
+
+  // generate chained include instructions for each entry
+  let currentNode = existingNode;
+
+  // process in reverse order so the first INCAFTER appears first
+  for (let i = incAfter.includes.length - 1; i >= 0; i--) {
+    const include = incAfter.includes[i];
+
+    // Generate a synthetic include item here
+    // This allows us to perform LSP operations to jump to the included file
+    const includeItem = ast.createIncludeItem();
+    includeItem.fileName = include.process;
+    includeItem.token = include.token || null;
+    if (include.token) {
+      includeItem.token = include.token;
+      include.token.element = includeItem;
+      include.token.kind = CstNodeKind.IncludeItem_FileID;
+    }
+
+    // Create instruction for this include
+    const instruction: InstructionNode = {
+      labels: [],
+      instruction: createIncludeInstruction(
+        includeItem,
+        include.process,
+        false,
+        include.token,
+      ),
+      next: currentNode,
+    };
+    currentNode = instruction;
   }
-  // IncAfter runs as the very first instruction in the preprocessor.
-  // It allows to include ONE SINGLE file. Afterwards the preprocessor runs as normal.
-  const instruction: InstructionNode = {
-    labels: [],
-    instruction: createIncludeInstruction(
-      includeItem,
-      incAfter.process,
-      false,
-      incAfter.token,
-    ),
-    next: existingNode,
-  };
-  return instruction;
+
+  return currentNode;
 }

--- a/packages/language/test/fourslash/preprocessor/compiler-options/flag-no-duplicate-error.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/flag-no-duplicate-error.ts
@@ -1,0 +1,18 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: main.pli
+////*PROCESS FLAG(W) FLAG(S);
+//// DCL TEST FIXED;
+
+verify.noDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/include/incafter-accumulate.ts
+++ b/packages/language/test/fourslash/preprocessor/include/incafter-accumulate.ts
@@ -1,0 +1,28 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: cpy/lib1.pli
+//// DECLARE LIB1_VAR FIXED;
+
+// @filename: cpy/lib2.pli
+//// DECLARE LIB2_VAR FIXED;
+
+// @filename: main.pli
+////*PROCESS INCAFTER(PROCESS(lib1)) INCAFTER(PROCESS(lib2));
+//// DCL TEST FIXED;
+
+preprocessor.expectTokens(`
+  DECLARE LIB1_VAR FIXED;
+  DECLARE LIB2_VAR FIXED;
+  DCL TEST FIXED;
+`);


### PR DESCRIPTION
Closes point 1 from #335 by:

- Supporting multiple compiler options declarations for INCAFTER & FLAG
- Adds a 'multipleAllowed' prop to ID such options
- Avoids producing a duplicate option validation for these options
- INCAFTER accumulates includes for each case
- Flag just replaces it's value (I don't think it can accumulate after reading it over, seems like it just overrides like any other rule?)
- Tests to ensure multiple options of INCAFTER & FLAG don't trigger diagnostics + verifying multiple INCAFTERs work as expected.
