### PR TITLE
Fix comparison operation in macro interpreter

### DIFF
--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -1028,6 +1028,14 @@ function stringOperation(
   };
 }
 
+function stringBoolOperation(
+  callback: (left: string, right: string) => boolean,
+): ValueOperation {
+  return (left: ScalarValue, right: ScalarValue) => {
+    return boolToValue(callback(left.value, right.value));
+  };
+}
+
 const plus = intOperation((left, right) => left + right);
 const minus = intOperation((left, right) => left - right);
 const multiply = intOperation((left, right) => left * right);
@@ -1036,10 +1044,10 @@ const exponentiate = intOperation((left, right) => left ** right);
 const concat = stringOperation((left, right) => left + right);
 const lessThan = intBoolOperation((left, right) => left < right);
 const greaterThan = intBoolOperation((left, right) => left > right);
-const equals = intBoolOperation((left, right) => left === right);
+const equals = stringBoolOperation((left, right) => left === right);
 const lessThanEquals = intBoolOperation((left, right) => left <= right);
 const greaterThanEquals = intBoolOperation((left, right) => left >= right);
-const notEquals = intBoolOperation((left, right) => left !== right);
+const notEquals = stringBoolOperation((left, right) => left !== right);
 const and = intOperation((left, right) => left & right);
 const or = intOperation((left, right) => left | right);
 const xor = intOperation((left, right) => left ^ right);

--- a/packages/language/test/fourslash/preprocessor/if-number-comparison-conversion.ts
+++ b/packages/language/test/fourslash/preprocessor/if-number-comparison-conversion.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+//// %A = 12;
+//// %IF A = "12" %THEN
+////   CORRECT
+//// %ELSE
+////   ERROR
+
+preprocessor.expectTokens("CORRECT");

--- a/packages/language/test/fourslash/preprocessor/if-number-comparison-negative.ts
+++ b/packages/language/test/fourslash/preprocessor/if-number-comparison-negative.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+//// %A = 12;
+//// %IF A = 3 %THEN
+////   ERROR
+//// %ELSE
+////   CORRECT
+
+preprocessor.expectTokens("CORRECT");

--- a/packages/language/test/fourslash/preprocessor/if-number-comparison.ts
+++ b/packages/language/test/fourslash/preprocessor/if-number-comparison.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+//// %A = 12;
+//// %IF A = 12 %THEN
+////   CORRECT
+//// %ELSE
+////   ERROR
+
+preprocessor.expectTokens("CORRECT");

--- a/packages/language/test/fourslash/preprocessor/if-string-comparison.ts
+++ b/packages/language/test/fourslash/preprocessor/if-string-comparison.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+//// %A = "HELLO";
+//// %IF A = "HELLO" %THEN
+////   CORRECT
+//// %ELSE
+////   ERROR
+
+preprocessor.expectTokens("CORRECT");

--- a/packages/language/test/fourslash/preprocessor/if-string-not-comparison.ts
+++ b/packages/language/test/fourslash/preprocessor/if-string-not-comparison.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+//// %A = "HELLO";
+//// %IF A <> "HELLO" %THEN
+////   ERROR
+//// %ELSE
+////   CORRECT
+
+preprocessor.expectTokens("CORRECT");


### PR DESCRIPTION
Related to (5) in https://github.com/zowe/zowe-pli-language-support/issues/431.

Adds a bunch of tests that confirm that this now behaves as expected (with a few negative tests as well).