### PR TITLE
Support inline procedure calls

### DIFF
--- a/packages/language/src/preprocessor/instruction-generator.ts
+++ b/packages/language/src/preprocessor/instruction-generator.ts
@@ -80,24 +80,29 @@ function generateProcedureInstructionContainer(
   statement: ast.Statement,
 ): inst.ProcedureInstructionContainer {
   const names: string[] = [];
-  const args: string[] = [];
+  const labels: ast.LabelPrefix[] = [];
+  const params: string[] = [];
   for (const label of statement.labels) {
     if (label.name) {
       names.push(label.name);
+      labels.push(label);
     }
   }
   const procedure = statement.value as ast.ProcedureStatement;
-  for (const arg of procedure.parameters) {
-    const name = arg.ref?.text;
+  for (const param of procedure.parameters) {
+    const name = param.ref?.text;
     if (name) {
-      args.push(name);
+      params.push(name);
     }
   }
   const statements = procedure.statements;
+  const statementType = procedure.statement;
   const instructionList = generateInstructions(statements);
   return {
     names,
-    parameters: args,
+    labels,
+    statement: statementType,
+    parameters: params,
     node: instructionList.entryNode,
   };
 }

--- a/packages/language/src/preprocessor/instruction-generator.ts
+++ b/packages/language/src/preprocessor/instruction-generator.ts
@@ -80,12 +80,12 @@ function generateProcedureInstructionContainer(
   statement: ast.Statement,
 ): inst.ProcedureInstructionContainer {
   const names: string[] = [];
-  const labels: ast.LabelPrefix[] = [];
+  const labels = new Map<string, ast.LabelPrefix>();
   const params: string[] = [];
   for (const label of statement.labels) {
     if (label.name) {
       names.push(label.name);
-      labels.push(label);
+      labels.set(label.name, label);
     }
   }
   const procedure = statement.value as ast.ProcedureStatement;

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -1182,7 +1182,7 @@ function performTokenScan(
   let advance: number = 1;
   let immediateFollow = token.immediateFollow;
   if (procedure && context.activeProcedures.has(image)) {
-    const label = procedure.labels.find((label) => label.name === image);
+    const label = procedure.labels.get(image);
     refNode = label;
     const procedureParseResult = parseAndEvaluateProcedure(
       tokens,
@@ -1190,11 +1190,9 @@ function performTokenScan(
       procedure,
       context,
     );
-    if (procedureParseResult) {
-      value = procedureParseResult.value;
-      advance = procedureParseResult.advance;
-      immediateFollow = procedureParseResult.immediateFollow;
-    }
+    value = procedureParseResult.value;
+    advance = procedureParseResult.advance;
+    immediateFollow = procedureParseResult.immediateFollow;
   } else if (variable?.active) {
     refNode = variable.declarationNode ?? undefined;
     value = variable.value;
@@ -1230,10 +1228,11 @@ function parseAndEvaluateProcedure(
   index: number,
   procedure: inst.ProcedureInstructionContainer,
   context: InterpreterContext,
-): InlineProcedureEvaluationResult | undefined {
+): InlineProcedureEvaluationResult {
   const evaluatedArgs: Value[] = [];
   let advance = 1;
   let immediateFollow = tokens[index].immediateFollow;
+  let suffix: string = "";
   if (!procedure.statement) {
     const parseResult = parseInlineProcedureInvocation(tokens, index);
     advance = parseResult.advance;
@@ -1250,11 +1249,12 @@ function parseAndEvaluateProcedure(
     const parseResult = parseInlineStatementProcedureInvocation(tokens, index);
     advance = parseResult.advance;
     immediateFollow = parseResult.immediateFollow;
+    suffix = parseResult.suffix;
     // Positional arguments
     for (const argTokens of parseResult.positionalArgs) {
       const replacedTokens = replaceTokensInText(argTokens, context);
       const text = stringifyTokens(replacedTokens);
-      evaluatedArgs.push(valueToString(text));
+      evaluatedArgs.push(stringToValue(text));
     }
     const usedParams = new Set<string>();
     // Named arguments
@@ -1265,7 +1265,7 @@ function parseAndEvaluateProcedure(
       if (argTokens) {
         const replacedTokens = replaceTokensInText(argTokens.tokens, context);
         const text = stringifyTokens(replacedTokens);
-        evaluatedArgs[i] = valueToString(text);
+        evaluatedArgs[i] = stringToValue(text);
       } else if (i >= evaluatedArgs.length) {
         // No argument specified for this parameter, use the default empty value
         // TODO: Replace with unset value!
@@ -1287,8 +1287,11 @@ function parseAndEvaluateProcedure(
     }
   }
 
-  const localContext = createLocalContext(context);
-  const value = runProcedure(procedure, evaluatedArgs, localContext);
+  const localContext = createLocalContext(context, procedure);
+  let value = runProcedure(procedure, evaluatedArgs, localContext);
+  if (isScalarValue(value) && suffix) {
+    value = stringToValue(value.value + suffix);
+  }
   return {
     value,
     advance,
@@ -1377,6 +1380,11 @@ interface InlineStatementProcedureParseResult {
   namedArgs: Map<string, InlineProcedureNamedArgument>;
   advance: number;
   immediateFollow: boolean;
+  /**
+   * If the procedure invocation is immediately followed by another token
+   * This token acts as a suffix to the procedure call and needs to be attached to the return value
+   */
+  suffix: string;
 }
 
 function parseInlineStatementProcedureInvocation(
@@ -1444,11 +1452,19 @@ function parseInlineStatementProcedureInvocation(
       tokens: argTokens,
     });
   }
+  let suffix = "";
+  if (immediateFollow && i < length) {
+    const suffixToken = tokens[i];
+    suffix = suffixToken.image;
+    immediateFollow = suffixToken.immediateFollow;
+    advance++;
+  }
   return {
     positionalArgs: positionalParseResult.args,
     namedArgs,
     advance,
     immediateFollow,
+    suffix,
   };
 }
 

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -1229,7 +1229,7 @@ function parseAndEvaluateProcedure(
   procedure: inst.ProcedureInstructionContainer,
   context: InterpreterContext,
 ): InlineProcedureEvaluationResult {
-  const evaluatedArgs: Value[] = [];
+  let evaluatedArgs: Value[];
   let advance = 1;
   let immediateFollow = tokens[index].immediateFollow;
   let suffix: string = "";
@@ -1237,59 +1237,29 @@ function parseAndEvaluateProcedure(
     const parseResult = parseInlineProcedureInvocation(tokens, index);
     advance = parseResult.advance;
     immediateFollow = parseResult.immediateFollow;
-    for (const argTokens of parseResult.args) {
-      const replacedTokens = replaceTokensInText(argTokens, context);
-      const text = stringifyTokens(replacedTokens);
-      evaluatedArgs.push({
-        type: inst.DeclaredType.Character,
-        value: text,
-      });
-    }
+    evaluatedArgs = evaluatePositionalArguments(parseResult.args, context);
   } else {
     const parseResult = parseInlineStatementProcedureInvocation(tokens, index);
     advance = parseResult.advance;
     immediateFollow = parseResult.immediateFollow;
     suffix = parseResult.suffix;
-    // Positional arguments
-    for (const argTokens of parseResult.positionalArgs) {
-      const replacedTokens = replaceTokensInText(argTokens, context);
-      const text = stringifyTokens(replacedTokens);
-      evaluatedArgs.push(stringToValue(text));
-    }
-    const usedParams = new Set<string>();
-    // Named arguments
-    for (let i = 0; i < procedure.parameters.length; i++) {
-      const param = procedure.parameters[i];
-      usedParams.add(param);
-      const argTokens = parseResult.namedArgs.get(param);
-      if (argTokens) {
-        const replacedTokens = replaceTokensInText(argTokens.tokens, context);
-        const text = stringifyTokens(replacedTokens);
-        evaluatedArgs[i] = stringToValue(text);
-      } else if (i >= evaluatedArgs.length) {
-        // No argument specified for this parameter, use the default empty value
-        // TODO: Replace with unset value!
-        evaluatedArgs[i] = defaultEmptyValue;
-      }
-    }
-    for (const [name, argTokens] of parseResult.namedArgs) {
-      // If the named argument doesn't match any parameter, report an error
-      if (!usedParams.has(name)) {
-        context.errors.push(
-          new PreprocessorError(
-            PLICodes.Error.IBM3581I.message(argTokens.nameToken.image),
-            argTokens.nameToken,
-            undefined,
-            PLICodes.Error.IBM3581I.fullCode,
-          ),
-        );
-      }
-    }
+    evaluatedArgs = evaluatePositionalArguments(
+      parseResult.positionalArgs,
+      context,
+    );
+    evaluateNamedArguments(
+      evaluatedArgs,
+      parseResult.namedArgs,
+      procedure.parameters,
+      context,
+    );
   }
 
   const localContext = createLocalContext(context, procedure);
   let value = runProcedure(procedure, evaluatedArgs, localContext);
   if (isScalarValue(value) && suffix) {
+    // Add the suffix to the value, as it was immediately following the procedure call
+    // Otherwise, the suffix will generate a separate token, which is not the intended behavior
     value = stringToValue(value.value + suffix);
   }
   return {
@@ -1297,6 +1267,54 @@ function parseAndEvaluateProcedure(
     advance,
     immediateFollow,
   };
+}
+
+function evaluatePositionalArguments(
+  args: InlineProcedureArgument[],
+  context: InterpreterContext,
+): Value[] {
+  const evaluatedArgs: Value[] = [];
+  for (const argTokens of args) {
+    const replacedTokens = replaceTokensInText(argTokens, context);
+    const text = stringifyTokens(replacedTokens);
+    evaluatedArgs.push(stringToValue(text));
+  }
+  return evaluatedArgs;
+}
+
+function evaluateNamedArguments(
+  args: Value[],
+  namedArgs: Map<string, InlineProcedureNamedArgument>,
+  procParams: string[],
+  context: InterpreterContext,
+): void {
+  const usedParams = new Set<string>();
+  for (let i = 0; i < procParams.length; i++) {
+    const param = procParams[i];
+    usedParams.add(param);
+    const argTokens = namedArgs.get(param);
+    if (argTokens) {
+      const replacedTokens = replaceTokensInText(argTokens.tokens, context);
+      const text = stringifyTokens(replacedTokens);
+      args[i] = stringToValue(text);
+    } else if (i >= args.length) {
+      // No argument specified for this parameter, use the unset variable
+      args[i] = unsetVariable;
+    }
+  }
+  for (const [name, argTokens] of namedArgs) {
+    // If the named argument doesn't match any parameter, report an error
+    if (!usedParams.has(name)) {
+      context.errors.push(
+        new PreprocessorError(
+          PLICodes.Error.IBM3581I.message(argTokens.nameToken.image),
+          argTokens.nameToken,
+          undefined,
+          PLICodes.Error.IBM3581I.fullCode,
+        ),
+      );
+    }
+  }
 }
 
 function stringifyTokens(tokens: Token[]): string {
@@ -1392,8 +1410,9 @@ function parseInlineStatementProcedureInvocation(
   index: number,
 ): InlineStatementProcedureParseResult {
   const positionalParseResult = parseInlineProcedureInvocation(tokens, index);
+  // Advance by the amount of tokens consumed by the positional argument parser
   index += positionalParseResult.advance;
-  // Positional arguments have been parsed, now we can start parsing named arguments
+  // We can now start parsing named arguments
   const namedArgs: Map<string, InlineProcedureNamedArgument> = new Map();
   let advance = positionalParseResult.advance;
   let immediateFollow = positionalParseResult.immediateFollow;

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -35,6 +35,9 @@ import { CstNodeKind } from "../syntax-tree/cst";
 import { tokenize } from "../parser/tokenizer";
 import { preprocessorParserStateFromText } from "./pli-preprocessor-parser-state";
 import { preprocessorParse } from "./preprocessor-parser";
+import { PreprocessorTokens } from "./pli-preprocessor-tokens";
+import { tokenMatcher } from "chevrotain";
+import { PLICodes } from "../validation/messages";
 
 interface Variable {
   name: string;
@@ -1062,6 +1065,8 @@ function runActivateInstruction(
     // TODO: Report IBM3530I if the variable is an array
     variable.active = true;
   } else if (context.procedures.has(name)) {
+    // Only activate the specified procedure name, even if the procedure has multiple names
+    // The compiler will not activate the other names of the procedure
     context.activeProcedures.add(name);
   }
 }
@@ -1110,7 +1115,7 @@ function runTokenInstruction(
     // In the next step, we need to merge them again
     const firstToken = replacedTokens.shift();
     const mergedTokens = lex(prefix.image + (firstToken?.image ?? ""));
-    setImmediateFollowProperty(firstToken, mergedTokens);
+    setImmediateFollowProperty(firstToken?.immediateFollow, mergedTokens);
     // Push merged and new tokens to the stack
     largePush(context.result.all, mergedTokens);
     largePush(context.result.all, replacedTokens);
@@ -1139,51 +1144,321 @@ function replaceTokensInText(
   tokens: Token[],
   context: InterpreterContext,
 ): Token[] {
+  let i = 0;
+  const length = tokens.length;
   const tokenList: Token[] = [];
-  for (let i = 0; i < tokens.length; i++) {
-    const token = tokens[i];
-    const result = performTokenScan(token, context);
+  while (i < length) {
+    const result = performTokenScan(tokens, i, context);
     if (result) {
       // Replace the token with the scan result
       // i.e. the variable content, recursively replaced
-      largePush(tokenList, result);
+      largePush(tokenList, result.tokens);
+      i += result.advance;
     } else {
       // If the scan found no active variable, push the original token
-      tokenList.push(token);
+      tokenList.push(tokens[i++]);
     }
   }
   return tokenList;
 }
 
+interface TokenScanResult {
+  tokens: Token[];
+  advance: number;
+}
+
 function performTokenScan(
-  token: Token,
+  tokens: Token[],
+  index: number,
   context: InterpreterContext,
-): Token[] | undefined {
+): TokenScanResult | undefined {
+  const token = tokens[index];
   const image = token.image;
+  const procedure = context.procedures.get(image);
   // Token scan can only take global variables into account (because it cannot run inside of a procedure)
   const variable = context.variables.get(image);
-  // If there is no active variable with that name, return undefined
-  // The caller side will simply push the token to the output
-  if (!variable?.active) {
-    return undefined;
-  } else if (token.uri && variable.declarationNode) {
-    // If the token has a URI, we assume it actually exists in the source code
-    // We can now create a synthetic reference to the variable for it
-    token.element = generateSyntheticRefItem(
-      token,
-      variable.declarationNode,
+  let refNode: ast.SyntaxNode | undefined = undefined;
+  let value: Value | undefined = undefined;
+  let advance: number = 1;
+  let immediateFollow = token.immediateFollow;
+  if (procedure && context.activeProcedures.has(image)) {
+    const label = procedure.labels.find((label) => label.name === image);
+    refNode = label;
+    const procedureParseResult = parseAndEvaluateProcedure(
+      tokens,
+      index,
+      procedure,
       context,
     );
+    if (procedureParseResult) {
+      value = procedureParseResult.value;
+      advance = procedureParseResult.advance;
+      immediateFollow = procedureParseResult.immediateFollow;
+    }
+  } else if (variable?.active) {
+    refNode = variable.declarationNode ?? undefined;
+    value = variable.value;
+  }
+  if (token.uri && refNode) {
+    // If the token has a URI, we assume it actually exists in the source code
+    // We can now create a synthetic reference to the variable/procedure for it
+    token.element = generateSyntheticRefItem(token, refNode, context);
     token.kind = CstNodeKind.ReferenceItem_Ref;
   }
-  const variableValue = variable.value;
-  if (!isScalarValue(variableValue)) {
+  if (!value || !isScalarValue(value)) {
     // Cannot replace tokens for array variables
     // TODO: There is a warning/error for this, that should be reported
     return undefined;
   }
-  const tokens = lex(variableValue.value);
-  setImmediateFollowProperty(token, tokens);
+  if (advance < 1) {
+    throw new Error("Advance must be at least 1");
+  }
+  return {
+    tokens: replaceTokenWithValue(value.value, immediateFollow, context),
+    advance,
+  };
+}
+
+interface InlineProcedureEvaluationResult {
+  value: Value | undefined;
+  advance: number;
+  immediateFollow: boolean;
+}
+
+function parseAndEvaluateProcedure(
+  tokens: Token[],
+  index: number,
+  procedure: inst.ProcedureInstructionContainer,
+  context: InterpreterContext,
+): InlineProcedureEvaluationResult | undefined {
+  const evaluatedArgs: Value[] = [];
+  let advance = 1;
+  let immediateFollow = tokens[index].immediateFollow;
+  if (!procedure.statement) {
+    const parseResult = parseInlineProcedureInvocation(tokens, index);
+    advance = parseResult.advance;
+    immediateFollow = parseResult.immediateFollow;
+    for (const argTokens of parseResult.args) {
+      const replacedTokens = replaceTokensInText(argTokens, context);
+      const text = stringifyTokens(replacedTokens);
+      evaluatedArgs.push({
+        type: inst.DeclaredType.Character,
+        value: text,
+      });
+    }
+  } else {
+    const parseResult = parseInlineStatementProcedureInvocation(tokens, index);
+    advance = parseResult.advance;
+    immediateFollow = parseResult.immediateFollow;
+    // Positional arguments
+    for (const argTokens of parseResult.positionalArgs) {
+      const replacedTokens = replaceTokensInText(argTokens, context);
+      const text = stringifyTokens(replacedTokens);
+      evaluatedArgs.push(valueToString(text));
+    }
+    const usedParams = new Set<string>();
+    // Named arguments
+    for (let i = 0; i < procedure.parameters.length; i++) {
+      const param = procedure.parameters[i];
+      usedParams.add(param);
+      const argTokens = parseResult.namedArgs.get(param);
+      if (argTokens) {
+        const replacedTokens = replaceTokensInText(argTokens.tokens, context);
+        const text = stringifyTokens(replacedTokens);
+        evaluatedArgs[i] = valueToString(text);
+      } else if (i >= evaluatedArgs.length) {
+        // No argument specified for this parameter, use the default empty value
+        // TODO: Replace with unset value!
+        evaluatedArgs[i] = defaultEmptyValue;
+      }
+    }
+    for (const [name, argTokens] of parseResult.namedArgs) {
+      // If the named argument doesn't match any parameter, report an error
+      if (!usedParams.has(name)) {
+        context.errors.push(
+          new PreprocessorError(
+            PLICodes.Error.IBM3581I.message(argTokens.nameToken.image),
+            argTokens.nameToken,
+            undefined,
+            PLICodes.Error.IBM3581I.fullCode,
+          ),
+        );
+      }
+    }
+  }
+
+  const localContext = createLocalContext(context);
+  const value = runProcedure(procedure, evaluatedArgs, localContext);
+  return {
+    value,
+    advance,
+    immediateFollow,
+  };
+}
+
+function stringifyTokens(tokens: Token[]): string {
+  let text = "";
+  for (const token of tokens) {
+    text += token.image;
+    if (!token.immediateFollow) {
+      text += " ";
+    }
+  }
+  return text.trimEnd();
+}
+
+type InlineProcedureArgument = Token[];
+
+interface InlineProcedureParseResult {
+  args: InlineProcedureArgument[];
+  advance: number;
+  immediateFollow: boolean;
+}
+
+function parseInlineProcedureInvocation(
+  tokens: Token[],
+  index: number,
+): InlineProcedureParseResult {
+  const args: InlineProcedureArgument[] = [];
+  let currentArg: Token[] = [];
+  let advance = 1;
+  let immediateFollow = false;
+  let parenDepth = 1;
+  let i = index + 1; // Start after the procedure name
+  const nextToken = tokens[i++];
+  if (!nextToken || !tokenMatcher(nextToken, PreprocessorTokens.LParen)) {
+    // No opening parenthesis, so no arguments
+    return {
+      args: [],
+      advance,
+      immediateFollow: tokens[index].immediateFollow,
+    };
+  }
+  // Opening parenthesis found, start parsing arguments
+  advance++;
+  const length = tokens.length;
+  while (i < length) {
+    const token = tokens[i];
+    advance++;
+    if (tokenMatcher(token, PreprocessorTokens.LParen)) {
+      parenDepth++;
+    } else if (tokenMatcher(token, PreprocessorTokens.RParen)) {
+      if (--parenDepth === 0) {
+        // Closing parenthesis at the top level, end of argument list
+        args.push(currentArg);
+        immediateFollow = token.immediateFollow;
+        i++;
+        break;
+      }
+    }
+    if (tokenMatcher(token, PreprocessorTokens.Comma) && parenDepth === 1) {
+      // Argument separator at the top level
+      args.push(currentArg);
+      currentArg = [];
+    } else {
+      currentArg.push(token);
+    }
+    i++;
+  }
+  return {
+    args,
+    advance,
+    immediateFollow,
+  };
+}
+
+interface InlineProcedureNamedArgument {
+  nameToken: Token;
+  tokens: Token[];
+}
+
+interface InlineStatementProcedureParseResult {
+  positionalArgs: InlineProcedureArgument[];
+  namedArgs: Map<string, InlineProcedureNamedArgument>;
+  advance: number;
+  immediateFollow: boolean;
+}
+
+function parseInlineStatementProcedureInvocation(
+  tokens: Token[],
+  index: number,
+): InlineStatementProcedureParseResult {
+  const positionalParseResult = parseInlineProcedureInvocation(tokens, index);
+  index += positionalParseResult.advance;
+  // Positional arguments have been parsed, now we can start parsing named arguments
+  const namedArgs: Map<string, InlineProcedureNamedArgument> = new Map();
+  let advance = positionalParseResult.advance;
+  let immediateFollow = positionalParseResult.immediateFollow;
+  let i = index;
+  const length = tokens.length;
+  while (i < length) {
+    const nextToken = tokens[i++];
+    if (nextToken && tokenMatcher(nextToken, PreprocessorTokens.Semicolon)) {
+      // End of procedure invocation
+      immediateFollow = nextToken.immediateFollow;
+      advance++;
+      break;
+    }
+    if (!nextToken || !tokenMatcher(nextToken, PreprocessorTokens.Id)) {
+      // Named argument must start with an identifier
+      break;
+    }
+    advance++;
+    immediateFollow = nextToken.immediateFollow;
+    const openParenToken = tokens[i++];
+    if (
+      !openParenToken ||
+      !tokenMatcher(openParenToken, PreprocessorTokens.LParen)
+    ) {
+      // Named argument must have an opening parenthesis after the name
+      // If there is no opening parenthesis, we assume the argument has an empty value
+      namedArgs.set(nextToken.image, {
+        nameToken: nextToken,
+        tokens: [],
+      });
+      break;
+    }
+    advance++;
+    // Begin parsing the argument tokens until the closing parenthesis
+    let parenDepth = 1;
+    const argTokens: Token[] = [];
+    while (i < length) {
+      const token = tokens[i];
+      if (tokenMatcher(token, PreprocessorTokens.LParen)) {
+        parenDepth++;
+      } else if (tokenMatcher(token, PreprocessorTokens.RParen)) {
+        if (--parenDepth === 0) {
+          // End of argument
+          immediateFollow = token.immediateFollow;
+          i++;
+          advance++;
+          break;
+        }
+      }
+      argTokens.push(token);
+      i++;
+      advance++;
+    }
+    namedArgs.set(nextToken.image, {
+      nameToken: nextToken,
+      tokens: argTokens,
+    });
+  }
+  return {
+    positionalArgs: positionalParseResult.args,
+    namedArgs,
+    advance,
+    immediateFollow,
+  };
+}
+
+function replaceTokenWithValue(
+  value: string,
+  immediateFollow: boolean,
+  context: InterpreterContext,
+): Token[] {
+  const tokens = lex(value);
+  setImmediateFollowProperty(immediateFollow, tokens);
   return replaceTokensInText(tokens, context);
 }
 
@@ -1205,10 +1480,10 @@ function lex(text: string): Token[] {
 }
 
 function setImmediateFollowProperty(
-  token: Token | undefined,
+  immediateFollow: boolean | undefined,
   tokens: Token[],
 ): void {
-  if (token?.immediateFollow && tokens.length > 0) {
+  if (immediateFollow && tokens.length > 0) {
     // The last token inherits the immediateFollow property of the original token
     tokens[tokens.length - 1].immediateFollow = true;
   }

--- a/packages/language/src/preprocessor/instructions.ts
+++ b/packages/language/src/preprocessor/instructions.ts
@@ -106,7 +106,9 @@ export type Instruction =
 
 export interface ProcedureInstructionContainer {
   names: string[];
+  labels: ast.LabelPrefix[];
   parameters: string[];
+  statement: boolean;
   node: InstructionNode;
 }
 

--- a/packages/language/src/preprocessor/instructions.ts
+++ b/packages/language/src/preprocessor/instructions.ts
@@ -106,7 +106,7 @@ export type Instruction =
 
 export interface ProcedureInstructionContainer {
   names: string[];
-  labels: ast.LabelPrefix[];
+  labels: Map<string, ast.LabelPrefix>;
   parameters: string[];
   statement: boolean;
   node: InstructionNode;

--- a/packages/language/src/preprocessor/pli-lexer.ts
+++ b/packages/language/src/preprocessor/pli-lexer.ts
@@ -37,6 +37,7 @@ export interface LexingIssue {
   readonly severity: Severity;
   readonly range: Range | undefined;
   readonly uri: URI | undefined;
+  readonly code?: string;
 }
 
 export interface LexerResult {

--- a/packages/language/src/preprocessor/pli-preprocessor-error.ts
+++ b/packages/language/src/preprocessor/pli-preprocessor-error.ts
@@ -19,6 +19,11 @@ export class PreprocessorError implements LexingIssue {
   private _range: Range | undefined;
   private _message: string;
   private _severity: Severity;
+  private _code: string | undefined;
+
+  get code(): string | undefined {
+    return this._code;
+  }
 
   get uri(): URI | undefined {
     return this._uri;
@@ -40,6 +45,7 @@ export class PreprocessorError implements LexingIssue {
     message: string,
     range: Range | Token | null | undefined,
     uri?: URI,
+    code?: string,
   ) {
     this._message = message;
     this._severity = Severity.E;
@@ -55,5 +61,6 @@ export class PreprocessorError implements LexingIssue {
       }
     }
     this._uri ??= uri;
+    this._code = code;
   }
 }

--- a/packages/language/src/validation/validator.ts
+++ b/packages/language/src/validation/validator.ts
@@ -143,7 +143,7 @@ export function lexerIssuesToDiagnostics(
         severity: error.severity,
         range: error.range,
         message: error.message,
-        source: "lexer",
+        code: error.code,
       });
     }
   }

--- a/packages/language/test/fourslash/linker/preprocessor-inline-procedure.ts
+++ b/packages/language/test/fourslash/linker/preprocessor-inline-procedure.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+/**
+ Preprocessor variables can be linked from PL/I code.
+ */
+//// %<|1:TEST|>: PROC RETURNS (CHAR);
+////   RETURN ("VALUE");
+//// %END;
+//// %ACTIVATE TEST;
+//// <|1>TEST
+
+linker.expectLinks();

--- a/packages/language/test/fourslash/preprocessor/procedures/inline-procedure-inactive.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/inline-procedure-inactive.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %TEST: PROC RETURNS (CHAR);
+////   RETURN ("VAR");
+//// %END;
+//// TEST
+
+/* TEST is inactive, therefore does not get replaced */
+preprocessor.expectTokens("TEST");

--- a/packages/language/test/fourslash/preprocessor/procedures/inline-procedure-merges-with-next-token.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/inline-procedure-merges-with-next-token.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %TEST: PROC RETURNS (CHAR);
+////   RETURN ("VALUE");
+//// %END;
+//// %ACTIVATE TEST;
+//// TEST%;VAR
+
+preprocessor.expectTokens("VALUEVAR");

--- a/packages/language/test/fourslash/preprocessor/procedures/inline-procedure-simple.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/inline-procedure-simple.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %TEST: PROC RETURNS (CHAR);
+////   RETURN ("VALUE");
+//// %END;
+//// %ACTIVATE TEST;
+//// TEST
+
+/* TEST is activated, expect the returned value */
+preprocessor.expectTokens("VALUE");

--- a/packages/language/test/fourslash/preprocessor/procedures/inline-procedure-with-arguments-merges-with-next-token.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/inline-procedure-with-arguments-merges-with-next-token.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %TEST: PROC (X) RETURNS (CHAR);
+////   RETURN (X);
+//// %END;
+//// %ACTIVATE TEST;
+//// TEST(VALUE)%;VAR
+
+preprocessor.expectTokens("VALUEVAR");

--- a/packages/language/test/fourslash/preprocessor/procedures/inline-procedure-with-arguments-replaced.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/inline-procedure-with-arguments-replaced.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %TEST: PROC (INPUT) RETURNS (CHAR);
+////   RETURN (INPUT || " WORLD");
+//// %END;
+//// %ACTIVATE TEST;
+//// %DCL X CHAR;
+//// %X = "HELLO";
+//// PREFIX TEST(X) SUFFIX
+
+/* Expect output = input */
+preprocessor.expectTokens("PREFIX HELLO WORLD SUFFIX");

--- a/packages/language/test/fourslash/preprocessor/procedures/inline-procedure-with-arguments.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/inline-procedure-with-arguments.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %TEST: PROC (INPUT) RETURNS (CHAR);
+////   RETURN (INPUT || " + 8");
+//// %END;
+//// %ACTIVATE TEST;
+//// PREFIX TEST(2 + 3 * 4) SUFFIX
+
+/* Expect output = input */
+preprocessor.expectTokens("PREFIX 2 + 3 * 4 + 8 SUFFIX");

--- a/packages/language/test/fourslash/preprocessor/procedures/inline-procedure-with-empty-arguments.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/inline-procedure-with-empty-arguments.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %TEST: PROC (A, B) RETURNS (CHAR);
+////   RETURN (A || " INFIX " || B);
+//// %END;
+//// %ACTIVATE TEST;
+//// PREFIX TEST(,23) SUFFIX
+
+/* Expect output = input */
+preprocessor.expectTokens("PREFIX INFIX 23 SUFFIX");

--- a/packages/language/test/fourslash/preprocessor/procedures/inline-statement-procedure-merges-with-next-token.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/inline-statement-procedure-merges-with-next-token.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %TEST: PROC (X) STATEMENT RETURNS (CHAR);
+////   RETURN (X);
+//// %END;
+//// %ACTIVATE TEST;
+//// TEST(VALUE);VAR
+
+preprocessor.expectTokens("VALUEVAR");

--- a/packages/language/test/fourslash/preprocessor/procedures/inline-statement-procedure-named-merges-with-next-token.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/inline-statement-procedure-named-merges-with-next-token.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %TEST: PROC (X) STATEMENT RETURNS (CHAR);
+////   RETURN (X);
+//// %END;
+//// %ACTIVATE TEST;
+//// TEST X(VALUE);VAR
+
+preprocessor.expectTokens("VALUEVAR");

--- a/packages/language/test/fourslash/preprocessor/procedures/inline-statement-procedure-with-arguments.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/inline-statement-procedure-with-arguments.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %TEST: PROC (INPUT) STATEMENT RETURNS (CHAR);
+////   RETURN (INPUT || " + 8");
+//// %END;
+//// %ACTIVATE TEST;
+//// PREFIX TEST(2 + 3 * 4); SUFFIX
+
+preprocessor.expectTokens("PREFIX 2 + 3 * 4 + 8 SUFFIX");

--- a/packages/language/test/fourslash/preprocessor/procedures/inline-statement-procedure-with-mixed-arguments.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/inline-statement-procedure-with-mixed-arguments.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %TEST: PROC (A, B, C) STATEMENT RETURNS (CHAR);
+////   RETURN (A || B || C);
+//// %END;
+//// %ACTIVATE TEST;
+//// PREFIX TEST(,2) A(1) C(3); SUFFIX
+
+/* Expect output = input */
+preprocessor.expectTokens("PREFIX 123 SUFFIX");

--- a/packages/language/test/fourslash/preprocessor/procedures/inline-statement-procedure-with-multiple-arguments.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/inline-statement-procedure-with-multiple-arguments.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %TEST: PROC (A, B, C) STATEMENT RETURNS (CHAR);
+////   RETURN (A || B || C);
+//// %END;
+//// %ACTIVATE TEST;
+//// PREFIX TEST A(1) B(2) C(3); SUFFIX
+
+/* Expect output = input */
+preprocessor.expectTokens("PREFIX 123 SUFFIX");

--- a/packages/language/test/fourslash/preprocessor/procedures/inline-statement-procedure-with-named-arguments.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/inline-statement-procedure-with-named-arguments.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %TEST: PROC (INPUT) STATEMENT RETURNS (CHAR);
+////   RETURN (INPUT || " + 8");
+//// %END;
+//// %ACTIVATE TEST;
+//// PREFIX TEST INPUT(2 + 3 * 4); SUFFIX
+
+preprocessor.expectTokens("PREFIX 2 + 3 * 4 + 8 SUFFIX");

--- a/packages/language/test/fourslash/preprocessor/procedures/inline-statement-procedure-with-unknown-argument.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/inline-statement-procedure-with-unknown-argument.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %TEST: PROC (INPUT) STATEMENT RETURNS (CHAR);
+////   RETURN (INPUT);
+//// %END;
+//// %ACTIVATE TEST;
+//// PREFIX TEST INPUT(123) <|1:OUTPUT|>(321); SUFFIX
+
+preprocessor.expectTokens("PREFIX 123 SUFFIX");
+verify.expectExclusiveErrorCodesAt("1", [code.Error.IBM3581I.fullCode]);

--- a/packages/language/test/fourslash/preprocessor/procedures/inline-statement-procedure-with-unordered-arguments.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/inline-statement-procedure-with-unordered-arguments.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %TEST: PROC (A, B, C) STATEMENT RETURNS (CHAR);
+////   RETURN (A || B || C);
+//// %END;
+//// %ACTIVATE TEST;
+//// PREFIX TEST B(2) C(3) A(1); SUFFIX
+
+/* Expect output = input */
+preprocessor.expectTokens("PREFIX 123 SUFFIX");


### PR DESCRIPTION
Enables users to call activated preprocessor procedures in normal PLI code. Takes special care of the `STATEMENT` attribute of procedures as per the documentation:

<img width="1205" height="601" alt="image" src="https://github.com/user-attachments/assets/d179fb31-b13b-4e1c-9811-150f5f85e479" />
