### PR TITLE
Implement support for IBM2412I

### DIFF
--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -542,6 +542,7 @@ export class PliParser extends AbstractParser {
         element,
         CstNodeKind.ProcedureStatement_PROCEDURE,
       );
+      element.procToken = token;
     });
     this.OPTION2(() => {
       this.CONSUME_ASSIGN1(tokens.OpenParen, (token) => {

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -1922,6 +1922,7 @@ export interface ProcedureStatement extends AstNode {
   statements: Statement[];
   options: ProcedureOption[];
   end: EndStatement | null;
+  procToken: Token | null;
 }
 export function createProcedureStatement(): ProcedureStatement {
   return {
@@ -1933,6 +1934,7 @@ export function createProcedureStatement(): ProcedureStatement {
     statements: [],
     options: [],
     end: null,
+    procToken: null,
   };
 }
 export type ProcedureOption =

--- a/packages/language/src/validation/messages/error-severity/IBM2412I-proc-with-return-stmt-needs-returns-att.ts
+++ b/packages/language/src/validation/messages/error-severity/IBM2412I-proc-with-return-stmt-needs-returns-att.ts
@@ -1,0 +1,54 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { ValidationAcceptor } from "../../validator";
+import * as AST from "../../../syntax-tree/ast";
+import {
+  Severity,
+  tokenToRange,
+  tokenToUri,
+} from "../../../language-server/types";
+import * as PLICodes from "./../pli-codes";
+import { findFirstNodeOfKind } from "../../../syntax-tree/ast-iterator";
+
+/**
+ * IBM2412I: If a procedure contains a RETURN statement, it should have the RETURNS attribute
+ * specified on its PROCEDURE statement.
+ *
+ * @param node
+ * @param acceptor
+ * @returns
+ */
+export function IBM2412I_proc_with_return_stmt_needs_returns_att(
+  node: AST.ProcedureStatement,
+  acceptor: ValidationAcceptor,
+): void {
+  const hasReturnsAtt = node.options?.some(
+    (att) => att.kind === AST.SyntaxKind.ReturnsOption,
+  );
+  if (hasReturnsAtt) return;
+
+  const returnStmt = findFirstNodeOfKind(node, AST.SyntaxKind.ReturnStatement);
+  if (!returnStmt) return;
+
+  const token = node.procToken;
+  if (!token) return;
+
+  const errorRange = tokenToRange(token);
+  const errorUri = tokenToUri(token);
+  if (!errorRange || !errorUri) return;
+
+  acceptor(Severity.E, PLICodes.Error.IBM2412I.message, {
+    code: PLICodes.Error.IBM2412I.fullCode,
+    range: errorRange,
+    uri: errorUri,
+  });
+}

--- a/packages/language/src/validation/pli-validator.ts
+++ b/packages/language/src/validation/pli-validator.ts
@@ -30,6 +30,7 @@ import { IBM1388IE_NODESCRIPTOR_attribute_is_invalid_when_any_parameter_has_NONC
 import { IBM2615I_do_loops_execute_once } from "./messages/warning-severity/IBM2615I-do-loops-execute-once";
 import * as PLICodes from "./messages/pli-codes";
 import { ValidationAcceptor, ValidationChecks, Validator } from "./validator";
+import { IBM2412I_proc_with_return_stmt_needs_returns_att } from "./messages/error-severity/IBM2412I-proc-with-return-stmt-needs-returns-att";
 
 /**
  * A function that accepts a diagnostic for PL/I validation
@@ -49,6 +50,7 @@ export function registerPliValidationChecks(unit: CompilationUnit): Validator {
     // MemberCall: [IBM1747IS_Function_cannot_be_used_before_the_functions_descriptor_list_has_been_scanned],
     ProcedureStatement: [
       IBM1388IE_NODESCRIPTOR_attribute_is_invalid_when_any_parameter_has_NONCONNECTED_attribute,
+      IBM2412I_proc_with_return_stmt_needs_returns_att,
     ],
     LabelReference: [validator.checkLabelReference],
     CallStatement: [validator.checkCallStatement],

--- a/packages/language/test/fourslash/validate/IBM2412I/proc-with-return-and-returns-att.ts
+++ b/packages/language/test/fourslash/validate/IBM2412I/proc-with-return-and-returns-att.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: main
+//// <|1:PROC|> RETURNS(BIN FIXED);
+////   RETURN(0);
+//// END;
+
+verify.noDiagnostics(1);

--- a/packages/language/test/fourslash/validate/IBM2412I/proc-with-return-without-returns-att.ts
+++ b/packages/language/test/fourslash/validate/IBM2412I/proc-with-return-without-returns-att.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: main
+//// <|1:PROC|>;
+////   RETURN(0);
+//// END;
+
+verify.expectExclusiveErrorCodesAt(1, code.Error.IBM2412I.fullCode);

--- a/packages/language/test/fourslash/validate/IBM2412I/proc-without-return-and-returns-att.ts
+++ b/packages/language/test/fourslash/validate/IBM2412I/proc-without-return-and-returns-att.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: main
+//// <|1:PROC|>;
+////   X = 1;
+////   Y = 2;
+//// END;
+
+verify.noDiagnostics(1);


### PR DESCRIPTION
**Implement IBM2412I: Procedure with RETURN must specify RETURNS attribute**
Issue: #383 

**Summary**
This PR adds a validator that implements IBM2412I: Inform when a procedure contains a RETURN statement but does not declare a RETURNS attribute on its PROCEDURE statement. The check inspects the procedure’s options for a ReturnsOption and searches for the presence of any ReturnStatement in the body. If a RETURN is found without a corresponding RETURNS attribute, an error is reported.

**Changes**
IBM2412I_proc_with_return_stmt_needs_returns_att: validation code implementing the rule described above.
pli-validator: register the new validation code.
AST and parser: add "procToken" property to ProcedureStatement.
Tests: add fourslash tests under packages/language/test/fourslash/validate/IBM2412I/ 