### PR TITLE
Add range validation for Margins compiler option

### DIFF
--- a/packages/language/src/preprocessor/compiler-options/codes.ts
+++ b/packages/language/src/preprocessor/compiler-options/codes.ts
@@ -302,7 +302,22 @@ export const CompilerOptionsCodes = {
     } as ParametricPLICode,
   },
 
-  // TODO ssmifi: Add codes for margins.
+  Margins: {
+    InvalidMarginPosition: {
+      code: "COMR01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `The left margin must be less than the right margin.`,
+      fullCode: "COMR01W",
+    } as ParametricPLICode,
+    InvalidAnsPosition: {
+      code: "COMR02",
+      severity: Severity.W,
+      message: (value: string) =>
+        `The ANS character should be located outside of the values specified by m and n.`,
+      fullCode: "COMR02W",
+    } as ParametricPLICode,
+  },
 
   MaxInit: {
     InvalidParameter: {

--- a/packages/language/src/preprocessor/compiler-options/options.ts
+++ b/packages/language/src/preprocessor/compiler-options/options.ts
@@ -768,7 +768,7 @@ export declare namespace CompilerOptions {
      *
      * Specifying MARGINS(,,c) is an alternative to using %PAGE and %SKIP statements .
      */
-    c?: string;
+    c?: number;
   }
   export interface MaxMsg {
     severity: Flag;

--- a/packages/language/src/preprocessor/compiler-options/translator.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator.ts
@@ -1994,38 +1994,36 @@ translator.rule(
     ensureArguments(option, 2, 3);
     const m = option.values[0];
     const n = option.values[1];
-    const c = option.values[2];
-    ensureType(m, "plain");
-    ensureType(n, "plain");
-    // Default values for the margins are 2, 72.
-    const mValue: number = m.value === "" ? 2 : Number(m.value);
-    const nValue: number = n.value === "" ? 72 : Number(n.value);
-    let cValue: string | undefined = undefined;
-    if (isNaN(mValue)) {
-      throw new TranslationError(m.token, "Expected a number.", 1);
-    }
-    if (isNaN(nValue)) {
-      throw new TranslationError(n.token, "Expected a number.", 1);
-    }
+    ensureType(m, "plainNotEmpty");
+    ensureType(n, "plainNotEmpty");
+    const mValue = ensureNumberValue(m, 1, 100);
+    const nValue = ensureNumberValue(n, 1, 200);
     if (mValue >= nValue) {
-      throw new TranslationError(
-        option.token,
-        "Left margin must be smaller than right margin.",
-        1,
+      throw TranslationError.fromCode(
+        m.token,
+        CompilerOptionsCodes.Margins.InvalidMarginPosition,
       );
-    }
-    if (c) {
-      ensureType(c, "plain");
-      cValue = c.value;
     }
     options.margins = {
       m: mValue,
       n: nValue,
-      c: cValue,
     };
+    if (option.values.length > 2) {
+      const c = option.values[2];
+      ensureType(c, "plainNotEmpty");
+      const cValue = ensureNumberValue(c, 0, 200);
+      if (cValue >= mValue && cValue <= nValue) {
+        throw TranslationError.fromCode(
+          c.token,
+          CompilerOptionsCodes.Margins.InvalidAnsPosition,
+        );
+      }
+      options.margins.c = cValue;
+    }
   },
   ["NOMARGINS"],
-  (_, options) => {
+  (option, options) => {
+    ensureArguments(option, 0, 0);
     options.margins = false;
   },
 );

--- a/packages/language/test/compiler/options-parser.test.ts
+++ b/packages/language/test/compiler/options-parser.test.ts
@@ -93,58 +93,6 @@ describe("CompilerOptions parser", async () => {
 });
 
 describe("CompilerOptions translator", async () => {
-  test("Translates MARGINS with values", async () => {
-    const options = await parseAbstractCompilerOptions("MARGINS(4, 80)");
-    const translated = translateCompilerOptions(options).options;
-    expect(translated.margins).toEqual({ m: 4, n: 80 });
-  });
-
-  test("Translates MARGINS with short identifier", async () => {
-    const options = await parseAbstractCompilerOptions("MAR(4, 80)");
-    const translated = translateCompilerOptions(options).options;
-    expect(translated.margins).toEqual({ m: 4, n: 80 });
-  });
-
-  test("Translates MARGINS default value", async () => {
-    const options = await parseAbstractCompilerOptions("MARGINS(4,)");
-    const translated = translateCompilerOptions(options).options;
-    expect(translated.margins).toEqual({ m: 4, n: 72 });
-  });
-
-  test("Translates MARGINS - negative", async () => {
-    // Margins requires two or three arguments
-    const options = await parseAbstractCompilerOptions("MARGINS(4)");
-    const translated = translateCompilerOptions(options).options;
-    // If the parsing fails, the option is set to its default values
-    expect(translated.margins).toEqual({ m: 2, n: 72 });
-  });
-
-  test("Translates MARGINS with c", async () => {
-    const options = await parseAbstractCompilerOptions("MARGINS(0, 14,)");
-    const translated = translateCompilerOptions(options).options;
-    expect(translated.margins).toEqual({ m: 0, n: 14, c: "" });
-  });
-
-  test("Translates NOMARGINS", async () => {
-    const options = await parseAbstractCompilerOptions("NOMARGINS");
-    const translated = translateCompilerOptions(options).options;
-    expect(translated.margins).toEqual(false);
-  });
-
-  test("Produce issue for text value in MARGINS m", async () => {
-    const options = await parseAbstractCompilerOptions("MARGINS(M,444)");
-    const issues = translateCompilerOptions(options).issues;
-    expect(issues).toHaveLength(1);
-    expect(issues[0].message).toBe("Expected a number.");
-  });
-
-  test("Produce issue for text value in MARGINS n", async () => {
-    const options = await parseAbstractCompilerOptions("MARGINS(112, R)");
-    const issues = translateCompilerOptions(options).issues;
-    expect(issues).toHaveLength(1);
-    expect(issues[0].message).toBe("Expected a number.");
-  });
-
   test("Produce issue for text value when string is expected", async () => {
     const options = await parseAbstractCompilerOptions("BRACKETS(TEST)");
     const issues = translateCompilerOptions(options).issues;

--- a/packages/language/test/fourslash-harness/harness-interface.ts
+++ b/packages/language/test/fourslash-harness/harness-interface.ts
@@ -76,8 +76,8 @@ export interface HarnessTesterInterface {
      * Expect that the compilation unit has no diagnostics apart from the given regexes.
      * @param regexes The regexes to expect no diagnostics apart from.
      */
-    noDiagnosticsExcept(regexes: RegExp[]): void;
-    noDiagnosticsExceptAt(label: Label, regexes: RegExp[]): void;
+    noDiagnosticsExcept(regexes: RegExp[] | string[]): void;
+    noDiagnosticsExceptAt(label: Label, regexes: RegExp[] | string[]): void;
 
     /**
      * Expect that the given function throws an error.

--- a/packages/language/test/fourslash-harness/implementation/test-builder.ts
+++ b/packages/language/test/fourslash-harness/implementation/test-builder.ts
@@ -48,10 +48,10 @@ export function createTestBuilderHarnessImplementation(
         label !== undefined
           ? testBuilder.expectNoDiagnosticsAt(label)
           : testBuilder.expectNoDiagnostics(),
-      noDiagnosticsExcept: (regex: RegExp[]) =>
+      noDiagnosticsExcept: (regex: RegExp[] | string[]) =>
         testBuilder.noDiagnosticsExcept(regex),
-      noDiagnosticsExceptAt: (label, regexes) =>
-        testBuilder.noDiagnosticsExcept(regexes, label),
+      noDiagnosticsExceptAt: (label, regex: RegExp[] | string[]) =>
+        testBuilder.noDiagnosticsExcept(regex, label),
       expectToThrow: (fn, messageToThrow) =>
         testBuilder.expectToThrow(fn, messageToThrow),
       expectCompilerOptions: (expectedOptions) =>

--- a/packages/language/test/fourslash/lexer/margins-error-left-margin-directive.ts
+++ b/packages/language/test/fourslash/lexer/margins-error-left-margin-directive.ts
@@ -24,7 +24,7 @@
 //// }
 
 // @filename: main.pli
-////*PROCESS MARGINS(4,)
+////*PROCESS MARGINS(4,72)
 ////<|1: RG|>T005: PACKAGE EXPORTS(RGT005);
 ////   DCL SYSNULL BUILTIN;
 ////   RGT005: PROCEDURE(Z) OPTIONS(MAIN);

--- a/packages/language/test/fourslash/preprocessor/compiler-options/margins/margin-invald-position.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/margins/margin-invald-position.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS MARGINS(<|1:80|>, 4);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.Margins.InvalidMarginPosition.message(),
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/margins/margin-n-missing.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/margins/margin-n-missing.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:MARGINS|>(4);
+////*PROCESS MARGINS(4,<|2:)|>;
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(1, 2, 3),
+});
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/margins/margin-values-ans.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/margins/margin-values-ans.ts
@@ -1,0 +1,37 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS MARGINS(2, 80, <|1:)|>;
+////*PROCESS MARGINS(2, 80, <|2:10|>);
+////*PROCESS MARGINS(2, 80, <|3:201|>);
+////*PROCESS MARGINS(2, 80, <|4:0|>);
+////*PROCESS MARGINS(2, 80, <|5:100|>);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.Margins.InvalidAnsPosition.message(),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.ExpectedNumberRange.message(201, 0, 200),
+});
+verify.noDiagnostics([4, 5]);
+verify.expectCompilerOptions({
+  margins: {
+    m: 2,
+    n: 80,
+    c: 100,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/margins/margin-values-invalid.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/margins/margin-values-invalid.ts
@@ -1,0 +1,41 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS MARGINS(4, 80);
+////*PROCESS <|2:MARGINS|>(<|3:m|>, 80);
+////*PROCESS <|4:MARGINS|>(2, <|5:n|>);
+////*PROCESS <|6:MARGINS|>(2, 72, <|7:c|>);
+////*PROCESS <|8:MARGINS|>(<|9:101|>, 80);
+////*PROCESS <|10:MARGINS|>(4, <|11:201|>);
+
+verify.expectDiagnosticsAt([2, 4, 6, 8, 10], {
+  message: code.CompilerOptions.DupeOptionIssue.message("MARGINS"),
+});
+verify.expectDiagnosticsAt([3, 5, 7], {
+  message: code.CompilerOptions.ExpectedNumber.message(),
+});
+verify.expectDiagnosticsAt(9, {
+  message: code.CompilerOptions.ExpectedNumberRange.message(101, 1, 100),
+});
+verify.expectDiagnosticsAt(11, {
+  message: code.CompilerOptions.ExpectedNumberRange.message(201, 1, 200),
+});
+verify.expectCompilerOptions({
+  margins: {
+    // Fallback to defaults.
+    m: 2,
+    n: 72,
+    c: undefined,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/margins/margin-values.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/margins/margin-values.ts
@@ -1,0 +1,30 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS MARGINS(4, 80);
+////*PROCESS <|1:MAR|>(2, 82);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.DupeOptionIssue.message("MAR"),
+});
+verify.noDiagnosticsExcept([
+  code.CompilerOptions.DupeOptionIssue.message("MAR"),
+]);
+verify.expectCompilerOptions({
+  margins: {
+    m: 2,
+    n: 82,
+    c: undefined,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/margins/nomargin.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/margins/nomargin.ts
@@ -1,0 +1,27 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS MARGINS(4, 80);
+////*PROCESS <|1:NOMARGINS|>(2, 80);
+////*PROCESS <|2:NOMARGINS|>;
+
+verify.expectDiagnosticsAt([1, 2], {
+  message: code.CompilerOptions.MutexOptionIssue.message("NOMARGINS"),
+});
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(2, 0, 0),
+});
+verify.expectCompilerOptions({
+  margins: false,
+});

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -39,6 +39,7 @@ import {
 import { InternalCodes } from "../src/validation/messages";
 import { CompilerOptions } from "../src/preprocessor/compiler-options/options";
 import { tokenize } from "../src/parser/tokenizer";
+import { escapeRegExp } from "../src/parser/tokens";
 
 export type Label = string | number | string[] | number[];
 
@@ -486,13 +487,25 @@ export class TestBuilder {
     return this;
   }
 
-  noDiagnosticsExcept(regex: RegExp[], label?: Label): TestBuilder {
+  noDiagnosticsExcept(
+    exceptions: RegExp[] | string[],
+    label?: Label,
+  ): TestBuilder {
+    if (exceptions.length === 0) {
+      return this;
+    }
+    if (typeof exceptions[0] === "string") {
+      exceptions = (exceptions as string[]).map(
+        (s) => new RegExp(escapeRegExp(s)),
+      );
+    }
     if (Array.isArray(label)) {
       for (const l of label) {
-        this.noDiagnosticsExcept(regex, l);
+        this.noDiagnosticsExcept(exceptions, l);
       }
       return this;
     }
+    const regex = exceptions as RegExp[];
 
     const diagnostics = label
       ? this.getMatchingDiagnostics(label.toString()).exactMatches


### PR DESCRIPTION
Closes https://github.com/zowe/zowe-pli-language-support/issues/374 d
Based on https://github.com/zowe/zowe-pli-language-support/pull/368

- Added range checks for the margins process directive (and refactored to latest changes). 
- `expectDiagnosticsExcept` now also accepts plain strings.
- Moved margins compiler options tests to the fourslash harness.