### PR TITLE
Extend compiler options and tests #Rules

### DIFF
--- a/packages/language/src/linking/error.ts
+++ b/packages/language/src/linking/error.ts
@@ -154,7 +154,7 @@ export class LinkerErrorReporter {
    */
   reportImplicitDeclaration(node: QualifiedSyntaxNode) {
     // This should only emit a warning during the 'NOLAXDCL' compiler flag.
-    if (this.unit.compilerOptions.rules?.laxdef) {
+    if (this.unit.compilerOptions.rules?.laxDef) {
       return;
     }
 

--- a/packages/language/src/preprocessor/compiler-options/codes.ts
+++ b/packages/language/src/preprocessor/compiler-options/codes.ts
@@ -84,13 +84,19 @@ export const CompilerOptionsCodes = {
   ExpectedNumberRange: {
     code: "COOP09",
     severity: Severity.W,
-    message: (number: number, min: number, max: number) => {
+    message: (
+      number: number,
+      min: number | undefined,
+      max: number | undefined,
+    ) => {
       if (min !== undefined && max !== undefined) {
         return `Expected a number between ${min} and ${max}, but received ${number}.`;
-      } else if (min) {
+      } else if (min !== undefined) {
         return `Expected a number greater than or equal to ${min}, but received ${number}.`;
-      } else {
+      } else if (max !== undefined) {
         return `Expected a number less than or equal to ${max}, but received ${number}.`;
+      } else {
+        throw new Error("At least one of min or max must be defined");
       }
     },
     fullCode: "COOP09W",
@@ -140,6 +146,16 @@ export const CompilerOptionsCodes = {
       message: (value: string) =>
         `Expected "ASSERT", "DISPLAY" or "PUT", but received '${value}'.`,
       fullCode: "COIG01W",
+    } as ParametricPLICode,
+  },
+
+  IncAfter: {
+    InvalidParameter: {
+      code: "COIA01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "PROCESS" option with a process name, but received '${value}'.`,
+      fullCode: "COIA01W",
     } as ParametricPLICode,
   },
 
@@ -505,6 +521,72 @@ export const CompilerOptionsCodes = {
       message: (value: string) =>
         `Expected "NONULLPTR", "NULLPTR" or "NULL370", but received '${value}'.`,
       fullCode: "CORT01W",
+    } as ParametricPLICode,
+  },
+
+  Rules: {
+    InvalidParameter: {
+      code: "CORU01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Received unknown RULES parameter: '${value}'.`,
+      fullCode: "CORU01W",
+    } as ParametricPLICode,
+    ExpectAllSourceParameter: {
+      code: "CORU02",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "ALL" or "SOURCE", but received '${value}'.`,
+      fullCode: "CORU02W",
+    } as ParametricPLICode,
+    InvalidGotoParameter: {
+      code: "CORU03",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "STRICT", "LOOSE" or "LOOSEFORWARD", but received '${value}'.`,
+      fullCode: "CORU03W",
+    } as ParametricPLICode,
+    InvalidLaxEntryParameter: {
+      code: "CORU04",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "STRICT" or "LOOSE", but received '${value}'.`,
+      fullCode: "CORU04W",
+    } as ParametricPLICode,
+    InvalidLaxInOutParameter: {
+      code: "CORU05",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "ALL", "SOURCE", "STRICT" or "LOOSE", but received '${value}'.`,
+      fullCode: "CORU05W",
+    } as ParametricPLICode,
+    InvalidLaxMarginsParameter: {
+      code: "CORU06",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "STRICT" or "XNUMERIC", but received '${value}'.`,
+      fullCode: "CORU06W",
+    } as ParametricPLICode,
+    InvalidLaxQualParameter: {
+      code: "CORU07",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "ALL", "FORCE", "STRICT", "LOOSE" or "FULL", but received '${value}'.`,
+      fullCode: "CORU07W",
+    } as ParametricPLICode,
+    InvalidLaxScaleParameter: {
+      code: "CORU08",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "ALL", "SOURCE", "STRICT" or "LOOSE", but received '${value}'.`,
+      fullCode: "CORU08W",
+    } as ParametricPLICode,
+    InvalidPaddingParameter: {
+      code: "CORU08",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected "ALL", "SOURCE", "STRICT" or "LOOSE", but received '${value}'.`,
+      fullCode: "CORU08W",
     } as ParametricPLICode,
   },
 

--- a/packages/language/src/preprocessor/compiler-options/options.ts
+++ b/packages/language/src/preprocessor/compiler-options/options.ts
@@ -305,7 +305,7 @@ export interface CompilerOptions {
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-margini
    */
-  margini?: CompilerOptions.Margini | false;
+  margini?: string;
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-margins
    */
@@ -853,171 +853,79 @@ export declare namespace CompilerOptions {
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-rules
    */
   export type Rules = {
-    ibm?: boolean;
-    ans?: boolean;
-    yy?: boolean;
-    byname?: boolean;
-    complex?:
-      | true
-      | {
-          value?: "ALL" | "SOURCE";
-        };
+    ibm?: "IBM" | "ANS";
+    byName?: boolean;
+    complex?: "ALL" | "SOURCE" | true;
     controlled?: boolean;
-    decsize?: boolean;
-    elseif?: boolean;
-    evendec?: boolean;
-    global?:
-      | true
-      | {
-          value?: "ALL" | "SOURCE";
-        };
+    decSize?: boolean;
+    elseIf?: boolean;
+    evenDec?: boolean;
+    global?: "ALL" | "SOURCE" | true;
     globalDo?: boolean;
-    goto?:
-      | true
-      | {
-          value?: "STRICT" | "LOOSE" | "LOOSEFORWARD";
-        };
-    laxbif?: boolean;
-    laxconv?:
-      | true
-      | {
-          value?: "ALL" | "SOURCE";
-        };
-    laxctl?: boolean;
-    laxdef?: boolean;
+    goto?: "STRICT" | "LOOSE" | "LOOSEFORWARD" | true;
+    laxBIf?: boolean;
+    laxConv?: "ALL" | "SOURCE" | true;
+    laxCtl?: boolean;
+    laxDcl?: boolean;
+    laxDef?: boolean;
+    laxEntry?: "STRICT" | "LOOSE" | true;
     laxExports?: boolean;
     laxFields?: boolean;
-    laxInterface?: boolean;
-    laxEntry?:
-      | true
-      | {
-          value?: "STRICT" | "LOOSE";
-        };
     laxIf?: boolean;
     laxInOut?:
-      | true
       | {
           source?: "ALL" | "SOURCE";
           strict?: "STRICT" | "LOOSE";
-        };
+        }
+      | true;
+    laxInterface?: boolean;
     laxLink?: boolean;
-    laxMargins?:
-      | true
-      | {
-          strict?: "STRICT" | "XNUMERIC";
-        };
-    laxNested?:
-      | true
-      | {
-          source?: "ALL" | "SOURCE";
-        };
-    laxOptional?:
-      | true
-      | {
-          source?: "ALL" | "SOURCE";
-        };
+    laxMargins?: "STRICT" | "XNUMERIC" | true;
+    laxNested?: "ALL" | "SOURCE" | true;
+    laxOptional?: "ALL" | "SOURCE" | true;
     laxPackage?: boolean;
-    laxParams?:
-      | true
-      | {
-          source?: "ALL" | "SOURCE";
-        };
+    laxParms?: "ALL" | "SOURCE" | true;
     laxPunc?: boolean;
     laxQual?:
-      | true
       | {
-          strict?: "LOOSE" | "STRICT" | "FULL";
-          force?: "ALL" | "FORCE";
-        };
+          source?: "ALL" | "FORCE";
+          strict?: "STRICT" | "LOOSE" | "FULL";
+        }
+      | true;
     laxReturn?: boolean;
     laxScale?:
-      | true
-      | {
-          strict?: "LOOSE" | "STRICT";
-          source?: "ALL" | "SOURCE";
-        };
-    laxSemi?: boolean;
-    laxStg?: boolean;
-    laxStmt?:
-      | true
-      | {
-          source?: "ALL" | "SOURCE";
-        };
-    laxStrz?: boolean;
-    multiClose?: boolean;
-    multiEntry?:
-      | true
-      | {
-          source?: "ALL" | "SOURCE";
-        };
-    multiExit?:
-      | true
-      | {
-          source?: "ALL" | "SOURCE";
-        };
-    multiSemi?:
-      | true
-      | {
-          source?: "ALL" | "SOURCE";
-        };
-    padding?:
-      | true
       | {
           source?: "ALL" | "SOURCE";
           strict?: "STRICT" | "LOOSE";
-        };
-    procEndOnly?:
-      | true
+        }
+      | true;
+    laxSemi?: boolean;
+    laxStg?: boolean;
+    laxStmt?: "ALL" | "SOURCE" | true;
+    laxStrz?: boolean;
+    multiClose?: boolean;
+    multiEntry?: "ALL" | "SOURCE" | true;
+    multiExit?: "ALL" | "SOURCE" | true;
+    multiSemi?: "ALL" | "SOURCE" | true;
+    padding?:
       | {
           source?: "ALL" | "SOURCE";
-        };
+          strict?: "STRICT" | "LOOSE";
+        }
+      | true;
+    procEndOnly?: "ALL" | "SOURCE" | true;
     recursive?: boolean;
     selfAssign?: boolean;
-    unref?:
-      | true
-      | {
-          source?: "ALL" | "SOURCE";
-        };
-    unrefBased?:
-      | true
-      | {
-          source?: "ALL" | "SOURCE";
-        };
-    unrefCtl?:
-      | true
-      | {
-          source?: "ALL" | "SOURCE";
-        };
-    unrefDefined?:
-      | true
-      | {
-          source?: "ALL" | "SOURCE";
-        };
-    unrefEntry?:
-      | true
-      | {
-          source?: "ALL" | "SOURCE";
-        };
-    unrefDefFile?:
-      | true
-      | {
-          source?: "ALL" | "SOURCE";
-        };
-    unrefStatic?:
-      | true
-      | {
-          source?: "ALL" | "SOURCE";
-        };
-    unrefValue?:
-      | true
-      | {
-          source?: "ALL" | "SOURCE";
-        };
-    unset?:
-      | true
-      | {
-          source?: "ALL" | "SOURCE";
-        };
+    unref?: "ALL" | "SOURCE" | true;
+    unrefBased?: "ALL" | "SOURCE" | true;
+    unrefCtl?: "ALL" | "SOURCE" | true;
+    unrefDefined?: "ALL" | "SOURCE" | true;
+    unrefEntry?: "ALL" | "SOURCE" | true;
+    unrefFile?: "ALL" | "SOURCE" | true;
+    unrefStatic?: "ALL" | "SOURCE" | true;
+    unrefValue?: "ALL" | "SOURCE" | true;
+    unset?: boolean;
+    yy?: boolean;
   };
   export type Semantic = {
     // *PROCESS NOSEMANTIC; actually results in NOSEMANTIC( I );
@@ -1127,6 +1035,7 @@ const $1K = 1024;
 const $1M = 1024 * 1024;
 
 const defaultCompilerOptions: CompilerOptions = {
+  goNumber: false,
   json: {
     case: "UPPER",
     get: "HEEDCASE",
@@ -1148,6 +1057,7 @@ const defaultCompilerOptions: CompilerOptions = {
   },
   lineCount: 31415,
   initAuto: "FULL",
+  margini: " ",
   margins: {
     m: 2,
     n: 72,
@@ -1209,6 +1119,61 @@ const defaultCompilerOptions: CompilerOptions = {
   resExp: true,
   respect: { date: false },
   rtCheck: "NONULLPTR",
+  rules: {
+    ibm: "IBM",
+    byName: true,
+    complex: true,
+    controlled: true,
+    decSize: false,
+    elseIf: true,
+    evenDec: true,
+    global: true,
+    globalDo: true,
+    goto: true,
+    laxBIf: false,
+    laxConv: true,
+    laxCtl: false,
+    laxDcl: false,
+    laxDef: false,
+    laxEntry: true,
+    laxExports: true,
+    laxFields: true,
+    laxIf: false,
+    laxInOut: true,
+    laxInterface: true,
+    laxLink: true,
+    laxMargins: true,
+    laxNested: true,
+    laxOptional: true,
+    laxPackage: true,
+    laxParms: true,
+    laxPunc: true,
+    laxQual: true,
+    laxReturn: true,
+    laxScale: { source: "ALL", strict: "LOOSE" },
+    laxSemi: true,
+    laxStg: true,
+    laxStmt: true,
+    laxStrz: false,
+    multiClose: false,
+    multiEntry: true,
+    multiExit: true,
+    multiSemi: true,
+    padding: true,
+    procEndOnly: true,
+    recursive: true,
+    selfAssign: true,
+    unref: true,
+    unrefBased: true,
+    unrefCtl: true,
+    unrefDefined: true,
+    unrefEntry: true,
+    unrefFile: true,
+    unrefStatic: true,
+    unrefValue: true,
+    unset: true,
+    yy: true,
+  },
   service: "",
   source: true,
   spill: 512,

--- a/packages/language/src/preprocessor/compiler-options/translator.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator.ts
@@ -1458,21 +1458,17 @@ translator.rule(
     ensureArguments(option, 1, 1);
     const value = option.values[0];
     ensureType(value, "plain");
-    if (value.value === "SEPARATE") {
-      options.goNumber = {
-        separate: true,
-      };
-    } else if (value.value === "NOSEPARATE") {
-      options.goNumber = {
-        separate: false,
-      };
-    } else {
-      throw TranslationError.fromCode(
-        value.token,
-        CompilerOptionsCodes.GoNumber.InvalidParameter,
-        value.value,
-      );
+    if (!options.goNumber) {
+      // TODO ssmifi: Replace with ensureToBeDefined after merging #381.
+      options.goNumber = false;
     }
+    options.goNumber = {
+      separate: ensureFlag(
+        value,
+        CompilerOptionsCodes.GoNumber.InvalidParameter,
+        ["SEPARATE", "NOSEPARATE"],
+      ),
+    };
   },
   ["NOGONUMBER", "NGN"],
   (option, options) => {
@@ -1553,27 +1549,41 @@ translator.rule(
 
 /** {@link CompilerOptions.incAfter} */
 translator.rule(["INCAFTER"], (option, options) => {
-  ensureArguments(option, 1, 1);
-  const value = option.values[0];
-  if (value.kind === SyntaxKind.CompilerOption) {
-    if (value.name.toUpperCase() !== "PROCESS") {
-      throw new TranslationError(
-        value.token,
-        `Expected "PROCESS", but received '${value.name}'.`,
-        1,
-      );
-    }
-    ensureArguments(value, 1, 1);
-    const processValue = value.values[0];
-    ensureType(processValue, "plain");
-    options.incAfter = {
-      process: processValue.value,
-      token: processValue.token,
-    };
-  } else {
-    ensureType(value, "plain");
-    options.incAfter = undefined;
+  ensureArguments(option, 0, 1);
+  // INCAFTER; and INCAFTER(); are accepted by the mainframe and treated as INCAFTER(PROCESS("")).
+  if (option.values.length === 0) {
+    options.incAfter = { process: "", token: option.token };
+    return;
   }
+  const value = option.values[0];
+  if (value.kind === SyntaxKind.CompilerOptionText) {
+    if (value.value.length === 0) {
+      options.incAfter = { process: "", token: option.token };
+      return;
+    }
+    throw TranslationError.fromCode(
+      value.token,
+      CompilerOptionsCodes.IncAfter.InvalidParameter,
+      value.value,
+    );
+  }
+
+  ensureType(value, "option");
+  if (value.name.toUpperCase() !== "PROCESS") {
+    throw TranslationError.fromCode(
+      value.token,
+      CompilerOptionsCodes.IncAfter.InvalidParameter,
+      value.name,
+    );
+  }
+  ensureType(value, "option");
+  ensureArguments(value, 1, 1);
+  const processValue = value.values[0];
+  ensureType(processValue, "plainNotEmpty");
+  options.incAfter = {
+    process: processValue.value,
+    token: processValue.token,
+  };
 });
 
 /** {@link CompilerOptions.incDir} */
@@ -1660,7 +1670,7 @@ translator.flag("initStatic", ["INITSTATIC"], ["NOINITSTATIC"]);
 
 /** {@link CompilerOptions.inSource} */
 translator.rule(
-  ["INSOURCE"],
+  ["INSOURCE", "IS"],
   (option, options) => {
     ensureArguments(option, 0, 1);
     options.inSource = {};
@@ -1678,7 +1688,7 @@ translator.rule(
       }
     }
   },
-  ["NOINSOURCE"],
+  ["NOINSOURCE", "NIS"],
   (option, options) => {
     ensureArguments(option, 0, 0);
     options.inSource = false;
@@ -1969,21 +1979,23 @@ translator.rule(
     ensureArguments(option, 1, 1);
     const value = option.values[0];
     ensureType(value, "string");
-    if (value.value.length !== 1) {
+    if (value.value.length === 0) {
+      // Empty string sets ' ' on the mainframe.
+      options.margini = " ";
+      return;
+    } else if (value.value.length !== 1) {
       throw TranslationError.fromCode(
         value.token,
         CompilerOptionsCodes.Margini.InvalidParameter,
         value.value,
       );
     }
-    options.margini = {
-      character: value.value,
-    };
+    options.margini = value.value;
   },
   ["NOMARGINI", "NMI"],
   (option, options) => {
     ensureArguments(option, 0, 0);
-    options.margini = false;
+    options.margini = " ";
   },
 );
 
@@ -2792,6 +2804,598 @@ translator.rule(["RTCHECK"], (option, options) => {
 });
 
 /** {@link CompilerOptions.rules} */
+translator.rule(["RULES"], (option, options) => {
+  ensureArguments(option, 1);
+  // Multiple RULES calls are accumulated.
+  if (!options.rules) {
+    options.rules = getDefaultCompilerOptions().rules;
+  }
+  for (const value of option.values) {
+    if (value.kind === SyntaxKind.CompilerOptionText) {
+      if (value.value.length === 0) {
+        throw TranslationError.fromCode(
+          value.token,
+          CompilerOptionsCodes.ExpectedPlainNotEmpty,
+        );
+      }
+      const name = value.value.toUpperCase();
+      // TODO ssmifi: Refactor non-null assertions after #388.
+      switch (name) {
+        case "IBM":
+          options.rules!.ibm = "IBM";
+          break;
+        case "ANS":
+          options.rules!.ibm = "ANS";
+          break;
+        case "BYNAME":
+          options.rules!.byName = true;
+          break;
+        case "NOBYNAME":
+          options.rules!.byName = false;
+          break;
+        case "COMPLEX":
+          options.rules!.complex = true;
+          break;
+        case "NOCOMPLEX":
+          options.rules!.complex = "ALL";
+          break;
+        case "CONTROLLED":
+          options.rules!.controlled = true;
+          break;
+        case "NOCONTROLLED":
+          options.rules!.controlled = false;
+          break;
+        case "DECSIZE":
+          options.rules!.decSize = true;
+          break;
+        case "NODECSIZE":
+          options.rules!.decSize = false;
+          break;
+        case "ELSEIF":
+          options.rules!.elseIf = true;
+          break;
+        case "NOELSEIF":
+          options.rules!.elseIf = false;
+          break;
+        case "EVENDEC":
+          options.rules!.evenDec = true;
+          break;
+        case "NOEVENDEC":
+          options.rules!.evenDec = false;
+          break;
+        case "GLOBAL":
+          options.rules!.global = true;
+          break;
+        case "NOGLOBAL":
+          options.rules!.global = "ALL";
+          break;
+        case "GLOBALDO":
+          options.rules!.globalDo = true;
+          break;
+        case "NOGLOBALDO":
+          options.rules!.globalDo = false;
+          break;
+        case "GOTO":
+          options.rules!.goto = true;
+          break;
+        case "NOGOTO":
+          options.rules!.goto = "STRICT";
+          break;
+        case "LAXBIF":
+          options.rules!.laxBIf = true;
+          break;
+        case "NOLAXBIF":
+          options.rules!.laxBIf = false;
+          break;
+        case "LAXCONV":
+          options.rules!.laxConv = true;
+          break;
+        case "NOLAXCONV":
+          options.rules!.laxConv = "ALL";
+          break;
+        case "LAXCTL":
+          options.rules!.laxCtl = true;
+          break;
+        case "NOLAXCTL":
+          options.rules!.laxCtl = false;
+          break;
+        case "LAXDCL":
+          options.rules!.laxDcl = true;
+          break;
+        case "NOLAXDCL":
+          options.rules!.laxDcl = false;
+          break;
+        case "LAXDEF":
+          options.rules!.laxDef = true;
+          break;
+        case "NOLAXDEF":
+          options.rules!.laxDef = false;
+          break;
+        case "LAXENTRY":
+          options.rules!.laxEntry = true;
+          break;
+        case "NOLAXENTRY":
+          options.rules!.laxEntry = "STRICT";
+          break;
+        case "LAXEXPORTS":
+          options.rules!.laxExports = true;
+          break;
+        case "NOLAXEXPORTS":
+          options.rules!.laxExports = false;
+          break;
+        case "LAXFIELDS":
+          options.rules!.laxFields = true;
+          break;
+        case "NOLAXFIELDS":
+          options.rules!.laxFields = false;
+          break;
+        case "LAXIF":
+          options.rules!.laxIf = true;
+          break;
+        case "NOLAXIF":
+          options.rules!.laxIf = false;
+          break;
+        case "LAXINOUT":
+          options.rules!.laxInOut = true;
+          break;
+        case "NOLAXINOUT":
+          options.rules!.laxInOut = { source: "ALL", strict: "STRICT" };
+          break;
+        case "LAXINTERFACE":
+          options.rules!.laxInterface = true;
+          break;
+        case "NOLAXINTERFACE":
+          options.rules!.laxInterface = false;
+          break;
+        case "LAXLINK":
+          options.rules!.laxLink = true;
+          break;
+        case "NOLAXLINK":
+          options.rules!.laxLink = false;
+          break;
+        case "LAXMARGINS":
+          options.rules!.laxMargins = true;
+          break;
+        case "NOLAXMARGINS":
+          options.rules!.laxMargins = "STRICT";
+          break;
+        case "LAXNESTED":
+          options.rules!.laxNested = true;
+          break;
+        case "NOLAXNESTED":
+          options.rules!.laxNested = "ALL";
+          break;
+        case "LAXOPTIONAL":
+          options.rules!.laxOptional = true;
+          break;
+        case "NOLAXOPTIONAL":
+          options.rules!.laxOptional = "ALL";
+          break;
+        case "LAXPACKAGE":
+          options.rules!.laxPackage = true;
+          break;
+        case "NOLAXPACKAGE":
+          options.rules!.laxPackage = false;
+          break;
+        case "LAXPARMS":
+          options.rules!.laxParms = true;
+          break;
+        case "NOLAXPARMS":
+          options.rules!.laxParms = "ALL";
+          break;
+        case "LAXPUNC":
+          options.rules!.laxPunc = true;
+          break;
+        case "NOLAXPUNC":
+          options.rules!.laxPunc = false;
+          break;
+        case "LAXQUAL":
+          options.rules!.laxQual = true;
+          break;
+        case "NOLAXQUAL":
+          options.rules!.laxQual = { source: "ALL", strict: "LOOSE" };
+          break;
+        case "LAXRETURN":
+          options.rules!.laxReturn = true;
+          break;
+        case "NOLAXRETURN":
+          options.rules!.laxReturn = false;
+          break;
+        case "LAXSCALE":
+          options.rules!.laxScale = true;
+          break;
+        case "NOLAXSCALE":
+          options.rules!.laxScale = { source: "ALL", strict: "LOOSE" };
+          break;
+        case "LAXSEMI":
+          options.rules!.laxSemi = true;
+          break;
+        case "NOLAXSEMI":
+          options.rules!.laxSemi = false;
+          break;
+        case "LAXSTG":
+          options.rules!.laxStg = true;
+          break;
+        case "NOLAXSTG":
+          options.rules!.laxStg = false;
+          break;
+        case "LAXSTMT":
+          options.rules!.laxStmt = true;
+          break;
+        case "NOLAXSTMT":
+          options.rules!.laxStmt = "ALL";
+          break;
+        case "LAXSTRZ":
+          options.rules!.laxStrz = true;
+          break;
+        case "NOLAXSTRZ":
+          options.rules!.laxStrz = false;
+          break;
+        case "MULTICLOSE":
+          options.rules!.multiClose = true;
+          break;
+        case "NOMULTICLOSE":
+          options.rules!.multiClose = false;
+          break;
+        case "MULTIENTRY":
+          options.rules!.multiEntry = true;
+          break;
+        case "NOMULTIENTRY":
+          options.rules!.multiEntry = "ALL";
+          break;
+        case "MULTIEXIT":
+          options.rules!.multiExit = true;
+          break;
+        case "NOMULTIEXIT":
+          options.rules!.multiExit = "ALL";
+          break;
+        case "MULTISEMI":
+          options.rules!.multiSemi = true;
+          break;
+        case "NOMULTISEMI":
+          options.rules!.multiSemi = "ALL";
+          break;
+        case "PADDING":
+          options.rules!.padding = true;
+          break;
+        case "NOPADDING":
+          options.rules!.padding = { source: "ALL", strict: "LOOSE" };
+          break;
+        case "PROCENDONLY":
+          options.rules!.procEndOnly = true;
+          break;
+        case "NOPROCENDONLY":
+          options.rules!.procEndOnly = "ALL";
+          break;
+        case "RECURSIVE":
+          options.rules!.recursive = true;
+          break;
+        case "NORECURSIVE":
+          options.rules!.recursive = false;
+          break;
+        case "SELFASSIGN":
+          options.rules!.selfAssign = true;
+          break;
+        case "NOSELFASSIGN":
+          options.rules!.selfAssign = false;
+          break;
+        case "UNREF":
+          options.rules!.unref = true;
+          break;
+        case "NOUNREF":
+          options.rules!.unref = "ALL";
+          break;
+        case "UNREFBASED":
+          options.rules!.unrefBased = true;
+          break;
+        case "NOUNREFBASED":
+          options.rules!.unrefBased = "ALL";
+          break;
+        case "UNREFCTL":
+          options.rules!.unrefCtl = true;
+          break;
+        case "NOUNREFCTL":
+          options.rules!.unrefCtl = "ALL";
+          break;
+        case "UNREFDEFINED":
+          options.rules!.unrefDefined = true;
+          break;
+        case "NOUNREFDEFINED":
+          options.rules!.unrefDefined = "ALL";
+          break;
+        case "UNREFENTRY":
+          options.rules!.unrefEntry = true;
+          break;
+        case "NOUNREFENTRY":
+          options.rules!.unrefEntry = "ALL";
+          break;
+        case "UNREFFILE":
+          options.rules!.unrefFile = true;
+          break;
+        case "NOUNREFFILE":
+          options.rules!.unrefFile = "ALL";
+          break;
+        case "UNREFSTATIC":
+          options.rules!.unrefStatic = true;
+          break;
+        case "NOUNREFSTATIC":
+          options.rules!.unrefStatic = "ALL";
+          break;
+        case "UNREFVALUE":
+          options.rules!.unrefValue = true;
+          break;
+        case "NOUNREFVALUE":
+          options.rules!.unrefValue = "ALL";
+          break;
+        case "UNSET":
+          options.rules!.unset = true;
+          break;
+        case "NOUNSET":
+          options.rules!.unset = false;
+          break;
+        case "YY":
+          options.rules!.yy = true;
+          break;
+        case "NOYY":
+          options.rules!.yy = false;
+          break;
+        default:
+          throw TranslationError.fromCode(
+            value.token,
+            CompilerOptionsCodes.Rules.InvalidParameter,
+            name,
+          );
+      }
+    } else if (value.kind === SyntaxKind.CompilerOption) {
+      const subOption = value.values[0];
+      ensureType(subOption, "plainNotEmpty");
+      const name = value.name.toUpperCase();
+      switch (name) {
+        case "NOCOMPLEX":
+          options.rules!.complex = ensureArgument(
+            subOption,
+            CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
+            ["ALL", "SOURCE"],
+          );
+          break;
+        case "NOGLOBAL":
+          options.rules!.global = ensureArgument(
+            subOption,
+            CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
+            ["ALL", "SOURCE"],
+          );
+          break;
+        case "NOGOTO":
+          options.rules!.goto = ensureArgument(
+            subOption,
+            CompilerOptionsCodes.Rules.InvalidGotoParameter,
+            ["STRICT", "LOOSE", "LOOSEFORWARD"],
+          );
+          break;
+        case "NOLAXCONV":
+          options.rules!.laxConv = ensureArgument(
+            subOption,
+            CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
+            ["ALL", "SOURCE"],
+          );
+          break;
+        case "NOLAXENTRY":
+          options.rules!.laxEntry = ensureArgument(
+            subOption,
+            CompilerOptionsCodes.Rules.InvalidLaxEntryParameter,
+            ["STRICT", "LOOSE"],
+          );
+          break;
+        case "NOLAXINOUT":
+          options.rules!.laxInOut = { source: "ALL", strict: "STRICT" };
+          for (const sub of value.values) {
+            ensureType(sub, "plainNotEmpty");
+            const subName = sub.value.toUpperCase();
+            if (["ALL", "SOURCE"].includes(subName)) {
+              options.rules!.laxInOut.source = ensureArgument(
+                sub,
+                CompilerOptionsCodes.Rules.InvalidLaxInOutParameter,
+                ["ALL", "SOURCE"],
+              );
+            } else {
+              options.rules!.laxInOut.strict = ensureArgument(
+                sub,
+                CompilerOptionsCodes.Rules.InvalidLaxInOutParameter,
+                ["STRICT", "LOOSE"],
+              );
+            }
+          }
+          break;
+        case "NOLAXMARGINS":
+          options.rules!.laxMargins = ensureArgument(
+            subOption,
+            CompilerOptionsCodes.Rules.InvalidLaxMarginsParameter,
+            ["STRICT", "XNUMERIC"],
+          );
+          break;
+        case "NOLAXNESTED":
+          options.rules!.laxNested = ensureArgument(
+            subOption,
+            CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
+            ["ALL", "SOURCE"],
+          );
+          break;
+        case "NOLAXOPTIONAL":
+          options.rules!.laxOptional = ensureArgument(
+            subOption,
+            CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
+            ["ALL", "SOURCE"],
+          );
+          break;
+        case "NOLAXPARMS":
+          options.rules!.laxParms = ensureArgument(
+            subOption,
+            CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
+            ["ALL", "SOURCE"],
+          );
+          break;
+        case "NOLAXQUAL":
+          options.rules!.laxQual = { source: "ALL", strict: "LOOSE" };
+          for (const sub of value.values) {
+            ensureType(sub, "plainNotEmpty");
+            const subName = sub.value.toUpperCase();
+            if (["ALL", "FORCE"].includes(subName)) {
+              options.rules!.laxQual.source = ensureArgument(
+                sub,
+                CompilerOptionsCodes.Rules.InvalidLaxQualParameter,
+                ["ALL", "FORCE"],
+              );
+            } else {
+              options.rules!.laxQual.strict = ensureArgument(
+                sub,
+                CompilerOptionsCodes.Rules.InvalidLaxQualParameter,
+                ["STRICT", "LOOSE", "FULL"],
+              );
+            }
+          }
+          break;
+        case "NOLAXSCALE":
+          options.rules!.laxScale = { source: "ALL", strict: "STRICT" };
+          for (const sub of value.values) {
+            ensureType(sub, "plainNotEmpty");
+            const subName = sub.value.toUpperCase();
+            if (["ALL", "SOURCE"].includes(subName)) {
+              options.rules!.laxScale.source = ensureArgument(
+                sub,
+                CompilerOptionsCodes.Rules.InvalidLaxScaleParameter,
+                ["ALL", "SOURCE"],
+              );
+            } else {
+              options.rules!.laxScale.strict = ensureArgument(
+                sub,
+                CompilerOptionsCodes.Rules.InvalidLaxScaleParameter,
+                ["STRICT", "LOOSE"],
+              );
+            }
+          }
+          break;
+        case "NOLAXSTMT":
+          options.rules!.laxStmt = ensureArgument(
+            subOption,
+            CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
+            ["ALL", "SOURCE"],
+          );
+          break;
+        case "NOMULTIENTRY":
+          options.rules!.multiEntry = ensureArgument(
+            subOption,
+            CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
+            ["ALL", "SOURCE"],
+          );
+          break;
+        case "NOMULTIEXIT":
+          options.rules!.multiExit = ensureArgument(
+            subOption,
+            CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
+            ["ALL", "SOURCE"],
+          );
+          break;
+        case "NOMULTISEMI":
+          options.rules!.multiSemi = ensureArgument(
+            subOption,
+            CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
+            ["ALL", "SOURCE"],
+          );
+          break;
+        case "NOPADDING":
+          options.rules!.padding = { source: "ALL", strict: "LOOSE" };
+          for (const sub of value.values) {
+            ensureType(sub, "plainNotEmpty");
+            const subName = sub.value.toUpperCase();
+            if (["ALL", "SOURCE"].includes(subName)) {
+              options.rules!.padding.source = ensureArgument(
+                sub,
+                CompilerOptionsCodes.Rules.InvalidPaddingParameter,
+                ["ALL", "SOURCE"],
+              );
+            } else {
+              options.rules!.padding.strict = ensureArgument(
+                sub,
+                CompilerOptionsCodes.Rules.InvalidPaddingParameter,
+                ["STRICT", "LOOSE"],
+              );
+            }
+          }
+          break;
+        case "NOPROCENDONLY":
+          options.rules!.procEndOnly = ensureArgument(
+            subOption,
+            CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
+            ["ALL", "SOURCE"],
+          );
+          break;
+        case "NOUNREF":
+          options.rules!.unref = ensureArgument(
+            subOption,
+            CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
+            ["ALL", "SOURCE"],
+          );
+          break;
+        case "NOUNREFBASED":
+          options.rules!.unrefBased = ensureArgument(
+            subOption,
+            CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
+            ["ALL", "SOURCE"],
+          );
+          break;
+        case "NOUNREFCTL":
+          options.rules!.unrefCtl = ensureArgument(
+            subOption,
+            CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
+            ["ALL", "SOURCE"],
+          );
+          break;
+        case "NOUNREFDEFINED":
+          options.rules!.unrefDefined = ensureArgument(
+            subOption,
+            CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
+            ["ALL", "SOURCE"],
+          );
+          break;
+        case "NOUNREFENTRY":
+          options.rules!.unrefEntry = ensureArgument(
+            subOption,
+            CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
+            ["ALL", "SOURCE"],
+          );
+          break;
+        case "NOUNREFFILE":
+          options.rules!.unrefFile = ensureArgument(
+            subOption,
+            CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
+            ["ALL", "SOURCE"],
+          );
+          break;
+        case "NOUNREFSTATIC":
+          options.rules!.unrefStatic = ensureArgument(
+            subOption,
+            CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
+            ["ALL", "SOURCE"],
+          );
+          break;
+        case "NOUNREFVALUE":
+          options.rules!.unrefValue = ensureArgument(
+            subOption,
+            CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
+            ["ALL", "SOURCE"],
+          );
+          break;
+        default:
+          throw TranslationError.fromCode(
+            value.token,
+            CompilerOptionsCodes.Rules.InvalidParameter,
+            name,
+          );
+      }
+    }
+  }
+});
+
 /** {@link CompilerOptions.semantic} */
 translator.rule(
   ["SEMANTIC", "SEM"],

--- a/packages/language/test/fourslash/preprocessor/compiler-options/gonumber.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/gonumber.ts
@@ -19,7 +19,7 @@
 ////*PROCESS <|4:NOGONUMBER|>;
 ////*PROCESS <|5:GN|>(NOSEPARATE);
 ////*PROCESS <|6:NGN|>;
-////*PROCESS <|7:GN|>(SEPARATE);
+////*PROCESS <|7:GN|>(<|8:separate|>);
 
 verify.expectDiagnosticsAt(1, {
   message: code.CompilerOptions.GoNumber.InvalidParameter.message("Nxx"),
@@ -42,6 +42,7 @@ verify.expectDiagnosticsAt(6, {
 verify.expectDiagnosticsAt(7, {
   message: code.CompilerOptions.DupeOptionIssue.message("GN"),
 });
+verify.noDiagnostics(8);
 verify.expectCompilerOptions({
   goNumber: {
     separate: true,

--- a/packages/language/test/fourslash/preprocessor/compiler-options/incafter.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/incafter.ts
@@ -1,0 +1,43 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:INCAFTER|>;
+////*PROCESS <|2:INCAFTER|>(<|3:)|>;
+////*PROCESS <|4:INCAFTER|>(<|5:lib|>);
+////*PROCESS <|6:INCAFTER|>(<|7:process|>);
+////*PROCESS <|8:INCAFTER|>(process(<|9:)|>);
+////*PROCESS <|10:INCAFTER|>(<|11:macro|>());
+////*PROCESS <|12:INCAFTER|>(PROCESS(lib));
+
+verify.noDiagnostics([1, 3]);
+verify.expectDiagnosticsAt([2, 4, 6, 8, 10, 12], {
+  message: code.CompilerOptions.DupeOptionIssue.message("INCAFTER"),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.IncAfter.InvalidParameter.message("lib"),
+});
+verify.expectDiagnosticsAt(7, {
+  message: code.CompilerOptions.IncAfter.InvalidParameter.message("process"),
+});
+verify.expectDiagnosticsAt(9, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(11, {
+  message: code.CompilerOptions.IncAfter.InvalidParameter.message("macro"),
+});
+verify.expectCompilerOptions({
+  incAfter: {
+    process: "lib",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/insource.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/insource.ts
@@ -17,6 +17,8 @@
 ////*PROCESS <|2:INSOURCE|>(<|3:INVALID|>);
 ////*PROCESS <|4:INSOURCE|>(<|5:'FULL'|>);
 ////*PROCESS <|6:INSOURCE|>(FULL);
+////*PROCESS <|8:NIS|>;
+////*PROCESS <|10:IS|>(FULL);
 
 verify.expectDiagnosticsAt([1, 2, 4, 6], {
   message: code.CompilerOptions.MutexOptionIssue.message("INSOURCE"),
@@ -26,6 +28,12 @@ verify.expectDiagnosticsAt(3, {
 });
 verify.expectDiagnosticsAt(5, {
   message: code.CompilerOptions.ExpectedPlain.message(),
+});
+verify.expectDiagnosticsAt(8, {
+  message: code.CompilerOptions.DupeOptionIssue.message("NIS"),
+});
+verify.expectDiagnosticsAt(10, {
+  message: code.CompilerOptions.MutexOptionIssue.message("IS"),
 });
 verify.expectCompilerOptions({
   inSource: {

--- a/packages/language/test/fourslash/preprocessor/compiler-options/margini.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/margini.ts
@@ -17,8 +17,9 @@
 ////*PROCESS <|2:MARGINI|>(<|3:)|>;
 ////*PROCESS <|4:MARGINI|>(<|5:INVALID|>);
 ////*PROCESS <|6:MARGINI|>(<|7:"INVALID"|>);
-////*PROCESS <|8:NMI|>;
-////*PROCESS <|9:MI|>('c');
+////*PROCESS <|8:MARGINI|>(<|9:''|>);
+////*PROCESS <|10:NMI|>;
+////*PROCESS <|12:MI|>('c');
 
 verify.expectDiagnosticsAt(1, {
   message: code.CompilerOptions.DupeOptionIssue.message("NOMARGINI"),
@@ -26,7 +27,7 @@ verify.expectDiagnosticsAt(1, {
 verify.expectDiagnosticsAt(1, {
   message: code.CompilerOptions.InvalidParameterCount.message(1, 0, 0),
 });
-verify.expectDiagnosticsAt([2, 4, 6], {
+verify.expectDiagnosticsAt([2, 4, 6, 8], {
   message: code.CompilerOptions.MutexOptionIssue.message("MARGINI"),
 });
 verify.expectDiagnosticsAt([3, 5], {
@@ -35,14 +36,13 @@ verify.expectDiagnosticsAt([3, 5], {
 verify.expectDiagnosticsAt(7, {
   message: code.CompilerOptions.Margini.InvalidParameter.message("INVALID"),
 });
-verify.expectDiagnosticsAt(8, {
+verify.expectDiagnosticsAt(10, {
   message: code.CompilerOptions.DupeOptionIssue.message("NMI"),
 });
-verify.expectDiagnosticsAt(9, {
+verify.expectDiagnosticsAt(12, {
   message: code.CompilerOptions.MutexOptionIssue.message("MI"),
 });
+verify.noDiagnostics(9);
 verify.expectCompilerOptions({
-  margini: {
-    character: "c",
-  },
+  margini: "c",
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/margins/margin-values-invalid.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/margins/margin-values-invalid.ts
@@ -36,6 +36,5 @@ verify.expectCompilerOptions({
     // Fallback to defaults.
     m: 2,
     n: 72,
-    c: undefined,
   },
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/margins/margin-values.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/margins/margin-values.ts
@@ -25,6 +25,5 @@ verify.expectCompilerOptions({
   margins: {
     m: 2,
     n: 82,
-    c: undefined,
   },
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-complex.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-complex.ts
@@ -1,0 +1,37 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS RULES(COMPLEX(<|1:)|>);
+////*PROCESS RULES(<|2:COMPLEX|>);
+////*PROCESS RULES(<|3:NOCOMPLEX|>);
+////*PROCESS RULES(NOCOMPLEX(<|4:)|>);
+////*PROCESS RULES(NOCOMPLEX(<|5:INVALID|>));
+////*PROCESS RULES(NOCOMPLEX(<|6:SOURCE|>));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.noDiagnostics([2, 3, 6]);
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message:
+    code.CompilerOptions.Rules.ExpectAllSourceParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  rules: {
+    complex: "SOURCE",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-global.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-global.ts
@@ -1,0 +1,37 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS RULES(GLOBAL(<|1:)|>);
+////*PROCESS RULES(<|2:GLOBAL|>);
+////*PROCESS RULES(<|3:NOGLOBAL|>);
+////*PROCESS RULES(NOGLOBAL(<|4:)|>);
+////*PROCESS RULES(NOGLOBAL(<|5:INVALID|>));
+////*PROCESS RULES(NOGLOBAL(<|6:SOURCE|>));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.noDiagnostics([2, 3, 6]);
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message:
+    code.CompilerOptions.Rules.ExpectAllSourceParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  rules: {
+    global: "SOURCE",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-goto.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-goto.ts
@@ -1,0 +1,36 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS RULES(GOTO(<|1:)|>);
+////*PROCESS RULES(<|2:GOTO|>);
+////*PROCESS RULES(<|3:NOGOTO|>);
+////*PROCESS RULES(NOGOTO(<|4:)|>);
+////*PROCESS RULES(NOGOTO(<|5:INVALID|>));
+////*PROCESS RULES(NOGOTO(<|6:LOOSE|>));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.noDiagnostics([2, 3, 6]);
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.Rules.InvalidGotoParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  rules: {
+    goto: "LOOSE",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-laxconv.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-laxconv.ts
@@ -1,0 +1,37 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS RULES(LAXCONV(<|1:)|>);
+////*PROCESS RULES(<|2:LAXCONV|>);
+////*PROCESS RULES(<|3:NOLAXCONV|>);
+////*PROCESS RULES(NOLAXCONV(<|4:)|>);
+////*PROCESS RULES(NOLAXCONV(<|5:INVALID|>));
+////*PROCESS RULES(NOLAXCONV(<|6:SOURCE|>));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.noDiagnostics([2, 3, 6]);
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message:
+    code.CompilerOptions.Rules.ExpectAllSourceParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  rules: {
+    laxConv: "SOURCE",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-laxentry.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-laxentry.ts
@@ -1,0 +1,37 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS RULES(LAXENTRY(<|1:)|>);
+////*PROCESS RULES(<|2:LAXENTRY|>);
+////*PROCESS RULES(<|3:NOLAXENTRY|>);
+////*PROCESS RULES(NOLAXENTRY(<|4:)|>);
+////*PROCESS RULES(NOLAXENTRY(<|5:INVALID|>));
+////*PROCESS RULES(NOLAXENTRY(<|6:LOOSE|>));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.noDiagnostics([2, 3, 6]);
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message:
+    code.CompilerOptions.Rules.InvalidLaxEntryParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  rules: {
+    laxEntry: "LOOSE",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-laxinout.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-laxinout.ts
@@ -1,0 +1,40 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS RULES(LAXINOUT(<|1:)|>);
+////*PROCESS RULES(<|2:LAXINOUT|>);
+////*PROCESS RULES(<|3:NOLAXINOUT|>);
+////*PROCESS RULES(NOLAXINOUT(<|4:)|>);
+////*PROCESS RULES(NOLAXINOUT(<|5:INVALID|>));
+////*PROCESS RULES(NOLAXINOUT(ALL LOOSE STRICT <|6:SOURCE|>));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.noDiagnostics([2, 3, 6]);
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message:
+    code.CompilerOptions.Rules.InvalidLaxInOutParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  rules: {
+    laxInOut: {
+      source: "SOURCE",
+      strict: "STRICT",
+    },
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-laxmargins.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-laxmargins.ts
@@ -1,0 +1,37 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS RULES(LAXMARGINS(<|1:)|>);
+////*PROCESS RULES(<|2:LAXMARGINS|>);
+////*PROCESS RULES(<|3:NOLAXMARGINS|>);
+////*PROCESS RULES(NOLAXMARGINS(<|4:)|>);
+////*PROCESS RULES(NOLAXMARGINS(<|5:INVALID|>));
+////*PROCESS RULES(NOLAXMARGINS(<|6:XNUMERIC|>));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.noDiagnostics([2, 3, 6]);
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message:
+    code.CompilerOptions.Rules.InvalidLaxMarginsParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  rules: {
+    laxMargins: "XNUMERIC",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-laxnested.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-laxnested.ts
@@ -1,0 +1,37 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS RULES(LAXNESTED(<|1:)|>);
+////*PROCESS RULES(<|2:LAXNESTED|>);
+////*PROCESS RULES(<|3:NOLAXNESTED|>);
+////*PROCESS RULES(NOLAXNESTED(<|4:)|>);
+////*PROCESS RULES(NOLAXNESTED(<|5:INVALID|>));
+////*PROCESS RULES(NOLAXNESTED(<|6:SOURCE|>));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.noDiagnostics([2, 3, 6]);
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message:
+    code.CompilerOptions.Rules.ExpectAllSourceParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  rules: {
+    laxNested: "SOURCE",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-laxoptional.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-laxoptional.ts
@@ -1,0 +1,37 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS RULES(LAXOPTIONAL(<|1:)|>);
+////*PROCESS RULES(<|2:LAXOPTIONAL|>);
+////*PROCESS RULES(<|3:NOLAXOPTIONAL|>);
+////*PROCESS RULES(NOLAXOPTIONAL(<|4:)|>);
+////*PROCESS RULES(NOLAXOPTIONAL(<|5:INVALID|>));
+////*PROCESS RULES(NOLAXOPTIONAL(<|6:SOURCE|>));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.noDiagnostics([2, 3, 6]);
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message:
+    code.CompilerOptions.Rules.ExpectAllSourceParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  rules: {
+    laxOptional: "SOURCE",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-laxparms.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-laxparms.ts
@@ -1,0 +1,37 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS RULES(LAXPARMS(<|1:)|>);
+////*PROCESS RULES(<|2:LAXPARMS|>);
+////*PROCESS RULES(<|3:NOLAXPARMS|>);
+////*PROCESS RULES(NOLAXPARMS(<|4:)|>);
+////*PROCESS RULES(NOLAXPARMS(<|5:INVALID|>));
+////*PROCESS RULES(NOLAXPARMS(<|6:SOURCE|>));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.noDiagnostics([2, 3, 6]);
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message:
+    code.CompilerOptions.Rules.ExpectAllSourceParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  rules: {
+    laxParms: "SOURCE",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-laxqual.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-laxqual.ts
@@ -1,0 +1,40 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS RULES(LAXQUAL(<|1:)|>);
+////*PROCESS RULES(<|2:LAXQUAL|>);
+////*PROCESS RULES(<|3:NOLAXQUAL|>);
+////*PROCESS RULES(NOLAXQUAL(<|4:)|>);
+////*PROCESS RULES(NOLAXQUAL(<|5:INVALID|>));
+////*PROCESS RULES(NOLAXQUAL(ALL LOOSE FULL STRICT <|6:FORCE|>));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.noDiagnostics([2, 3, 6]);
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message:
+    code.CompilerOptions.Rules.InvalidLaxQualParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  rules: {
+    laxQual: {
+      source: "FORCE",
+      strict: "STRICT",
+    },
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-laxscale.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-laxscale.ts
@@ -1,0 +1,40 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS RULES(LAXSCALE(<|1:)|>);
+////*PROCESS RULES(<|2:LAXSCALE|>);
+////*PROCESS RULES(<|3:NOLAXSCALE|>);
+////*PROCESS RULES(NOLAXSCALE(<|4:)|>);
+////*PROCESS RULES(NOLAXSCALE(<|5:INVALID|>));
+////*PROCESS RULES(NOLAXSCALE(ALL LOOSE STRICT <|6:SOURCE|>));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.noDiagnostics([2, 3, 6]);
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message:
+    code.CompilerOptions.Rules.InvalidLaxScaleParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  rules: {
+    laxScale: {
+      source: "SOURCE",
+      strict: "STRICT",
+    },
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-laxstmt.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-laxstmt.ts
@@ -1,0 +1,37 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS RULES(LAXSTMT(<|1:)|>);
+////*PROCESS RULES(<|2:LAXSTMT|>);
+////*PROCESS RULES(<|3:NOLAXSTMT|>);
+////*PROCESS RULES(NOLAXSTMT(<|4:)|>);
+////*PROCESS RULES(NOLAXSTMT(<|5:INVALID|>));
+////*PROCESS RULES(NOLAXSTMT(<|6:SOURCE|>));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.noDiagnostics([2, 3, 6]);
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message:
+    code.CompilerOptions.Rules.ExpectAllSourceParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  rules: {
+    laxStmt: "SOURCE",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-multientry.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-multientry.ts
@@ -1,0 +1,37 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS RULES(MULTIENTRY(<|1:)|>);
+////*PROCESS RULES(<|2:MULTIENTRY|>);
+////*PROCESS RULES(<|3:NOMULTIENTRY|>);
+////*PROCESS RULES(NOMULTIENTRY(<|4:)|>);
+////*PROCESS RULES(NOMULTIENTRY(<|5:INVALID|>));
+////*PROCESS RULES(NOMULTIENTRY(<|6:SOURCE|>));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.noDiagnostics([2, 3, 6]);
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message:
+    code.CompilerOptions.Rules.ExpectAllSourceParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  rules: {
+    multiEntry: "SOURCE",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-multiexit.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-multiexit.ts
@@ -1,0 +1,37 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS RULES(MULTIEXIT(<|1:)|>);
+////*PROCESS RULES(<|2:MULTIEXIT|>);
+////*PROCESS RULES(<|3:NOMULTIEXIT|>);
+////*PROCESS RULES(NOMULTIEXIT(<|4:)|>);
+////*PROCESS RULES(NOMULTIEXIT(<|5:INVALID|>));
+////*PROCESS RULES(NOMULTIEXIT(<|6:SOURCE|>));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.noDiagnostics([2, 3, 6]);
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message:
+    code.CompilerOptions.Rules.ExpectAllSourceParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  rules: {
+    multiExit: "SOURCE",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-multisemi.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-multisemi.ts
@@ -1,0 +1,37 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS RULES(MULTISEMI(<|1:)|>);
+////*PROCESS RULES(<|2:MULTISEMI|>);
+////*PROCESS RULES(<|3:NOMULTISEMI|>);
+////*PROCESS RULES(NOMULTISEMI(<|4:)|>);
+////*PROCESS RULES(NOMULTISEMI(<|5:INVALID|>));
+////*PROCESS RULES(NOMULTISEMI(<|6:SOURCE|>));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.noDiagnostics([2, 3, 6]);
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message:
+    code.CompilerOptions.Rules.ExpectAllSourceParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  rules: {
+    multiSemi: "SOURCE",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-padding.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-padding.ts
@@ -1,0 +1,40 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS RULES(PADDING(<|1:)|>);
+////*PROCESS RULES(<|2:PADDING|>);
+////*PROCESS RULES(<|3:NOPADDING|>);
+////*PROCESS RULES(NOPADDING(<|4:)|>);
+////*PROCESS RULES(NOPADDING(<|5:INVALID|>));
+////*PROCESS RULES(NOPADDING(ALL LOOSE STRICT <|6:SOURCE|>));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.noDiagnostics([2, 3, 6]);
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message:
+    code.CompilerOptions.Rules.InvalidPaddingParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  rules: {
+    padding: {
+      source: "SOURCE",
+      strict: "STRICT",
+    },
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-procendonly.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-procendonly.ts
@@ -1,0 +1,37 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS RULES(PROCENDONLY(<|1:)|>);
+////*PROCESS RULES(<|2:PROCENDONLY|>);
+////*PROCESS RULES(<|3:NOPROCENDONLY|>);
+////*PROCESS RULES(NOPROCENDONLY(<|4:)|>);
+////*PROCESS RULES(NOPROCENDONLY(<|5:INVALID|>));
+////*PROCESS RULES(NOPROCENDONLY(<|6:SOURCE|>));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.noDiagnostics([2, 3, 6]);
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message:
+    code.CompilerOptions.Rules.ExpectAllSourceParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  rules: {
+    procEndOnly: "SOURCE",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-unref.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-unref.ts
@@ -1,0 +1,37 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS RULES(UNREF(<|1:)|>);
+////*PROCESS RULES(<|2:UNREF|>);
+////*PROCESS RULES(<|3:NOUNREF|>);
+////*PROCESS RULES(NOUNREF(<|4:)|>);
+////*PROCESS RULES(NOUNREF(<|5:INVALID|>));
+////*PROCESS RULES(NOUNREF(<|6:SOURCE|>));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.noDiagnostics([2, 3, 6]);
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message:
+    code.CompilerOptions.Rules.ExpectAllSourceParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  rules: {
+    unref: "SOURCE",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-unrefbased.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-unrefbased.ts
@@ -1,0 +1,37 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS RULES(UNREFBASED(<|1:)|>);
+////*PROCESS RULES(<|2:UNREFBASED|>);
+////*PROCESS RULES(<|3:NOUNREFBASED|>);
+////*PROCESS RULES(NOUNREFBASED(<|4:)|>);
+////*PROCESS RULES(NOUNREFBASED(<|5:INVALID|>));
+////*PROCESS RULES(NOUNREFBASED(<|6:SOURCE|>));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.noDiagnostics([2, 3, 6]);
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message:
+    code.CompilerOptions.Rules.ExpectAllSourceParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  rules: {
+    unrefBased: "SOURCE",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-unrefctl.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-unrefctl.ts
@@ -1,0 +1,37 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS RULES(UNREFCTL(<|1:)|>);
+////*PROCESS RULES(<|2:UNREFCTL|>);
+////*PROCESS RULES(<|3:NOUNREFCTL|>);
+////*PROCESS RULES(NOUNREFCTL(<|4:)|>);
+////*PROCESS RULES(NOUNREFCTL(<|5:INVALID|>));
+////*PROCESS RULES(NOUNREFCTL(<|6:SOURCE|>));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.noDiagnostics([2, 3, 6]);
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message:
+    code.CompilerOptions.Rules.ExpectAllSourceParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  rules: {
+    unrefCtl: "SOURCE",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-unrefdefined.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-unrefdefined.ts
@@ -1,0 +1,37 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS RULES(UNREFDEFINED(<|1:)|>);
+////*PROCESS RULES(<|2:UNREFDEFINED|>);
+////*PROCESS RULES(<|3:NOUNREFDEFINED|>);
+////*PROCESS RULES(NOUNREFDEFINED(<|4:)|>);
+////*PROCESS RULES(NOUNREFDEFINED(<|5:INVALID|>));
+////*PROCESS RULES(NOUNREFDEFINED(<|6:SOURCE|>));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.noDiagnostics([2, 3, 6]);
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message:
+    code.CompilerOptions.Rules.ExpectAllSourceParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  rules: {
+    unrefDefined: "SOURCE",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-unrefentry.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-unrefentry.ts
@@ -1,0 +1,37 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS RULES(UNREFENTRY(<|1:)|>);
+////*PROCESS RULES(<|2:UNREFENTRY|>);
+////*PROCESS RULES(<|3:NOUNREFENTRY|>);
+////*PROCESS RULES(NOUNREFENTRY(<|4:)|>);
+////*PROCESS RULES(NOUNREFENTRY(<|5:INVALID|>));
+////*PROCESS RULES(NOUNREFENTRY(<|6:SOURCE|>));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.noDiagnostics([2, 3, 6]);
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message:
+    code.CompilerOptions.Rules.ExpectAllSourceParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  rules: {
+    unrefEntry: "SOURCE",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-unreffile.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-unreffile.ts
@@ -1,0 +1,37 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS RULES(UNREFFILE(<|1:)|>);
+////*PROCESS RULES(<|2:UNREFFILE|>);
+////*PROCESS RULES(<|3:NOUNREFFILE|>);
+////*PROCESS RULES(NOUNREFFILE(<|4:)|>);
+////*PROCESS RULES(NOUNREFFILE(<|5:INVALID|>));
+////*PROCESS RULES(NOUNREFFILE(<|6:SOURCE|>));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.noDiagnostics([2, 3, 6]);
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message:
+    code.CompilerOptions.Rules.ExpectAllSourceParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  rules: {
+    unrefFile: "SOURCE",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-unrefstatic.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-unrefstatic.ts
@@ -1,0 +1,37 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS RULES(UNREFSTATIC(<|1:)|>);
+////*PROCESS RULES(<|2:UNREFSTATIC|>);
+////*PROCESS RULES(<|3:NOUNREFSTATIC|>);
+////*PROCESS RULES(NOUNREFSTATIC(<|4:)|>);
+////*PROCESS RULES(NOUNREFSTATIC(<|5:INVALID|>));
+////*PROCESS RULES(NOUNREFSTATIC(<|6:SOURCE|>));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.noDiagnostics([2, 3, 6]);
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message:
+    code.CompilerOptions.Rules.ExpectAllSourceParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  rules: {
+    unrefStatic: "SOURCE",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-unrefvalue.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules-unrefvalue.ts
@@ -1,0 +1,37 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS RULES(UNREFVALUE(<|1:)|>);
+////*PROCESS RULES(<|2:UNREFVALUE|>);
+////*PROCESS RULES(<|3:NOUNREFVALUE|>);
+////*PROCESS RULES(NOUNREFVALUE(<|4:)|>);
+////*PROCESS RULES(NOUNREFVALUE(<|5:INVALID|>));
+////*PROCESS RULES(NOUNREFVALUE(<|6:SOURCE|>));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.noDiagnostics([2, 3, 6]);
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(5, {
+  message:
+    code.CompilerOptions.Rules.ExpectAllSourceParameter.message("INVALID"),
+});
+verify.expectCompilerOptions({
+  rules: {
+    unrefValue: "SOURCE",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules/rules.ts
@@ -1,0 +1,92 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|0:RULES|>;
+////*PROCESS <|d1:RULES|>(<|1:)|>;
+////*PROCESS <|d2:RULES|>(<|2:INVALID|>);
+////*PROCESS <|d3:RULES|>(IBM, <|3:BYNAME|>);
+////*PROCESS <|d4:RULES|>(ANS <|4:NOBYNAME|>);
+////*PROCESS <|d5:RULES|>(NOCONTROLLED);
+////*PROCESS <|d6:RULES|>(DECSIZE);
+////*PROCESS <|d7:RULES|>(NOELSEIF);
+////*PROCESS <|d8:RULES|>(NOEVENDEC);
+////*PROCESS <|d9:RULES|>(NOGLOBALDO);
+////*PROCESS <|d10:RULES|>(LAXBIF);
+////*PROCESS <|d11:RULES|>(LAXCTL);
+////*PROCESS <|d12:RULES|>(LAXDCL);
+////*PROCESS <|d13:RULES|>(LAXDEF);
+////*PROCESS <|d14:RULES|>(NOLAXEXPORTS);
+////*PROCESS <|d15:RULES|>(NOLAXFIELDS);
+////*PROCESS <|d16:RULES|>(LAXIF);
+////*PROCESS <|d17:RULES|>(NOLAXINTERFACE);
+////*PROCESS <|d18:RULES|>(NOLAXLINK);
+////*PROCESS <|d19:RULES|>(NOLAXPACKAGE);
+////*PROCESS <|d20:RULES|>(NOLAXPUNC);
+////*PROCESS <|d21:RULES|>(NOLAXRETURN);
+////*PROCESS <|d22:RULES|>(NOLAXSEMI);
+////*PROCESS <|d23:RULES|>(NOLAXSTG);
+////*PROCESS <|d24:RULES|>(NOLAXSTRZ);
+////*PROCESS <|d25:RULES|>(MULTICLOSE);
+////*PROCESS <|d25:RULES|>(NORECURSIVE);
+////*PROCESS <|d25:RULES|>(NOSELFASSIGN);
+////*PROCESS <|d25:RULES|>(NOUNSET);
+////*PROCESS <|d25:RULES|>(NOYY);
+
+verify.expectDiagnosticsAt(0, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1),
+});
+verify.expectDiagnosticsAt(
+  Array.from({ length: 24 }, (_, i) => `d${i + 1}`),
+  {
+    message: code.CompilerOptions.DupeOptionIssue.message("RULES"),
+  },
+);
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
+});
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.Rules.InvalidParameter.message("INVALID"),
+});
+verify.noDiagnostics([3, 4]);
+verify.expectCompilerOptions({
+  rules: {
+    ibm: "ANS",
+    byName: false,
+    controlled: false,
+    decSize: true,
+    elseIf: false,
+    evenDec: false,
+    globalDo: false,
+    laxBIf: true,
+    laxCtl: true,
+    laxDcl: true,
+    laxDef: true,
+    laxExports: false,
+    laxFields: false,
+    laxIf: true,
+    laxInterface: false,
+    laxLink: false,
+    laxPackage: false,
+    laxPunc: false,
+    laxReturn: false,
+    laxSemi: false,
+    laxStg: false,
+    laxStrz: false,
+    multiClose: true,
+    recursive: false,
+    selfAssign: false,
+    unset: false,
+    yy: false,
+  },
+});

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -548,7 +548,14 @@ export class TestBuilder {
   ): TestBuilder {
     const actualOptions = this.unit.compilerOptions;
     for (const [key, value] of Object.entries(expectedOptions)) {
-      expect(actualOptions[key as keyof CompilerOptions]).toEqual(value);
+      // If the value is an object, only check for the options that are expected.
+      if (typeof value === "object" && value !== null) {
+        expect(actualOptions[key as keyof CompilerOptions]).toEqual(
+          expect.objectContaining(value),
+        );
+      } else {
+        expect(actualOptions[key as keyof CompilerOptions]).toEqual(value);
+      }
     }
     return this;
   }


### PR DESCRIPTION
Part of https://github.com/zowe/zowe-pli-language-support/issues/296
Based on https://github.com/zowe/zowe-pli-language-support/pull/378

- Implemented compiler options `rules`.
- `expectCompilerOptions` can test for partial objects.

Also improved some diagnostics that were reported in https://github.com/zowe/zowe-pli-language-support/issues/374 f: 
- Fixed `undefined` in `MAXGEN`, `MAXBRANCH`.
- Added abbreviations for `INSOURCE`.
- Improved reporting in `INCAFTER` and `GONUMBER`.
- Added test for `INCAFTER`.