### PR TITLE
Support hover and definition request for INSCAN

### DIFF
--- a/packages/language/src/language-server/definition-request.ts
+++ b/packages/language/src/language-server/definition-request.ts
@@ -69,7 +69,8 @@ export function definitionRequest(
     ];
   } else if (
     isIncludeItemToken(token.kind) &&
-    token.element?.kind === SyntaxKind.IncludeItem
+    (token.element?.kind === SyntaxKind.IncludeItem ||
+      token.element?.kind === SyntaxKind.InscanDirective)
   ) {
     // allow jumping to the resolved file when present
     const filePath = token.element.filePath;

--- a/packages/language/src/language-server/hover-request.ts
+++ b/packages/language/src/language-server/hover-request.ts
@@ -242,12 +242,14 @@ interface IncludeItemNode {
 function getIncludeItemRepresentation(
   unit: CompilationUnit,
   node: IncludeItemNode,
-  include: boolean,
+  type: string,
 ): string | null {
   if (!node.filePath || !node.relativeFilePath) {
     return null;
   }
 
+  // TODO: Don't store the file content in the node itself
+  // Instead, implement a proper caching mechanism
   let partialContent = node.sourceText;
   const fileUri = URI.parse(node.filePath);
 
@@ -270,7 +272,15 @@ function getIncludeItemRepresentation(
     // cache for later requests
     node.sourceText = partialContent;
   }
-  return `${formatPliCodeBlock(`%${include ? "INCLUDE" : "INSCAN"} "${node.relativeFilePath}"`)}\n\n---\n${formatPliCodeBlock(partialContent)}`;
+  return generateIncludeItemMarkup(type, node.relativeFilePath, partialContent);
+}
+
+export function generateIncludeItemMarkup(
+  type: string,
+  relativePath: string,
+  sourceText: string,
+): string {
+  return `${formatPliCodeBlock(`${type} "${relativePath}"`)}\n\n---\n${formatPliCodeBlock(sourceText)}`;
 }
 
 /**
@@ -286,9 +296,17 @@ function getNodeRepresentation(
     case SyntaxKind.LabelPrefix:
       return getLabelPrefixRepresentation(node);
     case SyntaxKind.IncludeItem:
-      return getIncludeItemRepresentation(unit, node, true);
+      let type = "%INCLUDE";
+      const ppInclude = unit.compilerOptions?.pp?.ppInclude?.value;
+      if (
+        node.container?.kind === SyntaxKind.IncludeAltDirective &&
+        ppInclude
+      ) {
+        type = ppInclude;
+      }
+      return getIncludeItemRepresentation(unit, node, type);
     case SyntaxKind.InscanDirective:
-      return getIncludeItemRepresentation(unit, node, false);
+      return getIncludeItemRepresentation(unit, node, "%INSCAN");
     default:
       return null;
   }

--- a/packages/language/src/language-server/hover-request.ts
+++ b/packages/language/src/language-server/hover-request.ts
@@ -25,7 +25,6 @@ import {
   DimensionBound,
   Dimensions,
   Expression,
-  IncludeItem,
   LabelPrefix,
   ProcedureStatement,
   SyntaxKind,
@@ -230,15 +229,22 @@ function decodeBound(bound: Bound | null): string | null {
   }
 }
 
+interface IncludeItemNode {
+  sourceText: string | null;
+  filePath: string | null;
+  relativeFilePath: string | null;
+}
+
 /**
- * Converts an IncludeItem node to a string representation.
+ * Converts an IncludeItem or InscanDirective to a string representation.
  * Ex. %INCLUDE "/path/to/file.pli"
  */
 function getIncludeItemRepresentation(
   unit: CompilationUnit,
-  node: IncludeItem,
+  node: IncludeItemNode,
+  include: boolean,
 ): string | null {
-  if (!node.filePath) {
+  if (!node.filePath || !node.relativeFilePath) {
     return null;
   }
 
@@ -264,7 +270,7 @@ function getIncludeItemRepresentation(
     // cache for later requests
     node.sourceText = partialContent;
   }
-  return `%INCLUDE "${fileUri.fsPath}"\n\n---\n${formatPliCodeBlock(partialContent)}`;
+  return `${formatPliCodeBlock(`%${include ? "INCLUDE" : "INSCAN"} "${node.relativeFilePath}"`)}\n\n---\n${formatPliCodeBlock(partialContent)}`;
 }
 
 /**
@@ -280,7 +286,9 @@ function getNodeRepresentation(
     case SyntaxKind.LabelPrefix:
       return getLabelPrefixRepresentation(node);
     case SyntaxKind.IncludeItem:
-      return getIncludeItemRepresentation(unit, node);
+      return getIncludeItemRepresentation(unit, node, true);
+    case SyntaxKind.InscanDirective:
+      return getIncludeItemRepresentation(unit, node, false);
     default:
       return null;
   }

--- a/packages/language/src/language-server/semantic-tokens.ts
+++ b/packages/language/src/language-server/semantic-tokens.ts
@@ -160,6 +160,7 @@ function isVariableType(token: Token): boolean {
     case CstNodeKind.HandleAttribute_TypeId0:
     case CstNodeKind.HandleAttribute_TypeId1:
     case CstNodeKind.LabelReference_LabelRef:
+    case CstNodeKind.IncludeItem_FileID:
       return true;
   }
   return false;

--- a/packages/language/src/linking/tokens.ts
+++ b/packages/language/src/linking/tokens.ts
@@ -73,6 +73,7 @@ export function isIncludeItemToken(kind: CstNodeKind | undefined): boolean {
   switch (kind) {
     case CstNodeKind.IncludeItem_FileString:
     case CstNodeKind.IncludeItem_FileID:
+    case CstNodeKind.InscanDirective_INSCAN:
       return true;
   }
   return false;

--- a/packages/language/src/preprocessor/instruction-generator.ts
+++ b/packages/language/src/preprocessor/instruction-generator.ts
@@ -561,6 +561,7 @@ function generateInscanInstruction(
     kind: inst.InstructionKind.Inscan,
     variable: generateReferenceItemInstruction(node.item),
     idempotent: node.idempotent,
+    node,
   };
   return instruction;
 }

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -1654,7 +1654,7 @@ function setImmediateFollowProperty(
   }
 }
 
-function runInscanInstruction(
+async function runInscanInstruction(
   instruction: inst.InscanInstruction,
   context: InterpreterContext,
 ): Promise<void> {
@@ -1663,16 +1663,15 @@ function runInscanInstruction(
     // Inscan cannot be used with array variables
     return Promise.resolve();
   }
-  return runInclude(
+  const filePath = await runInclude(
     {
-      // No item is provided here, which is only availble in the IncludeInstruction
-      item: null,
       fileName: value.value,
       token: instruction.variable.reference?.token,
       idempotent: instruction.idempotent,
     },
     context,
   );
+  setFilePath(instruction.node, filePath, context);
 }
 
 async function runIncludeInstruction(
@@ -1681,22 +1680,47 @@ async function runIncludeInstruction(
 ): Promise<void> {
   for (const item of instruction.items) {
     if (item.fileName) {
-      await runInclude(
+      const filePath = await runInclude(
         {
           fileName: item.fileName,
-          item: item,
           idempotent: instruction.idempotent,
           token: item.token,
         },
         context,
       );
+      setFilePath(item, filePath, context);
+    }
+  }
+}
+
+function setFilePath(
+  item: { filePath: string | null; relativeFilePath: string | null },
+  filePath: string | null,
+  context: InterpreterContext,
+): void {
+  if (filePath) {
+    item.filePath = filePath;
+    if (context.currentUri) {
+      const dirname = UriUtils.dirname(context.currentUri);
+      let relative = UriUtils.relative(dirname, filePath);
+      if (
+        // If the path isn't already relative
+        !relative.startsWith("../") &&
+        !relative.startsWith("./") &&
+        // If the path isn't absolute (Unix & Windows)
+        !relative.startsWith("/") &&
+        !(relative.charAt(1) === ":" && relative.charAt(2) === "/")
+      ) {
+        // Make sure the path is explicitly relative
+        relative = "./" + relative;
+      }
+      item.relativeFilePath = relative;
     }
   }
 }
 
 interface IncludeItem {
   fileName: string;
-  item: ast.IncludeItem | null;
   token?: Token | null;
   idempotent: boolean;
 }
@@ -1704,7 +1728,7 @@ interface IncludeItem {
 async function runInclude(
   item: IncludeItem,
   context: InterpreterContext,
-): Promise<void> {
+): Promise<string | null> {
   const uri = await resolveIncludeFileUri(item, context);
 
   function failToResolve(error?: any): void {
@@ -1718,26 +1742,20 @@ async function runInclude(
 
   if (!uri) {
     failToResolve();
-    return;
-  }
-
-  if (item.item) {
-    // Set the resolved file path on the item
-    // This will be used later in the LSP definition provider
-    item.item.filePath = uri.toString();
+    return null;
   }
 
   if (item.idempotent && context.xIncludes.has(uri.toString())) {
     // Do nothing
     // TODO: Display a warning?
-    return;
+    return uri.toString();
   }
 
   context.xIncludes.add(uri.toString());
 
   if (context.uris.includes(uri.toString())) {
     failToResolve();
-    return;
+    return null;
   }
 
   try {
@@ -1784,6 +1802,8 @@ async function runInclude(
   } catch (err) {
     failToResolve(err);
   }
+
+  return uri.toString();
 }
 
 /**

--- a/packages/language/src/preprocessor/instructions.ts
+++ b/packages/language/src/preprocessor/instructions.ts
@@ -299,6 +299,7 @@ export function createIncludeInstruction(
 export interface InscanInstruction {
   kind: InstructionKind.Inscan;
   variable: ReferenceItemInstruction;
+  node: ast.InscanDirective;
   idempotent: boolean;
 }
 

--- a/packages/language/src/syntax-tree/ast-iterator.ts
+++ b/packages/language/src/syntax-tree/ast-iterator.ts
@@ -541,6 +541,9 @@ export function forEachNode(
     case SyntaxKind.IncludeDirective:
       node.items.forEach(action);
       break;
+    case SyntaxKind.IncludeAltDirective:
+      node.items.forEach(action);
+      break;
     case SyntaxKind.IncludeItem:
       break;
     case SyntaxKind.InscanDirective:

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -1518,8 +1518,10 @@ export interface IncludeItem extends AstNode {
   fileName: string | null;
   string: boolean;
   ddname: string | null;
-  filePath: string | null;
   token: Token | null;
+  // Properties filled by the preprocessor
+  filePath: string | null;
+  relativeFilePath: string | null;
   sourceText: string | null;
 }
 export function createIncludeItem(): IncludeItem {
@@ -1530,6 +1532,7 @@ export function createIncludeItem(): IncludeItem {
     string: false,
     ddname: null,
     filePath: null,
+    relativeFilePath: null,
     token: null,
     sourceText: null,
   };
@@ -1539,6 +1542,10 @@ export interface InscanDirective extends AstNode {
   token: Token | null;
   item: ReferenceItem | null;
   idempotent: boolean;
+  // Properties filled by the preprocessor
+  filePath: string | null;
+  relativeFilePath: string | null;
+  sourceText: string | null;
 }
 export function createInscanDirective(): InscanDirective {
   return {
@@ -1546,7 +1553,10 @@ export function createInscanDirective(): InscanDirective {
     container: null,
     token: null,
     item: null,
+    filePath: null,
+    relativeFilePath: null,
     idempotent: false,
+    sourceText: null,
   };
 }
 export interface IndForAttribute extends AstNode {

--- a/packages/language/test/fourslash-harness/harness-interface.ts
+++ b/packages/language/test/fourslash-harness/harness-interface.ts
@@ -115,10 +115,18 @@ export interface HarnessTesterInterface {
      * Expect that the hover at the given label is an include directive.
      *
      * @param label The label to expect the hover at.
-     * @param filePath File path to resolve in an OS-dependent fashion
+     * @param filePath Relative file path
      * @param content The expected hover content of the included file
      */
     expectIncludeAt(label: Label, filePath: string, content: string): void;
+    /**
+     * Expect that the hover at the given label is an inscan directive.
+     *
+     * @param label The label to expect the hover at.
+     * @param filePath Relative file path
+     * @param content The expected hover content of the included file
+     */
+    expectInscanAt(label: Label, filePath: string, content: string): void;
     /**
      * Expect that the hover at the given label is the given markdown.
      *

--- a/packages/language/test/fourslash-harness/harness-interface.ts
+++ b/packages/language/test/fourslash-harness/harness-interface.ts
@@ -112,22 +112,6 @@ export interface HarnessTesterInterface {
 
   hover: {
     /**
-     * Expect that the hover at the given label is an include directive.
-     *
-     * @param label The label to expect the hover at.
-     * @param filePath Relative file path
-     * @param content The expected hover content of the included file
-     */
-    expectIncludeAt(label: Label, filePath: string, content: string): void;
-    /**
-     * Expect that the hover at the given label is an inscan directive.
-     *
-     * @param label The label to expect the hover at.
-     * @param filePath Relative file path
-     * @param content The expected hover content of the included file
-     */
-    expectInscanAt(label: Label, filePath: string, content: string): void;
-    /**
      * Expect that the hover at the given label is the given markdown.
      *
      * @param label The label to expect the hover at.
@@ -150,6 +134,14 @@ export interface HarnessTesterInterface {
      * hover.codeBlock("DCL A;") === "```pli\nDCL A;\n```\n"
      */
     codeBlock(text: string): string;
+    /**
+     * Format the given include directive as a code block.
+     * @param type The type of the include directive.
+     * @param filePath The file path of the included file.
+     * @param content The content of the included file.
+     * @returns The formatted include directive.
+     */
+    include(type: string, filePath: string, content: string): string;
   };
 
   completion: {

--- a/packages/language/test/fourslash-harness/harness.test.ts
+++ b/packages/language/test/fourslash-harness/harness.test.ts
@@ -66,6 +66,7 @@ async function createTestingHarnessImplementation(
     hover: {
       codeBlock: (text) => text,
       expectIncludeAt: listen("hover.expectIncludeAt"),
+      expectInscanAt: listen("hover.expectInscanAt"),
       expectMarkdownAt: listen("hover.expectMarkdownAt"),
       expectTextAt: listen("hover.expectTextAt"),
     },

--- a/packages/language/test/fourslash-harness/harness.test.ts
+++ b/packages/language/test/fourslash-harness/harness.test.ts
@@ -18,6 +18,7 @@ import { parseHarnessTest } from "./harness-parser";
 import { parseWrapperFile } from "./wrapper";
 import { HarnessConstants } from "./implementation/constants";
 import { TestBuilder } from "../test-builder";
+import { generateIncludeItemMarkup } from "../../src/language-server/hover-request";
 
 type HarnessImplementationListener = (method: string, ...args: any[]) => void;
 
@@ -65,8 +66,7 @@ async function createTestingHarnessImplementation(
     },
     hover: {
       codeBlock: (text) => text,
-      expectIncludeAt: listen("hover.expectIncludeAt"),
-      expectInscanAt: listen("hover.expectInscanAt"),
+      include: generateIncludeItemMarkup,
       expectMarkdownAt: listen("hover.expectMarkdownAt"),
       expectTextAt: listen("hover.expectTextAt"),
     },

--- a/packages/language/test/fourslash-harness/implementation/test-builder.ts
+++ b/packages/language/test/fourslash-harness/implementation/test-builder.ts
@@ -11,7 +11,6 @@
 
 import { MarkupKind } from "vscode-languageserver";
 import { SemanticTokenTypes } from "vscode-languageserver-types";
-import { URI } from "vscode-uri";
 import { formatPliCodeBlock } from "../../../src/utils/code-block";
 import { TestBuilder } from "../../test-builder";
 import { HarnessTesterInterface } from "../harness-interface";
@@ -65,7 +64,13 @@ export function createTestBuilderHarnessImplementation(
       expectIncludeAt(label, filePath, markdown) {
         testBuilder.expectHover(label.toString(), {
           kind: MarkupKind.Markdown,
-          value: `%INCLUDE "${URI.parse(filePath).fsPath}"\n\n---\n${markdown}`,
+          value: `${formatPliCodeBlock(`%INCLUDE "${filePath}"`)}\n\n---\n${markdown}`,
+        });
+      },
+      expectInscanAt(label, filePath, markdown) {
+        testBuilder.expectHover(label.toString(), {
+          kind: MarkupKind.Markdown,
+          value: `${formatPliCodeBlock(`%INSCAN "${filePath}"`)}\n\n---\n${markdown}`,
         });
       },
       expectMarkdownAt: (label, markdown) =>

--- a/packages/language/test/fourslash-harness/implementation/test-builder.ts
+++ b/packages/language/test/fourslash-harness/implementation/test-builder.ts
@@ -16,6 +16,7 @@ import { TestBuilder } from "../../test-builder";
 import { HarnessTesterInterface } from "../harness-interface";
 import { HarnessCodes } from "./codes";
 import { HarnessConstants } from "./constants";
+import { generateIncludeItemMarkup } from "../../../src/language-server/hover-request";
 
 /**
  * Create a harness implementation that can be used to run the harness test.
@@ -61,18 +62,6 @@ export function createTestBuilderHarnessImplementation(
         testBuilder.expectCompletions(label.toString(), content),
     },
     hover: {
-      expectIncludeAt(label, filePath, markdown) {
-        testBuilder.expectHover(label.toString(), {
-          kind: MarkupKind.Markdown,
-          value: `${formatPliCodeBlock(`%INCLUDE "${filePath}"`)}\n\n---\n${markdown}`,
-        });
-      },
-      expectInscanAt(label, filePath, markdown) {
-        testBuilder.expectHover(label.toString(), {
-          kind: MarkupKind.Markdown,
-          value: `${formatPliCodeBlock(`%INSCAN "${filePath}"`)}\n\n---\n${markdown}`,
-        });
-      },
       expectMarkdownAt: (label, markdown) =>
         testBuilder.expectHover(label.toString(), {
           kind: MarkupKind.Markdown,
@@ -84,6 +73,7 @@ export function createTestBuilderHarnessImplementation(
           value: text,
         }),
       codeBlock: formatPliCodeBlock,
+      include: generateIncludeItemMarkup,
     },
     semanticTokens: {
       expectAt: (label, tokenType = label.toString()) =>

--- a/packages/language/test/fourslash/hover/copybook-include-alt.ts
+++ b/packages/language/test/fourslash/hover/copybook-include-alt.ts
@@ -18,11 +18,10 @@
 // @filename: cpy/lib.pli
 //// DECLARE LIB_VAR FIXED;
 
-//// %DCL X CHAR;
-//// %X = "lib";
-//// %<|1>INSCAN X;
+////*PROCESS PP(INCLUDE('ID(++INC)'));
+//// ++INC <|1>lib;
 
 hover.expectMarkdownAt(
   1,
-  hover.include("%INSCAN", "./cpy/lib.pli", " DECLARE LIB_VAR FIXED;"),
+  hover.include("++INC", "./cpy/lib.pli", " DECLARE LIB_VAR FIXED;"),
 );

--- a/packages/language/test/fourslash/hover/copybook-inscan.ts
+++ b/packages/language/test/fourslash/hover/copybook-inscan.ts
@@ -18,9 +18,11 @@
 // @filename: cpy/lib.pli
 //// DECLARE LIB_VAR FIXED;
 
-//// %include <|1>"lib.pli";
+//// %DCL X CHAR;
+//// %X = "lib";
+//// %<|1>INSCAN X;
 
-hover.expectIncludeAt(
+hover.expectInscanAt(
   1,
   "./cpy/lib.pli",
   hover.codeBlock(" DECLARE LIB_VAR FIXED;"),

--- a/packages/language/test/fourslash/hover/copybook.ts
+++ b/packages/language/test/fourslash/hover/copybook.ts
@@ -20,8 +20,7 @@
 
 //// %include <|1>"lib.pli";
 
-hover.expectIncludeAt(
+hover.expectMarkdownAt(
   1,
-  "./cpy/lib.pli",
-  hover.codeBlock(" DECLARE LIB_VAR FIXED;"),
+  hover.include("%INCLUDE", "./cpy/lib.pli", " DECLARE LIB_VAR FIXED;"),
 );

--- a/packages/language/test/fourslash/linker/preprocessor-include-token.ts
+++ b/packages/language/test/fourslash/linker/preprocessor-include-token.ts
@@ -11,17 +11,11 @@
 
 /// <reference path="../framework.ts" />
 
-/**
- * Failing test for hover on copybook (include) directive
- */
+// @filename: cpy/LIB.pli
+////<|1:|> DECLARE LIB_VAR FIXED;
 
-// @filename: cpy/lib.pli
-//// DECLARE LIB_VAR FIXED;
+// @wrap: main
+// @filename: main.pli
+//// %INCLUDE <|1>LIB;
 
-//// %include <|1>"lib.pli";
-
-hover.expectIncludeAt(
-  1,
-  "./cpy/lib.pli",
-  hover.codeBlock(" DECLARE LIB_VAR FIXED;"),
-);
+linker.expectLinks();

--- a/packages/language/test/fourslash/linker/preprocessor-inscan-token.ts
+++ b/packages/language/test/fourslash/linker/preprocessor-inscan-token.ts
@@ -11,17 +11,13 @@
 
 /// <reference path="../framework.ts" />
 
-/**
- * Failing test for hover on copybook (include) directive
- */
+// @filename: cpy/LIB.pli
+////<|1:|> DECLARE LIB_VAR FIXED;
 
-// @filename: cpy/lib.pli
-//// DECLARE LIB_VAR FIXED;
+// @wrap: main
+// @filename: main.pli
+//// %DECLARE X CHARACTER;
+//// %X = 'LIB';
+//// %<|1>INSCAN X;
 
-//// %include <|1>"lib.pli";
-
-hover.expectIncludeAt(
-  1,
-  "./cpy/lib.pli",
-  hover.codeBlock(" DECLARE LIB_VAR FIXED;"),
-);
+linker.expectLinks();

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -746,11 +746,11 @@ export class TestBuilder {
     return this.createPositionMessage(start, this.unit.uri.toString());
   }
 
-  async expectHover(label: string, content: MarkupContent) {
+  expectHover(label: string, content: MarkupContent) {
     const indices = this.getLabelPositions(label);
 
     for (const index of indices) {
-      const hoverResult = await hoverRequest(this.unit, this.unit.uri, index);
+      const hoverResult = hoverRequest(this.unit, this.unit.uri, index);
 
       const message = `Expected hover for label "${label}" (${this.createLabelPositionMessage(label)})`;
       expect(hoverResult, message).toBeDefined();

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -755,6 +755,7 @@ export class TestBuilder {
       const message = `Expected hover for label "${label}" (${this.createLabelPositionMessage(label)})`;
       expect(hoverResult, message).toBeDefined();
       expect(hoverResult?.contents, message).toEqual(content);
+      // TODO: Also test the range
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/zowe/zowe-pli-language-support/issues/375

Note that this change supports the hover and definition request on the `INSCAN` token, not the token after the keyword. The token after the keyword is always a variable, which has its own hover/definition result.