### PR TITLE
Improved compiler options checks

### DIFF
--- a/packages/language/src/preprocessor/compiler-options/codes.ts
+++ b/packages/language/src/preprocessor/compiler-options/codes.ts
@@ -456,6 +456,23 @@ export const CompilerOptionsCodes = {
     } as ParametricPLICode,
   },
 
+  Or: {
+    InvalidParameterLength: {
+      code: "COOR01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected a single character, but received '${value}'.`,
+      fullCode: "COOR01W",
+    } as ParametricPLICode,
+    InvalidParameterCharacter: {
+      code: "COOR02",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected a valid or character, but received '${value}'.`,
+      fullCode: "COOR02W",
+    } as ParametricPLICode,
+  },
+
   PP: {
     InvalidParameterType: {
       code: "COPP01",
@@ -792,39 +809,11 @@ export const CompilerOptionsCodes = {
         `Expected "DEF", "NODEF", "MSG", "NOMSG", "SYM", "NOSYM", "SYN", "NOSYN", "XML", or "NOXML", but received '${value}'.`,
       fullCode: "COXI01W",
     } as ParametricPLICode,
-    InvalidDefParameter: {
-      code: "COXI02",
-      severity: Severity.W,
-      message: (value: string) =>
-        `Expected "DEF" or "NODEF", but received '${value}'.`,
-      fullCode: "COXI02W",
-    } as ParametricPLICode,
-    InvalidMsgParameter: {
-      code: "COXI03",
-      severity: Severity.W,
-      message: (value: string) =>
-        `Expected "MSG" or "NOMSG", but received '${value}'.`,
-      fullCode: "COXI03W",
-    } as ParametricPLICode,
-    InvalidSymParameter: {
-      code: "COXI04",
-      severity: Severity.W,
-      message: (value: string) =>
-        `Expected "SYM" or "NOSYM", but received '${value}'.`,
-      fullCode: "COXI04W",
-    } as ParametricPLICode,
-    InvalidSynParameter: {
-      code: "COXI05",
-      severity: Severity.W,
-      message: (value: string) =>
-        `Expected "SYN" or "NOSYN", but received '${value}'.`,
-      fullCode: "COXI05W",
-    } as ParametricPLICode,
     InvalidXmlParameter: {
       code: "COXI06",
       severity: Severity.W,
       message: (value: string) =>
-        `Expected "XML" or "NOXML", but received '${value}'.`,
+        `Expected "HASH" or "NOHASH", but received '${value}'.`,
       fullCode: "COXI06W",
     } as ParametricPLICode,
   },

--- a/packages/language/src/preprocessor/compiler-options/options-pli.ts
+++ b/packages/language/src/preprocessor/compiler-options/options-pli.ts
@@ -403,7 +403,7 @@ export interface CompilerOptions {
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-ppmacro
    */
-  ppMacro?: string | false;
+  ppMacro?: CompilerOptions.PPValue | false;
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-ppsql
    */
@@ -808,8 +808,10 @@ export declare namespace CompilerOptions {
     value: string;
   }
 
-  export interface PPItem {
+  export interface PPItem extends PPValue {
     name: "MACRO" | "SQL" | "CICS" | "INCLUDE";
+  }
+  export interface PPValue {
     value?: string;
     token?: Token;
   }

--- a/packages/language/src/preprocessor/compiler-options/translate.ts
+++ b/packages/language/src/preprocessor/compiler-options/translate.ts
@@ -17,7 +17,10 @@ import {
 import { CompilerOption, SyntaxKind } from "../../syntax-tree/ast";
 import { getTranslator as getTranslatorPLI } from "./translator-pli";
 import { getTranslator as getTranslatorMacro } from "./translator-macro";
-import { CompilerOptions as CompilerOptionsPLI } from "./options-pli";
+import {
+  CompilerOptions,
+  CompilerOptions as CompilerOptionsPLI,
+} from "./options-pli";
 import { CompilerOptions as CompilerOptionsMacro } from "./options-macro";
 
 const translator = getTranslatorPLI();
@@ -40,19 +43,22 @@ export function translateCompilerOptions(
 
   // Handle nested compiler options that are not yet parsed.
   translatorMacro.clear();
-  if (translator.options.pp) {
-    for (const item of translator.options.pp.items.filter(
-      (item) => item.name === "MACRO" && typeof item.value === "string",
-    )) {
-      const nestedOptions = parseAbstractCompilerOptions(
-        item.value as string,
-        (item.token?.startOffset ?? 0) + 1,
-      );
-      for (const nestedOption of nestedOptions.options) {
-        translatorMacro.translate(nestedOption);
-      }
-      translatorMacro.issues.push(...nestedOptions.issues);
-    }
+  const macroItems: CompilerOptions.PPValue[] = [
+    ...(translator.options.ppMacro ? [translator.options.ppMacro] : []),
+    ...(translator.options.pp?.items
+      .filter((item) => item.name === "MACRO" && typeof item.value === "string")
+      .map((item) => ({ value: item.value, token: item.token })) ?? []),
+  ];
+
+  for (const item of macroItems) {
+    const nestedOptions = parseAbstractCompilerOptions(
+      item.value as string,
+      (item.token?.startOffset ?? 0) + 1,
+    );
+    nestedOptions.options.forEach((option) =>
+      translatorMacro.translate(option),
+    );
+    translatorMacro.issues.push(...nestedOptions.issues);
   }
 
   return {

--- a/packages/language/src/preprocessor/compiler-options/translator-pli.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator-pli.ts
@@ -2083,60 +2083,83 @@ translator.rule(
 );
 
 /** {@link CompilerOptions.or} */
-translator.rule(
-  ["OR"],
-  stringTranslate((options, text) => {
-    options.or = text.value;
-  }),
-);
+translator.rule(["OR"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "string");
+  if (value.value.length !== 1) {
+    throw TranslationError.fromCode(
+      value.token,
+      CompilerOptionsCodes.Or.InvalidParameterLength,
+      value.value,
+    );
+  }
+  if (value.value !== "|" && Options.PLI_CHARACTER_REGEX.test(value.value)) {
+    throw TranslationError.fromCode(
+      value.token,
+      CompilerOptionsCodes.Or.InvalidParameterCharacter,
+      value.value,
+    );
+  }
+  options.or = value.value;
+});
 
 /** {@link CompilerOptions.pp} */
-translator.rule(["PP"], (option, options) => {
-  // 1 or more pre-processor options to collect
-  ensureArguments(option, 1);
-  ensureToBeDefined(options.pp);
+translator.rule(
+  ["PP"],
+  (option, options) => {
+    // 1 or more pre-processor options to collect
+    ensureArguments(option, 1);
+    ensureToBeDefined(options.pp);
+    ensureToBeDefined(options.pp.items);
 
-  for (const value of option.values) {
-    const name = ensureArgument<CompilerOptions.PPItem["name"]>(
-      value,
-      CompilerOptionsCodes.PP.InvalidParameter,
-      ["MACRO", "SQL", "CICS", "INCLUDE"],
-    );
-    if (value.kind === SyntaxKind.CompilerOptionText) {
-      options.pp.items.push({ name });
-    } else if (value.kind === SyntaxKind.CompilerOption) {
-      if (value.values.length !== 1) {
+    for (const value of option.values) {
+      const name = ensureArgument<CompilerOptions.PPItem["name"]>(
+        value,
+        CompilerOptionsCodes.PP.InvalidParameter,
+        ["MACRO", "SQL", "CICS", "INCLUDE"],
+      );
+      if (value.kind === SyntaxKind.CompilerOptionText) {
+        options.pp.items.push({ name });
+      } else if (value.kind === SyntaxKind.CompilerOption) {
+        if (value.values.length !== 1) {
+          throw TranslationError.fromCode(
+            value.token,
+            CompilerOptionsCodes.PP.InvalidOptionParameter,
+            value.token.image,
+            value.values.length,
+          );
+        }
+        ensureType(value.values[0], "string");
+        options.pp.items.push({
+          name,
+          value: value.values[0].value,
+          token: value.values[0].token,
+        });
+
+        if (name === "INCLUDE") {
+          // set this as the effective INCLUDE PP option value, overriding any previous INCLUDE options
+          const match = value.values[0].value.match(/ID\(([^\)]+)\)\s*$/);
+          if (match && match.length > 0) {
+            options.pp.ppInclude = {
+              value: match[0].slice(3, -1).toUpperCase(),
+            };
+          }
+        }
+      } else {
         throw TranslationError.fromCode(
           value.token,
-          CompilerOptionsCodes.PP.InvalidOptionParameter,
-          value.token.image,
-          value.values.length,
+          CompilerOptionsCodes.PP.InvalidParameterType,
         );
       }
-      ensureType(value.values[0], "string");
-      options.pp.items.push({
-        name,
-        value: value.values[0].value,
-        token: value.values[0].token,
-      });
-
-      if (name === "INCLUDE") {
-        // set this as the effective INCLUDE PP option value, overriding any previous INCLUDE options
-        const match = value.values[0].value.match(/ID\(([^\)]+)\)\s*$/);
-        if (match && match.length > 0) {
-          options.pp.ppInclude = {
-            value: match[0].slice(3, -1).toUpperCase(),
-          };
-        }
-      }
-    } else {
-      throw TranslationError.fromCode(
-        value.token,
-        CompilerOptionsCodes.PP.InvalidParameterType,
-      );
     }
-  }
-});
+  },
+  ["NOPP"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.pp = { items: [] };
+  },
+);
 
 /** {@link CompilerOptions.ppCics} */
 translator.rule(
@@ -2189,7 +2212,10 @@ translator.rule(
     ensureArguments(option, 1, 1);
     const value = option.values[0];
     ensureType(value, "string");
-    options.ppMacro = value.value;
+    options.ppMacro = {
+      value: value.value,
+      token: value.token,
+    };
   },
   ["NOPPMACRO"],
   (option, options) => {
@@ -2233,16 +2259,11 @@ translator.rule(["PRECTYPE"], (option, options) => {
   ensureArguments(option, 1, 1);
   const value = option.values[0];
   ensureType(value, "plainNotEmpty");
-  const name = value.value.toUpperCase();
-  if (["AND", "DECDIGIT", "DECRESULT"].includes(name)) {
-    options.precType = name as CompilerOptions.PrecType;
-  } else {
-    throw TranslationError.fromCode(
-      value.token,
-      CompilerOptionsCodes.PrecType.InvalidParameter,
-      name,
-    );
-  }
+  options.precType = ensureArgument(
+    value,
+    CompilerOptionsCodes.PrecType.InvalidParameter,
+    ["ANS", "DECDIGIT", "DECRESULT"],
+  );
 });
 
 /** {@link CompilerOptions.prefix} */
@@ -2352,7 +2373,7 @@ translator.rule(["QUOTE"], (option, options) => {
       value.value,
     );
   }
-  if (Options.PLI_CHARACTER_REGEX.test(value.value)) {
+  if (value.value !== '"' && Options.PLI_CHARACTER_REGEX.test(value.value)) {
     throw TranslationError.fromCode(
       value.token,
       CompilerOptionsCodes.Quote.InvalidParameterCharacter,
@@ -3034,7 +3055,7 @@ translator.rule(
 
 /** {@link CompilerOptions.service} */
 translator.rule(
-  ["SERVICE"],
+  ["SERVICE", "SERV"],
   (option, options) => {
     ensureArguments(option, 1, 1);
     const value = option.values[0];
@@ -3058,7 +3079,7 @@ translator.rule(
     }
     options.service = value.value;
   },
-  ["NOSERVICE"],
+  ["NOSERVICE", "NOSERV"],
   (option, options) => {
     ensureArguments(option, 0, 0);
     options.service = false;
@@ -3417,7 +3438,7 @@ translator.rule(["XINFO"], (option, options) => {
       case "NODEF":
         options.xInfo.def = ensureFlag(
           value,
-          CompilerOptionsCodes.XInfo.InvalidDefParameter,
+          CompilerOptionsCodes.XInfo.InvalidParameter,
           ["DEF", "NODEF"],
         );
         break;
@@ -3425,7 +3446,7 @@ translator.rule(["XINFO"], (option, options) => {
       case "NOMSG":
         options.xInfo.msg = ensureFlag(
           value,
-          CompilerOptionsCodes.XInfo.InvalidMsgParameter,
+          CompilerOptionsCodes.XInfo.InvalidParameter,
           ["MSG", "NOMSG"],
         );
         break;
@@ -3433,7 +3454,7 @@ translator.rule(["XINFO"], (option, options) => {
       case "NOSYM":
         options.xInfo.sym = ensureFlag(
           value,
-          CompilerOptionsCodes.XInfo.InvalidSymParameter,
+          CompilerOptionsCodes.XInfo.InvalidParameter,
           ["SYM", "NOSYM"],
         );
         break;
@@ -3441,9 +3462,13 @@ translator.rule(["XINFO"], (option, options) => {
       case "NOSYN":
         options.xInfo.syn = ensureFlag(
           value,
-          CompilerOptionsCodes.XInfo.InvalidSynParameter,
+          CompilerOptionsCodes.XInfo.InvalidParameter,
           ["SYN", "NOSYN"],
         );
+        break;
+      case "XML":
+        ensureType(value, "plain");
+        options.xInfo.xml = { hash: false };
         break;
       case "NOXML":
         ensureType(value, "plain");
@@ -3499,7 +3524,10 @@ translator.rule(
     ensureArguments(option, 0);
     ensureToBeDefined(options.xRef);
     for (const value of option.values) {
-      ensureType(value, "plainNotEmpty");
+      ensureType(value, "plain");
+      if (value.value.length === 0) {
+        continue;
+      }
       switch (value.value.toUpperCase()) {
         case "FULL":
         case "SHORT":

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-macro/ppmacro-invalid.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-macro/ppmacro-invalid.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|12:PPMACRO|>('<|13:INVALID|>');
+
+verify.expectDiagnosticsAt(13, {
+  message: code.Warning.IBM1159I.message("INVALID"),
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-macro/ppmacro.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-macro/ppmacro.ts
@@ -1,0 +1,36 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|2:PPMACRO|>;
+////*PROCESS <|4:PPMACRO|>(<|5:)|>;
+////*PROCESS <|6:PPMACRO|>(<|7:INVALID|>);
+////*PROCESS <|8:PPMACRO|>(<|9:''|>);
+////*PROCESS <|10:PPMACRO|>(<|11:'   '|>);
+////*PROCESS <|12:PPMACRO|>('CASE(UPPER)');
+
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
+});
+verify.expectDiagnosticsAt([4, 6, 8, 10, 12], {
+  message: code.CompilerOptions.DupeOptionIssue.message("PPMACRO"),
+});
+verify.expectDiagnosticsAt([5, 7], {
+  message: code.CompilerOptions.ExpectedString.message(),
+});
+verify.noDiagnostics([9, 11]);
+verify.expectCompilerOptions({
+  macroOptions: {
+    case: "UPPER",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/or.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/or.ts
@@ -12,19 +12,19 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS <|2:QUOTE|>;
-////*PROCESS <|4:QUOTE|>(<|5:)|>;
-////*PROCESS <|6:QUOTE|>(<|7:INVALID|>);
-////*PROCESS <|8:QUOTE|>(<|9:'##'|>);
-////*PROCESS <|10:QUOTE|>(<|11:'z'|>);
-////*PROCESS <|12:QUOTE|>(<|13:'"'|>);
-////*PROCESS <|14:QUOTE|>('$');
+////*PROCESS <|2:OR|>;
+////*PROCESS <|4:OR|>(<|5:)|>;
+////*PROCESS <|6:OR|>(<|7:INVALID|>);
+////*PROCESS <|8:OR|>(<|9:'##'|>);
+////*PROCESS <|10:OR|>(<|11:'z'|>);
+////*PROCESS <|12:OR|>(<|13:'|'|>);
+////*PROCESS <|14:OR|>('$');
 
 verify.expectDiagnosticsAt(2, {
   message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
 });
 verify.expectDiagnosticsAt([4, 6, 8, 10, 12, 14], {
-  message: code.CompilerOptions.DupeOptionIssue.message("QUOTE"),
+  message: code.CompilerOptions.DupeOptionIssue.message("OR"),
 });
 verify.expectDiagnosticsAt(5, {
   message: code.CompilerOptions.ExpectedString.message(),
@@ -33,12 +33,12 @@ verify.expectDiagnosticsAt(7, {
   message: code.CompilerOptions.ExpectedString.message(),
 });
 verify.expectDiagnosticsAt(9, {
-  message: code.CompilerOptions.Quote.InvalidParameterLength.message("##"),
+  message: code.CompilerOptions.Or.InvalidParameterLength.message("##"),
 });
 verify.expectDiagnosticsAt(11, {
-  message: code.CompilerOptions.Quote.InvalidParameterCharacter.message("z"),
+  message: code.CompilerOptions.Or.InvalidParameterCharacter.message("z"),
 });
 verify.noDiagnostics(13);
 verify.expectCompilerOptions({
-  quote: "$",
+  or: "$",
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/pp.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/pp.ts
@@ -21,12 +21,10 @@
 ////*PROCESS <|12:PP|>(<|11:MACRO|>("X", "Z">));
 ////*PROCESS <|14:PP|>(MACRO, SQL, CICS);
 
-verify.expectDiagnosticsAt(1, {
-  message: code.Warning.IBM1159I.message("NOPP"),
-});
-// TODO ssmifi: Should actually not report a dupe warning in the future.
+verify.noDiagnostics(1);
+// TODO ssmifi: Should actually not report a dupe/mutex warning in the future.
 verify.expectDiagnosticsAt([4, 6, 8], {
-  message: code.CompilerOptions.DupeOptionIssue.message("PP"),
+  message: code.CompilerOptions.MutexOptionIssue.message("PP"),
 });
 verify.expectDiagnosticsAt(2, {
   message: code.CompilerOptions.InvalidParameterCount.message(0, 1),

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/prectype.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/prectype.ts
@@ -15,7 +15,7 @@
 ////*PROCESS <|1:PRECTYPE|>;
 ////*PROCESS <|2:PRECTYPE|>(<|3:)|>;
 ////*PROCESS <|4:PRECTYPE|>(<|5:INVALID|>);
-////*PROCESS <|6:PRECTYPE|>(ANS, DECDIGIT);
+////*PROCESS <|6:PRECTYPE|>(<|7:ANS|>, DECDIGIT);
 ////*PROCESS <|8:PRECTYPE|>(DECDIGIT);
 
 verify.expectDiagnosticsAt(1, {
@@ -33,6 +33,7 @@ verify.expectDiagnosticsAt(5, {
 verify.expectDiagnosticsAt(6, {
   message: code.CompilerOptions.InvalidParameterCount.message(2, 1, 1),
 });
+verify.noDiagnostics(7);
 verify.expectCompilerOptions({
   precType: "DECDIGIT",
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/rtcheck.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/rtcheck.ts
@@ -14,17 +14,19 @@
 // @wrap: process
 ////*PROCESS <|1:RTCHECK|>;
 ////*PROCESS <|2:RTCHECK|>(<|3:INVALID|>);
-////*PROCESS <|4:RTCHECK|>(NULL370);
+////*PROCESS <|4:RTCHECK|>(<|5:)|>;
+////*PROCESS <|6:RTCHECK|>(NULL370);
 
 verify.expectDiagnosticsAt(1, {
   message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
 });
-verify.expectDiagnosticsAt([2, 4], {
+verify.expectDiagnosticsAt([2, 4, 6], {
   message: code.CompilerOptions.DupeOptionIssue.message("RTCHECK"),
 });
 verify.expectDiagnosticsAt(3, {
   message: code.CompilerOptions.RtCheck.InvalidParameter.message("INVALID"),
 });
+verify.noDiagnostics(5);
 verify.expectCompilerOptions({
   rtCheck: "NULL370",
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/service.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/service.ts
@@ -18,7 +18,9 @@
 ////*PROCESS <|6:SERVICE|>(<|7:"xXx"|>);
 ////*PROCESS <|8:SERVICE|>(<|9:'yYy'|>);
 ////*PROCESS <|10:SERVICE|>(<|11:xxxxxxxxx1xxxxxxxxx2xxxxxxxxx3xxxxxxxxx4xxxxxxxxx5xxxxxxxxx6xxxxxxxxx7xxxxxxxxx8|>);
-////*PROCESS <|12:SERVICE|>(xYz);
+////*PROCESS <|12:SERVICE|>(xXx);
+////*PROCESS <|14:NOSERV|>;
+////*PROCESS <|16:SERV|>(xYz);
 
 verify.noDiagnostics([1, 7, 9]);
 verify.expectDiagnosticsAt([2, 4, 6, 8, 10], {
@@ -32,6 +34,12 @@ verify.expectDiagnosticsAt(5, {
 });
 verify.expectDiagnosticsAt(11, {
   message: code.CompilerOptions.Service.InvalidParameterLength.message("80"),
+});
+verify.expectDiagnosticsAt(14, {
+  message: code.CompilerOptions.DupeOptionIssue.message("NOSERV"),
+});
+verify.expectDiagnosticsAt(16, {
+  message: code.CompilerOptions.MutexOptionIssue.message("SERV"),
 });
 verify.expectCompilerOptions({
   service: "XYZ", // Checked capitalization on the mainframe.

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/xinfo.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/xinfo.ts
@@ -16,17 +16,18 @@
 ////*PROCESS <|d2:XINFO|>();
 ////*PROCESS <|d3:XINFO|>(<|2:INVALID|>);
 ////*PROCESS <|d3:XINFO|>(<|3:INVALID|>());
-////*PROCESS <|d4:XINFO|>(XML(<|4:INVALID|>));
-////*PROCESS <|d5:XINFO|>(XML(HASH));
-////*PROCESS <|d6:XINFO|>(DEF);
-////*PROCESS <|d7:XINFO|>(MSG SYM);
-////*PROCESS <|d8:XINFO|>(NOSYM, SYN);
+////*PROCESS <|d4:XINFO|>(<|4:XML|>);
+////*PROCESS <|d5:XINFO|>(XML(<|5:INVALID|>));
+////*PROCESS <|d6:XINFO|>(XML(HASH));
+////*PROCESS <|d7:XINFO|>(DEF);
+////*PROCESS <|d8:XINFO|>(MSG SYM);
+////*PROCESS <|d9:XINFO|>(NOSYM, SYN);
 
 verify.expectDiagnosticsAt(1, {
   message: code.CompilerOptions.InvalidParameterCount.message(0, 1),
 });
 verify.expectDiagnosticsAt(
-  Array.from({ length: 7 }, (_, i) => `d${i + 2}`),
+  Array.from({ length: 8 }, (_, i) => `d${i + 2}`),
   {
     message: code.CompilerOptions.DupeOptionIssue.message("XINFO"),
   },
@@ -37,7 +38,8 @@ verify.expectDiagnosticsAt(2, {
 verify.expectDiagnosticsAt(3, {
   message: code.CompilerOptions.ExpectedPlain.message(),
 });
-verify.expectDiagnosticsAt(4, {
+verify.noDiagnostics(4);
+verify.expectDiagnosticsAt(5, {
   message: code.CompilerOptions.XInfo.InvalidXmlParameter.message("INVALID"),
 });
 verify.expectCompilerOptions({

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/xref.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/xref.ts
@@ -15,7 +15,7 @@
 ////*PROCESS <|1:NOXREF|>;
 ////*PROCESS <|2:NX|>();
 ////*PROCESS <|4:XREF|>;
-////*PROCESS <|6:XREF|>();
+////*PROCESS <|6:XREF|>(<|7:)|>;
 ////*PROCESS <|8:XREF|>(<|9:INVALID|>);
 ////*PROCESS <|10:X|>(FULL SHORT IMPLICIT EXPLICIT);
 
@@ -26,11 +26,12 @@ verify.expectDiagnosticsAt(2, {
 verify.expectDiagnosticsAt([4, 6, 8], {
   message: code.CompilerOptions.MutexOptionIssue.message("XREF"),
 });
-verify.expectDiagnosticsAt(10, {
-  message: code.CompilerOptions.MutexOptionIssue.message("X"),
-});
+verify.noDiagnostics(7);
 verify.expectDiagnosticsAt(9, {
   message: code.CompilerOptions.XRef.InvalidParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt(10, {
+  message: code.CompilerOptions.MutexOptionIssue.message("X"),
 });
 verify.expectCompilerOptions({
   xRef: {


### PR DESCRIPTION
Handles the findings from https://github.com/zowe/zowe-pli-language-support/issues/374 g)
Also fixes https://github.com/zowe/zowe-pli-language-support/issues/374 f)

- Spaces are actually allowed in `ppmacro` (and similar) on the mainframe. Refactored and added tests.
- Fixed message in `PRECTYPE(ANS)`.
- Fixed: allow " as character in `QUOTE`.
- `*PROCESS RTCHECK();` is valid and falls back to the the default RTCHECK( NONULLPTR ).
- Yes. The last one takes effect in `RULES`. Added an issue to keep track of the reporting of the suboptions: https://github.com/zowe/zowe-pli-language-support/issues/419
- Added abbreviations to `SERVICE`.
- `*PROCESS TEST;` is valid and falls back to the defaults.
- The tests are all valid. As said, exclusive suboptions should be reported separately in an upcoming feature.
- Fixed both messages in `XINFO`.
- No brackets are valid in `XREF`.
- Fixed no arguments in `XREF`, which is also valid and falls back to the defaults.