### PR TITLE
Update NOT compiler option

### DIFF
--- a/packages/language/src/parser/tokenizer.ts
+++ b/packages/language/src/parser/tokenizer.ts
@@ -18,6 +18,7 @@ import {
 } from "../preprocessor/compiler-options/options";
 import { diagnostic, Diagnostic } from "../language-server/types";
 import { PLICodes } from "../validation/messages";
+import { NOT_CHARACTER } from "../utils/const";
 
 interface TwoCharToken {
   char: string;
@@ -433,7 +434,7 @@ function isWhitespace(char: number): boolean {
 // Function map
 const funcs = new Map<string, TokenizeFunc>();
 const defaultOr = "|";
-const defaultNot = "¬^";
+const defaultNot = NOT_CHARACTER + "^";
 let orSymbols = defaultOr;
 let notSymbols = defaultNot;
 let includeAlt: string | undefined = undefined;

--- a/packages/language/src/preprocessor/compiler-options/codes.ts
+++ b/packages/language/src/preprocessor/compiler-options/codes.ts
@@ -415,6 +415,23 @@ export const CompilerOptionsCodes = {
     InvalidParameterLengths: PLICodes.Warning.IBM1205I,
   },
 
+  Not: {
+    InvalidParameterLength: {
+      code: "CONO01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected a single character, but received '${value}'.`,
+      fullCode: "CONO01W",
+    } as ParametricPLICode,
+    InvalidParameterCharacter: {
+      code: "CONO02",
+      severity: Severity.W,
+      message: (value: string) =>
+        `Expected a valid not character, but received '${value}'.`,
+      fullCode: "CONO02W",
+    } as ParametricPLICode,
+  },
+
   OffsetSize: {
     // [Warning] IBM1161I: The suboption 3 is not valid for the OFFSETSIZE compiler option.
     InvalidParameter: {

--- a/packages/language/src/preprocessor/compiler-options/options.ts
+++ b/packages/language/src/preprocessor/compiler-options/options.ts
@@ -13,6 +13,7 @@ import { Diagnostic, Range, Severity } from "../../language-server/types";
 import { Token } from "../../parser/tokens";
 import * as Pli from "./options-pli";
 import * as Macro from "./options-macro";
+import { NOT_CHARACTER } from "../../utils/const";
 
 export type CompilerOptionsPP = Pli.CompilerOptions | Macro.CompilerOptions;
 
@@ -45,11 +46,14 @@ export function compilerOptionIssueToDiagnostics(
 }
 
 export namespace CompilerOptions {
-  export const PLI_CHARACTER_REGEX = /[A-Za-z0-9 =+\-*/()\.,'"%;:&|<>_¬]/;
+  export const PLI_CHARACTER_REGEX = new RegExp(
+    `[A-Za-z0-9 =+\\-*/()\\.,'"%;:&|<>_${NOT_CHARACTER}]`,
+  );
   export const PLI_CHARACTER_SET = new Set(
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 =+-*/().,'\"%;:&|<>_¬".split(
-      "",
-    ),
+    (
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 =+-*/().,'\"%;:&|<>_" +
+      NOT_CHARACTER
+    ).split(""),
   );
 }
 

--- a/packages/language/src/preprocessor/compiler-options/translator-pli.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator-pli.ts
@@ -15,6 +15,7 @@ import {
   CompilerOptionText,
   SyntaxKind,
 } from "../../syntax-tree/ast";
+import { NOT_CHARACTER } from "../../utils/const";
 import { CompilerOptionsCodes } from "./codes";
 import { CompilerOptions as Options } from "./options";
 import {
@@ -1942,12 +1943,29 @@ translator.rule(["NATLANG"], (option, options) => {
 translator.flag("nest", ["NEST"], ["NONEST"]);
 
 /** {@link CompilerOptions.not} */
-translator.rule(
-  ["NOT"],
-  stringTranslate((options, text) => {
-    options.not = text.value;
-  }),
-);
+translator.rule(["NOT"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "string");
+  if (value.value.length !== 1) {
+    throw TranslationError.fromCode(
+      value.token,
+      CompilerOptionsCodes.Not.InvalidParameterLength,
+      value.value,
+    );
+  }
+  if (
+    value.value !== NOT_CHARACTER &&
+    Options.PLI_CHARACTER_REGEX.test(value.value)
+  ) {
+    throw TranslationError.fromCode(
+      value.token,
+      CompilerOptionsCodes.Not.InvalidParameterCharacter,
+      value.value,
+    );
+  }
+  options.not = value.value;
+});
 
 /** {@link CompilerOptions.nullDate} */
 translator.flag("nullDate", ["NULLDATE"], ["NONULLDATE"]);

--- a/packages/language/src/utils/const.ts
+++ b/packages/language/src/utils/const.ts
@@ -1,0 +1,12 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+export const NOT_CHARACTER = "\u00AC"; // '¬'

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/not.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/not.ts
@@ -1,0 +1,44 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|2:NOT|>;
+////*PROCESS <|4:NOT|>(<|5:)|>;
+////*PROCESS <|6:NOT|>(<|7:INVALID|>);
+////*PROCESS <|8:NOT|>(<|9:'##'|>);
+////*PROCESS <|10:NOT|>(<|11:'z'|>);
+////*PROCESS <|12:NOT|>(<|13:'¬'|>);
+////*PROCESS <|14:NOT|>('$');
+
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
+});
+verify.expectDiagnosticsAt([4, 6, 8, 10, 12, 14], {
+  message: code.CompilerOptions.DupeOptionIssue.message("NOT"),
+});
+verify.expectDiagnosticsAt(5, {
+  message: code.CompilerOptions.ExpectedString.message(),
+});
+verify.expectDiagnosticsAt(7, {
+  message: code.CompilerOptions.ExpectedString.message(),
+});
+verify.expectDiagnosticsAt(9, {
+  message: code.CompilerOptions.Not.InvalidParameterLength.message("##"),
+});
+verify.expectDiagnosticsAt(11, {
+  message: code.CompilerOptions.Not.InvalidParameterCharacter.message("z"),
+});
+verify.noDiagnostics(13);
+verify.expectCompilerOptions({
+  not: "$",
+});


### PR DESCRIPTION
Updates NOT compiler option to latest changes, basically fixed https://github.com/zowe/zowe-pli-language-support/issues/431 6).