### PR TITLE
Implement support for IBM1059I

### DIFF
--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -5660,6 +5660,7 @@ export class PliParser extends AbstractParser {
       on: null,
       statements: [],
       end: null,
+      selectToken: null,
     };
   }
 
@@ -5668,6 +5669,7 @@ export class PliParser extends AbstractParser {
 
     this.CONSUME_ASSIGN1(tokens.SELECT, (token) => {
       this.tokenPayload(token, element, CstNodeKind.SelectStatement_SELECT);
+      element.selectToken = token;
     });
     this.OPTION1(() => {
       this.CONSUME_ASSIGN1(tokens.OpenParen, (token) => {

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -2112,6 +2112,7 @@ export interface SelectStatement extends AstNode {
   on: Expression | null;
   statements: (WhenStatement | OtherwiseStatement)[];
   end: EndStatement | null;
+  selectToken: Token | null;
 }
 export interface SignalStatement extends AstNode {
   kind: SyntaxKind.SignalStatement;

--- a/packages/language/src/validation/messages/info-severity/IBM1059I-select-without-otherwise.ts
+++ b/packages/language/src/validation/messages/info-severity/IBM1059I-select-without-otherwise.ts
@@ -1,0 +1,45 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { PLICodes } from "../../../validation/messages";
+import {
+  Severity,
+  tokenToRange,
+  tokenToUri,
+} from "../../../language-server/types";
+import * as AST from "../../../syntax-tree/ast";
+import { ValidationAcceptor } from "../../validator";
+
+/**
+ * IBM1059I: The ERROR condition will be raised if SELECT statement contains no OTHERWISE clause.
+ */
+export function IBM1059I_select_without_otherwise(
+  node: AST.SelectStatement,
+  acceptor: ValidationAcceptor,
+) {
+  const otherwiseStatement = node.statements?.some(
+    (stmt) => stmt.kind === AST.SyntaxKind.OtherwiseStatement,
+  );
+  if (otherwiseStatement) return;
+
+  const token = node.selectToken;
+  if (!token) return;
+
+  const infoRange = tokenToRange(token);
+  const infoUri = tokenToUri(token);
+  if (!infoRange || !infoUri) return;
+
+  acceptor(Severity.I, PLICodes.Info.IBM1059I.message, {
+    code: PLICodes.Info.IBM1059I.fullCode,
+    range: infoRange,
+    uri: infoUri,
+  });
+}

--- a/packages/language/src/validation/pli-validator.ts
+++ b/packages/language/src/validation/pli-validator.ts
@@ -24,6 +24,7 @@ import {
   ProcessGroup,
   ProgramConfig,
 } from "../workspace/plugin-configuration-provider";
+import { IBM1059I_select_without_otherwise } from "./messages/info-severity/IBM1059I-select-without-otherwise";
 import { IBM1219I_leave_exits_noniterative_do } from "./messages/IBM1219I-leave-exits-noniterative-do";
 import { IBM1324IE_name_occurs_more_than_once_within_exports_clause } from "./messages/IBM1324IE-name-occurs-more-than-once-within-exports-clause.js";
 import { IBM1388IE_NODESCRIPTOR_attribute_is_invalid_when_any_parameter_has_NONCONNECTED_attribute } from "./messages/IBM1388IE-NODESCRIPTOR-attribute-is-invalid-when-any-parameter-has-NONCONNECTED-attribute.js";
@@ -57,6 +58,7 @@ export function registerPliValidationChecks(unit: CompilationUnit): Validator {
     ReferenceItem: [validator.checkImplicitBuiltins.bind(validator)],
     DoStatement: [IBM2615I_do_loops_execute_once],
     LeaveStatement: [IBM1219I_leave_exits_noniterative_do],
+    SelectStatement: [IBM1059I_select_without_otherwise],
   });
 
   return validator;

--- a/packages/language/test/fourslash/validate/IBM1059I/select-multiple-when-without-otherwise.ts
+++ b/packages/language/test/fourslash/validate/IBM1059I/select-multiple-when-without-otherwise.ts
@@ -1,0 +1,25 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+/**
+ * SELECT with multiple WHENs without OTHERWISE does trigger.
+ */
+
+// @wrap: main
+//// DCL X FIXED BIN(15) INIT(3);
+//// <|1:SELECT|>;
+////   WHEN (X = 1) PUT SKIP LIST('One');
+////   WHEN (X = 2) PUT SKIP LIST('Two');
+//// END;
+
+verify.expectExclusiveErrorCodesAt(1, code.Information.IBM1059I.fullCode);

--- a/packages/language/test/fourslash/validate/IBM1059I/select-with-otherwise.ts
+++ b/packages/language/test/fourslash/validate/IBM1059I/select-with-otherwise.ts
@@ -1,0 +1,25 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+/**
+ * SELECT with OTHERWISE does NOT trigger.
+ */
+
+// @wrap: main
+//// DCL X FIXED BIN(15) INIT(1);
+//// <|1:SELECT|>;
+////   WHEN (X = 1) PUT SKIP LIST('Matched');
+////   OTHERWISE PUT SKIP LIST('Default');
+//// END;
+
+verify.noDiagnostics(1);

--- a/packages/language/test/fourslash/validate/IBM1059I/select-with-when-and-comments-without-otherwise.ts
+++ b/packages/language/test/fourslash/validate/IBM1059I/select-with-when-and-comments-without-otherwise.ts
@@ -1,0 +1,28 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+/**
+ * SELECT with WHEN and comments and without OTHERWISE does trigger.
+ */
+
+// @wrap: main
+//// DCL X FIXED BIN(15) INIT(5);
+//// <|1:SELECT|>;
+////   WHEN (X = 5) DO;
+////     /* do something */
+////     PUT SKIP LIST('Five');
+////   END;
+////   /* missing OTHERWISE */
+//// END;
+
+verify.expectExclusiveErrorCodesAt(1, code.Information.IBM1059I.fullCode);

--- a/packages/language/test/fourslash/validate/IBM1059I/select-without-otherwise.ts
+++ b/packages/language/test/fourslash/validate/IBM1059I/select-without-otherwise.ts
@@ -1,0 +1,24 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+/**
+ * SELECT without OTHERWISE should inform.
+ */
+
+// @wrap: main
+//// DCL X FIXED BIN(15) INIT(1);
+//// <|1:SELECT|>;
+////   WHEN (X = 1) PUT SKIP LIST('Matched');
+//// END;
+
+verify.expectExclusiveErrorCodesAt(1, code.Information.IBM1059I.fullCode);

--- a/packages/language/test/fourslash/validate/IBM1059I/select-without-when-with-otherwise.ts
+++ b/packages/language/test/fourslash/validate/IBM1059I/select-without-when-with-otherwise.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+/**
+ * SELECT without WHEN with OTHERWISE does NOT trigger.
+ */
+// @wrap: main
+//// DCL X FIXED BIN(15) INIT(3);
+//// <|1:SELECT|>;
+////   OTHERWISE PUT SKIP LIST('Fallback');
+//// END;
+
+verify.noDiagnostics(1);


### PR DESCRIPTION
### implement IBM1059I: SELECT statement contains no OTHERWISE clause.

Issue: [#344 ](https://github.com/zowe/zowe-pli-language-support/issues/344)

**Summary:**
This PR adds a validator that implements IBM1059I: Inform when a SELECT statement doesn't provide an OTHERWISE statement by checking the presence of an OtherwiseStatement within the node.statements.

**Changes**

IBM1059I_select_without_otherwise: validation code described above.
pli-validator: register validation code.
Parser: update SelectStatement rule to assign element.selectToken = token in the CONSUME(tokens.SELECT, ...) callback
AST: add selectToken to SelectStatement
Tests: add tests under packages/language/test/fourslash/validate/IBM1059I/