### PR TITLE
Implement IBM2412I, IBM2409I, IBM2410I

### DIFF
--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -542,6 +542,7 @@ export class PliParser extends AbstractParser {
         element,
         CstNodeKind.ProcedureStatement_PROCEDURE,
       );
+      element.procToken = token;
     });
     this.OPTION2(() => {
       this.CONSUME_ASSIGN1(tokens.OpenParen, (token) => {
@@ -5516,6 +5517,7 @@ export class PliParser extends AbstractParser {
       kind: ast.SyntaxKind.ReturnStatement,
       container: null,
       expression: null,
+      returnToken: null,
     };
   }
 
@@ -5524,6 +5526,7 @@ export class PliParser extends AbstractParser {
 
     this.CONSUME_ASSIGN1(tokens.RETURN, (token) => {
       this.tokenPayload(token, element, CstNodeKind.ReturnStatement_RETURN);
+      element.returnToken = token;
     });
     this.OPTION1(() => {
       this.CONSUME_ASSIGN1(tokens.OpenParen, (token) => {

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -1934,6 +1934,7 @@ export interface ProcedureStatement extends AstNode {
   statements: Statement[];
   options: ProcedureOption[];
   end: EndStatement | null;
+  procToken: Token | null;
 }
 export function createProcedureStatement(): ProcedureStatement {
   return {
@@ -1945,6 +1946,7 @@ export function createProcedureStatement(): ProcedureStatement {
     statements: [],
     options: [],
     end: null,
+    procToken: null,
   };
 }
 export type ProcedureOption =
@@ -2094,12 +2096,14 @@ export function createReturnsOption(): ReturnsOption {
 export interface ReturnStatement extends AstNode {
   kind: SyntaxKind.ReturnStatement;
   expression: Expression | null;
+  returnToken: Token | null;
 }
 export function createReturnStatement(): ReturnStatement {
   return {
     kind: SyntaxKind.ReturnStatement,
     container: null,
     expression: null,
+    returnToken: null,
   };
 }
 export interface RevertStatement extends AstNode {

--- a/packages/language/src/validation/messages/error-severity/IBM2412I-IBM2410I-IBM2409I-handle-return-stmt-and-returns-att.ts
+++ b/packages/language/src/validation/messages/error-severity/IBM2412I-IBM2410I-IBM2409I-handle-return-stmt-and-returns-att.ts
@@ -1,0 +1,96 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { ValidationAcceptor } from "../../validator";
+import * as AST from "../../../syntax-tree/ast";
+import { diagnosticFromCode } from "../../../language-server/types";
+import * as PLICodes from "../pli-codes";
+import {
+  TraversalState,
+  traverseAllNodes,
+} from "../../../syntax-tree/ast-iterator";
+
+/**
+ * IBM2412I: If a procedure contains a RETURN statement, it should have the RETURNS attribute
+ * specified on its PROCEDURE statement.
+ *
+ * IBM2409I: RETURN statement without an expression is invalid inside a nested PROCEDURE that
+ * specifies the RETURNS attribute. All RETURN statements inside functions must specify a value
+ * to be returned.
+ *
+ * IBM2410I: Functions must contain at least one RETURN statement.
+ *
+ * @param node The AST node being analyzed.
+ * @param acceptor The mechanism used to collect validation issues.
+ * @returns Validation results or diagnostics, as appropriate.
+ */
+export function IBM2412I_IBM2410I_IBM2409I_handle_return_stmt_and_returns_att(
+  node: AST.ProcedureStatement,
+  acceptor: ValidationAcceptor,
+): void {
+  const returnStmts: AST.ReturnStatement[] = [];
+
+  traverseAllNodes(node, (n) => {
+    if (n !== node && n.kind === AST.SyntaxKind.ProcedureStatement)
+      return TraversalState.Stop;
+    if (n.kind === AST.SyntaxKind.ReturnStatement)
+      returnStmts.push(n as AST.ReturnStatement);
+
+    return TraversalState.Continue;
+  });
+
+  const hasReturnsAtt = node.options?.some(
+    (att) => att.kind === AST.SyntaxKind.ReturnsOption,
+  );
+
+  if (returnStmts.length === 0 && !hasReturnsAtt) return;
+
+  const returnSomething: AST.ReturnStatement[] = [];
+  const returnNothing: AST.ReturnStatement[] = [];
+
+  for (const ret of returnStmts) {
+    if (ret.expression) returnSomething.push(ret);
+    else returnNothing.push(ret);
+  }
+
+  if (hasReturnsAtt && returnSomething.length > 0 && returnNothing.length === 0)
+    return;
+
+  // IBM2409I: All RETURN statements inside functions that specified the RETURNS attribute must specify a value to be returned.
+  if (hasReturnsAtt && returnNothing.length > 0) {
+    for (const ret of returnNothing) {
+      const returnToken = ret.returnToken;
+      if (!returnToken) return;
+
+      acceptor(diagnosticFromCode(PLICodes.Error.IBM2409I, returnToken));
+    }
+    return;
+  }
+
+  const procToken = node.procToken;
+  if (!procToken) return;
+
+  //IBM2410I: Procedures with RETURNS attribute must contain at least one RETURN statement.
+  if (hasReturnsAtt && returnStmts.length === 0) {
+    const procName =
+      node.container?.kind === AST.SyntaxKind.Statement &&
+      node.container.labels[0]?.nameToken?.originalImage
+        ? node.container.labels[0].nameToken.originalImage
+        : "<unnamed>";
+
+    acceptor(diagnosticFromCode(PLICodes.Error.IBM2410I, procToken, procName));
+  }
+
+  // IBM2412I: If a procedure contains a RETURN (...) statement, it should have the RETURNS attribute.
+  if (returnSomething.length > 0 && !hasReturnsAtt) {
+    acceptor(diagnosticFromCode(PLICodes.Error.IBM2412I, procToken));
+  }
+}

--- a/packages/language/src/validation/pli-validator.ts
+++ b/packages/language/src/validation/pli-validator.ts
@@ -26,6 +26,7 @@ import { IBM1388IE_NODESCRIPTOR_attribute_is_invalid_when_any_parameter_has_NONC
 import { IBM2615I_do_loops_execute_once } from "./messages/warning-severity/IBM2615I-do-loops-execute-once";
 import * as PLICodes from "./messages/pli-codes";
 import { ValidationAcceptor, ValidationChecks, Validator } from "./validator";
+import { IBM2412I_IBM2410I_IBM2409I_handle_return_stmt_and_returns_att } from "./messages/error-severity/IBM2412I-IBM2410I-IBM2409I-handle-return-stmt-and-returns-att";
 
 /**
  * A function that accepts a diagnostic for PL/I validation
@@ -45,6 +46,7 @@ export function registerPliValidationChecks(unit: CompilationUnit): Validator {
     // MemberCall: [IBM1747IS_Function_cannot_be_used_before_the_functions_descriptor_list_has_been_scanned],
     ProcedureStatement: [
       IBM1388IE_NODESCRIPTOR_attribute_is_invalid_when_any_parameter_has_NONCONNECTED_attribute,
+      IBM2412I_IBM2410I_IBM2409I_handle_return_stmt_and_returns_att,
     ],
     LabelReference: [validator.checkLabelReference],
     CallStatement: [validator.checkCallStatement],
@@ -54,6 +56,7 @@ export function registerPliValidationChecks(unit: CompilationUnit): Validator {
     DoStatement: [IBM2615I_do_loops_execute_once],
     LeaveStatement: [IBM1219I_leave_exits_noniterative_do],
     SelectStatement: [IBM1059I_select_without_otherwise],
+    // TODO @wagner-laranjeiras -> When adding ReturnStatement to this list, make sure to include comment about IBM2412/10/09I.
   });
 
   return validator;

--- a/packages/language/test/fourslash/hover/procedure.ts
+++ b/packages/language/test/fourslash/hover/procedure.ts
@@ -30,7 +30,6 @@
 //// CALL <|2>MyProc;
 //// CALL <|3>MyProc2;
 
-verify.noDiagnostics();
 const expectedMarkdown = hover.codeBlock(
   "MYPROC: PROC(A,B,C) OPTIONS(MAIN, ORDER) RECURSIVE REORDER RETURNS(FIXED BIN(31));",
 );

--- a/packages/language/test/fourslash/validate/IBM2409I/multiple-procs-without-return-and-returns.ts
+++ b/packages/language/test/fourslash/validate/IBM2409I/multiple-procs-without-return-and-returns.ts
@@ -1,0 +1,34 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: main
+//// MAINPR: <|1:proc|> options( main );
+////    b: <|2:proc|> returns( OPTIONAL byvalue fixed bin(31) );
+////        return(32);
+////    end b;
+////    call b();
+////    c: proc;
+////        return(32);
+////    end c;
+////    call c();
+////    d: proc returns( OPTIONAL byvalue fixed bin(31) );
+////        return;
+////    end d;
+////    call d();
+////    e: proc returns( OPTIONAL byvalue fixed bin(31) );
+////    end e;
+////    call e();
+//// end MAINPR;
+
+verify.noDiagnostics(1); // No RETURN, no RETURNS -> ok
+verify.noDiagnostics(2); // Has RETURN, has RETURNS -> ok

--- a/packages/language/test/fourslash/validate/IBM2409I/multiple-procs-without-valid-return-with-returns-att.ts
+++ b/packages/language/test/fourslash/validate/IBM2409I/multiple-procs-without-valid-return-with-returns-att.ts
@@ -1,0 +1,33 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: main
+//// MAINPR: proc options( main );
+////    b: proc returns( OPTIONAL byvalue fixed bin(31) );
+////        return(32);
+////    end b;
+////    call b();
+////    c: proc;
+////        return(32);
+////    end c;
+////    call c();
+////    d: proc returns( OPTIONAL byvalue fixed bin(31) );
+////        <|1:return|>;
+////    end d;
+////    call d();
+////    e: proc returns( OPTIONAL byvalue fixed bin(31) );
+////    end e;
+////    call e();
+//// end MAINPR;
+
+verify.expectExclusiveErrorCodesAt(1, code.Error.IBM2409I.fullCode); // Has RETURN, has RETURNS -> RETURN must return something

--- a/packages/language/test/fourslash/validate/IBM2409I/nested-proc-with-invalid-return-with-returns-att.ts
+++ b/packages/language/test/fourslash/validate/IBM2409I/nested-proc-with-invalid-return-with-returns-att.ts
@@ -1,0 +1,22 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: main
+//// MAINPR: proc options( main );
+////    d: proc returns( OPTIONAL byvalue fixed bin(31) );
+////        <|1:return|>;
+////    end d;
+////    call d();
+//// end MAINPR;
+
+verify.expectExclusiveErrorCodesAt(1, code.Error.IBM2409I.fullCode);

--- a/packages/language/test/fourslash/validate/IBM2409I/proc-with-invalid-return.ts
+++ b/packages/language/test/fourslash/validate/IBM2409I/proc-with-invalid-return.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: main
+//// proc returns( OPTIONAL byvalue fixed bin(31) );
+////    <|1:return|>;
+//// end;
+
+verify.expectExclusiveErrorCodesAt(1, code.Error.IBM2409I.fullCode);

--- a/packages/language/test/fourslash/validate/IBM2409I/proc-without-return-and-returns.ts
+++ b/packages/language/test/fourslash/validate/IBM2409I/proc-without-return-and-returns.ts
@@ -1,0 +1,22 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: main
+//// MAINPR: <|1:proc|> options( main );
+////    d: proc returns( OPTIONAL byvalue fixed bin(31) );
+////        return;
+////    end d;
+////    call d();
+//// end MAINPR;
+
+verify.noDiagnostics(1);

--- a/packages/language/test/fourslash/validate/IBM2410I/multiple-procs-without-return-with-returns-att.ts
+++ b/packages/language/test/fourslash/validate/IBM2410I/multiple-procs-without-return-with-returns-att.ts
@@ -1,0 +1,33 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: main
+//// MAINPR: proc options( main );
+////    b: proc returns( OPTIONAL byvalue fixed bin(31) );
+////        return(32);
+////    end b;
+////    call b();
+////    c: proc;
+////        return(32);
+////    end c;
+////    call c();
+////    d: proc returns( OPTIONAL byvalue fixed bin(31) );
+////        return;
+////    end d;
+////    call d();
+////    target: <|1:proc|> returns( OPTIONAL byvalue fixed bin(31) );
+////    end target;
+////    call target();
+//// end MAINPR;
+
+verify.expectExclusiveErrorCodesAt(1, code.Error.IBM2410I.fullCode); // Has no RETURN, has RETURNS -> must have RETURN (...)

--- a/packages/language/test/fourslash/validate/IBM2410I/proc-with-nested-return.ts
+++ b/packages/language/test/fourslash/validate/IBM2410I/proc-with-nested-return.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: main
+//// OUTER: <|1:PROC|> RETURNS(FIXED);
+////   INNER: PROC;
+////        RETURN (0);
+////   END INNER;
+//// END OUTER;
+
+verify.expectExclusiveErrorCodesAt(1, code.Error.IBM2410I.fullCode);

--- a/packages/language/test/fourslash/validate/IBM2410I/proc-without-return-and-returns.ts
+++ b/packages/language/test/fourslash/validate/IBM2410I/proc-without-return-and-returns.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: main
+//// <|1:PROC|>;
+////   X = 1;
+////   Y = 2;
+//// END;
+
+verify.noDiagnostics(1);

--- a/packages/language/test/fourslash/validate/IBM2412I/multiple-procs-with-valid-return-without-returns-att.ts
+++ b/packages/language/test/fourslash/validate/IBM2412I/multiple-procs-with-valid-return-without-returns-att.ts
@@ -1,0 +1,33 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: main
+//// MAINPR: proc options( main );
+////    b: proc returns( OPTIONAL byvalue fixed bin(31) );
+////        return(32);
+////    end b;
+////    call b();
+////    c: <|1:proc|>;
+////        return(32);
+////    end c;
+////    call c();
+////    d: proc returns( OPTIONAL byvalue fixed bin(31) );
+////        return;
+////    end d;
+////    call d();
+////    e: proc returns( OPTIONAL byvalue fixed bin(31) );
+////    end e;
+////    call e();
+//// end MAINPR;
+
+verify.expectExclusiveErrorCodesAt(1, code.Error.IBM2412I.fullCode); // Has RETURN (...), has no RETURNS -> Needs att

--- a/packages/language/test/fourslash/validate/IBM2412I/nested-proc-without-returns-att.ts
+++ b/packages/language/test/fourslash/validate/IBM2412I/nested-proc-without-returns-att.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: main
+//// OUTER: PROC RETURNS(FIXED);
+////   INNER: <|1:PROC|>;
+////        RETURN (0);
+////   END INNER;
+//// END OUTER;
+
+verify.expectExclusiveErrorCodesAt(1, code.Error.IBM2412I.fullCode);

--- a/packages/language/test/fourslash/validate/IBM2412I/proc-with-multiple-return-no-returns.ts
+++ b/packages/language/test/fourslash/validate/IBM2412I/proc-with-multiple-return-no-returns.ts
@@ -1,0 +1,24 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+/**
+ * Procedure with several RETURN statements but no RETURNS attribute must trigger IBM2412I
+ */
+
+// @wrap: main
+//// e: <|1:proc|>;
+////   return(0);
+////   return(1);
+//// end;
+
+verify.expectExclusiveErrorCodesAt(1, code.Error.IBM2412I.fullCode);

--- a/packages/language/test/fourslash/validate/IBM2412I/proc-with-return-and-returns.ts
+++ b/packages/language/test/fourslash/validate/IBM2412I/proc-with-return-and-returns.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: main
+//// <|1:PROC|> RETURNS(BIN FIXED);
+////   RETURN(0);
+//// END;
+
+verify.noDiagnostics(1);

--- a/packages/language/test/fourslash/validate/IBM2412I/proc-with-return-inside-if-no-returns-att.ts
+++ b/packages/language/test/fourslash/validate/IBM2412I/proc-with-return-inside-if-no-returns-att.ts
@@ -1,0 +1,22 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: main
+//// b: <|1:proc|>;
+////    if 6 > 5 then
+////        return (1);
+////    else
+////        return (0);
+//// end b;
+
+verify.expectExclusiveErrorCodesAt(1, code.Error.IBM2412I.fullCode);

--- a/packages/language/test/fourslash/validate/IBM2412I/proc-with-return-inside-if.ts
+++ b/packages/language/test/fourslash/validate/IBM2412I/proc-with-return-inside-if.ts
@@ -1,0 +1,26 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+/**
+ * Procedure with RETURNS attribute and RETURN statement must NOT trigger IBM2412I
+ */
+
+// @wrap: main
+//// b: <|1:proc|> returns(fixed);
+////    if 4 > 5 then
+////        return (1);
+////    else
+////        return (0);
+//// end;
+
+verify.noDiagnostics(1);

--- a/packages/language/test/fourslash/validate/IBM2412I/proc-with-return-without-returns-att.ts
+++ b/packages/language/test/fourslash/validate/IBM2412I/proc-with-return-without-returns-att.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: main
+//// <|1:PROC|>;
+////   RETURN(0);
+//// END;
+
+verify.expectExclusiveErrorCodesAt(1, code.Error.IBM2412I.fullCode);

--- a/packages/language/test/fourslash/validate/IBM2412I/proc-without-return-and-returns.ts
+++ b/packages/language/test/fourslash/validate/IBM2412I/proc-without-return-and-returns.ts
@@ -1,0 +1,22 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @wrap: main
+//// OUTER: <|1:PROC|>;
+////   INNER: PROC RETURNS(FIXED);
+////        RETURN (0);
+////   END INNER;
+////   RETURN;
+//// END OUTER;
+
+verify.noDiagnostics(1);


### PR DESCRIPTION
### Implement IBM2412I, IBM2409I, IBM2410I: RETURN statement and RETURNS attribute validations

Issue: #383

**Summary:**

This PR introduces validation logic for RETURN statements in procedures and their interaction with the RETURNS attribute. The following IBM PL/I rules are enforced:

_IBM2412I:_ If a procedure contains a RETURN ( ... ) statement, it should declare the RETURNS attribute.
_IBM2409I_: When a procedure specifies the RETURNS attribute, all RETURN statements must provide an expression.
_IBM2410I:_ Procedures with the RETURNS attribute must contain at least one RETURN statement.

**Changes**

IBM2412I_IBM2410I_IBM2409I_handle_return_stmt_and_returns_att: new validation function implementing the rules above.
pli-validator: register the new validation logic.
AST: ensure ProcedureStatement and ReturnStatement expose the necessary tokens (procToken, returnToken).
Tests: add cases covering each of the three validation scenarios under packages/language/test/fourslash/validate/<IBM2412I or IBM2409I or IBM2410I>