### PR TITLE
Fix comments following *process

### DIFF
--- a/packages/language/src/preprocessor/compiler-options/parser.ts
+++ b/packages/language/src/preprocessor/compiler-options/parser.ts
@@ -26,7 +26,7 @@ import {
   CompilerOptionValue,
   SyntaxKind,
 } from "../../syntax-tree/ast";
-import { Token } from "../../parser/tokens";
+import { ML_COMMENT, SL_COMMENT, Token } from "../../parser/tokens";
 
 const commaToken = createToken({ name: "comma", pattern: "," });
 const semicolonToken = createToken({ name: "semicolon", pattern: ";" });
@@ -38,6 +38,11 @@ const wordToken = createToken({ name: "value", pattern: /[\w\d\-+_]+/ });
 const parenOpen = createToken({ name: "parenOpen", pattern: "(" });
 const parenClose = createToken({ name: "parenClose", pattern: ")" });
 const ws = createToken({ name: "ws", pattern: /\s+/, group: Lexer.SKIPPED });
+const HALF_ML_COMMENT = createToken({
+  name: "HALF_ML_COMMENT",
+  pattern: /\/\*[\s\S]/y,
+  group: Lexer.SKIPPED,
+});
 const tokenTypes = [
   ws,
   commaToken,
@@ -46,6 +51,9 @@ const tokenTypes = [
   parenOpen,
   parenClose,
   wordToken,
+  ML_COMMENT,
+  HALF_ML_COMMENT,
+  SL_COMMENT,
 ];
 const lexer = new Lexer(tokenTypes, {
   positionTracking: "full",

--- a/packages/language/test/fourslash/preprocessor/compiler-options/parser/comments-ml-break-half.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/parser/comments-ml-break-half.ts
@@ -1,0 +1,18 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS MARGINS(2, 100); /* test
+//// //*/
+
+verify.noDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/compiler-options/parser/comments-ml-break.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/parser/comments-ml-break.ts
@@ -1,0 +1,18 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS MARGINS(2, 100); /* test
+//// */
+
+verify.expectToThrow(() => verify.noDiagnostics());

--- a/packages/language/test/fourslash/preprocessor/compiler-options/parser/comments-ml.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/parser/comments-ml.ts
@@ -1,0 +1,17 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS MARGINS(2, 100); /* test */
+
+verify.noDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/compiler-options/parser/comments-sl.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/parser/comments-sl.ts
@@ -1,0 +1,17 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS MARGINS(2, 100); // test
+
+verify.noDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/compiler-options/parser/correct-skip-crlf.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/parser/correct-skip-crlf.ts
@@ -9,7 +9,7 @@
  *
  */
 
-/// <reference path="../../framework.ts" />
+/// <reference path="../../../framework.ts" />
 
 // @filename: .pliplugin/proc_grps.json
 //// {

--- a/packages/language/test/fourslash/preprocessor/compiler-options/parser/correct-skip-standalone-crlf.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/parser/correct-skip-standalone-crlf.ts
@@ -9,7 +9,7 @@
  *
  */
 
-/// <reference path="../../framework.ts" />
+/// <reference path="../../../framework.ts" />
 
 // @filename: .pliplugin/proc_grps.json
 //// {
@@ -27,7 +27,7 @@
 ////*PROCESS GRAPHIC;
 ////*PROCESS NOGRAPHIC;
 ////*PROCESS NGR;
-////*PROCESS GR;
+////*PROCESS GR;\r\n
 
 verify.noDiagnosticsExcept([
   new RegExp(code.CompilerOptions.DupeOptionIssue.message("").substring(0, 20)),

--- a/packages/language/test/fourslash/preprocessor/compiler-options/parser/correct-skip-standalone.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/parser/correct-skip-standalone.ts
@@ -9,7 +9,7 @@
  *
  */
 
-/// <reference path="../../framework.ts" />
+/// <reference path="../../../framework.ts" />
 
 // @filename: .pliplugin/proc_grps.json
 //// {
@@ -28,12 +28,13 @@
 ////*PROCESS NOGRAPHIC;
 ////*PROCESS NGR;
 ////*PROCESS GR;
-//// STARTPR: PROCEDURE OPTIONS (MAIN);
-//// END STARTPR;`;
 
 verify.noDiagnosticsExcept([
   new RegExp(code.CompilerOptions.DupeOptionIssue.message("").substring(0, 20)),
   new RegExp(
     code.CompilerOptions.MutexOptionIssue.message("").substring(0, 20),
+  ),
+  new RegExp(
+    code.Severe.IBM1917I.message, // no program, but the options parser should work nonetheless
   ),
 ]);

--- a/packages/language/test/fourslash/preprocessor/compiler-options/parser/correct-skip.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/parser/correct-skip.ts
@@ -9,7 +9,7 @@
  *
  */
 
-/// <reference path="../../framework.ts" />
+/// <reference path="../../../framework.ts" />
 
 // @filename: .pliplugin/proc_grps.json
 //// {
@@ -24,13 +24,16 @@
 //// }
 
 // @filename: main.pli
-// @wrap: process
-////*PROCESS MARGINS(1, 72); xxx
+////*PROCESS GRAPHIC;
+////*PROCESS NOGRAPHIC;
+////*PROCESS NGR;
+////*PROCESS GR;
+//// STARTPR: PROCEDURE OPTIONS (MAIN);
+//// END STARTPR;`;
 
-verify.noDiagnostics();
-verify.expectCompilerOptions({
-  margins: {
-    m: 1,
-    n: 72,
-  },
-});
+verify.noDiagnosticsExcept([
+  new RegExp(code.CompilerOptions.DupeOptionIssue.message("").substring(0, 20)),
+  new RegExp(
+    code.CompilerOptions.MutexOptionIssue.message("").substring(0, 20),
+  ),
+]);

--- a/packages/language/test/fourslash/preprocessor/compiler-options/parser/right-clutter.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/parser/right-clutter.ts
@@ -9,7 +9,7 @@
  *
  */
 
-/// <reference path="../../framework.ts" />
+/// <reference path="../../../framework.ts" />
 
 // @filename: .pliplugin/proc_grps.json
 //// {
@@ -24,17 +24,13 @@
 //// }
 
 // @filename: main.pli
-////*PROCESS GRAPHIC;
-////*PROCESS NOGRAPHIC;
-////*PROCESS NGR;
-////*PROCESS GR;\r\n
+// @wrap: process
+////*PROCESS MARGINS(1, 72); xxx
 
-verify.noDiagnosticsExcept([
-  new RegExp(code.CompilerOptions.DupeOptionIssue.message("").substring(0, 20)),
-  new RegExp(
-    code.CompilerOptions.MutexOptionIssue.message("").substring(0, 20),
-  ),
-  new RegExp(
-    code.Severe.IBM1917I.message, // no program, but the options parser should work nonetheless
-  ),
-]);
+verify.noDiagnostics();
+verify.expectCompilerOptions({
+  margins: {
+    m: 1,
+    n: 72,
+  },
+});


### PR DESCRIPTION
Suggestion for https://github.com/zowe/zowe-pli-language-support/issues/374 a

Fixes the obvious cases of ML and SL comments on the process line. 
However, as stated in https://github.com/zowe/zowe-pli-language-support/pull/338 everything behind the `;` is basically just ignored on the mainframe. So, in 
```
*PROCESS MARGINS(2, 72); /* xxx 
*PROCESS MARGINS(2, 74);  xxx */
```
the second directive is actually executed normally. Since our options currently parses the directives separately, tokens like `/*` become possible. Also, the syntax highlighting does not reflect this. So 
```
*PROCESS MARGINS(2, 72); 
*PROCESS MARGINS(2, 74);  /* xxx 
```
is valid, but the program afterwards is highlighted as a comment.

Conversely, 
```
*PROCESS MARGINS(2, 100); /* test 
 */
```
is not valid code on the mainframe. 