### PR TITLE
Resolve Absolute Lib Paths

### DIFF
--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -1938,10 +1938,7 @@ async function resolveIncludeFileUri(
         );
       } else {
         // use lib path over workspace
-        const libUri = URI.from({
-          scheme: "file",
-          path: lib,
-        });
+        const libUri = URI.file(lib);
         libFileUri = UriUtils.joinPath(libUri, item.fileName);
       }
 

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -1926,7 +1926,7 @@ async function resolveIncludeFileUri(
 
   if (pgroup) {
     // lib file as either a string or a member from a known process group
-    const absPathRegex = /^\/|\\|[A-Z]:/i;
+    const absPathRegex = /^(?:\/|\\|[A-Z]:)/i;
     for (const lib of pgroup.libs) {
       let libFileUri: URI;
       if (!absPathRegex.test(lib)) {
@@ -1938,7 +1938,9 @@ async function resolveIncludeFileUri(
         );
       } else {
         // use lib path over workspace
-        const libUri = URI.file(lib);
+        const libUri = URI.file(lib).with({
+          scheme: context.entryUri.scheme,
+        });
         libFileUri = UriUtils.joinPath(libUri, item.fileName);
       }
 

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -1759,6 +1759,14 @@ async function runIncludeInstruction(
   }
 }
 
+/**
+ * Sets the filePath & relativeFilePath of the given item, if a filePath is provided
+ * The relativeFilePath is calculated based on the currentUri in the context
+ *
+ * @param item Item to set the file paths for
+ * @param filePath File path to set, if null, no changes are made
+ * @param context Used for currentUri to calculate relative paths
+ */
 function setFilePath(
   item: { filePath: string | null; relativeFilePath: string | null },
   filePath: string | null,
@@ -1918,12 +1926,25 @@ async function resolveIncludeFileUri(
 
   if (pgroup) {
     // lib file as either a string or a member from a known process group
+    const absPathRegex = /^\/|\\|[A-Z]:/i;
     for (const lib of pgroup.libs) {
-      const libFileUri = UriUtils.joinPath(
-        URI.parse(PluginConfigurationProviderInstance.getWorkspacePath()),
-        lib,
-        item.fileName,
-      );
+      let libFileUri: URI;
+      if (!absPathRegex.test(lib)) {
+        // relative lib path, combine w/ workspace
+        libFileUri = UriUtils.joinPath(
+          URI.parse(PluginConfigurationProviderInstance.getWorkspacePath()),
+          lib,
+          item.fileName,
+        );
+      } else {
+        // use lib path over workspace
+        const libUri = URI.from({
+          scheme: "file",
+          path: lib
+        });
+        libFileUri = UriUtils.joinPath(libUri, item.fileName);
+      }
+
       const match = await FileSystemProviderInstance.search({
         path: libFileUri,
         extensions: pgroup.includeExtensions,

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -244,8 +244,8 @@ export interface EvaluationResults {
 
 interface InterpreterContext {
   unit: CompilationUnit;
-  currentUri?: URI;
-  entryUri?: URI;
+  currentUri: URI;
+  entryUri: URI;
   /**
    * These are global variables that are defined on the root level of the preprocessor
    */

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -1940,7 +1940,7 @@ async function resolveIncludeFileUri(
         // use lib path over workspace
         const libUri = URI.from({
           scheme: "file",
-          path: lib
+          path: lib,
         });
         libFileUri = UriUtils.joinPath(libUri, item.fileName);
       }

--- a/packages/language/test/fourslash/preprocessor/include/from-absolute-lib-path.ts
+++ b/packages/language/test/fourslash/preprocessor/include/from-absolute-lib-path.ts
@@ -21,7 +21,6 @@
 ////   ]
 //// }
 
-
 // @filename: .pliplugin/proc_grps.json
 //// {
 ////     "pgroups": [

--- a/packages/language/test/fourslash/preprocessor/include/from-absolute-lib-path.ts
+++ b/packages/language/test/fourslash/preprocessor/include/from-absolute-lib-path.ts
@@ -40,13 +40,8 @@
 //// DECLARE LIB_VAR FIXED;
 
 // @filename: /progs/main.pli
-//// %INCLUDE <|1>"lib.pli";
+//// %INCLUDE "lib.pli";
 
 preprocessor.expectTokens(`
   DECLARE LIB_VAR FIXED;
 `);
-
-hover.expectMarkdownAt(
-  1,
-  hover.include("%INCLUDE", "../tmp/cpy/lib.pli", " DECLARE LIB_VAR FIXED;"),
-);

--- a/packages/language/test/fourslash/preprocessor/include/from-absolute-lib-path.ts
+++ b/packages/language/test/fourslash/preprocessor/include/from-absolute-lib-path.ts
@@ -9,6 +9,8 @@
  *
  */
 
+// Test that specifying an absolute path to a library in proc_grps.json works correctly
+
 /// <reference path="../../framework.ts" />
 
 // @filename: .pliplugin/pgm_conf.json

--- a/packages/language/test/fourslash/preprocessor/include/from-absolute-lib-path.ts
+++ b/packages/language/test/fourslash/preprocessor/include/from-absolute-lib-path.ts
@@ -1,0 +1,53 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: .pliplugin/pgm_conf.json
+//// {
+////   "pgms": [
+////     {
+////       "program": "/progs/*.pli",
+////       "pgroup": "default"
+////     }
+////   ]
+//// }
+
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////             "name": "default",
+////             "libs": [
+////                 "/tmp/cpy"
+////             ],
+////             "include-extensions": [
+////                 ".pli"
+////             ]
+////         }
+////     ]
+//// }
+
+// @filename: /tmp/cpy/lib.pli
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: /progs/main.pli
+//// %INCLUDE <|1>"lib.pli";
+
+preprocessor.expectTokens(`
+  DECLARE LIB_VAR FIXED;
+`);
+
+hover.expectMarkdownAt(
+  1,
+  hover.include("%INCLUDE", "../tmp/cpy/lib.pli", " DECLARE LIB_VAR FIXED;"),
+);

--- a/packages/language/test/preprocessor/pli-preprocessor.test.ts
+++ b/packages/language/test/preprocessor/pli-preprocessor.test.ts
@@ -10,118 +10,131 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
-import { PluginConfigurationProviderInstance, ProcessGroup, ProgramConfig, setPluginConfigurationProvider } from "../../src/workspace/plugin-configuration-provider";
+import {
+  PluginConfigurationProviderInstance,
+  ProcessGroup,
+  ProgramConfig,
+  setPluginConfigurationProvider,
+} from "../../src/workspace/plugin-configuration-provider";
 import { URI } from "vscode-uri";
 import { parse } from "../utils";
-import { FileSystemProviderInstance, setFileSystemProvider, VirtualFileSystemProvider } from "../../src/workspace/file-system-provider";
+import {
+  FileSystemProviderInstance,
+  setFileSystemProvider,
+  VirtualFileSystemProvider,
+} from "../../src/workspace/file-system-provider";
 import { resetDocumentProviders } from "../../src/language-server/text-documents";
 
 /**
  * Helper to modify the program config & process group w/ a given lib for each os-specific test
  */
 async function init(libPath: string) {
-    const programConfig: ProgramConfig = {
-        program: "test.pli",
-        pgroup: "testGroup",
-        pliOptions: {},
-    };
-    const processGroupConfig: ProcessGroup = {
-        name: "testGroup",
-        compilerOptions: [],
-        implicitBuiltins: new Set(),
-        includeExtensions: [],
-        libs: [
-            libPath
-        ],
-        lspOptions: { checkMargins: false },
-        pliOptions: {},
-    };
+  const programConfig: ProgramConfig = {
+    program: "test.pli",
+    pgroup: "testGroup",
+    pliOptions: {},
+  };
+  const processGroupConfig: ProcessGroup = {
+    name: "testGroup",
+    compilerOptions: [],
+    implicitBuiltins: new Set(),
+    includeExtensions: [],
+    libs: [libPath],
+    lspOptions: { checkMargins: false },
+    pliOptions: {},
+  };
 
-    await PluginConfigurationProviderInstance.init("/test");
-        PluginConfigurationProviderInstance.setProgramConfigs("/test", [
-        programConfig,
-    ]);
-    PluginConfigurationProviderInstance.setProcessGroupConfigs([
-        processGroupConfig,
-    ]);
+  await PluginConfigurationProviderInstance.init("/test");
+  PluginConfigurationProviderInstance.setProgramConfigs("/test", [
+    programConfig,
+  ]);
+  PluginConfigurationProviderInstance.setProcessGroupConfigs([
+    processGroupConfig,
+  ]);
 }
 
 /**
  * Expect tokens for a given workspace, by dictating the main file + lib files to create & test.
  * One compile unit will be generated from the main file, which will include the lib files as needed.
  * Note that this function does not clean up the vfs afterwards.
- * 
+ *
  * @param mainFileContent Main file to build a compile unit from, name is fixed to /test/test.pli
  * @param libFiles Pairs of [path, content] entries to create lib files in the virtual file system
  * @param expectedTokens Expected array of tokens (by image) to be found in the resulting compile unit once done
  */
-async function expectTokensForWorkspace(mainFileContent: string, libFiles: Array<[string,string]>, expectedTokens: string[]): Promise<void> {
-    for (const [path, content] of libFiles) {
-        FileSystemProviderInstance.writeFile(URI.file(path), content);
-    }
+async function expectTokensForWorkspace(
+  mainFileContent: string,
+  libFiles: Array<[string, string]>,
+  expectedTokens: string[],
+): Promise<void> {
+  for (const [path, content] of libFiles) {
+    FileSystemProviderInstance.writeFile(URI.file(path), content);
+  }
 
-    // parse the main program
-    const cu = await parse(mainFileContent, {
-        validate: true,
-        uri: URI.file("/test/test.pli")
-    });
+  // parse the main program
+  const cu = await parse(mainFileContent, {
+    validate: true,
+    uri: URI.file("/test/test.pli"),
+  });
 
-    // ensure we have a clean result w/ the right tokens
-    expect(cu.diagnostics.lexer).toHaveLength(0);
-    expect(cu.diagnostics.parser).toHaveLength(0);
-    const tokenImgs = cu.tokens.map(t => t.image);
-    expect(tokenImgs).toEqual(expectedTokens);
+  // ensure we have a clean result w/ the right tokens
+  expect(cu.diagnostics.lexer).toHaveLength(0);
+  expect(cu.diagnostics.parser).toHaveLength(0);
+  const tokenImgs = cu.tokens.map((t) => t.image);
+  expect(tokenImgs).toEqual(expectedTokens);
 }
 
 describe("Preprocessor Tests", () => {
+  beforeEach(() => {
+    const vfs = new VirtualFileSystemProvider();
+    setFileSystemProvider(vfs);
+    resetDocumentProviders();
+  });
 
-    beforeEach(() => {
-        const vfs = new VirtualFileSystemProvider();
-        setFileSystemProvider(vfs);
-        resetDocumentProviders();
-    });
+  afterEach(() => {
+    setFileSystemProvider(undefined);
+    setPluginConfigurationProvider(undefined);
+    PluginConfigurationProviderInstance.setProgramConfigs("", []);
+    PluginConfigurationProviderInstance.setProcessGroupConfigs([]);
+  });
 
-    afterEach(() => {
-        setFileSystemProvider(undefined);
-        setPluginConfigurationProvider(undefined);
-        PluginConfigurationProviderInstance.setProgramConfigs("", []);
-        PluginConfigurationProviderInstance.setProcessGroupConfigs([]);
-    });
+  test.runIf(["darwin", "linux"].includes(process.platform))(
+    "unix path resolution",
+    async () => {
+      await init("/test/libs");
 
-    test.runIf(["darwin","linux"].includes(process.platform))("unix path resolution", async () => {
-        await init("/test/libs");
+      await expectTokensForWorkspace(
+        ` %INCLUDE "lib.pli";`,
+        [["/test/libs/lib.pli", ` DECLARE LIB_VAR FIXED;`]],
+        ["DECLARE", "LIB_VAR", "FIXED", ";"],
+      );
+    },
+  );
 
-        await expectTokensForWorkspace(
-            ` %INCLUDE "lib.pli";`,
-            [
-                ["/test/libs/lib.pli", ` DECLARE LIB_VAR FIXED;`]
-            ],
-            ["DECLARE", "LIB_VAR", "FIXED", ";"]
-        );
-    });
+  test.runIf(process.platform === "win32")(
+    "Windows path resolution",
+    async () => {
+      await init("C:/test/libs/");
 
-    test.runIf(process.platform === "win32")("Windows path resolution", async () => {
-        await init("C:/test/libs/");
+      await expectTokensForWorkspace(
+        ` %INCLUDE "lib.pli";`,
+        [["C:/test/libs/lib.pli", ` DECLARE LIB_VAR FIXED;`]],
+        ["DECLARE", "LIB_VAR", "FIXED", ";"],
+      );
+    },
+  );
 
-        await expectTokensForWorkspace(
-            ` %INCLUDE "lib.pli";`,
-            [
-                ["C:/test/libs/lib.pli", ` DECLARE LIB_VAR FIXED;`]
-            ],
-            ["DECLARE", "LIB_VAR", "FIXED", ";"]
-        );
-    });
+  test.runIf(process.platform === "win32")(
+    "Windows path resolution",
+    async () => {
+      // also test absolute path resolution w/ windows too
+      await init("/test/libs/");
 
-    test.runIf(process.platform === "win32")("Windows path resolution", async () => {
-        // also test absolute path resolution w/ windows too
-        await init("/test/libs/");
-
-        await expectTokensForWorkspace(
-            ` %INCLUDE "lib.pli";`,
-            [
-                ["/test/libs/lib.pli", ` DECLARE LIB_VAR FIXED;`]
-            ],
-            ["DECLARE", "LIB_VAR", "FIXED", ";"]
-        );
-    });
+      await expectTokensForWorkspace(
+        ` %INCLUDE "lib.pli";`,
+        [["/test/libs/lib.pli", ` DECLARE LIB_VAR FIXED;`]],
+        ["DECLARE", "LIB_VAR", "FIXED", ";"],
+      );
+    },
+  );
 });

--- a/packages/language/test/preprocessor/pli-preprocessor.test.ts
+++ b/packages/language/test/preprocessor/pli-preprocessor.test.ts
@@ -68,7 +68,7 @@ async function expectTokensForWorkspace(
   expectedTokens: string[],
 ): Promise<void> {
   for (const [path, content] of libFiles) {
-    FileSystemProviderInstance.writeFile(URI.file(path), content);
+    await FileSystemProviderInstance.writeFile(URI.file(path), content);
   }
 
   // parse the main program
@@ -99,7 +99,7 @@ describe("Preprocessor Tests", () => {
   });
 
   // macOS + linux absolute path resolution
-  test.runIf(["darwin", "linux"].includes(process.platform))(
+  test.runIf(["darwin", "linux", "win32"].includes(process.platform))(
     "unix path resolution",
     async () => {
       await init("/test/libs");
@@ -121,21 +121,6 @@ describe("Preprocessor Tests", () => {
       await expectTokensForWorkspace(
         ` %INCLUDE "lib.pli";`,
         [["C:/test/libs/lib.pli", ` DECLARE LIB_VAR FIXED;`]],
-        ["DECLARE", "LIB_VAR", "FIXED", ";"],
-      );
-    },
-  );
-
-  // test win absolute path resolution w/out a drive letter
-  test.runIf(process.platform === "win32")(
-    "Windows path resolution",
-    async () => {
-      // also test absolute path resolution w/ windows too
-      await init("/test/libs/");
-
-      await expectTokensForWorkspace(
-        ` %INCLUDE "lib.pli";`,
-        [["/test/libs/lib.pli", ` DECLARE LIB_VAR FIXED;`]],
         ["DECLARE", "LIB_VAR", "FIXED", ";"],
       );
     },

--- a/packages/language/test/preprocessor/pli-preprocessor.test.ts
+++ b/packages/language/test/preprocessor/pli-preprocessor.test.ts
@@ -1,0 +1,127 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { PluginConfigurationProviderInstance, ProcessGroup, ProgramConfig, setPluginConfigurationProvider } from "../../src/workspace/plugin-configuration-provider";
+import { URI } from "vscode-uri";
+import { parse } from "../utils";
+import { FileSystemProviderInstance, setFileSystemProvider, VirtualFileSystemProvider } from "../../src/workspace/file-system-provider";
+import { resetDocumentProviders } from "../../src/language-server/text-documents";
+
+/**
+ * Helper to modify the program config & process group w/ a given lib for each os-specific test
+ */
+async function init(libPath: string) {
+    const programConfig: ProgramConfig = {
+        program: "test.pli",
+        pgroup: "testGroup",
+        pliOptions: {},
+    };
+    const processGroupConfig: ProcessGroup = {
+        name: "testGroup",
+        compilerOptions: [],
+        implicitBuiltins: new Set(),
+        includeExtensions: [],
+        libs: [
+            libPath
+        ],
+        lspOptions: { checkMargins: false },
+        pliOptions: {},
+    };
+
+    await PluginConfigurationProviderInstance.init("/test");
+        PluginConfigurationProviderInstance.setProgramConfigs("/test", [
+        programConfig,
+    ]);
+    PluginConfigurationProviderInstance.setProcessGroupConfigs([
+        processGroupConfig,
+    ]);
+}
+
+/**
+ * Expect tokens for a given workspace, by dictating the main file + lib files to create & test.
+ * One compile unit will be generated from the main file, which will include the lib files as needed.
+ * Note that this function does not clean up the vfs afterwards.
+ * 
+ * @param mainFileContent Main file to build a compile unit from, name is fixed to /test/test.pli
+ * @param libFiles Pairs of [path, content] entries to create lib files in the virtual file system
+ * @param expectedTokens Expected array of tokens (by image) to be found in the resulting compile unit once done
+ */
+async function expectTokensForWorkspace(mainFileContent: string, libFiles: Array<[string,string]>, expectedTokens: string[]): Promise<void> {
+    for (const [path, content] of libFiles) {
+        FileSystemProviderInstance.writeFile(URI.file(path), content);
+    }
+
+    // parse the main program
+    const cu = await parse(mainFileContent, {
+        validate: true,
+        uri: URI.file("/test/test.pli")
+    });
+
+    // ensure we have a clean result w/ the right tokens
+    expect(cu.diagnostics.lexer).toHaveLength(0);
+    expect(cu.diagnostics.parser).toHaveLength(0);
+    const tokenImgs = cu.tokens.map(t => t.image);
+    expect(tokenImgs).toEqual(expectedTokens);
+}
+
+describe("Preprocessor Tests", () => {
+
+    beforeEach(() => {
+        const vfs = new VirtualFileSystemProvider();
+        setFileSystemProvider(vfs);
+        resetDocumentProviders();
+    });
+
+    afterEach(() => {
+        setFileSystemProvider(undefined);
+        setPluginConfigurationProvider(undefined);
+        PluginConfigurationProviderInstance.setProgramConfigs("", []);
+        PluginConfigurationProviderInstance.setProcessGroupConfigs([]);
+    });
+
+    test.runIf(["darwin","linux"].includes(process.platform))("unix path resolution", async () => {
+        await init("/test/libs");
+
+        await expectTokensForWorkspace(
+            ` %INCLUDE "lib.pli";`,
+            [
+                ["/test/libs/lib.pli", ` DECLARE LIB_VAR FIXED;`]
+            ],
+            ["DECLARE", "LIB_VAR", "FIXED", ";"]
+        );
+    });
+
+    test.runIf(process.platform === "win32")("Windows path resolution", async () => {
+        await init("C:/test/libs/");
+
+        await expectTokensForWorkspace(
+            ` %INCLUDE "lib.pli";`,
+            [
+                ["C:/test/libs/lib.pli", ` DECLARE LIB_VAR FIXED;`]
+            ],
+            ["DECLARE", "LIB_VAR", "FIXED", ";"]
+        );
+    });
+
+    test.runIf(process.platform === "win32")("Windows path resolution", async () => {
+        // also test absolute path resolution w/ windows too
+        await init("/test/libs/");
+
+        await expectTokensForWorkspace(
+            ` %INCLUDE "lib.pli";`,
+            [
+                ["/test/libs/lib.pli", ` DECLARE LIB_VAR FIXED;`]
+            ],
+            ["DECLARE", "LIB_VAR", "FIXED", ";"]
+        );
+    });
+});

--- a/packages/language/test/preprocessor/pli-preprocessor.test.ts
+++ b/packages/language/test/preprocessor/pli-preprocessor.test.ts
@@ -98,6 +98,7 @@ describe("Preprocessor Tests", () => {
     PluginConfigurationProviderInstance.setProcessGroupConfigs([]);
   });
 
+  // macOS + linux absolute path resolution
   test.runIf(["darwin", "linux"].includes(process.platform))(
     "unix path resolution",
     async () => {
@@ -111,6 +112,7 @@ describe("Preprocessor Tests", () => {
     },
   );
 
+  // tets win absolute path resolution w/ a drive letter
   test.runIf(process.platform === "win32")(
     "Windows path resolution",
     async () => {
@@ -124,6 +126,7 @@ describe("Preprocessor Tests", () => {
     },
   );
 
+  // test win absolute path resolution w/out a drive letter
   test.runIf(process.platform === "win32")(
     "Windows path resolution",
     async () => {


### PR DESCRIPTION
Resolves the first point of #394 by modifying the `setFilePath` logic to compute the `libFileUri` based on whether or not the current lib path is absolute or not (unix & windows in this case). Testing is setup for the `/` case but not for windows, given the behavior for handling drive letters only kicks in when `win32` is present. I did do a manual check for that case since that was the issue was originally reported for windows drive letters in the first place. But please feel free to do a secondary check on windows for that case.

There's a small existing issue in the hover logic on windows based on the hover logic computation when a lib is absolute but _not_ a windows drive letter. This leads to a mismatch between the from/to uris when the lib entry is something like `/A/...` instead of `C:/A/...`. The path still resolves in the context of the current drive letter, but on hover displays as `./A/...`. I'm leaving this alone for now, since it involves tweaking the relative path computation logic in a way that feels problematic, and doesn't impact functionality at the time.