### PR TITLE
Support macro parse of ENTRY attribute

### DIFF
--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -7579,22 +7579,9 @@ export class PliParser extends AbstractParser {
 
     return this.pop<ast.EnvironmentAttributeItem>();
   });
-  private createEntryAttribute(): ast.EntryAttribute {
-    return {
-      kind: ast.SyntaxKind.EntryAttribute,
-      container: null,
-      limited: [],
-      attributes: [],
-      options: [],
-      variable: [],
-      returns: [],
-      environmentName: [],
-      entryToken: null,
-    };
-  }
 
   EntryAttribute = this.RULE("EntryAttribute", () => {
-    let element = this.push(this.createEntryAttribute());
+    let element = this.push(ast.createEntryAttribute());
 
     this.MANY1(() => {
       this.CONSUME_ASSIGN1(tokens.LIMITED, (token) => {

--- a/packages/language/src/parser/preprocessor-parser.ts
+++ b/packages/language/src/parser/preprocessor-parser.ts
@@ -1355,6 +1355,16 @@ function attributes(state: ParserState): ast.DeclarationAttribute[] {
       const dimensionAttribute = ast.createDimensionsDataAttribute();
       dimensionAttribute.dimensions = dim;
       attributes.push(dimensionAttribute);
+    } else if (state.canConsume(t.ENTRY)) {
+      // TODO: This is not the full entry attribute syntax
+      // This is just to provide support for the common case of "ENTRY" on declarations
+      const entryAttribute = ast.createEntryAttribute();
+      entryAttribute.entryToken = state.consume(
+        entryAttribute,
+        CstNodeKind.EntryAttribute_ENTRY,
+        t.ENTRY,
+      );
+      attributes.push(entryAttribute);
     } else {
       break;
     }

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -1393,6 +1393,19 @@ export interface EntryAttribute extends AstNode {
   environmentName: Expression[];
   entryToken: Token | null;
 }
+export function createEntryAttribute(): EntryAttribute {
+  return {
+    kind: SyntaxKind.EntryAttribute,
+    container: null,
+    limited: [],
+    attributes: [],
+    options: [],
+    variable: [],
+    returns: [],
+    environmentName: [],
+    entryToken: null,
+  };
+}
 export interface EntryParameterDescription extends AstNode {
   kind: SyntaxKind.EntryParameterDescription;
   attributes: DeclarationAttribute[];

--- a/packages/language/test/fourslash/parser/pp/variable-with-entry.ts
+++ b/packages/language/test/fourslash/parser/pp/variable-with-entry.ts
@@ -1,0 +1,36 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %DCL VAR <|entry:ENTRY|>;
+
+verify.noDiagnostics("entry");
+
+verify.expectPPAst({
+  kind: Syntax.DeclareStatement,
+  items: [
+    {
+      kind: Syntax.DeclaredItem,
+      elements: [
+        {
+          kind: Syntax.DeclaredVariable,
+          name: "VAR",
+        },
+      ],
+      attributes: [
+        {
+          kind: Syntax.EntryAttribute,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
Adds preliminary support to parse the `entry` attribute keyword on preprocessor declarations. Does not implement actual support in the interpreter for it.