### PR TITLE
Remove `langium` dependency remnants

### DIFF
--- a/packages/language/package.json
+++ b/packages/language/package.json
@@ -49,7 +49,6 @@
     "minimatch": "^10.0.3"
   },
   "devDependencies": {
-    "langium-cli": "~3.4.0",
     "@types/lodash-es": "^4.17.12"
   }
 }

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -26,7 +26,6 @@
     "@codingame/monaco-vscode-configuration-service-override": "~17.2.1",
     "@codingame/monaco-vscode-outline-service-override": "~17.2.1",
     "@codingame/monaco-vscode-api": "~17.2.1",
-    "langium": "~3.4.0",
     "lz-string": "~1.5.0",
     "pli-language": "workspace:*",
     "vscode-languageserver-protocol": "~3.17.5",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -111,7 +111,6 @@
   },
   "dependencies": {
     "@vscode/extension-telemetry": "^0.9.8",
-    "langium": "~3.4.0",
     "glob": "^11.0.2",
     "pli-language": "workspace:*",
     "util": "^0.12.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,9 +75,6 @@ importers:
       '@types/lodash-es':
         specifier: ^4.17.12
         version: 4.17.12
-      langium-cli:
-        specifier: ~3.4.0
-        version: 3.4.0
 
   packages/playground:
     dependencies:
@@ -111,9 +108,6 @@ importers:
       '@codingame/monaco-vscode-views-service-override':
         specifier: ~17.2.1
         version: 17.2.1
-      langium:
-        specifier: ~3.4.0
-        version: 3.4.0
       lz-string:
         specifier: ~1.5.0
         version: 1.5.0
@@ -163,9 +157,6 @@ importers:
       glob:
         specifier: ^11.0.2
         version: 11.0.2
-      langium:
-        specifier: ~3.4.0
-        version: 3.4.0
       pli-language:
         specifier: workspace:*
         version: link:../language
@@ -1363,10 +1354,6 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
-  chalk@5.3.0:
-    resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
@@ -1403,10 +1390,6 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
-
-  commander@11.0.0:
-    resolution: {integrity: sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==}
-    engines: {node: '>=16'}
 
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
@@ -1620,10 +1603,6 @@ packages:
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
-
-  fs-extra@11.1.1:
-    resolution: {integrity: sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==}
-    engines: {node: '>=14.14'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1878,9 +1857,6 @@ packages:
   jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
 
-  jsonschema@1.4.1:
-    resolution: {integrity: sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==}
-
   jsonwebtoken@9.0.2:
     resolution: {integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==}
     engines: {node: '>=12', npm: '>=6'}
@@ -1899,18 +1875,6 @@ packages:
 
   keytar@7.9.0:
     resolution: {integrity: sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==}
-
-  langium-cli@3.4.0:
-    resolution: {integrity: sha512-7dU5kPlfzwzPLkaaMcBCc0tfnVPHOcxcgMW/l2xRDy9Y/cljTCXSV8y3lJUlHASQa3LZDF0+8bGZX3Noxa+GLw==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
-
-  langium-railroad@3.4.0:
-    resolution: {integrity: sha512-dTSTm4+UI2byf+kMnjXBJgcif6XjpvFrFv4HhRONV6ZzQIVWweAycg40q7Wm8D/iagtZa/eFa1l5yCxQf896eA==}
-
-  langium@3.4.0:
-    resolution: {integrity: sha512-7xufsaF5jYGFMXHOTka8bN48b9FHn2vZGL2R+PGgyi+JY/xgimUFDKYcz/h4gm5m8p3sSRtZDh+sK2U63K0MNg==}
-    engines: {node: '>=18.0.0'}
 
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
@@ -2218,9 +2182,6 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-
-  railroad-diagrams@1.0.0:
-    resolution: {integrity: sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==}
 
   rc-config-loader@4.1.3:
     resolution: {integrity: sha512-kD7FqML7l800i6pS6pvLyIE2ncbk9Du8Q0gp/4hMPhJU6ZxApkoLcGD8ZeqgiAlfwZ6BlETq6qqe+12DUL207w==}
@@ -4512,8 +4473,6 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  chalk@5.3.0: {}
-
   check-error@2.1.1: {}
 
   cheerio-select@2.1.0:
@@ -4567,8 +4526,6 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
-
-  commander@11.0.0: {}
 
   commander@12.1.0: {}
 
@@ -4805,12 +4762,6 @@ snapshots:
     optional: true
 
   fs-extra@10.1.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.1.0
-      universalify: 2.0.1
-
-  fs-extra@11.1.1:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.1.0
@@ -5083,8 +5034,6 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
-  jsonschema@1.4.1: {}
-
   jsonwebtoken@9.0.2:
     dependencies:
       jws: 3.2.2
@@ -5125,29 +5074,6 @@ snapshots:
       node-addon-api: 4.3.0
       prebuild-install: 7.1.2
     optional: true
-
-  langium-cli@3.4.0:
-    dependencies:
-      chalk: 5.3.0
-      commander: 11.0.0
-      fs-extra: 11.1.1
-      jsonschema: 1.4.1
-      langium: 3.4.0
-      langium-railroad: 3.4.0
-      lodash: 4.17.21
-
-  langium-railroad@3.4.0:
-    dependencies:
-      langium: 3.4.0
-      railroad-diagrams: 1.0.0
-
-  langium@3.4.0:
-    dependencies:
-      chevrotain: 11.0.3
-      chevrotain-allstar: 0.3.1(chevrotain@11.0.3)
-      vscode-languageserver: 9.0.1
-      vscode-languageserver-textdocument: 1.0.12
-      vscode-uri: 3.0.8
 
   leven@3.1.0: {}
 
@@ -5462,8 +5388,6 @@ snapshots:
       side-channel: 1.0.6
 
   queue-microtask@1.2.3: {}
-
-  railroad-diagrams@1.0.0: {}
 
   rc-config-loader@4.1.3:
     dependencies:


### PR DESCRIPTION
I believe I wasn't really throughout enough, when removing the references to the `langium` package. This removes all package references.