### PR TITLE
Extend compiler options and tests #5

### DIFF
--- a/packages/language/src/preprocessor/compiler-options/codes.ts
+++ b/packages/language/src/preprocessor/compiler-options/codes.ts
@@ -420,6 +420,22 @@ export const CompilerOptionsCodes = {
     } as ParametricPLICode,
   },
 
+  Prefix: {
+    InvalidParameter: {
+      code: "COPX01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected one of the compiler condition "CONFORMANCE", "CONVERSION", "FIXEDOVERFLOW", "INVALIDOP", "OVERFLOW", "SIZE", "STRINGRANGE", "STRINGSIZE", "SUBSCRIPTRANGE", "UNDERFLOW" or "ZERODIVIDE", but received '${value}'.`,
+      fullCode: "COPX01W",
+    } as ParametricPLICode,
+    ConditionIsAlwaysEnabled: {
+      code: "COPX02",
+      severity: Severity.W,
+      message: (value: string) => `Condition '${value}' is always enabled.`,
+      fullCode: "COPX02W",
+    } as ParametricPLICode,
+  },
+
   Proceed: {
     InvalidParameter: {
       code: "COPR01",
@@ -531,6 +547,198 @@ export const CompilerOptionsCodes = {
       message: (value: string) =>
         `Expected "S", "E" or "W", but received '${value}'.`,
       fullCode: "COSY01W",
+    } as ParametricPLICode,
+  },
+
+  Test: {
+    InvalidParameter: {
+      code: "COTS01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "ALL", "BLOCK", "NONE", "PATH", "STMT", "HOOK", "NOHOOK", "SEPARATE", "NOSEPARATE", "SEPNAME", "NOSEPNAME", "SOURCE", "NOSOURCE", "SYM" or "NOSYM", but received '${value}'.`,
+      fullCode: "COTS01W",
+    } as ParametricPLICode,
+  },
+
+  Unroll: {
+    InvalidParameter: {
+      code: "COUN01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "AUTO" or "NO", but received '${value}'.`,
+      fullCode: "COUN01W",
+    } as ParametricPLICode,
+  },
+
+  Usage: {
+    InvalidParameter: {
+      code: "COUS01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "HEX", "REGEX", "ROUND", "SUBSTR", "UNSPEC", "UUID" or "VALIDDATE", but received '${value}'.`,
+      fullCode: "COUS01W",
+    } as ParametricPLICode,
+    InvalidHexParameter: {
+      code: "COUS02",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "SIZE" or "CURRENTSIZE", but received '${value}'.`,
+      fullCode: "COUS02W",
+    } as ParametricPLICode,
+    InvalidRegexParameter: {
+      code: "COUS03",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "RESET" or "NORESET", but received '${value}'.`,
+      fullCode: "COUS03W",
+    } as ParametricPLICode,
+    InvalidRoundParameter: {
+      code: "COUS04",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "IBM" or "ANS", but received '${value}'.`,
+      fullCode: "COUS04W",
+    } as ParametricPLICode,
+    InvalidSubstrParameter: {
+      code: "COUS05",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "STRICT" or "LOOSE", but received '${value}'.`,
+      fullCode: "COUS05W",
+    } as ParametricPLICode,
+    InvalidUnspecParameter: {
+      code: "COUS06",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "IBM" or "ANS", but received '${value}'.`,
+      fullCode: "COUS06W",
+    } as ParametricPLICode,
+    InvalidUuidParameter: {
+      code: "COUS07",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "UPPER" or "LOWER", but received '${value}'.`,
+      fullCode: "COUS07W",
+    } as ParametricPLICode,
+    InvalidValidDateParameter: {
+      code: "COUS08",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "LOOSE" or "STRICT", but received '${value}'.`,
+      fullCode: "COUS08W",
+    } as ParametricPLICode,
+  },
+
+  WideChar: {
+    InvalidParameter: {
+      code: "COWC01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "BIGENDIAN" or "LITTLEENDIAN", but received '${value}'.`,
+      fullCode: "COWC01W",
+    } as ParametricPLICode,
+  },
+
+  Writable: {
+    InvalidParameter: {
+      code: "COWR01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "FWS" or "PRV", but received '${value}'.`,
+      fullCode: "COWR01W",
+    } as ParametricPLICode,
+  },
+
+  XInfo: {
+    InvalidParameter: {
+      code: "COXI01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "DEF", "NODEF", "MSG", "NOMSG", "SYM", "NOSYM", "SYN", "NOSYN", "XML", or "NOXML", but received '${value}'.`,
+      fullCode: "COXI01W",
+    } as ParametricPLICode,
+    InvalidDefParameter: {
+      code: "COXI02",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "DEF" or "NODEF", but received '${value}'.`,
+      fullCode: "COXI02W",
+    } as ParametricPLICode,
+    InvalidMsgParameter: {
+      code: "COXI03",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "MSG" or "NOMSG", but received '${value}'.`,
+      fullCode: "COXI03W",
+    } as ParametricPLICode,
+    InvalidSymParameter: {
+      code: "COXI04",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "SYM" or "NOSYM", but received '${value}'.`,
+      fullCode: "COXI04W",
+    } as ParametricPLICode,
+    InvalidSynParameter: {
+      code: "COXI05",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "SYN" or "NOSYN", but received '${value}'.`,
+      fullCode: "COXI05W",
+    } as ParametricPLICode,
+    InvalidXmlParameter: {
+      code: "COXI06",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "XML" or "NOXML", but received '${value}'.`,
+      fullCode: "COXI06W",
+    } as ParametricPLICode,
+  },
+
+  Xml: {
+    InvalidParameter: {
+      code: "COXM01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "UPPER", "CASE" or "XMLATTR", but received '${value}'.`,
+      fullCode: "COXM01W",
+    } as ParametricPLICode,
+    InvalidCaseParameter: {
+      code: "COXM02",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "UPPER" or "ASIS", but received '${value}'.`,
+      fullCode: "COXM02W",
+    } as ParametricPLICode,
+    InvalidXmlAttrParameter: {
+      code: "COXM03",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "APOSTROPHE" or "QUOTE", but received '${value}'.`,
+      fullCode: "COXM03W",
+    } as ParametricPLICode,
+  },
+
+  XRef: {
+    InvalidParameter: {
+      code: "COXR01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "FULL", "SHORT", "IMPLICIT", or "EXPLICIT", but received '${value}'.`,
+      fullCode: "COXR01W",
+    } as ParametricPLICode,
+    InvalidLengthParameter: {
+      code: "COXR02",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "FULL" or "SHORT", but received '${value}'.`,
+      fullCode: "COXR02W",
+    } as ParametricPLICode,
+    InvalidStructureParameter: {
+      code: "COXR03",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "FULL", "SHORT", "IMPLICIT", or "EXPLICIT", but received '${value}'.`,
+      fullCode: "COXR03W",
     } as ParametricPLICode,
   },
 };

--- a/packages/language/src/preprocessor/compiler-options/options.ts
+++ b/packages/language/src/preprocessor/compiler-options/options.ts
@@ -445,7 +445,7 @@ export interface CompilerOptions {
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-prefix
    */
-  prefix?: string[];
+  prefix?: CompilerConditions.ConditionOptions;
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-proceed
    */
@@ -541,7 +541,7 @@ export interface CompilerOptions {
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-unroll
    */
-  unroll?: "AUTO" | "NO";
+  unroll?: CompilerOptions.Unroll;
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-usage
    */
@@ -1029,16 +1029,18 @@ export declare namespace CompilerOptions {
     noSyntax: Flag;
   };
   export type System = "MVS" | "CICS" | "IMS" | "OS" | "TSO";
+  export type TestLevel = "ALL" | "BLOCK" | "NONE" | "PATH" | "STMT";
   export type Test =
-    | false
     | {
-        level?: "ALL" | "BLOCK" | "NONE" | "PATH" | "STMT";
+        level?: TestLevel;
         hook?: boolean;
         separate?: boolean;
         sepName?: boolean;
         source?: boolean;
         sym?: boolean;
-      };
+      }
+    | false;
+  export type Unroll = "AUTO" | "NO";
   export type Usage = {
     hex?: "SIZE" | "CURRENTSIZE";
     regex?: {
@@ -1053,12 +1055,13 @@ export declare namespace CompilerOptions {
   export type Writable =
     | true
     | {
-        value?: "FWS" | "PRV";
+        noWritable?: "FWS" | "PRV";
       };
   export type XInfo = {
     def?: boolean;
     msg?: boolean;
     sym?: boolean;
+    syn?: boolean;
     xml?:
       | false
       | {
@@ -1069,9 +1072,54 @@ export declare namespace CompilerOptions {
     case?: "UPPER" | "ASIS";
     xmlAttr?: "APOSTROPHE" | "QUOTE";
   };
-  export type XRef = {
-    length?: Length;
-    structure?: "EXPLICIT" | "IMPLICIT";
+  export type XRef =
+    | {
+        length?: Length;
+        structure?: "EXPLICIT" | "IMPLICIT";
+      }
+    | false;
+}
+
+export namespace CompilerConditions {
+  export type Condition = {
+    condition: string[];
+    alwaysEnabled?: boolean;
+  };
+
+  export const PLI_CONDITIONS = [
+    { condition: ["ANYCONDITION", "ANYCOND"], alwaysEnabled: true },
+    { condition: ["AREA"], alwaysEnabled: true },
+    { condition: ["ASSERTION"], alwaysEnabled: true },
+    { condition: ["ATTENTION", "ATTN"], alwaysEnabled: true },
+    { condition: ["CONDITION"], alwaysEnabled: true },
+    { condition: ["CONFORMANCE"] },
+    { condition: ["CONVERSION", "CONV"] },
+    { condition: ["ENDFILE"], alwaysEnabled: true },
+    { condition: ["ENDPAGE"], alwaysEnabled: true },
+    { condition: ["ERROR"], alwaysEnabled: true },
+    { condition: ["FINISH"], alwaysEnabled: true },
+    { condition: ["FIXEDOVERFLOW", "FOFL"] },
+    { condition: ["INVALIDOP"] },
+    { condition: ["KEY"], alwaysEnabled: true },
+    { condition: ["NAME"], alwaysEnabled: true },
+    { condition: ["OVERFLOW", "OFL"] },
+    { condition: ["RECORD"], alwaysEnabled: true },
+    { condition: ["SIZE"] },
+    { condition: ["STORAGE"], alwaysEnabled: true },
+    { condition: ["STRINGRANGE", "STRNG"] },
+    { condition: ["STRINGSIZE", "STRSZ"] },
+    { condition: ["SUBSCRIPTRANGE", "SUBRG"] },
+    { condition: ["TRANSMIT"], alwaysEnabled: true },
+    { condition: ["UNDEFINEDFILE", "UNDF"], alwaysEnabled: true },
+    { condition: ["UNDERFLOW", "UFL"] },
+    { condition: ["ZERODIVIDE", "ZDIV"] },
+  ] as const;
+
+  export type All = (typeof PLI_CONDITIONS)[number];
+  export type NotAlwaysEnabled = Exclude<All, { alwaysEnabled: true }>;
+  export type AssignableConditions = NotAlwaysEnabled["condition"][0];
+  export type ConditionOptions = {
+    [K in Lowercase<AssignableConditions>]?: boolean;
   };
 }
 
@@ -1140,6 +1188,19 @@ const defaultCompilerOptions: CompilerOptions = {
   optimize: 0,
   options: "DOC",
   precType: "ANS",
+  prefix: {
+    conformance: false,
+    conversion: true,
+    fixedoverflow: true,
+    invalidop: true,
+    overflow: true,
+    size: false,
+    stringrange: false,
+    stringsize: false,
+    subscriptrange: false,
+    underflow: true,
+    zerodivide: true,
+  },
   proceed: { noProceed: "S" },
   process: "DELETE",
   quote: '"',
@@ -1159,6 +1220,40 @@ const defaultCompilerOptions: CompilerOptions = {
   syntax: { noSyntax: "S" },
   system: "MVS",
   sysParm: "",
+  terminal: true,
+  test: false,
+  unroll: "AUTO",
+  usage: {
+    hex: "SIZE",
+    regex: {
+      reset: true,
+    },
+    round: "IBM",
+    substr: "STRICT",
+    unspec: "IBM",
+    uuid: "UPPER",
+    validDate: "LOOSE",
+  },
+  widechar: "BIGENDIAN",
+  window: 1950,
+  writable: true,
+  xInfo: {
+    def: false,
+    msg: false,
+    sym: false,
+    syn: false,
+    xml: {
+      hash: false,
+    },
+  },
+  xml: {
+    case: "UPPER",
+    xmlAttr: "APOSTROPHE",
+  },
+  xRef: {
+    length: "FULL",
+    structure: "IMPLICIT",
+  },
 };
 
 /**

--- a/packages/language/src/preprocessor/compiler-options/translator.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator.ts
@@ -10,6 +10,7 @@
  */
 
 import {
+  CompilerConditions,
   CompilerOptionIssue,
   CompilerOptionResult,
   CompilerOptions,
@@ -313,6 +314,38 @@ function ensureNumberValue(
     );
   }
   return num;
+}
+
+function ensureArgument<T>(
+  optionValue: CompilerOptionValue,
+  code: ParametricPLICode,
+  args: T[],
+): (typeof args)[number] {
+  let value;
+  if (optionValue.kind === SyntaxKind.CompilerOptionText) {
+    value = optionValue.value;
+  } else if (optionValue.kind === SyntaxKind.CompilerOptionString) {
+    value = optionValue.value;
+  } else if (optionValue.kind === SyntaxKind.CompilerOption) {
+    value = optionValue.name;
+  } else {
+    throw new Error("Compiler option value is not supported.");
+  }
+  const valueUpperCase = value.toUpperCase();
+  for (const arg of args) {
+    if (valueUpperCase === arg) {
+      return arg;
+    }
+  }
+  throw TranslationError.fromCode(optionValue.token, code, value);
+}
+
+function ensureFlag(
+  optionValue: CompilerOptionValue,
+  code: ParametricPLICode,
+  args: string[],
+): boolean {
+  return ensureArgument(optionValue, code, args) === args[0];
 }
 
 function stringToNumber(text: string): number {
@@ -2591,6 +2624,44 @@ translator.rule(["PRECTYPE"], (option, options) => {
 });
 
 /** {@link CompilerOptions.prefix} */
+translator.rule(["PREFIX"], (option, options) => {
+  ensureArguments(option, 1);
+  if (!options.prefix) {
+    // TODO: Prefix does not override prev settings. (no dupe?)
+    options.prefix = getDefaultCompilerOptions().prefix;
+  }
+  for (const value of option.values) {
+    ensureType(value, "plain");
+    if (value.value.length === 0) {
+      // Will only happen, if the arguments list is empty.
+      return;
+    }
+    const valueName = value.value.toUpperCase();
+    const setCondition = !valueName.startsWith("NO");
+    const name = setCondition ? valueName : valueName.slice(2);
+    const condition = CompilerConditions.PLI_CONDITIONS.find((c) =>
+      (c.condition as readonly string[]).includes(name),
+    ) as CompilerConditions.Condition | undefined;
+    if (!condition) {
+      throw TranslationError.fromCode(
+        value.token,
+        CompilerOptionsCodes.Prefix.InvalidParameter,
+        value.value,
+      );
+    }
+    if (condition.alwaysEnabled) {
+      throw TranslationError.fromCode(
+        value.token,
+        CompilerOptionsCodes.Prefix.ConditionIsAlwaysEnabled,
+        value.value,
+      );
+    }
+    options.prefix![
+      condition.condition[0].toLowerCase() as keyof CompilerConditions.ConditionOptions
+    ] = setCondition;
+  }
+});
+
 /** {@link CompilerOptions.proceed} */
 translator.rule(
   ["PROCEED", "PRO"],
@@ -2896,16 +2967,375 @@ translator.rule(
     "TSO",
   ),
 );
+
 /** {@link CompilerOptions.terminal} */
+translator.flag("terminal", ["TERMINAL", "TERM"], ["NOTERMINAL", "NTERM"]);
+
 /** {@link CompilerOptions.test} */
+translator.rule(
+  ["TEST"],
+  (option, options) => {
+    // If there are multiple *PROCESS TEST directives,
+    // the last one takes precedence and all suboptions that are not specified
+    // are set to default.
+    options.test = {
+      level: "ALL",
+      hook: true,
+      separate: false,
+      sepName: true,
+      source: false,
+      sym: true,
+    };
+    for (const value of option.values) {
+      ensureType(value, "plain");
+      const name = value.value.toUpperCase();
+      switch (name) {
+        // TODO ssmifi: We could also report contradicting suboptions here,
+        // but that would abort the option evaluation. We can add a way to
+        // report multiple diagnostics per rule in the future.
+        // In case of a contradiction, the last suboption takes effect.
+        case "ALL":
+        case "BLOCK":
+        case "NONE":
+        case "PATH":
+        case "STMT":
+          options.test.level = name as CompilerOptions.TestLevel;
+          break;
+        case "HOOK":
+          options.test.hook = true;
+          break;
+        case "NOHOOK":
+          options.test.hook = false;
+          break;
+        case "SEPARATE":
+          options.test.separate = true;
+          break;
+        case "NOSEPARATE":
+          options.test.separate = false;
+          break;
+        case "SEPNAME":
+          options.test.sepName = true;
+          break;
+        case "NOSEPNAME":
+          options.test.sepName = false;
+          break;
+        case "SOURCE":
+          options.test.source = true;
+          break;
+        case "NOSOURCE":
+          options.test.source = false;
+          break;
+        case "SYM":
+          options.test.sym = true;
+          break;
+        case "NOSYM":
+          options.test.sym = false;
+          break;
+        default:
+          throw TranslationError.fromCode(
+            value.token,
+            CompilerOptionsCodes.Test.InvalidParameter,
+            name,
+          );
+      }
+    }
+  },
+  ["NOTEST"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.test = false;
+  },
+);
+
 /** {@link CompilerOptions.unroll} */
+translator.rule(["UNROLL"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "plainNotEmpty");
+  const name = value.value.toUpperCase();
+  if (["AUTO", "NO"].includes(name)) {
+    options.unroll = name as CompilerOptions.Unroll;
+  } else {
+    throw TranslationError.fromCode(
+      value.token,
+      CompilerOptionsCodes.Unroll.InvalidParameter,
+      name,
+    );
+  }
+});
+
 /** {@link CompilerOptions.usage} */
+translator.rule(["USAGE"], (option, options) => {
+  ensureArguments(option, 1);
+  if (!options.usage) {
+    options.usage = getDefaultCompilerOptions().usage;
+  }
+  for (const value of option.values) {
+    ensureType(value, "option");
+    const name = value.name.toUpperCase();
+    ensureArguments(value, 1, 1);
+    const argument = value.values[0];
+    ensureType(argument, "plain");
+    switch (name) {
+      case "HEX":
+        options.usage!.hex = ensureArgument(
+          argument,
+          CompilerOptionsCodes.Usage.InvalidHexParameter,
+          ["SIZE", "CURRENTSIZE"],
+        );
+        break;
+      case "REGEX":
+        options.usage!.regex!.reset = ensureFlag(
+          argument,
+          CompilerOptionsCodes.Usage.InvalidRegexParameter,
+          ["RESET", "NORESET"],
+        );
+        break;
+      case "ROUND":
+        options.usage!.round = ensureArgument(
+          argument,
+          CompilerOptionsCodes.Usage.InvalidRoundParameter,
+          ["IBM", "ANS"],
+        );
+        break;
+      case "SUBSTR":
+        options.usage!.substr = ensureArgument(
+          argument,
+          CompilerOptionsCodes.Usage.InvalidSubstrParameter,
+          ["STRICT", "LOOSE"],
+        );
+        break;
+      case "UNSPEC":
+        options.usage!.unspec = ensureArgument(
+          argument,
+          CompilerOptionsCodes.Usage.InvalidUnspecParameter,
+          ["IBM", "ANS"],
+        );
+        break;
+      case "UUID":
+        options.usage!.uuid = ensureArgument(
+          argument,
+          CompilerOptionsCodes.Usage.InvalidUuidParameter,
+          ["UPPER", "LOWER"],
+        );
+        break;
+      case "VALIDDATE":
+        options.usage!.validDate = ensureArgument(
+          argument,
+          CompilerOptionsCodes.Usage.InvalidValidDateParameter,
+          ["LOOSE", "STRICT"],
+        );
+        break;
+      default:
+        throw TranslationError.fromCode(
+          value.token,
+          CompilerOptionsCodes.Usage.InvalidParameter,
+          name,
+        );
+    }
+  }
+});
+
 /** {@link CompilerOptions.widechar} */
+translator.rule(["WIDECHAR"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "plainNotEmpty");
+  options.widechar = ensureArgument(
+    value,
+    CompilerOptionsCodes.WideChar.InvalidParameter,
+    ["BIGENDIAN", "LITTLEENDIAN"],
+  );
+});
+
 /** {@link CompilerOptions.window} */
+translator.rule(["WINDOW"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "plainNotEmpty");
+  // The spec does not define any boundaries.
+  options.window = ensureNumberValue(value);
+});
+
 /** {@link CompilerOptions.writable} */
+translator.rule(
+  ["WRITABLE"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.writable = true;
+  },
+  ["NOWRITABLE"],
+  (option, options) => {
+    ensureArguments(option, 0, 1);
+    if (option.values.length === 0) {
+      options.writable = { noWritable: "FWS" };
+      return;
+    }
+    const value = option.values[0];
+    ensureType(value, "plainNotEmpty");
+    options.writable = {
+      noWritable: ensureArgument(
+        value,
+        CompilerOptionsCodes.Writable.InvalidParameter,
+        ["FWS", "PRV"],
+      ),
+    };
+  },
+);
+
 /** {@link CompilerOptions.xInfo} */
+translator.rule(["XINFO"], (option, options) => {
+  ensureArguments(option, 1);
+  if (!options.xInfo) {
+    options.xInfo = getDefaultCompilerOptions().xInfo;
+  }
+  for (const value of option.values) {
+    if (value.kind === SyntaxKind.CompilerOption) {
+      ensureArguments(value, 1, 1);
+      const optionName = value.name.toUpperCase();
+      if (optionName === "XML") {
+        options.xInfo!.xml = {
+          hash: ensureFlag(
+            value.values[0],
+            CompilerOptionsCodes.XInfo.InvalidXmlParameter,
+            ["HASH", "NOHASH"],
+          ),
+        };
+        continue;
+      }
+    }
+    ensureType(value, "plainNotEmpty");
+    const name = value.value.toUpperCase();
+    switch (name) {
+      case "DEF":
+      case "NODEF":
+        options.xInfo!.def = ensureFlag(
+          value,
+          CompilerOptionsCodes.XInfo.InvalidDefParameter,
+          ["DEF", "NODEF"],
+        );
+        break;
+      case "MSG":
+      case "NOMSG":
+        options.xInfo!.msg = ensureFlag(
+          value,
+          CompilerOptionsCodes.XInfo.InvalidMsgParameter,
+          ["MSG", "NOMSG"],
+        );
+        break;
+      case "SYM":
+      case "NOSYM":
+        options.xInfo!.sym = ensureFlag(
+          value,
+          CompilerOptionsCodes.XInfo.InvalidSymParameter,
+          ["SYM", "NOSYM"],
+        );
+        break;
+      case "SYN":
+      case "NOSYN":
+        options.xInfo!.syn = ensureFlag(
+          value,
+          CompilerOptionsCodes.XInfo.InvalidSynParameter,
+          ["SYN", "NOSYN"],
+        );
+        break;
+      case "NOXML":
+        ensureType(value, "plain");
+        options.xInfo!.xml = false;
+        break;
+      default:
+        throw TranslationError.fromCode(
+          value.token,
+          CompilerOptionsCodes.XInfo.InvalidParameter,
+          value.value,
+        );
+    }
+  }
+});
+
 /** {@link CompilerOptions.xml} */
+translator.rule(["XML"], (option, options) => {
+  ensureArguments(option, 1);
+  if (!options.xml) {
+    options.xml = getDefaultCompilerOptions().xml;
+  }
+  for (const value of option.values) {
+    ensureType(value, "option");
+    ensureArguments(value, 1, 1);
+    switch (value.name.toUpperCase()) {
+      case "CASE":
+        options.xml!.case = ensureArgument(
+          value.values[0],
+          CompilerOptionsCodes.Xml.InvalidCaseParameter,
+          ["UPPER", "ASIS"],
+        );
+        break;
+      case "XMLATTR":
+        options.xml!.xmlAttr = ensureArgument(
+          value.values[0],
+          CompilerOptionsCodes.Xml.InvalidXmlAttrParameter,
+          ["APOSTROPHE", "QUOTE"],
+        );
+        break;
+      default:
+        throw TranslationError.fromCode(
+          value.token,
+          CompilerOptionsCodes.Xml.InvalidParameter,
+          value.name,
+        );
+    }
+  }
+});
+
 /** {@link CompilerOptions.xRef} */
+translator.rule(
+  ["XREF", "X"],
+  (option, options) => {
+    // No arguments is ok.
+    ensureArguments(option, 0);
+    if (!options.xRef) {
+      options.xRef = getDefaultCompilerOptions().xRef;
+    }
+    for (const value of option.values) {
+      ensureType(value, "plainNotEmpty");
+      switch (value.value.toUpperCase()) {
+        case "FULL":
+        case "SHORT":
+          options.xRef! = {
+            ...options.xRef!,
+            length: ensureArgument(
+              value,
+              CompilerOptionsCodes.XRef.InvalidLengthParameter,
+              ["FULL", "SHORT"],
+            ),
+          };
+          break;
+        case "IMPLICIT":
+        case "EXPLICIT":
+          options.xRef! = {
+            ...options.xRef!,
+            structure: ensureArgument(
+              value,
+              CompilerOptionsCodes.XRef.InvalidStructureParameter,
+              ["IMPLICIT", "EXPLICIT"],
+            ),
+          };
+          break;
+        default:
+          throw TranslationError.fromCode(
+            value.token,
+            CompilerOptionsCodes.XRef.InvalidParameter,
+            value.value,
+          );
+      }
+    }
+  },
+  ["NOXREF", "NX"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.xRef = false;
+  },
+);
 
 export function translateCompilerOptions(
   input: AbstractCompilerOptions,

--- a/packages/language/test/fourslash/preprocessor/compiler-options/prefix.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/prefix.ts
@@ -1,0 +1,111 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:PREFIX|>;
+////*PROCESS <|d2:PREFIX|>();
+////*PROCESS <|d3:PREFIX|>(<|3:INVALID|>);
+////*PROCESS <|d4:PREFIX|>(<|4:ANYCONDITION|>);
+////*PROCESS <|d5:PREFIX|>(<|5:AREA|>);
+////*PROCESS <|d6:PREFIX|>(<|6:ASSERTION|>);
+////*PROCESS <|d7:PREFIX|>(<|7:ATTENTION|>);
+////*PROCESS <|d8:PREFIX|>(<|8:ENDFILE|>);
+////*PROCESS <|d9:PREFIX|>(<|9:ENDPAGE|>);
+////*PROCESS <|d10:PREFIX|>(<|10:ERROR|>);
+////*PROCESS <|d11:PREFIX|>(<|11:FINISH|>);
+////*PROCESS <|d12:PREFIX|>(<|12:KEY|>);
+////*PROCESS <|d13:PREFIX|>(<|13:NAME|>);
+////*PROCESS <|d14:PREFIX|>(<|14:RECORD|>);
+////*PROCESS <|d15:PREFIX|>(<|15:STORAGE|>);
+////*PROCESS <|d16:PREFIX|>(<|16:TRANSMIT|>);
+////*PROCESS <|d17:PREFIX|>(<|17:UNDEFINEDFILE|>);
+//// // These should work.
+////*PROCESS <|d20:PREFIX|>(<|20:CONFORMANCE|>);
+////*PROCESS <|d21:PREFIX|>(<|21:CONVERSION|>);
+////*PROCESS <|d22:PREFIX|>(<|22:CONV|>);
+////*PROCESS <|d23:PREFIX|>(<|23:NOFIXEDOVERFLOW|>);
+////*PROCESS <|d24:PREFIX|>(<|24:NOFOFL|>);
+////*PROCESS <|d25:PREFIX|>(<|25:SIZE|>);
+////*PROCESS <|d26:PREFIX|>(<|26:STRINGRANGE|>);
+////*PROCESS <|d27:PREFIX|>(<|27:STRNG|>);
+////*PROCESS <|d28:PREFIX|>(<|28:STRINGSIZE|>);
+////*PROCESS <|d29:PREFIX|>(<|29:STRSZ|>);
+////*PROCESS <|d30:PREFIX|>(<|30:SUBSCRIPTRANGE|>);
+////*PROCESS <|d31:PREFIX|>(<|31:SUBRG|>);
+////*PROCESS <|d32:PREFIX|>(<|32:UNDERFLOW|>);
+////*PROCESS <|d33:PREFIX|>(<|33:UFL|>);
+////*PROCESS <|d34:PREFIX|>(<|34:ZERODIVIDE|>);
+////*PROCESS <|d35:PREFIX|>(<|35:ZDIV|>);
+////*PROCESS <|d36:PREFIX|>(<|36:NOZDIV|> <|37:NOUNDERFLOW|>);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1),
+});
+// TODO ssmifi: Since Prefix does not override the previous settings, the dupe warning should probably be removed in the future.
+verify.expectDiagnosticsAt(
+  Array.from({ length: 15 }, (_, i) => `d${i + 2}`),
+  {
+    message: code.CompilerOptions.DupeOptionIssue.message("PREFIX"),
+  },
+);
+verify.expectDiagnosticsAt(
+  Array.from({ length: 16 }, (_, i) => `d${i + 20}`),
+  {
+    message: code.CompilerOptions.DupeOptionIssue.message("PREFIX"),
+  },
+);
+verify.noDiagnosticsExceptAt("d2", [
+  new RegExp(code.CompilerOptions.DupeOptionIssue.message("PREFIX")),
+]);
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.Prefix.InvalidParameter.message("INVALID"),
+});
+for (const [index, condition] of [
+  "ANYCONDITION",
+  "AREA",
+  "ASSERTION",
+  "ATTENTION",
+  "ENDFILE",
+  "ENDPAGE",
+  "ERROR",
+  "FINISH",
+  "KEY",
+  "NAME",
+  "RECORD",
+  "STORAGE",
+  "TRANSMIT",
+  "UNDEFINEDFILE",
+].entries()) {
+  verify.expectDiagnosticsAt(index + 4, {
+    message:
+      code.CompilerOptions.Prefix.ConditionIsAlwaysEnabled.message(condition),
+  });
+}
+for (let i = 20; i < 38; i++) {
+  verify.noDiagnostics(i);
+}
+verify.expectCompilerOptions({
+  prefix: {
+    conformance: true,
+    conversion: true,
+    fixedoverflow: false,
+    invalidop: true,
+    overflow: true,
+    size: true,
+    stringrange: true,
+    stringsize: true,
+    subscriptrange: true,
+    underflow: false,
+    zerodivide: false,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/terminal.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/terminal.ts
@@ -1,0 +1,34 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NOTERMINAL;
+////*PROCESS <|1:NTERM|>;
+////*PROCESS <|2:TERMINAL|>();
+////*PROCESS <|3:TERM|>;
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.DupeOptionIssue.message("NTERM"),
+});
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.InvalidParameterCount.message(1, 0, 0),
+});
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.MutexOptionIssue.message("TERMINAL"),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.MutexOptionIssue.message("TERM"),
+});
+verify.expectCompilerOptions({
+  terminal: true,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/test.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/test.ts
@@ -1,0 +1,42 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:TEST|>;
+////*PROCESS <|2:TEST|>();
+////*PROCESS <|4:TEST|>(<|5:INVALID|>);
+////*PROCESS <|6:TEST|>(<|7:BLOCK|>);
+////*PROCESS <|8:TEST|>(<|9:NOSEPARATE, NOSOURCE|>);
+////*PROCESS <|10:TEST|>(<|11:SYM NOHOOK|>);
+
+verify.noDiagnostics(1);
+verify.noDiagnosticsExceptAt(
+  [2, 4, 6, 8, 10],
+  [new RegExp(code.CompilerOptions.DupeOptionIssue.message("TEST"))],
+);
+verify.expectDiagnosticsAt([2, 4, 6, 8, 10], {
+  message: code.CompilerOptions.DupeOptionIssue.message("TEST"),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.Test.InvalidParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  test: {
+    level: "ALL",
+    hook: false,
+    separate: false,
+    sepName: true,
+    source: false,
+    sym: true,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/unroll.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/unroll.ts
@@ -1,0 +1,34 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:UNROLL|>;
+////*PROCESS <|2:UNROLL|>(<|3:)|>;
+////*PROCESS <|4:UNROLL|>(<|5:INVALID|>);
+////*PROCESS <|6:UNROLL|>(NO);
+
+verify.expectDiagnosticsAt([2, 4, 6], {
+  message: code.CompilerOptions.DupeOptionIssue.message("UNROLL"),
+});
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.Unroll.InvalidParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  unroll: "NO",
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/usage.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/usage.ts
@@ -1,0 +1,78 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:USAGE|>;
+////*PROCESS <|d2:USAGE|>();
+////*PROCESS <|d3:USAGE|>(<|2:INVALID|>);
+////*PROCESS <|d3:USAGE|>(<|3:INVALID|>());
+////*PROCESS <|d4:USAGE|>(HEX(<|4:INVALID|>));
+////*PROCESS <|d5:USAGE|>(REGEX(<|5:INVALID|>));
+////*PROCESS <|d6:USAGE|>(ROUND(<|6:INVALID|>));
+////*PROCESS <|d7:USAGE|>(SUBSTR(<|7:INVALID|>));
+////*PROCESS <|d8:USAGE|>(UNSPEC(<|8:INVALID|>));
+////*PROCESS <|d9:USAGE|>(UUID(<|9:INVALID|>));
+////*PROCESS <|d10:USAGE|>(VALIDDATE(<|10:INVALID|>));
+////*PROCESS <|d11:USAGE|>(HEX(CURRENTSIZE) REGEX(NORESET) ROUND(ANS));
+////*PROCESS <|d12:USAGE|>(SUBSTR(LOOSE) UNSPEC(ANS) UUID(LOWER) VALIDDATE(STRICT));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1),
+});
+verify.expectDiagnosticsAt(
+  Array.from({ length: 9 }, (_, i) => `d${i + 2}`),
+  {
+    message: code.CompilerOptions.DupeOptionIssue.message("USAGE"),
+  },
+);
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.ExpectedOption.message(),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.Usage.InvalidParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.Usage.InvalidHexParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.Usage.InvalidRegexParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt(6, {
+  message: code.CompilerOptions.Usage.InvalidRoundParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt(7, {
+  message: code.CompilerOptions.Usage.InvalidSubstrParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt(8, {
+  message: code.CompilerOptions.Usage.InvalidUnspecParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt(9, {
+  message: code.CompilerOptions.Usage.InvalidUuidParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt(10, {
+  message:
+    code.CompilerOptions.Usage.InvalidValidDateParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  usage: {
+    hex: "CURRENTSIZE",
+    regex: {
+      reset: false,
+    },
+    round: "ANS",
+    substr: "LOOSE",
+    unspec: "ANS",
+    uuid: "LOWER",
+    validDate: "STRICT",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/widechar.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/widechar.ts
@@ -1,0 +1,34 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:WIDECHAR|>;
+////*PROCESS <|2:WIDECHAR|>(<|3:)|>;
+////*PROCESS <|4:WIDECHAR|>(<|5:INVALID|>);
+////*PROCESS <|6:WIDECHAR|>(LITTLEENDIAN);
+
+verify.expectDiagnosticsAt([2, 4, 6], {
+  message: code.CompilerOptions.DupeOptionIssue.message("WIDECHAR"),
+});
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.WideChar.InvalidParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  widechar: "LITTLEENDIAN",
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/window.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/window.ts
@@ -1,0 +1,34 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:WINDOW|>;
+////*PROCESS <|2:WINDOW|>(<|3:)|>;
+////*PROCESS <|4:WINDOW|>(<|5:INVALID|>);
+////*PROCESS <|6:WINDOW|>(2k);
+
+verify.expectDiagnosticsAt([2, 4, 6], {
+  message: code.CompilerOptions.DupeOptionIssue.message("WINDOW"),
+});
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.ExpectedNumber.message(),
+});
+verify.expectCompilerOptions({
+  window: 2 * 1024,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/writable.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/writable.ts
@@ -1,0 +1,48 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:WRITABLE|>;
+////*PROCESS <|2:WRITABLE|>();
+////*PROCESS <|4:NOWRITABLE|>(<|5:)|>;
+////*PROCESS <|6:NOWRITABLE|>(<|7:INVALID|>);
+////*PROCESS <|8:NOWRITABLE|>;
+////*PROCESS <|10:NOWRITABLE|>(<|11:)|>;
+////*PROCESS <|12:NOWRITABLE|>(<|13:prv|>);
+
+verify.noDiagnostics([1, 13]);
+verify.noDiagnosticsExceptAt(
+  [8, 10],
+  [new RegExp(code.CompilerOptions.MutexOptionIssue.message("NOWRITABLE"))],
+);
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.DupeOptionIssue.message("WRITABLE"),
+});
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.InvalidParameterCount.message(1, 0, 0),
+});
+verify.expectDiagnosticsAt([4, 6, 8, 10, 12], {
+  message: code.CompilerOptions.MutexOptionIssue.message("NOWRITABLE"),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(""),
+});
+verify.expectDiagnosticsAt(7, {
+  message: code.CompilerOptions.Writable.InvalidParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt(11, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectCompilerOptions({
+  writable: { noWritable: "PRV" },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/xinfo.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/xinfo.ts
@@ -1,0 +1,51 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:XINFO|>;
+////*PROCESS <|d2:XINFO|>();
+////*PROCESS <|d3:XINFO|>(<|2:INVALID|>);
+////*PROCESS <|d3:XINFO|>(<|3:INVALID|>());
+////*PROCESS <|d4:XINFO|>(XML(<|4:INVALID|>));
+////*PROCESS <|d5:XINFO|>(XML(HASH));
+////*PROCESS <|d6:XINFO|>(DEF);
+////*PROCESS <|d7:XINFO|>(MSG SYM);
+////*PROCESS <|d8:XINFO|>(NOSYM, SYN);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1),
+});
+verify.expectDiagnosticsAt(
+  Array.from({ length: 7 }, (_, i) => `d${i + 2}`),
+  {
+    message: code.CompilerOptions.DupeOptionIssue.message("XINFO"),
+  },
+);
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.XInfo.InvalidParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.ExpectedPlain.message(),
+});
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.XInfo.InvalidXmlParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  xInfo: {
+    xml: { hash: true },
+    def: true,
+    msg: true,
+    sym: false,
+    syn: true,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/xml.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/xml.ts
@@ -1,0 +1,49 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:XML|>;
+////*PROCESS <|d2:XML|>();
+////*PROCESS <|d3:XML|>(<|2:INVALID|>);
+////*PROCESS <|d3:XML|>(<|3:INVALID|>());
+////*PROCESS <|d4:XML|>(CASE(<|4:INVALID|>));
+////*PROCESS <|d5:XML|>(XMLATTR(<|5:INVALID|>));
+////*PROCESS <|d6:XML|>(CASE(ASIS) XMLATTR(QUOTE));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1),
+});
+verify.expectDiagnosticsAt(
+  Array.from({ length: 5 }, (_, i) => `d${i + 2}`),
+  {
+    message: code.CompilerOptions.DupeOptionIssue.message("XML"),
+  },
+);
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.ExpectedOption.message(),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.Xml.InvalidParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.Xml.InvalidCaseParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.Xml.InvalidXmlAttrParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  xml: {
+    case: "ASIS",
+    xmlAttr: "QUOTE",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/xref.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/xref.ts
@@ -1,0 +1,40 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:NOXREF|>;
+////*PROCESS <|2:NX|>();
+////*PROCESS <|4:XREF|>;
+////*PROCESS <|6:XREF|>();
+////*PROCESS <|8:XREF|>(<|9:INVALID|>);
+////*PROCESS <|10:X|>(FULL SHORT IMPLICIT EXPLICIT);
+
+verify.noDiagnostics(1);
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.DupeOptionIssue.message("NX"),
+});
+verify.expectDiagnosticsAt([4, 6, 8], {
+  message: code.CompilerOptions.MutexOptionIssue.message("XREF"),
+});
+verify.expectDiagnosticsAt(10, {
+  message: code.CompilerOptions.MutexOptionIssue.message("X"),
+});
+verify.expectDiagnosticsAt(9, {
+  message: code.CompilerOptions.XRef.InvalidParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  xRef: {
+    length: "SHORT",
+    structure: "EXPLICIT",
+  },
+});

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -481,6 +481,13 @@ export class TestBuilder {
   }
 
   noDiagnosticsExcept(regex: RegExp[], label?: Label): TestBuilder {
+    if (Array.isArray(label)) {
+      for (const l of label) {
+        this.noDiagnosticsExcept(regex, l);
+      }
+      return this;
+    }
+
     const diagnostics = label
       ? this.getMatchingDiagnostics(label.toString()).exactMatches
       : this.diagnostics;


### PR DESCRIPTION
Part of https://github.com/zowe/zowe-pli-language-support/issues/296
Based on https://github.com/zowe/zowe-pli-language-support/pull/357

- Implemented compiler options `terminal`, `test`, `unroll`, `usage`, `widechar`, `window`, `writable`, `xinfo`, `xml`, `xref`, and `prefix`.
- `noDiagnosticsExcept` also accepts arrays now.
- Added `ensureArgument` to compiler options translator to add some convenience to argument selection. Should probably be applied to some old options to make the code more concise in a later PR.