### PR TITLE
Implement Quick Fix for unresolved INCLUDE files

### DIFF
--- a/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
+++ b/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
@@ -1,0 +1,102 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { URI } from "../../utils/uri";
+import { FileSystemProviderInstance } from "../../workspace/file-system-provider";
+import { UriUtils } from "../../utils/uri";
+import {
+  CodeAction,
+  CodeActionKind,
+  Diagnostic,
+} from "vscode-languageserver-types";
+import {
+  PluginConfigurationProvider,
+  PluginConfigurationProviderInstance,
+  serializeProcessGroup,
+} from "../../workspace/plugin-configuration-provider";
+
+export async function quickFixResolveInclude(
+  diagnostic: Diagnostic,
+): Promise<CodeAction | undefined> {
+  const unresolvedFile = diagnostic.data?.unresolvedFile;
+  const procGrpsConfig =
+    PluginConfigurationProviderInstance.getProcessGroupConfig("default");
+  if (!procGrpsConfig || !unresolvedFile) return undefined;
+
+  const configExtensions = procGrpsConfig.includeExtensions;
+  const unresolvedFilePath = await FileSystemProviderInstance.search({
+    path: URI.parse(unresolvedFile),
+    extensions: configExtensions,
+    global: true,
+  });
+  if (!unresolvedFilePath) return undefined;
+
+  const workspaceFolderUri = URI.parse(
+    PluginConfigurationProviderInstance.getWorkspacePath(),
+  );
+
+  let parentFolder = UriUtils.computeWorkspaceRelativeParentFolder(
+    unresolvedFilePath,
+    workspaceFolderUri,
+  );
+  if (!parentFolder) return undefined;
+  if (procGrpsConfig.libs.includes(parentFolder)) return undefined;
+
+  const serializedProcGrpsConfig = serializeProcessGroup(procGrpsConfig);
+  const newContent = JSON.stringify(
+    {
+      pgroups: [
+        {
+          ...serializedProcGrpsConfig,
+          libs: [...(serializedProcGrpsConfig.libs ?? []), parentFolder],
+        },
+      ],
+    },
+    undefined,
+    2,
+  );
+
+  const procGrpsFileUri = UriUtils.joinPath(
+    workspaceFolderUri,
+    PluginConfigurationProvider.PROCESS_GROUP_CONFIG_FILE,
+  );
+
+  const action: CodeAction = {
+    title: `Add '${parentFolder}' to INCLUDE libs`,
+    kind: CodeActionKind.QuickFix,
+    diagnostics: [diagnostic],
+    command: {
+      title: "Apply INCLUDE fix",
+      command: "pli.applyIncludeFix",
+      arguments: [procGrpsFileUri.toString(), newContent],
+    },
+  };
+
+  return action;
+}
+
+export async function applyQuickFixes(
+  diagnostics: Diagnostic[],
+): Promise<CodeAction[] | undefined> {
+  const actions: CodeAction[] = [];
+  // PLI CODES LIST
+  const CODE_UNRESOLVED_INCLUDE = "IBM3841IS"; // The INCLUDE file could not be found, or if found, it could not be opened.
+
+  for (const diagnostic of diagnostics) {
+    if (diagnostic.code === CODE_UNRESOLVED_INCLUDE) {
+      const action = await quickFixResolveInclude(diagnostic);
+      if (action) actions.push(action);
+    }
+  }
+
+  if (!actions.length) return undefined;
+  return actions;
+}

--- a/packages/language/src/language-server/connection-handler.ts
+++ b/packages/language/src/language-server/connection-handler.ts
@@ -20,7 +20,12 @@ import { URI, UriUtils } from "../utils/uri";
 import { definitionRequest } from "./definition-request";
 import { referencesRequest } from "./references-request";
 import { semanticTokenLegend, semanticTokens } from "./semantic-tokens";
-import { Location, TextEdit } from "vscode-languageserver-types";
+import {
+  CodeAction,
+  Diagnostic,
+  Location,
+  TextEdit,
+} from "vscode-languageserver-types";
 import {
   completionItemToLSP,
   documentSymbolToLSP,
@@ -35,6 +40,8 @@ import { PluginConfigurationProviderInstance } from "../workspace/plugin-configu
 import { completionRequest } from "./completion/completion-request";
 import { hoverRequest } from "./hover-request";
 import { Mutex } from "../workspace/mutex";
+import { applyQuickFixes } from "./code-actions/apply-quick-fixes";
+import { FileSystemProviderInstance } from "../workspace/file-system-provider";
 
 /**
  * Notification sent to the LS when the workspace's plugin configuration changes.
@@ -45,6 +52,8 @@ export const WorkspaceDidChangePlipluginConfigNotification =
 export function startLanguageServer(connection: Connection): void {
   const compilationUnitHandler = new CompilationUnitHandler();
   compilationUnitHandler.listen(connection);
+  const APPLY_QUICK_FIXES = "pli.applyIncludeFix";
+
   connection.onInitialize(async (params) => {
     // init the plugin config provider in reverse folder order, last plugin config encountered will take precedence
     // TODO @montymxb Apr 23rd, 2025: Consider addressing multiple workspaces w/ multiple plugin configs
@@ -71,6 +80,10 @@ export function startLanguageServer(connection: Connection): void {
         renameProvider: true,
         definitionProvider: true,
         referencesProvider: true,
+        codeActionProvider: true,
+        executeCommandProvider: {
+          commands: [APPLY_QUICK_FIXES],
+        },
         documentHighlightProvider: true,
         semanticTokensProvider: {
           legend: semanticTokenLegend,
@@ -291,5 +304,31 @@ export function startLanguageServer(connection: Connection): void {
       });
     },
   );
+
+  connection.onCodeAction(async (params) => {
+    return Mutex.read(async () => {
+      const diagnostics = params.context.diagnostics as Diagnostic[];
+      if (!diagnostics.length) return;
+      const actions: CodeAction[] | undefined =
+        await applyQuickFixes(diagnostics);
+      if (!actions) return;
+
+      return actions;
+    });
+  });
+
+  connection.onExecuteCommand(async (params) => {
+    if (params.command === APPLY_QUICK_FIXES) {
+      return Mutex.run(async () => {
+        const [uri, content] = params.arguments as string[];
+        try {
+          await FileSystemProviderInstance.writeFile(URI.parse(uri), content);
+        } catch (err) {
+          console.error("Failed to write proc_grps.json:", err);
+        }
+      });
+    }
+  });
+
   connection.listen();
 }

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -1886,9 +1886,13 @@ async function runInclude(
     if (error) {
       console.log("Failed to resolve include file:", error);
     }
-    context.diagnostics.push(
-      diagnosticFromCode(PLICodes.Severe.IBM3841I, item.token, item.fileName),
+    const diagnostic = diagnosticFromCode(
+      PLICodes.Severe.IBM3841I,
+      item.token,
+      item.fileName,
     );
+    if (item.fileName) diagnostic.data = { unresolvedFile: item.fileName };
+    context.diagnostics.push(diagnostic);
   }
 
   if (!uri) {
@@ -2025,7 +2029,7 @@ async function resolveIncludeFileUri(
       const match = await FileSystemProviderInstance.search({
         path: libFileUri,
         extensions: pgroup.includeExtensions,
-      });
+      })) as URI | undefined;
       if (match) {
         return match;
       }

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2026,10 +2026,10 @@ async function resolveIncludeFileUri(
         libFileUri = UriUtils.joinPath(libUri, item.fileName);
       }
 
-      const match = (await FileSystemProviderInstance.search({
+      const match = await FileSystemProviderInstance.search({
         path: libFileUri,
         extensions: pgroup.includeExtensions,
-      }))
+      });
       if (match) {
         return match;
       }

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2029,7 +2029,7 @@ async function resolveIncludeFileUri(
       const match = await FileSystemProviderInstance.search({
         path: libFileUri,
         extensions: pgroup.includeExtensions,
-      })) as URI | undefined;
+      }) as URI | undefined;
       if (match) {
         return match;
       }

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2029,7 +2029,7 @@ async function resolveIncludeFileUri(
       const match = (await FileSystemProviderInstance.search({
         path: libFileUri,
         extensions: pgroup.includeExtensions,
-      })) as URI | undefined;
+      }))
       if (match) {
         return match;
       }

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2026,10 +2026,10 @@ async function resolveIncludeFileUri(
         libFileUri = UriUtils.joinPath(libUri, item.fileName);
       }
 
-      const match = await FileSystemProviderInstance.search({
+      const match = (await FileSystemProviderInstance.search({
         path: libFileUri,
         extensions: pgroup.includeExtensions,
-      }) as URI | undefined;
+      })) as URI | undefined;
       if (match) {
         return match;
       }

--- a/packages/language/src/utils/uri.ts
+++ b/packages/language/src/utils/uri.ts
@@ -61,4 +61,35 @@ export namespace UriUtils {
   export function normalize(uri: URI | string): string {
     return URI.parse(uri.toString()).toString();
   }
+
+  /**
+   * Compute workspace-relative parent folder for a found file candidate.
+   *
+   * Examples:
+   *  - workspace root: /repo/plugin-example
+   *  - candidate: /repo/plugin-example/cpy/test-nested-included/nested-not-here.pli
+   *  -> returns "cpy/test-nested-included"
+   *
+   * If workspace-relative cannot be computed, returns the parent folder name (e.g. "test-nested-included").
+   * Returns undefined if candidate looks invalid.
+   */
+  export function computeWorkspaceRelativeParentFolder(
+    candidateRaw: URI,
+    workspaceFolderUri: URI,
+  ): string | undefined {
+    if (!candidateRaw) return undefined;
+
+    const candidate = normalize(candidateRaw);
+    const workspaceFolder = normalize(workspaceFolderUri);
+
+    if (!candidate.startsWith(workspaceFolder)) return undefined;
+
+    const relativePath = candidate.slice(workspaceFolder.length);
+    const parentDir = relativePath.substring(0, relativePath.lastIndexOf("/"));
+    const parentRelativePath = parentDir.startsWith("/")
+      ? parentDir.slice(1)
+      : parentDir;
+
+    return parentRelativePath;
+  }
 }

--- a/packages/language/src/workspace/file-system-provider.ts
+++ b/packages/language/src/workspace/file-system-provider.ts
@@ -14,6 +14,7 @@ import { URI } from "../utils/uri";
 export interface SearchOptions {
   path: URI;
   extensions: string[];
+  global?: boolean;
 }
 
 export interface FileSystemProvider {
@@ -95,18 +96,38 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
     this.files.delete(uri.toString().toLowerCase());
   }
 
-  async search(pattern: SearchOptions): Promise<URI | undefined> {
-    const uri = pattern.path.toString().toLowerCase();
-    if (this.files.has(uri)) {
-      return pattern.path;
-    }
-    const extensions = pattern.extensions ?? [];
-    for (const ext of extensions) {
-      const fullPath = uri + (ext.startsWith(".") ? ext : `.${ext}`);
-      if (this.files.has(fullPath)) {
-        return URI.parse(fullPath).with({ scheme: pattern.path.scheme });
+  async search(options: SearchOptions): Promise<URI | undefined> {
+    const searchPath = options.path
+      .toString()
+      .toLowerCase()
+      .replace(/\\/g, "/");
+    const extensions = options.extensions ?? [];
+
+    if (!options.global) {
+      if (this.files.has(searchPath)) {
+        return options.path;
+      }
+      for (const ext of extensions) {
+        const fullPath = searchPath + (ext.startsWith(".") ? ext : `.${ext}`);
+        if (this.files.has(fullPath)) {
+          return URI.parse(fullPath).with({ scheme: options.path.scheme });
+        }
+      }
+    } else {
+      // @wagner-laranjeiras. TODO: Optimize this matching pattern.
+      for (const [filePath] of this.files) {
+        if (filePath.endsWith(searchPath)) {
+          return URI.parse(filePath);
+        }
+        for (const ext of extensions) {
+          const fullPath = searchPath + (ext.startsWith(".") ? ext : `.${ext}`);
+          if (filePath.endsWith(fullPath)) {
+            return URI.parse(filePath).with({ scheme: options.path.scheme });
+          }
+        }
       }
     }
+
     return undefined;
   }
 }

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -85,7 +85,9 @@ export interface ProcessGroup {
   issueCount?: number;
 }
 
-function deserializeProcessGroup(obj: SerializedProcessGroup): ProcessGroup {
+export function deserializeProcessGroup(
+  obj: SerializedProcessGroup,
+): ProcessGroup {
   const compilerOptions = obj["compiler-options"] || [];
   const pliOptions = obj["pli-options"] || {};
   const includeExtensions = obj["include-extensions"] || [];
@@ -106,6 +108,24 @@ function deserializeProcessGroup(obj: SerializedProcessGroup): ProcessGroup {
       : new Set(),
     lspOptions: {
       checkMargins: isBoolean(checkMargins) ? checkMargins : false,
+    },
+  };
+}
+
+export function serializeProcessGroup(
+  group: ProcessGroup,
+): SerializedProcessGroup {
+  return {
+    name: group.name,
+    "compiler-options": group.compilerOptions,
+    "pli-options": group.pliOptions,
+    libs: group.libs,
+    "include-extensions": group.includeExtensions,
+    "implicit-builtins": Array.from(group.implicitBuiltins).map((b) =>
+      b.toLowerCase(),
+    ),
+    "lsp-options": {
+      "check-margins": group.lspOptions.checkMargins,
     },
   };
 }

--- a/packages/language/test/lsp/apply-quick-fixes.test.ts
+++ b/packages/language/test/lsp/apply-quick-fixes.test.ts
@@ -1,0 +1,133 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { Diagnostic } from "vscode-languageserver-types";
+import * as applyQuickFixes from "../../src/language-server/code-actions/apply-quick-fixes";
+import { FileSystemProviderInstance } from "../../src/workspace/file-system-provider";
+import {
+  deserializeProcessGroup,
+  PluginConfigurationProviderInstance,
+} from "../../src/workspace/plugin-configuration-provider";
+import { URI, UriUtils } from "../../src/utils/uri";
+
+// Mock dependencies
+vi.mock("../../workspace/file-system-provider");
+vi.mock("../../workspace/plugin-configuration-provider");
+vi.mock("../../utils/uri");
+const mockConfig = deserializeProcessGroup({
+  name: "default",
+  "include-extensions": [".inc"],
+  libs: [],
+});
+
+describe("quickFixResolveInclude", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test("should return undefined when no unresolved file in diagnostic", async () => {
+    const diagnostic = { data: {} } as Diagnostic;
+
+    PluginConfigurationProviderInstance.getProcessGroupConfig = vi
+      .fn()
+      .mockReturnValue(mockConfig);
+    const result = await applyQuickFixes.quickFixResolveInclude(diagnostic);
+    expect(result).toBeUndefined();
+  });
+
+  test("should return undefined when no process group config", async () => {
+    const diagnostic = { data: { unresolvedFile: "some/file" } } as Diagnostic;
+    PluginConfigurationProviderInstance.getProcessGroupConfig = vi
+      .fn()
+      .mockReturnValue(undefined);
+
+    const result = await applyQuickFixes.quickFixResolveInclude(diagnostic);
+    expect(result).toBeUndefined();
+  });
+
+  test("should return undefined when file not found", async () => {
+    const diagnostic = {
+      data: { unresolvedFile: "missing/file" },
+    } as Diagnostic;
+
+    PluginConfigurationProviderInstance.getProcessGroupConfig = vi
+      .fn()
+      .mockReturnValue(mockConfig);
+    FileSystemProviderInstance.search = vi.fn().mockResolvedValue(undefined);
+
+    const result = await applyQuickFixes.quickFixResolveInclude(diagnostic);
+    expect(result).toBeUndefined();
+  });
+
+  test("should return code action when all conditions are met", async () => {
+    const diagnostic = {
+      data: { unresolvedFile: "some/file.inc" },
+    } as Diagnostic;
+    PluginConfigurationProviderInstance.getProcessGroupConfig = vi
+      .fn()
+      .mockReturnValue(mockConfig);
+    FileSystemProviderInstance.search = vi
+      .fn()
+      .mockReturnValue(URI.parse("/workspace/some/file.inc"));
+    PluginConfigurationProviderInstance.getWorkspacePath = vi
+      .fn()
+      .mockReturnValue("workspace/");
+    const result = await applyQuickFixes.quickFixResolveInclude(diagnostic);
+
+    expect(result).toBeDefined();
+    expect(result!.title).toBe("Add 'some' to INCLUDE libs");
+    expect(result!.kind).toBe("quickfix");
+    expect(result!.command!.command).toBe("pli.applyIncludeFix");
+  });
+});
+
+describe("applyQuickFixes", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test("should return code actions only for IBM3841IS diagnostics", async () => {
+    const diagnostics = [
+      { code: "IBM3841IS", data: { unresolvedFile: "file1" } } as Diagnostic,
+      { code: "IBM3842IS", data: {} } as Diagnostic,
+      { code: "IBM3841IS", data: { unresolvedFile: "file2" } } as Diagnostic,
+    ];
+    FileSystemProviderInstance.search = vi
+      .fn()
+      .mockReturnValueOnce(URI.parse("/workspace/some/file1.inc"))
+      .mockReturnValueOnce(URI.parse("/workspace/some/file2.inc"));
+
+    vi.spyOn(UriUtils, "joinPath").mockReturnValue(
+      URI.parse("/workspace/proc-groups.json"),
+    );
+
+    PluginConfigurationProviderInstance.getProcessGroupConfig = vi
+      .fn()
+      .mockReturnValue(mockConfig);
+    PluginConfigurationProviderInstance.getWorkspacePath = vi
+      .fn()
+      .mockReturnValue("workspace/");
+
+    const resultApplyQuickFixes =
+      await applyQuickFixes.applyQuickFixes(diagnostics);
+    expect(resultApplyQuickFixes).toHaveLength(2);
+  });
+
+  test("should return undefined when no IBM3841IS diagnostics", async () => {
+    const diagnostics = [
+      { code: "IBM3842IS" } as Diagnostic,
+      { code: "IBM3844IS" } as Diagnostic,
+    ];
+
+    const result = await applyQuickFixes.applyQuickFixes(diagnostics);
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -40,7 +40,9 @@
           "PL/1"
         ],
         "extensions": [
-          ".pli", ".pl1", ".inc"
+          ".pli",
+          ".pl1",
+          ".inc"
         ],
         "firstLine": "^[*%][Pp][Rr][Oo][Cc][Ee][Ss][Ss]|\\s+[Dd][Ee][Cc][Ll][Aa][Rr][Ee]|\\s+[Dd][Cc][Ll]|\\s+\\w+: [Pp][Rr][Oo][Cc]",
         "icon": {
@@ -90,7 +92,11 @@
         },
         "pli.marginIndicator.rulers": {
           "type": "string",
-          "enum": ["off", "default", "automatic"],
+          "enum": [
+            "off",
+            "default",
+            "automatic"
+          ],
           "default": "automatic",
           "description": "Controls the rulers for the margin compiler option. 'off' disables rulers, 'default' shows the PL/I default rulers [2, 72], 'automatic' adds rulers based on margin compiler options."
         }
@@ -111,6 +117,7 @@
   },
   "dependencies": {
     "@vscode/extension-telemetry": "^0.9.8",
+    "glob": "11.0.2",
     "pli-language": "workspace:*",
     "vscode-languageclient": "~9.0.1",
     "vscode-languageserver": "~9.0.1"

--- a/packages/vscode-extension/src/common/messages.ts
+++ b/packages/vscode-extension/src/common/messages.ts
@@ -11,6 +11,7 @@
 
 export namespace Messages {
   export const ReadFile = "fs/readFile";
+  export const WriteFile = "fs/writeFile";
   export const FileExists = "fs/fileExists";
   export const Search = "fs/search";
 }

--- a/packages/vscode-extension/src/extension/main-browser.ts
+++ b/packages/vscode-extension/src/extension/main-browser.ts
@@ -80,4 +80,8 @@ function registerFileSystemProvider(client: LanguageClient): void {
       return result.map((r) => r[0]);
     });
   });
+  client.onRequest(Messages.WriteFile, async (uriString, value) => {
+    const uri = vscode.Uri.parse(uriString);
+    await vscode.workspace.fs.writeFile(uri, value);
+  });
 }

--- a/packages/vscode-extension/src/language/file-system.ts
+++ b/packages/vscode-extension/src/language/file-system.ts
@@ -49,9 +49,14 @@ export class VSCodeFileSystemProvider implements FileSystemProvider {
       return undefined;
     }
   }
-  writeFile(_uri: URI, _value: string): Promise<void> {
-    throw new Error("Not supported.");
+  async writeFile(uri: URI, value: string): Promise<void> {
+    const stringUri = uri.toString();
+    await this._connection.sendRequest(Messages.WriteFile, {
+      stringUri,
+      value,
+    });
   }
+
   deleteFile(_uri: URI): Promise<void> {
     throw new Error("Not supported.");
   }

--- a/packages/vscode-extension/src/language/main.ts
+++ b/packages/vscode-extension/src/language/main.ts
@@ -21,8 +21,7 @@ import {
   setFileSystemProvider,
 } from "pli-language";
 import * as fs from "fs";
-import * as nPath from "path";
-import { searchFiles } from "../common/file-search";
+import * as glob from "glob";
 
 class NodeFileSystemProvider implements FileSystemProvider {
   readFile(uri: URI): Promise<string> {
@@ -37,21 +36,26 @@ class NodeFileSystemProvider implements FileSystemProvider {
     }
   }
   async writeFile(uri: URI, value: string): Promise<void> {
-    throw new Error("Not supported.");
+    await fs.promises.writeFile(uri.fsPath, value, "utf8");
   }
   async deleteFile(uri: URI): Promise<void> {
     throw new Error("Not supported.");
   }
   async search(options: SearchOptions): Promise<URI | undefined> {
-    const path = await searchFiles(options, async (path) => {
-      const result = await fs.promises.readdir(path);
-      return result.map((file) => nPath.basename(file));
+    const GLOBAL_PATTERN = "**";
+    const path = options.path.fsPath.replace(/\\/g, "/");
+    const pattern = options.global
+      ? `${GLOBAL_PATTERN}${path}{,${options.extensions.join(",")}}`
+      : `${path}{,${options.extensions.join(",")}}`;
+    const files = await glob.glob(pattern, {
+      nodir: true,
+      absolute: true,
+      nocase: true,
     });
-    if (path) {
-      return options.path.with({ path });
-    } else {
-      return undefined;
-    }
+    if (!files.length) return undefined;
+    const result = URI.file(files[0]);
+    if (!result) return undefined;
+    return result;
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,9 @@ importers:
       '@vscode/extension-telemetry':
         specifier: ^0.9.8
         version: 0.9.9(tslib@2.8.1)
+      glob:
+        specifier: 11.0.2
+        version: 11.0.2
       pli-language:
         specifier: workspace:*
         version: link:../language
@@ -1633,8 +1636,8 @@ packages:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
     hasBin: true
 
-  glob@11.0.3:
-    resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
+  glob@11.0.2:
+    resolution: {integrity: sha512-YT7U7Vye+t5fZ/QMkBFrTJ7ZQxInIUjwyAjVj84CYXqgBdv30MFUPGnBR6sQaVq6Is15wYJUsnzTuWaGRBhBAQ==}
     engines: {node: 20 || >=22}
     hasBin: true
 
@@ -4252,7 +4255,7 @@ snapshots:
       cockatiel: 3.2.1
       commander: 12.1.0
       form-data: 4.0.4
-      glob: 11.0.3
+      glob: 11.0.2
       hosted-git-info: 4.1.0
       jsonc-parser: 3.3.1
       leven: 3.1.0
@@ -4725,7 +4728,7 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
-  glob@11.0.3:
+  glob@11.0.2:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 4.1.1


### PR DESCRIPTION
### Implement Quick Fix for unresolved INCLUDE files (update proc_grps.json libs)

Issue: #332

**Summary:**
This PR introduces a Quick Fix action that helps resolve unresolved INCLUDE files by automatically updating the proc_grps.json configuration. When an INCLUDE file is detected but not present in the libs of the default process group, this fix suggests adding the parent folder of the file to the configuration.

**Changes**
quickFixResolveInclude:
Retrieves unresolved INCLUDE file information from diagnostics.
Locates the file in the workspace using FileSystemProviderInstance.findFilesByGlob.
Computes the parent folder relative to the workspace.
Updates proc_grps.json by adding the folder path to the libs array of the default process group (if not already present).
Returns a CodeAction with a Quick Fix that applies the change through the pli.applyIncludeFix command.
Implemented `computeWorkspaceRelativeParentFolder` helper.

**Notes**
1. Had to reintroduce `findFilesByGlob` helper. Please let me know how we should proceed in order to avoid technical debt by having this function. I have another way to solve this in a local branch, but it seemed way over complicated/complex.
2. I couldn't think of a way to retrieve the unresolved file name other than: 1. adding it to the diagnostic or 2. slicing it from the diagnostic message. I thought it was cleaner to change the diagnostic, but any suggestion is welcome.
3. All tests were manual. I realized I would be taking more time in order to modify the `verify` function, so I opted for creating this PR already. I would like to tackle this later though, with you guys help.