### PR TITLE
Improve LSP services for builtins

### DIFF
--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -34,10 +34,8 @@ import {
   TextDocuments,
 } from "../language-server/text-documents.js";
 import {
-  Builtins,
-  BuiltinsMacro,
-  BuiltinsMacroUri,
-  BuiltinsUri,
+  BuiltinsMacroTextDocument,
+  BuiltinsTextDocument,
   BuiltinsUriSchema,
 } from "./builtins.js";
 import { PluginConfigurationProviderInstance } from "./plugin-configuration-provider.js";
@@ -102,76 +100,31 @@ export function collectDiagnostics(sourceFile: CompilationUnit): Diagnostic[] {
 const BuiltinFileStart = `${BuiltinsUriSchema}:/`;
 const isBuiltinFile = (uri: URI) => uri.toString().startsWith(BuiltinFileStart);
 
-/**
- * Creates a function that returns the root scope, with builtins.
- *
- * Caches the scope for reuse.
- */
-function createBuiltinScopeGetter() {
-  let builtinScope: Scope | undefined = undefined;
-
+function createBuiltinScopeGetter(builtinDocument: TextDocument) {
+  let builtinFileScope: Scope | undefined;
   return async (uri: URI, unit: CompilationUnit): Promise<Scope> => {
-    // Don't load the builtin symbol table for builtin files
     if (isBuiltinFile(uri)) {
       return Scope.createRoot(unit);
     }
+    if (!builtinFileScope) {
+      const fileUri = URI.parse(builtinDocument.uri);
+      const builtinUnit = await createCompilationUnit(fileUri);
+      await tokenize(builtinUnit, builtinDocument);
+      parse(builtinUnit);
+      generateSymbolTable(builtinUnit);
 
-    if (builtinScope === undefined) {
-      const uri = URI.parse(BuiltinsUri);
-      const unit = await createCompilationUnit(uri);
-      const document = TextDocument.create(BuiltinsUri, "pli", 0, Builtins);
-      await tokenize(unit, document);
-      parse(unit);
-      generateSymbolTable(unit);
-
-      builtinScope =
-        unit.scopeCaches.regular.get(unit.ast) ?? Scope.createRoot(unit);
+      builtinFileScope =
+        builtinUnit.scopeCaches.regular.get(builtinUnit.ast) ??
+        Scope.createRoot(builtinUnit);
     }
-
-    return builtinScope;
+    return builtinFileScope;
   };
 }
 
-const getBuiltinScope = createBuiltinScopeGetter();
-
-/**
- * Creates a function that returns the root scope, with builtins.
- *
- * Caches the scope for reuse.
- */
-function createBuiltinMacroScopeGetter() {
-  let builtinScope: Scope | undefined = undefined;
-
-  return async (uri: URI, unit: CompilationUnit): Promise<Scope> => {
-    // Don't load the builtin symbol table for builtin files
-    if (isBuiltinFile(uri)) {
-      return Scope.createRoot(unit);
-    }
-
-    if (builtinScope === undefined) {
-      const uri = URI.parse(BuiltinsMacroUri);
-      const unit = await createCompilationUnit(uri);
-      const document = TextDocument.create(
-        BuiltinsMacroUri,
-        "pli",
-        0,
-        BuiltinsMacro,
-      );
-      await tokenize(unit, document);
-      parse(unit);
-      generateSymbolTable(unit);
-
-      // Use the regular AST for easier handling
-      // Note that these are procedures that are used in preprocessor code!
-      builtinScope =
-        unit.scopeCaches.regular.get(unit.ast) ?? Scope.createRoot(unit);
-    }
-
-    return builtinScope;
-  };
-}
-
-const getRootPreprocessorScope = createBuiltinMacroScopeGetter();
+const getBuiltinScope = createBuiltinScopeGetter(BuiltinsTextDocument);
+const getRootPreprocessorScope = createBuiltinScopeGetter(
+  BuiltinsMacroTextDocument,
+);
 
 export async function createCompilationUnit(
   uri: URI,
@@ -328,6 +281,10 @@ export class CompilationUnitHandler {
       }
       const allDiagnostics = diagnosticsToLSP(unit, collectDiagnostics(unit));
       for (const file of unit.files.keys()) {
+        if (file.startsWith(BuiltinsUriSchema)) {
+          // do not report diagnostics for built-in files
+          continue;
+        }
         const fileDiagnostics = allDiagnostics.get(file);
         connection.sendDiagnostics({
           uri: file,

--- a/packages/language/src/workspace/file-store.ts
+++ b/packages/language/src/workspace/file-store.ts
@@ -12,6 +12,7 @@
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { Token } from "../parser/tokens";
 import { URI } from "../utils/uri";
+import { BuiltinDocuments } from "../language-server/text-documents";
 
 export interface CompilationUnitFile {
   readonly uri: URI;
@@ -31,7 +32,9 @@ export class FileStore {
   }
 
   getDocument(uri: URI | string): TextDocument | undefined {
-    return this.get(uri)?.textDocument;
+    // Builtin documents are not stored on the compilation unit
+    // To respond to LSP requests, we need to return them anyway
+    return this.get(uri)?.textDocument ?? BuiltinDocuments.get(uri);
   }
 
   set(file: CompilationUnitFile): void {


### PR DESCRIPTION
Fixes an issue where the `definition` request did not work for variables/procedures from builtin files.

Additionally does no longer send diagnostics for builtin files - if they are invalid, that's by design. See also https://github.com/zowe/zowe-pli-language-support/issues/395.