### PR TITLE
Fixes suffix issue in inline procedure calls

### DIFF
--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -1363,7 +1363,6 @@ function parseAndEvaluateProcedure(
   let evaluatedArgs: Value[];
   let advance = 1;
   let immediateFollow = tokens[index].immediateFollow;
-  let suffix: string = "";
   if (!procedure.statement) {
     const parseResult = parseInlineProcedureInvocation(tokens, index);
     advance = parseResult.advance;
@@ -1373,7 +1372,6 @@ function parseAndEvaluateProcedure(
     const parseResult = parseInlineStatementProcedureInvocation(tokens, index);
     advance = parseResult.advance;
     immediateFollow = parseResult.immediateFollow;
-    suffix = parseResult.suffix;
     evaluatedArgs = evaluatePositionalArguments(
       parseResult.positionalArgs,
       context,
@@ -1385,13 +1383,15 @@ function parseAndEvaluateProcedure(
       context,
     );
   }
-
   const localContext = createLocalContext(context, procedure);
   let value = runProcedure(procedure, evaluatedArgs, localContext);
-  if (isScalarValue(value) && suffix) {
+  if (isScalarValue(value) && immediateFollow && tokens[index + advance]) {
     // Add the suffix to the value, as it was immediately following the procedure call
     // Otherwise, the suffix will generate a separate token, which is not the intended behavior
-    value = stringToValue(value.value + suffix);
+    const nextToken = tokens[index + advance];
+    value = stringToValue(value.value + nextToken.originalImage);
+    advance++;
+    immediateFollow = nextToken.immediateFollow;
   }
   return {
     value,
@@ -1528,11 +1528,6 @@ interface InlineStatementProcedureParseResult {
   namedArgs: Map<string, InlineProcedureNamedArgument>;
   advance: number;
   immediateFollow: boolean;
-  /**
-   * If the procedure invocation is immediately followed by another token
-   * This token acts as a suffix to the procedure call and needs to be attached to the return value
-   */
-  suffix: string;
 }
 
 function parseInlineStatementProcedureInvocation(
@@ -1601,19 +1596,11 @@ function parseInlineStatementProcedureInvocation(
       tokens: argTokens,
     });
   }
-  let suffix = "";
-  if (immediateFollow && i < length) {
-    const suffixToken = tokens[i];
-    suffix = suffixToken.image;
-    immediateFollow = suffixToken.immediateFollow;
-    advance++;
-  }
   return {
     positionalArgs: positionalParseResult.args,
     namedArgs,
     advance,
     immediateFollow,
-    suffix,
   };
 }
 

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -1385,13 +1385,13 @@ function parseAndEvaluateProcedure(
   }
   const localContext = createLocalContext(context, procedure);
   let value = runProcedure(procedure, evaluatedArgs, localContext);
-  if (isScalarValue(value) && immediateFollow && tokens[index + advance]) {
-    // Add the suffix to the value, as it was immediately following the procedure call
-    // Otherwise, the suffix will generate a separate token, which is not the intended behavior
-    const nextToken = tokens[index + advance];
-    value = stringToValue(value.value + nextToken.originalImage);
+  const tokenAfterProcedureCall = tokens[index + advance];
+  if (isScalarValue(value) && immediateFollow && tokenAfterProcedureCall) {
+    // Add the token after the procedure call to the value, as it was immediately following the procedure call
+    // Otherwise, the token will be treated separately, which is not the intended behavior
+    value = stringToValue(value.value + tokenAfterProcedureCall.originalImage);
     advance++;
-    immediateFollow = nextToken.immediateFollow;
+    immediateFollow = tokenAfterProcedureCall.immediateFollow;
   }
   return {
     value,

--- a/packages/language/test/fourslash/preprocessor/procedures/inline-procedure-with-arguments-merges-with-next-token-null.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/inline-procedure-with-arguments-merges-with-next-token-null.ts
@@ -15,6 +15,6 @@
 ////   RETURN (X);
 //// %END;
 //// %ACTIVATE TEST;
-//// TEST(VALUE)VAR
+//// TEST(VALUE)%;VAR
 
 preprocessor.expectTokens("VALUEVAR");


### PR DESCRIPTION
I noticed an issue related to the suffix of non-statement procedure calls in the preprocessor while reviewing https://github.com/zowe/zowe-pli-language-support/pull/404. This change adds a test and a fix for this.