### PR TITLE
Include JSON schemas for config files in VSIX

### DIFF
--- a/packages/vscode-extension/.vscodeignore
+++ b/packages/vscode-extension/.vscodeignore
@@ -11,4 +11,5 @@
 !language-configuration.json
 !c4z.pli.code-snippets
 !syntaxes/pli.merged.json
+!schemas/*
 !LICENSE


### PR DESCRIPTION
Adds exclude rules to the `.vscodeignore` file to ensure that the JSON schemas are correctly packaged in the final VSIX build.