### PR TITLE
Add SQLCA and SQLDA as normal builtins

### DIFF
--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -1840,7 +1840,7 @@ async function resolveIncludeFileUri(
       );
       const files: string[] = [libFileUri.path];
       // Generate a glob pattern for each include extension
-      for (const ext of pgroup["include-extensions"] ?? []) {
+      for (const ext of pgroup.includeExtensions) {
         const extFileUri = libFileUri.with({
           path: `${libFileUri.path}${ext}`,
         });

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -1832,7 +1832,7 @@ async function resolveIncludeFileUri(
 
   if (pgroup) {
     // lib file as either a string or a member from a known process group
-    for (const lib of pgroup.libs ?? []) {
+    for (const lib of pgroup.libs) {
       const libFileUri = UriUtils.joinPath(
         URI.parse(PluginConfigurationProviderInstance.getWorkspacePath()),
         lib,

--- a/packages/language/src/preprocessor/pli-margins-processor.ts
+++ b/packages/language/src/preprocessor/pli-margins-processor.ts
@@ -53,8 +53,7 @@ export class PliMarginsProcessor implements MarginsProcessor {
           programConfig.pgroup,
         );
       if (processGroup) {
-        this.checkMargins =
-          processGroup["lsp-options"]?.["check-margins"] ?? false;
+        this.checkMargins = processGroup.lspOptions.checkMargins;
       }
     }
 

--- a/packages/language/src/utils/types.ts
+++ b/packages/language/src/utils/types.ts
@@ -1,0 +1,51 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+export type UnknownObject<T extends Object> = { [K in keyof T]: unknown };
+
+export function isObject<T extends Object>(
+  item: unknown,
+): item is UnknownObject<T> {
+  return Boolean(item) && typeof item === "object" && !Array.isArray(item);
+}
+
+export function isRecordOf<T extends Object>(
+  item: unknown,
+  elementCheck: (elem: unknown) => elem is T,
+): item is Record<string, T> {
+  return (
+    isObject<Record<string, unknown>>(item) &&
+    Object.values(item).every(elementCheck)
+  );
+}
+
+export function isArrayOf<T>(
+  item: unknown,
+  elementCheck: (elem: unknown) => elem is T,
+): item is T[] {
+  return Array.isArray(item) && item.every(elementCheck);
+}
+
+export function isString(item: unknown): item is string {
+  return typeof item === "string";
+}
+
+export function isNumber(item: unknown): item is number {
+  return typeof item === "number";
+}
+
+export function isStringArray(item: unknown): item is string[] {
+  return isArrayOf(item, isString);
+}
+
+export function isBoolean(item: unknown): item is boolean {
+  return typeof item === "boolean";
+}

--- a/packages/language/src/validation/pli-validator.ts
+++ b/packages/language/src/validation/pli-validator.ts
@@ -294,6 +294,8 @@ export class PliValidator implements Validator {
     }
   }
 
+  private knownBuiltins = new Set(["SQLCA", "SQLDA"]);
+
   checkImplicitBuiltins(
     node: AST.ReferenceItem,
     acceptor: ValidationAcceptor,
@@ -313,8 +315,15 @@ export class PliValidator implements Validator {
       return;
     }
 
+    if (node.container?.kind === AST.SyntaxKind.ReferenceItem) {
+      return; // skip qualified names
+    }
+
     const name = node.ref.node.name.toUpperCase();
-    if (!this.processGroup["implicit-builtins"]?.includes(name)) {
+    if (
+      !this.knownBuiltins.has(name) &&
+      !this.processGroup.implicitBuiltins.has(name)
+    ) {
       acceptor(
         diagnosticFromCode(
           PLICodes.Error.IBM1373I,

--- a/packages/language/src/validation/pli-validator.ts
+++ b/packages/language/src/validation/pli-validator.ts
@@ -294,7 +294,16 @@ export class PliValidator implements Validator {
     }
   }
 
-  private knownBuiltins = new Set(["SQLCA", "SQLDA"]);
+  private knownBuiltins = new Set([
+    "SQLCA",
+    "SQLDA",
+    "SQLDA2",
+    "SQLSIZE",
+    "SQLDAPTR",
+    "SQLTRIPLED",
+    "SQLDOUBLED",
+    "SQLSINGLED",
+  ]);
 
   checkImplicitBuiltins(
     node: AST.ReferenceItem,

--- a/packages/language/src/workspace/builtins.ts
+++ b/packages/language/src/workspace/builtins.ts
@@ -17,9 +17,69 @@ import { URI } from "../utils/uri";
  */
 
 export const BuiltinsUriSchema = "pli-builtin";
+
+export const BuiltinsSQLCA = `
+ DECLARE 1 SQLCA,
+    2 SQLCAID CHAR(8),
+    2 SQLCABC FIXED(31) BINARY,
+    2 SQLCODE FIXED(31) BINARY,
+    2 SQLERRM CHAR(70) VAR,
+    2 SQLERRP CHAR(8),
+    2 SQLERRD(6) FIXED(31) BINARY,
+    2 SQLWARN,
+      3 SQLWARN0 CHAR(1),
+      3 SQLWARN1 CHAR(1),
+      3 SQLWARN2 CHAR(1),
+      3 SQLWARN3 CHAR(1),
+      3 SQLWARN4 CHAR(1),
+      3 SQLWARN5 CHAR(1),
+      3 SQLWARN6 CHAR(1),
+      3 SQLWARN7 CHAR(1),
+    2 SQLEXT,
+      3 SQLWARN8 CHAR(1),
+      3 SQLWARN9 CHAR(1),
+      3 SQLWARNA CHAR(1),
+      3 SQLSTATE CHAR(5);
+`;
+
+export const BuiltinsSQLDA = `
+ DECLARE
+  1 SQLDA BASED(SQLDAPTR),
+    2 SQLDAID CHAR(8),
+    2 SQLDABC FIXED(31) BINARY,
+    2 SQLN    FIXED(15) BINARY,
+    2 SQLD    FIXED(15) BINARY,
+    2 SQLVAR(SQLSIZE REFER(SQLN)),
+      3 SQLTYPE  FIXED(15) BINARY,
+      3 SQLLEN   FIXED(15) BINARY,
+      3 SQLDATA  POINTER,
+      3 SQLIND   POINTER,
+      3 SQLNAME  CHAR(30)  VAR;
+ /* */
+ DECLARE
+  1 SQLDA2 BASED(SQLDAPTR),
+    2 SQLDAID2 CHAR(8),
+    2 SQLDABC2 FIXED(31) BINARY,
+    2 SQLN2    FIXED(15) BINARY,
+    2 SQLD2    FIXED(15) BINARY,
+    2 SQLVAR2(SQLSIZE REFER(SQLN2)),
+      3 SQLBIGLEN,
+        4 SQLLONGL FIXED(31) BINARY,
+        4 SQLRSVDL FIXED(31) BINARY,
+      3 SQLDATAL POINTER,
+      3 SQLTNAME CHAR(30) VAR;
+ /* */
+ DECLARE SQLSIZE    FIXED(15) BINARY;
+ DECLARE SQLDAPTR   POINTER;
+ DECLARE SQLTRIPLED CHAR(1)   INITIAL('3');
+ DECLARE SQLDOUBLED CHAR(1)   INITIAL('2');
+ DECLARE SQLSINGLED CHAR(1)   INITIAL(' ');
+`;
+
 export const BuiltinsFile = "builtins.pli";
 export const BuiltinsUri = `${BuiltinsUriSchema}:/${BuiltinsFile}`;
-export const Builtins = ` /* Arithmetic built-in functions */
+export const Builtins =
+  ` /* Arithmetic built-in functions */
  ABS: PROC (value) RETURNS ();
  END;
 
@@ -748,7 +808,9 @@ export const Builtins = ` /* Arithmetic built-in functions */
 
  define alias __SIGNED_INT signed fixed bin(31,0);
  define alias __UNSIGNED_INT unsigned fixed bin(32,0);
- `;
+ ` +
+  BuiltinsSQLCA +
+  BuiltinsSQLDA;
 
 export const BuiltinsTextDocument = TextDocument.create(
   URI.parse(BuiltinsUri).toString(),

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -18,6 +18,7 @@ import {
 import { translateCompilerOptions } from "../preprocessor/compiler-options/translator";
 import { minimatch } from "minimatch";
 import { CompilerOptionResult } from "../preprocessor/compiler-options/options";
+import { isBoolean, isRecordOf, isString, isStringArray } from "../utils/types";
 
 /**
  * Pli options are effectively macros to set w/ the given values
@@ -31,7 +32,7 @@ export type PliOptions = Record<string, string>;
 export interface ProgramConfig {
   program: string;
   pgroup: string;
-  "pli-options"?: PliOptions;
+  pliOptions: PliOptions;
 
   /**
    * Prebuilt abstract options for this program config.
@@ -47,11 +48,69 @@ export interface ProgramConfig {
   issueCount?: number;
 }
 
+interface SerializedProgramConfig {
+  program: string;
+  pgroup: string;
+  "pli-options"?: PliOptions;
+}
+
+function deserializeProgramConfig(obj: SerializedProgramConfig): ProgramConfig {
+  const pliOptions = obj["pli-options"] || {};
+  return {
+    program: obj.program,
+    pgroup: obj.pgroup,
+    pliOptions: isRecordOf(pliOptions, isString) ? pliOptions : {},
+  };
+}
+
 /**
  * Process group configuration. Corresponds to libraries, compiler options, and other
  * settings that are associated with a program config.
  */
 export interface ProcessGroup {
+  name: string;
+  compilerOptions: string[];
+  pliOptions: PliOptions;
+  libs: string[];
+  includeExtensions: string[];
+  implicitBuiltins: Set<string>;
+  lspOptions: {
+    checkMargins: boolean;
+  };
+
+  /**
+   * Number of issues found in the compiler options for this process group.
+   * Used to avoid duplicate issue reporting later on when running translation in a program context
+   */
+  issueCount?: number;
+}
+
+function deserializeProcessGroup(obj: SerializedProcessGroup): ProcessGroup {
+  const compilerOptions = obj["compiler-options"] || [];
+  const pliOptions = obj["pli-options"] || {};
+  const includeExtensions = obj["include-extensions"] || [];
+  const implicitBuiltins = obj["implicit-builtins"] || [];
+  const libs = obj.libs || [];
+  const lspOptions = obj["lsp-options"] || {};
+  const checkMargins = lspOptions["check-margins"] ?? false;
+  return {
+    name: obj.name,
+    compilerOptions: isStringArray(compilerOptions) ? compilerOptions : [],
+    pliOptions: isRecordOf(pliOptions, isString) ? pliOptions : {},
+    libs: isStringArray(libs) ? libs : [],
+    includeExtensions: isStringArray(includeExtensions)
+      ? includeExtensions
+      : [],
+    implicitBuiltins: isStringArray(implicitBuiltins)
+      ? new Set(implicitBuiltins.map((b) => b.toUpperCase()))
+      : new Set(),
+    lspOptions: {
+      checkMargins: isBoolean(checkMargins) ? checkMargins : false,
+    },
+  };
+}
+
+interface SerializedProcessGroup {
   name: string;
   "compiler-options"?: string[];
   "pli-options"?: PliOptions;
@@ -61,12 +120,6 @@ export interface ProcessGroup {
   "lsp-options"?: {
     "check-margins"?: boolean;
   };
-
-  /**
-   * Number of issues found in the compiler options for this process group.
-   * Used to avoid duplicate issue reporting later on when running translation in a program context
-   */
-  issueCount?: number;
 }
 
 /**
@@ -127,7 +180,7 @@ export class PluginConfigurationProvider {
     }
     for (const processGroup of this.processGroupConfigs.values()) {
       const libs = processGroup.libs || [];
-      const extensions = processGroup["include-extensions"] || [];
+      const extensions = processGroup.includeExtensions || [];
       for (let lib of libs) {
         lib = lib.replace(/[\\/]+$/, "");
         for (const ext of extensions) {
@@ -195,15 +248,12 @@ export class PluginConfigurationProvider {
 
       // add configs to our provider if they exist
       if (progConfig !== undefined) {
-        try {
-          const programConfigs: ProgramConfig[] = JSON.parse(
-            progConfig.toString(),
-          ).pgms;
-          // set w/ respect to the current workspace path
-          this.setProgramConfigs(this.workspacePath, programConfigs);
+        if (
+          !this.parseProgramConfigs(this.workspacePath, progConfig.toString())
+        ) {
+          console.error("Failed to load program config, skipping.");
+        } else {
           return;
-        } catch (e) {
-          console.error("Failed to load program config, skipping:", e);
         }
       } else {
         console.warn("No program config found.");
@@ -236,10 +286,7 @@ export class PluginConfigurationProvider {
 
       if (processGrpConfig !== undefined) {
         try {
-          const processGroupConfigs: ProcessGroup[] = JSON.parse(
-            processGrpConfig.toString(),
-          ).pgroups;
-          this.setProcessGroupConfigs(processGroupConfigs);
+          this.parseProcessGroupConfigs(processGrpConfig);
           this.postProcessProgramConfigs();
           return;
         } catch (e) {
@@ -271,7 +318,7 @@ export class PluginConfigurationProvider {
 
       // collect raw compiler options from the group
       const rawCompilerOptions = (
-        processGroupConfig?.["compiler-options"] || []
+        processGroupConfig?.compilerOptions || []
       ).join(" ");
       // collect raw pli-options from the group & program config
       const rawPliOptions =
@@ -310,6 +357,19 @@ export class PluginConfigurationProvider {
     return [abstractOptions, translatedOptions, collectedIssues];
   }
 
+  parseProgramConfigs(workspacePath: string, text: string): boolean {
+    try {
+      const programConfigs: SerializedProgramConfig[] = JSON.parse(text).pgms;
+      const programConfigsDeserialized = programConfigs.map(
+        deserializeProgramConfig,
+      );
+      this.setProgramConfigs(workspacePath, programConfigsDeserialized);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   /**
    * Sets the program configs of this plugin configuration provider, overwriting any existing configs.
    * The config key is set as the full path relative to the workspace.
@@ -325,6 +385,19 @@ export class PluginConfigurationProvider {
     for (const config of programConfigs) {
       const newPath = UriUtils.joinPath(workspaceUri, config.program);
       this.programConfigs.set(newPath.toString(), config);
+    }
+  }
+
+  parseProcessGroupConfigs(text: string): boolean {
+    try {
+      const processGroupConfigs: SerializedProcessGroup[] =
+        JSON.parse(text).pgroups;
+      const groupConfigs = processGroupConfigs.map(deserializeProcessGroup);
+      this.setProcessGroupConfigs(groupConfigs);
+      this.postProcessProgramConfigs();
+      return true;
+    } catch {
+      return false;
     }
   }
 
@@ -429,8 +502,8 @@ export class PluginConfigurationProvider {
     programConfig: ProgramConfig,
   ): string {
     const group = this.getProcessGroupConfig(programConfig.pgroup);
-    const groupOpts = group && group["pli-options"] ? group["pli-options"] : {};
-    const progOpts = programConfig["pli-options"] || {};
+    const groupOpts = group?.pliOptions ?? {};
+    const progOpts = programConfig.pliOptions || {};
     // merge w/ program config entries taking precedence
     const merged = { ...groupOpts, ...progOpts };
     if (Object.keys(merged).length === 0) {

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -179,8 +179,8 @@ export class PluginConfigurationProvider {
       wsPrefix += "/";
     }
     for (const processGroup of this.processGroupConfigs.values()) {
-      const libs = processGroup.libs || [];
-      const extensions = processGroup.includeExtensions || [];
+      const libs = processGroup.libs;
+      const extensions = processGroup.includeExtensions;
       for (let lib of libs) {
         lib = lib.replace(/[\\/]+$/, "");
         for (const ext of extensions) {
@@ -359,11 +359,9 @@ export class PluginConfigurationProvider {
 
   parseProgramConfigs(workspacePath: string, text: string): boolean {
     try {
-      const programConfigs: SerializedProgramConfig[] = JSON.parse(text).pgms;
-      const programConfigsDeserialized = programConfigs.map(
-        deserializeProgramConfig,
-      );
-      this.setProgramConfigs(workspacePath, programConfigsDeserialized);
+      const serializedData: SerializedProgramConfig[] = JSON.parse(text).pgms;
+      const programConfigs = serializedData.map(deserializeProgramConfig);
+      this.setProgramConfigs(workspacePath, programConfigs);
       return true;
     } catch {
       return false;
@@ -390,9 +388,8 @@ export class PluginConfigurationProvider {
 
   parseProcessGroupConfigs(text: string): boolean {
     try {
-      const processGroupConfigs: SerializedProcessGroup[] =
-        JSON.parse(text).pgroups;
-      const groupConfigs = processGroupConfigs.map(deserializeProcessGroup);
+      const serializedData: SerializedProcessGroup[] = JSON.parse(text).pgroups;
+      const groupConfigs = serializedData.map(deserializeProcessGroup);
       this.setProcessGroupConfigs(groupConfigs);
       this.postProcessProgramConfigs();
       return true;
@@ -503,7 +500,7 @@ export class PluginConfigurationProvider {
   ): string {
     const group = this.getProcessGroupConfig(programConfig.pgroup);
     const groupOpts = group?.pliOptions ?? {};
-    const progOpts = programConfig.pliOptions || {};
+    const progOpts = programConfig.pliOptions;
     // merge w/ program config entries taking precedence
     const merged = { ...groupOpts, ...progOpts };
     if (Object.keys(merged).length === 0) {

--- a/packages/language/test/fourslash-harness/execute.test.ts
+++ b/packages/language/test/fourslash-harness/execute.test.ts
@@ -61,13 +61,18 @@ beforeEach(() => {
     {
       program: "*.pli",
       pgroup: "default",
+      pliOptions: {},
     },
   ]);
   PluginConfigurationProviderInstance.setProcessGroupConfigs([
     {
       name: "default",
       libs: ["cpy"],
-      "include-extensions": [".pli"],
+      includeExtensions: [".pli"],
+      compilerOptions: [],
+      implicitBuiltins: new Set(),
+      lspOptions: { checkMargins: false },
+      pliOptions: {},
     },
   ]);
 });

--- a/packages/language/test/fourslash/linker/link-sql-includes.ts
+++ b/packages/language/test/fourslash/linker/link-sql-includes.ts
@@ -13,7 +13,9 @@
 
 // @wrap: main
 //// PUT(<|1:SQLCA|>.SQLCODE);
+//// PUT(<|2:SQLDA|>.SQLTYPE);
 
-// Should link to the SQLCA builtin copybook definition
+// Should link to the SQLCA/SQLDA builtin copybook definition
 // Therefore, no diagnostics expected
 verify.noDiagnostics(1);
+verify.noDiagnostics(2);

--- a/packages/language/test/fourslash/linker/link-sqlca.ts
+++ b/packages/language/test/fourslash/linker/link-sqlca.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// PUT(<|1:SQLCA|>.SQLCODE);
+
+// Should link to the SQLCA builtin copybook definition
+// Therefore, no diagnostics expected
+verify.noDiagnostics(1);

--- a/packages/language/test/parser/pli-lexer.test.ts
+++ b/packages/language/test/parser/pli-lexer.test.ts
@@ -13,7 +13,11 @@ import { beforeAll, describe, expect, test, afterAll } from "vitest";
 import { PliLexer } from "../../src/preprocessor/pli-lexer";
 import { URI } from "../../src/utils/uri";
 import { createCompilationUnit } from "../../src/workspace/compilation-unit";
-import { PluginConfigurationProviderInstance } from "../../src/workspace/plugin-configuration-provider";
+import {
+  PluginConfigurationProviderInstance,
+  ProcessGroup,
+  ProgramConfig,
+} from "../../src/workspace/plugin-configuration-provider";
 import { TextDocument } from "vscode-languageserver-textdocument";
 
 type TokenizeFunction = (text: string) => Promise<string[]>;
@@ -202,13 +206,19 @@ describe("PL/1 Lexer", () => {
       const inputText = `*PROCESS ARCH(10);
       DCL A fixed bin(31);`;
 
-      const programConfig = {
+      const programConfig: ProgramConfig = {
         program: "test.pli",
         pgroup: "testGroup",
+        pliOptions: {},
       };
-      const processGroupConfig = {
+      const processGroupConfig: ProcessGroup = {
         name: "testGroup",
-        "compiler-options": ["ASSERT(ENTRY)"],
+        compilerOptions: ["ASSERT(ENTRY)"],
+        implicitBuiltins: new Set(),
+        includeExtensions: [],
+        libs: [],
+        lspOptions: { checkMargins: false },
+        pliOptions: {},
       };
 
       await PluginConfigurationProviderInstance.init("/test");
@@ -236,9 +246,10 @@ describe("PL/1 Lexer", () => {
       const inputText = `*PROCESS ARCH(10);
       DCL A fixed bin(31);`;
 
-      const programConfig = {
+      const programConfig: ProgramConfig = {
         program: "test.pli",
         pgroup: "missingGroup",
+        pliOptions: {},
       };
 
       await PluginConfigurationProviderInstance.init("/test");
@@ -260,13 +271,19 @@ describe("PL/1 Lexer", () => {
       const uri = URI.file("/test/test.pli");
       const inputText = " DCL A fixed bin(31);";
 
-      const programConfig = {
+      const programConfig: ProgramConfig = {
         program: "test.pli",
         pgroup: "testGroup",
+        pliOptions: {},
       };
-      const processGroupConfig = {
+      const processGroupConfig: ProcessGroup = {
         name: "testGroup",
-        "compiler-options": ["ASSERT(ENTRY)"],
+        compilerOptions: ["ASSERT(ENTRY)"],
+        implicitBuiltins: new Set(),
+        includeExtensions: [],
+        libs: [],
+        lspOptions: { checkMargins: false },
+        pliOptions: {},
       };
 
       await PluginConfigurationProviderInstance.init("/test");

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -235,14 +235,14 @@ export class TestBuilder {
     // Check if the files contain a program config or process group.
     for (const [uri, file] of this.files) {
       if (uri.endsWith(PluginConfigurationProvider.PROGRAM_CONFIG_FILE)) {
-        PluginConfigurationProviderInstance.setProgramConfigs(
+        PluginConfigurationProviderInstance.parseProgramConfigs(
           "",
-          JSON.parse(file.output).pgms,
+          file.output,
         );
       }
       if (uri.endsWith(PluginConfigurationProvider.PROCESS_GROUP_CONFIG_FILE)) {
-        PluginConfigurationProviderInstance.setProcessGroupConfigs(
-          JSON.parse(file.output).pgroups,
+        PluginConfigurationProviderInstance.parseProcessGroupConfigs(
+          file.output,
         );
       }
     }

--- a/packages/language/test/workspace/compilation-unit.test.ts
+++ b/packages/language/test/workspace/compilation-unit.test.ts
@@ -59,6 +59,7 @@ describe("Compilation Unit Tests", () => {
       {
         program: "test/entry.pli",
         pgroup: "",
+        pliOptions: {},
       },
     ]);
     expect(
@@ -89,6 +90,7 @@ describe("Compilation Unit Tests", () => {
       {
         program: "test/*.pli",
         pgroup: "",
+        pliOptions: {},
       },
     ]);
 
@@ -127,15 +129,19 @@ describe("Compilation Unit Tests", () => {
       {
         program: "src/*.pli",
         pgroup: "default",
+        pliOptions: {},
       },
     ]);
     // Simulate the process group config (normally this would be loaded from a config file)
     PluginConfigurationProviderInstance.setProcessGroupConfigs([
       {
         name: "default",
-        "compiler-options": [],
+        compilerOptions: [],
         libs: ["cpy"],
-        "include-extensions": [".inc"],
+        includeExtensions: [".inc"],
+        lspOptions: { checkMargins: false },
+        pliOptions: {},
+        implicitBuiltins: new Set(),
       },
     ]);
 


### PR DESCRIPTION
Resolves https://github.com/zowe/zowe-pli-language-support/issues/391

Adds builtins for the `SQLCA` and `SQLDA` variables to our language server. Does not add any actual support for `EXEC SQL` statements so far.

Most of the changes are unrelated to the actual change - I was unhappy with how we pull the `pli-options`, etc. variable names throughout the whole language server without any validation, etc.