### PR TITLE
Fix issues in `%SELECT` statement

### DIFF
--- a/packages/language/src/preprocessor/instruction-generator.ts
+++ b/packages/language/src/preprocessor/instruction-generator.ts
@@ -473,16 +473,12 @@ function generateSelectInstructionFromIf(
   };
   const cases: inst.Cases[] = [];
   const trueBranch = generateInstructionForStatement(node.unit, context);
-  if (trueBranch) {
-    cases.push({
-      conditions: [compare],
-      body: trueBranch,
-    });
-  }
-  const falseBranch = node.else
-    ? generateInstructionForStatement(node.else, context)
-    : undefined;
-  if (falseBranch) {
+  cases.push({
+    conditions: [compare],
+    body: trueBranch,
+  });
+  if (node.else) {
+    const falseBranch = generateInstructionForStatement(node.else, context);
     // False branch doesn't need a condition, it is always entered if the true branch does not match
     cases.push({
       conditions: [],
@@ -492,8 +488,10 @@ function generateSelectInstructionFromIf(
   context.onFinish(() => {
     const instructionNode = context.nodes.get(node.container);
     for (const caseItem of cases) {
-      // All case bodies should point to the next instruction after the IF statement
-      caseItem.body.next = instructionNode?.next;
+      if (caseItem.body) {
+        // All case bodies should point to the next instruction after the IF statement
+        caseItem.body.next = instructionNode?.next;
+      }
     }
   });
   return inst.createSelectInstruction(node, undefined, cases);
@@ -519,18 +517,18 @@ function generateSelectInstruction(
       }
     }
     const body = generateInstructionForStatement(caseObj.unit, context);
-    if (body) {
-      cases.push({
-        body,
-        conditions,
-      });
-    }
+    cases.push({
+      body,
+      conditions,
+    });
   }
   context.onFinish(() => {
     const instructionNode = context.nodes.get(node.container);
     for (const caseItem of cases) {
-      // All case bodies should point to the next instruction after the SELECT statement
-      caseItem.body.next = instructionNode?.next;
+      if (caseItem.body) {
+        // All case bodies should point to the next instruction after the SELECT statement
+        caseItem.body.next = instructionNode?.next;
+      }
     }
   });
   return inst.createSelectInstruction(node, compare, cases);

--- a/packages/language/src/preprocessor/instructions.ts
+++ b/packages/language/src/preprocessor/instructions.ts
@@ -195,7 +195,11 @@ export interface Cases {
    * No conditions means "default" case or "else" branch, and will be executed if no other case matches.
    */
   conditions: ExpressionInstruction[];
-  body: InstructionNode;
+  /**
+   * In some cases the body can be empty, for example in empty do statements.
+   * If the empty body is returned during interpretation, the interpreter will just continue with the following instruction.
+   */
+  body?: InstructionNode;
 }
 
 export type ExpressionInstruction =

--- a/packages/language/src/preprocessor/preprocessor-parser.ts
+++ b/packages/language/src/preprocessor/preprocessor-parser.ts
@@ -1161,12 +1161,14 @@ function whenStatement(state: PreprocessorParserState): ast.WhenStatement {
     CstNodeKind.WhenStatement_CloseParen,
     PreprocessorTokens.RParen,
   );
-  when.range = {
-    start: state.current!.startOffset,
-    end: NaN,
-  };
+  const rangeStart = state.current?.startOffset;
   when.unit = statement(state);
-  when.range.end = state.last!.endOffset + 1;
+  if (rangeStart != undefined && state.last) {
+    when.range = {
+      start: rangeStart,
+      end: state.last.endOffset + 1,
+    };
+  }
   return when;
 }
 
@@ -1179,12 +1181,14 @@ function otherwiseStatement(
     CstNodeKind.OtherwiseStatement_OTHERWISE,
     PreprocessorTokens.Otherwise,
   );
-  otherwise.range = {
-    start: state.current!.startOffset,
-    end: NaN,
-  };
+  const rangeStart = state.current?.startOffset;
   otherwise.unit = statement(state);
-  otherwise.range.end = state.last!.endOffset + 1;
+  if (rangeStart != undefined && state.last) {
+    otherwise.range = {
+      start: rangeStart,
+      end: state.last.endOffset + 1,
+    };
+  }
   return otherwise;
 }
 
@@ -1207,24 +1211,28 @@ function ifStatement(state: PreprocessorParserState): ast.IfStatement {
     CstNodeKind.IfStatement_THEN,
     PreprocessorTokens.Then,
   );
-  ifStatement.unitRange = {
-    start: state.current!.startOffset,
-    end: NaN,
-  };
+  const unitRangeStart = state.current?.startOffset;
   ifStatement.unit = statement(state);
-  ifStatement.unitRange.end = state.last!.endOffset + 1;
+  if (unitRangeStart != undefined && state.last) {
+    ifStatement.unitRange = {
+      start: unitRangeStart,
+      end: state.last.endOffset + 1,
+    };
+  }
   if (state.canConsumeKeyword(PreprocessorTokens.Else)) {
     state.consumeKeyword(
       ifStatement,
       CstNodeKind.IfStatement_ELSE,
       PreprocessorTokens.Else,
     );
-    ifStatement.elseRange = {
-      start: state.current!.startOffset,
-      end: NaN,
-    };
+    const elseRangeStart = state.current?.startOffset;
     ifStatement.else = statement(state);
-    ifStatement.elseRange.end = state.last!.endOffset + 1;
+    if (elseRangeStart != undefined && state.last) {
+      ifStatement.elseRange = {
+        start: elseRangeStart,
+        end: state.last.endOffset + 1,
+      };
+    }
   }
   return ifStatement;
 }

--- a/packages/language/test/fourslash-harness/harness-interface.ts
+++ b/packages/language/test/fourslash-harness/harness-interface.ts
@@ -21,6 +21,8 @@ import { CompilerOptions } from "../../src/preprocessor/compiler-options/options
 
 type SemanticTokenTypesValues = `${SemanticTokenTypes}`;
 
+export type Not<T> = Omit<T, "not">;
+
 export interface HarnessTesterInterface {
   testAPI: {
     /**
@@ -169,6 +171,7 @@ export interface HarnessTesterInterface {
   };
 
   preprocessor: {
+    not: Not<HarnessTesterInterface["preprocessor"]>;
     /**
      * Expect that the preprocessor produces the given text or tokens.
      * @param textOrTokens The text or tokens to expect.

--- a/packages/language/test/fourslash-harness/harness.test.ts
+++ b/packages/language/test/fourslash-harness/harness.test.ts
@@ -74,6 +74,10 @@ async function createTestingHarnessImplementation(
       expectAt: listen("semanticTokens.expectAt"),
     },
     preprocessor: {
+      not: {
+        expectTokens: listen("preprocessor.not.expectTokens"),
+        expectSkippedCodeAt: listen("preprocessor.not.expectSkippedCodeAt"),
+      },
       expectTokens: listen("preprocessor.expectTokens"),
       expectSkippedCodeAt: listen("preprocessor.expectSkippedCodeAt"),
     },

--- a/packages/language/test/fourslash-harness/implementation/test-builder.ts
+++ b/packages/language/test/fourslash-harness/implementation/test-builder.ts
@@ -83,6 +83,11 @@ export function createTestBuilderHarnessImplementation(
         ),
     },
     preprocessor: {
+      not: {
+        expectTokens: (text) => testBuilder.not.expectPreprocessorTokens(text),
+        expectSkippedCodeAt: (label) =>
+          testBuilder.not.expectSkippedCode(label.toString()),
+      },
       expectTokens: (text) => testBuilder.expectPreprocessorTokens(text),
       expectSkippedCodeAt: (label) =>
         testBuilder.expectSkippedCode(label.toString()),

--- a/packages/language/test/fourslash/preprocessor/skipped-code-skipped-true-branch.ts
+++ b/packages/language/test/fourslash/preprocessor/skipped-code-skipped-true-branch.ts
@@ -12,10 +12,6 @@
 /// <reference path="../framework.ts" />
 
 // @wrap: main
-//// IGNO: PROCEDURE OPTIONS (MAIN);
-//// dcl A fixed bin(31);
-//// dcl B fixed bin(31);
-//// dcl WHAT fixed bin(31);
 //// %DECLARE C fixed;
 //// %C = 0;
 //// %IF C %THEN <|skipped:%DO;
@@ -24,6 +20,5 @@
 //// %ELSE %DO;
 ////   WHAT = 456;
 //// %END;
-//// END;
 
 preprocessor.expectSkippedCodeAt("skipped");

--- a/packages/language/test/fourslash/preprocessor/skipped-do-select-with-empty-do.ts
+++ b/packages/language/test/fourslash/preprocessor/skipped-do-select-with-empty-do.ts
@@ -12,13 +12,9 @@
 /// <reference path="../framework.ts" />
 
 // @wrap: main
-//// %DECLARE C fixed;
-//// %C = 1;
-//// %IF C %THEN %DO;
-////   WHAT = 123;
+//// %SELECT;
+//// %WHEN (1) <|notSkipped:%DO; %END;|>
+//// %WHEN (2) DCL TEST FIXED;
 //// %END;
-//// %ELSE <|skipped:%DO;
-////   WHAT = 456;
-//// %END;|>
 
-preprocessor.expectSkippedCodeAt("skipped");
+preprocessor.not.expectSkippedCodeAt("notSkipped");

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -57,6 +57,10 @@ export type TestBuilderOptions = {
   fs?: FileSystemProvider;
 
   /**
+   * Inverts the testing steps.
+   */
+  not?: boolean;
+  /**
    * Override the location of files.
    * This is useful for harness tests, where files are 'virtually' created inside a single test file
    */
@@ -166,6 +170,25 @@ export class TestBuilder {
         replaceNamedIndicesWithDocument(file),
       ]),
     );
+  }
+
+  get not(): TestBuilder {
+    const copy = this.copy();
+    copy.options.not = !this.options.not;
+    return copy;
+  }
+
+  private copy(): TestBuilder {
+    const copy = new TestBuilder([], {
+      ...this.options,
+    });
+    copy.files = this.files;
+    copy.unit = this.unit;
+    copy.output = this.output;
+    copy.indices = this.indices;
+    copy.ranges = this.ranges;
+    copy.diagnostics = this.diagnostics;
+    return copy;
   }
 
   private async init() {
@@ -292,9 +315,6 @@ export class TestBuilder {
   expectPreprocessorTokens(textOrTokens: string | string[]): void {
     const actualTokens = this.unit.tokens.map((e) => e.image);
     let expectedTokens: string[] = [];
-    // TODO: Instead of calling the lifecycle, we should simply call the lexer
-    // Currently, everything related to the lexer lives in rather complicated services
-    // Eventually, we want to refactor those to use functions
     if (Array.isArray(textOrTokens)) {
       expectedTokens = textOrTokens;
     } else {
@@ -302,7 +322,11 @@ export class TestBuilder {
         (e) => e.image,
       );
     }
-    expect(actualTokens).toEqual(expectedTokens);
+    let exp = expect(actualTokens);
+    if (this.options.not) {
+      exp = exp.not;
+    }
+    exp.toEqual(expectedTokens);
   }
 
   /**
@@ -712,16 +736,35 @@ export class TestBuilder {
       const textDocument = file.textDocument;
       const codeRanges = skippedCodeRanges(this.unit, textDocument);
 
-      const message = `Expected ${ranges.length} skipped code ranges but received ${codeRanges.length} for label "${label}" (${this.createLabelRangeMessage(label)})`;
-      expect(codeRanges, message).toHaveLength(ranges.length);
+      if (this.options.not) {
+        for (let i = 0; i < ranges.length; i++) {
+          const startPosition = textDocument.positionAt(ranges[i][0]);
+          const endPosition = textDocument.positionAt(ranges[i][1]);
+          const codeRange = codeRanges.find(
+            (cr) =>
+              cr.start.line === startPosition.line &&
+              cr.start.character === startPosition.character &&
+              cr.end.line === endPosition.line &&
+              cr.end.character === endPosition.character,
+          );
+          if (codeRange) {
+            fail(
+              `Found unexpected skipped code from ${formatPosition(startPosition)} to ${formatPosition(endPosition)} for label "${label}" (${this.createLabelRangeMessage(label)})`,
+            );
+          }
+        }
+      } else {
+        const message = `Expected ${ranges.length} skipped code ranges but received ${codeRanges.length} for label "${label}" (${this.createLabelRangeMessage(label)})`;
+        expect(codeRanges, message).toHaveLength(ranges.length);
 
-      for (let i = 0; i < ranges.length; i++) {
-        const startPosition = textDocument.positionAt(ranges[i][0]);
-        const endPosition = textDocument.positionAt(ranges[i][1]);
-        const messageStart = `Expected skipped code to start at ${formatPosition(startPosition)} but received ${formatPosition(codeRanges[i].start)} for label "${label}" (${this.createLabelRangeMessage(label)})`;
-        expect(codeRanges[i].start, messageStart).toEqual(startPosition);
-        const messageEnd = `Expected skipped code to end at ${formatPosition(endPosition)} but received ${formatPosition(codeRanges[i].end)} for label "${label}" (${this.createLabelRangeMessage(label)})`;
-        expect(codeRanges[i].end, messageEnd).toEqual(endPosition);
+        for (let i = 0; i < ranges.length; i++) {
+          const startPosition = textDocument.positionAt(ranges[i][0]);
+          const endPosition = textDocument.positionAt(ranges[i][1]);
+          const messageStart = `Expected skipped code to start at ${formatPosition(startPosition)} but received ${formatPosition(codeRanges[i].start)} for label "${label}" (${this.createLabelRangeMessage(label)})`;
+          expect(codeRanges[i].start, messageStart).toEqual(startPosition);
+          const messageEnd = `Expected skipped code to end at ${formatPosition(endPosition)} but received ${formatPosition(codeRanges[i].end)} for label "${label}" (${this.createLabelRangeMessage(label)})`;
+          expect(codeRanges[i].end, messageEnd).toEqual(endPosition);
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes a few issues related to the `%SELECT` statement that I've noticed in manual testing:

1. While writing an unfinished `%SELECT` statement, the language server crashed on me due to usage of `!` in the preprocessor code (no test, couldn't find a good way to reproduce).
2. Empty `%WHEN` statement bodies were incorrectly shown as "skipped" (this has a test case).

Also adds a `not` inversion feature to the `TestBuilder`, which makes negative testing a lot easier. Currently, it's only active for the `preprocessor` features, but we can extend it to other features in the future.