### PR TITLE
Resolve Libs Recursively

### DIFF
--- a/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
+++ b/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
@@ -48,7 +48,12 @@ export async function quickFixResolveInclude(
     workspaceFolderUri,
   );
   if (!parentFolder) return undefined;
-  if (procGrpsConfig.libs.includes(parentFolder)) return undefined;
+  if (
+    procGrpsConfig.libs.includes(parentFolder) ||
+    procGrpsConfig._subLibs.includes(parentFolder)
+  ) {
+    return undefined;
+  }
 
   const serializedProcGrpsConfig = serializeProcessGroup(procGrpsConfig);
   const newContent = JSON.stringify(

--- a/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
+++ b/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
@@ -47,11 +47,7 @@ export async function quickFixResolveInclude(
     unresolvedFilePath,
     workspaceFolderUri,
   );
-  if (!parentFolder) return undefined;
-  if (
-    procGrpsConfig.libs.includes(parentFolder) ||
-    procGrpsConfig._subLibs.includes(parentFolder)
-  ) {
+  if (!parentFolder || procGrpsConfig.$computedLibs.includes(parentFolder)) {
     return undefined;
   }
 

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2009,8 +2009,8 @@ async function resolveIncludeFileUri(
   if (pgroup) {
     // lib file as either a string or a member from a known process group
     const absPathRegex = /^(?:\/|\\|[A-Z]:)/i;
-    const allLibs = pgroup.libs.concat(pgroup._subLibs);
-    for (const lib of allLibs) {
+    const computedLibs = pgroup.$computedLibs;
+    for (const lib of computedLibs) {
       let libFileUri: URI;
       if (!absPathRegex.test(lib)) {
         // relative lib path, combine w/ workspace

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2009,7 +2009,8 @@ async function resolveIncludeFileUri(
   if (pgroup) {
     // lib file as either a string or a member from a known process group
     const absPathRegex = /^(?:\/|\\|[A-Z]:)/i;
-    for (const lib of pgroup.libs) {
+    const allLibs = pgroup.libs.concat(pgroup._subLibs);
+    for (const lib of allLibs) {
       let libFileUri: URI;
       if (!absPathRegex.test(lib)) {
         // relative lib path, combine w/ workspace

--- a/packages/language/src/workspace/file-system-provider.ts
+++ b/packages/language/src/workspace/file-system-provider.ts
@@ -19,11 +19,16 @@ export interface SearchOptions {
 
 export interface FileSystemProvider {
   readFile(uri: URI): Promise<string | undefined>;
+  /**
+   * Reads the contents of a directory. The result is an array of file and directory names w/ types
+   */
+  readDir(uri: URI): Promise<Array<[string, number]>>;
   fileExists(uri: URI): Promise<boolean>;
   writeFile(uri: URI, value: string): Promise<void>;
   deleteFile(uri: URI): Promise<void>;
   /**
    * Performs a file search. Implementation depends on the provider.
+   * Returns a singular URI if found, otherwise undefined.
    */
   search(options: SearchOptions): Promise<URI | undefined>;
 }
@@ -34,6 +39,10 @@ export interface FileSystemProvider {
 class _EmptyFileSystemProvider implements FileSystemProvider {
   readFile(_uri: URI): Promise<string | undefined> {
     return Promise.resolve("");
+  }
+
+  readDir(_uri: URI): Promise<Array<[string, number]>> {
+    return Promise.resolve([]);
   }
 
   fileExists(_uri: URI): Promise<boolean> {
@@ -83,6 +92,32 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
   }
 
   /**
+   * Reads the contents of a directory in the virtualized file system.
+   * The result is an array of file and directory names w/ types.
+   * Directories are only virtual in this case, only existing if there are files with matching prefixes.
+   * If no entries are found, an empty array is returned.
+   */
+  async readDir(uri: URI): Promise<Array<[string, number]>> {
+    // collect all entries which start with the given path
+    const path = uri.toString().toLowerCase();
+    const entries: Array<[string, number]> = [];
+    for (const filePath of this.files.keys()) {
+      if (filePath.startsWith(path)) {
+        const relativePath = filePath.substring(path.length);
+        const parts = relativePath.split("/").filter(p => p.length > 0);
+        if (parts.length === 1) {
+          // file
+          entries.push([parts[0], 1]);
+        } else {
+          // directory
+          entries.push([parts[0], 2]);
+        }
+      }
+    }
+    return entries;
+  }
+
+  /**
    * Checks if a file exists in the virtualized file system
    */
   async fileExists(uri: URI): Promise<boolean> {
@@ -96,6 +131,12 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
     this.files.delete(uri.toString().toLowerCase());
   }
 
+  /**
+   * Performs a simple search in the virtualized file system.
+   * Checks if the exact path exists, otherwise tries with each of the given extensions.
+   * @param options Options to configure the search
+   * @returns First match, or undefined if no match found
+   */
   async search(options: SearchOptions): Promise<URI | undefined> {
     const searchPath = options.path
       .toString()

--- a/packages/language/src/workspace/file-system-provider.ts
+++ b/packages/language/src/workspace/file-system-provider.ts
@@ -23,7 +23,7 @@ export interface SearchOptions {
 export enum DirEntryType {
   File = 1,
   Directory = 2,
-};
+}
 
 /**
  * Directory entry, used in readDir results
@@ -120,18 +120,18 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
     for (const filePath of this.files.keys()) {
       if (filePath.startsWith(path)) {
         const relativePath = filePath.substring(path.length);
-        const parts = relativePath.split("/").filter(p => p.length > 0);
+        const parts = relativePath.split("/").filter((p) => p.length > 0);
         if (parts.length === 1) {
           // file
           entries.push({
             name: parts[0],
-            type: DirEntryType.File
+            type: DirEntryType.File,
           });
         } else {
           // directory
           entries.push({
             name: parts[0],
-            type: DirEntryType.Directory
+            type: DirEntryType.Directory,
           });
         }
       }

--- a/packages/language/src/workspace/file-system-provider.ts
+++ b/packages/language/src/workspace/file-system-provider.ts
@@ -17,12 +17,28 @@ export interface SearchOptions {
   global?: boolean;
 }
 
+/**
+ * Directory entry types, used in readDir results
+ */
+export enum DirEntryType {
+  File = 1,
+  Directory = 2,
+};
+
+/**
+ * Directory entry, used in readDir results
+ */
+export interface DirEntry {
+  name: string;
+  type: DirEntryType;
+}
+
 export interface FileSystemProvider {
   readFile(uri: URI): Promise<string | undefined>;
   /**
-   * Reads the contents of a directory. The result is an array of file and directory names w/ types
+   * Reads the contents of a directory. The result is an array of directory entries w/ types
    */
-  readDir(uri: URI): Promise<Array<[string, number]>>;
+  readDir(uri: URI): Promise<DirEntry[]>;
   fileExists(uri: URI): Promise<boolean>;
   writeFile(uri: URI, value: string): Promise<void>;
   deleteFile(uri: URI): Promise<void>;
@@ -41,7 +57,7 @@ class _EmptyFileSystemProvider implements FileSystemProvider {
     return Promise.resolve("");
   }
 
-  readDir(_uri: URI): Promise<Array<[string, number]>> {
+  readDir(_uri: URI): Promise<DirEntry[]> {
     return Promise.resolve([]);
   }
 
@@ -93,24 +109,30 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
 
   /**
    * Reads the contents of a directory in the virtualized file system.
-   * The result is an array of file and directory names w/ types.
-   * Directories are only virtual in this case, only existing if there are files with matching prefixes.
+   * The result is an array of directory entries w/ types.
+   * Directories are virtual in this case, only existing if there are files with matching prefixes.
    * If no entries are found, an empty array is returned.
    */
-  async readDir(uri: URI): Promise<Array<[string, number]>> {
+  async readDir(uri: URI): Promise<DirEntry[]> {
     // collect all entries which start with the given path
     const path = uri.toString().toLowerCase();
-    const entries: Array<[string, number]> = [];
+    const entries: DirEntry[] = [];
     for (const filePath of this.files.keys()) {
       if (filePath.startsWith(path)) {
         const relativePath = filePath.substring(path.length);
         const parts = relativePath.split("/").filter(p => p.length > 0);
         if (parts.length === 1) {
           // file
-          entries.push([parts[0], 1]);
+          entries.push({
+            name: parts[0],
+            type: DirEntryType.File
+          });
         } else {
           // directory
-          entries.push([parts[0], 2]);
+          entries.push({
+            name: parts[0],
+            type: DirEntryType.Directory
+          });
         }
       }
     }

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -331,7 +331,7 @@ export class PluginConfigurationProvider {
 
       if (processGrpConfig !== undefined) {
         try {
-          this.parseProcessGroupConfigs(processGrpConfig);
+          await this.parseProcessGroupConfigs(processGrpConfig);
           this.postProcessProgramConfigs();
           await this.postProcessProcessGroups();
           return;
@@ -470,11 +470,11 @@ export class PluginConfigurationProvider {
    * @param text Raw text content of .pliplugin/proc_grps.json to parse
    * @returns Whether parsing was successful
    */
-  public parseProcessGroupConfigs(text: string): boolean {
+  public async parseProcessGroupConfigs(text: string): Promise<boolean> {
     try {
       const serializedData: SerializedProcessGroup[] = JSON.parse(text).pgroups;
       const groupConfigs = serializedData.map(deserializeProcessGroup);
-      this.setProcessGroupConfigs(groupConfigs);
+      await this.setProcessGroupConfigs(groupConfigs);
       this.postProcessProgramConfigs();
       return true;
     } catch {
@@ -569,7 +569,7 @@ export class PluginConfigurationProvider {
   public getProcessGroupConfigFromLib(libUri: URI): ProcessGroup | undefined {
     const dirname = UriUtils.basename(UriUtils.dirname(libUri));
     for (const config of this.processGroupConfigs.values()) {
-      if (config.$computedLibs?.includes(dirname)) {
+      if (config.$computedLibs.includes(dirname)) {
         return config;
       }
     }

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -308,6 +308,7 @@ export class PluginConfigurationProvider {
         try {
           this.parseProcessGroupConfigs(processGrpConfig);
           this.postProcessProgramConfigs();
+          await this.postProcessProcessGroups();
           return;
         } catch (e) {
           console.error("Failed to load process group config, skipping:", e);
@@ -322,6 +323,40 @@ export class PluginConfigurationProvider {
     console.warn(
       "No process group config found, clearing existing configurations.",
     );
+  }
+
+  /**
+   * Go through all process groups & expand libs recursively to ensure all libs are findable when searching
+   * Has a side-effect of adding sub-directories to the libs list of each process group
+   */
+  private async postProcessProcessGroups() {
+    for (const processGroup of this.processGroupConfigs.values()) {
+      const allLibs = new Set(processGroup.libs);
+      const libsToProcess = [...processGroup.libs];
+      while (libsToProcess.length > 0) {
+        const lib = libsToProcess.pop();
+        if (lib) {
+          // read all files in this lib path
+          // add any contained directories to the libs list, as well as the toProcess list
+          const libUri = UriUtils.joinPath(
+            URI.parse(this.workspacePath),
+            lib,
+          );
+          const entries = await FileSystemProviderInstance.readDir(libUri);
+          if (entries.length) {
+            for (const [fileName, fileType] of entries) {
+              if (fileType === 2) {
+                // directory to add for handling
+                libsToProcess.push(`${lib}/${fileName}`);
+                // also add to the full libs list
+                allLibs.add(`${lib}/${fileName}`);
+              }
+            }
+          }
+        }
+      }
+      processGroup.libs = Array.from(allLibs);
+    }
   }
 
   /**
@@ -406,7 +441,12 @@ export class PluginConfigurationProvider {
     }
   }
 
-  parseProcessGroupConfigs(text: string): boolean {
+  /**
+   * Parses & sets the process group configs of this plugin configuration provider, overwriting any existing configs.
+   * @param text Raw text content of .pliplugin/proc_grps.json to parse
+   * @returns Whether parsing was successful
+   */
+  public parseProcessGroupConfigs(text: string): boolean {
     try {
       const serializedData: SerializedProcessGroup[] = JSON.parse(text).pgroups;
       const groupConfigs = serializedData.map(deserializeProcessGroup);
@@ -424,12 +464,13 @@ export class PluginConfigurationProvider {
    * @param processGroupConfigs List of process group configs loaded from
    *  .pliplugin/proc_grps.json (when present)
    */
-  public setProcessGroupConfigs(processGroupConfigs: ProcessGroup[]): void {
+  public async setProcessGroupConfigs(processGroupConfigs: ProcessGroup[]): Promise<void> {
     this.processGroupConfigs.clear();
     for (const config of processGroupConfigs) {
       this.processGroupConfigs.set(config.name, config);
     }
     this.postProcessProgramConfigs();
+    await this.postProcessProcessGroups();
     this.libFileGlobPatterns = undefined;
   }
 
@@ -497,7 +538,7 @@ export class PluginConfigurationProvider {
    * Returns the process group config for the given URI. This is used to find the
    * process group associated with a library file. It is rather fuzzy and might not be 100% accurate.
    * @param libUri URI of the including file (likely a library file)
-   * @returns Associated process group config, or undefined if not found
+   * @returns First process group config that includes a matching lib path, or undefined if not found
    */
   public getProcessGroupConfigFromLib(libUri: URI): ProcessGroup | undefined {
     const dirname = UriUtils.basename(UriUtils.dirname(libUri));

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -72,6 +72,14 @@ export interface ProcessGroup {
   compilerOptions: string[];
   pliOptions: PliOptions;
   libs: string[];
+
+  /**
+   * Sub directories of libs, populated after reading the configs.
+   * A computed property that is not serialized like regular 'libs',
+   * but is also used to resolve includes.
+   */
+  _subLibs: string[];
+
   includeExtensions: string[];
   implicitBuiltins: Set<string>;
   lspOptions: {
@@ -85,6 +93,10 @@ export interface ProcessGroup {
   issueCount?: number;
 }
 
+/**
+ * Deserializes a process group config from a plain object.
+ * Generates an empty _subLibs array in the process, but does not populate it
+ */
 export function deserializeProcessGroup(
   obj: SerializedProcessGroup,
 ): ProcessGroup {
@@ -100,6 +112,7 @@ export function deserializeProcessGroup(
     compilerOptions: isStringArray(compilerOptions) ? compilerOptions : [],
     pliOptions: isRecordOf(pliOptions, isString) ? pliOptions : {},
     libs: isStringArray(libs) ? libs : [],
+    _subLibs: [],
     includeExtensions: isStringArray(includeExtensions)
       ? includeExtensions
       : [],
@@ -112,6 +125,10 @@ export function deserializeProcessGroup(
   };
 }
 
+/**
+ * Serializes a process group config to a plain object.
+ * Drops the _subLibs field in the process, to avoid polluting the original config
+ */
 export function serializeProcessGroup(
   group: ProcessGroup,
 ): SerializedProcessGroup {
@@ -199,9 +216,9 @@ export class PluginConfigurationProvider {
       wsPrefix += "/";
     }
     for (const processGroup of this.processGroupConfigs.values()) {
-      const libs = processGroup.libs;
+      const allLibs = processGroup.libs.concat(processGroup._subLibs);
       const extensions = processGroup.includeExtensions;
-      for (let lib of libs) {
+      for (let lib of allLibs) {
         lib = lib.replace(/[\\/]+$/, "");
         for (const ext of extensions) {
           patterns.push(`${wsPrefix}${lib}/*${ext}`);
@@ -327,7 +344,7 @@ export class PluginConfigurationProvider {
 
   /**
    * Go through all process groups & expand libs recursively to ensure all libs are findable when searching
-   * Has a side-effect of adding sub-directories to the libs list of each process group
+   * Has a side-effect of adding sub-directories to the _subLibs list of each process group
    */
   private async postProcessProcessGroups() {
     for (const processGroup of this.processGroupConfigs.values()) {
@@ -354,7 +371,7 @@ export class PluginConfigurationProvider {
           }
         }
       }
-      processGroup.libs = Array.from(allLibs);
+      processGroup._subLibs = Array.from(allLibs);
     }
   }
 
@@ -545,6 +562,8 @@ export class PluginConfigurationProvider {
     const dirname = UriUtils.basename(UriUtils.dirname(libUri));
     for (const config of this.processGroupConfigs.values()) {
       if (config.libs?.includes(dirname)) {
+        return config;
+      } else if (config._subLibs?.includes(dirname)) {
         return config;
       }
     }

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -338,10 +338,7 @@ export class PluginConfigurationProvider {
         if (lib) {
           // read all files in this lib path
           // add any contained directories to the libs list, as well as the toProcess list
-          const libUri = UriUtils.joinPath(
-            URI.parse(this.workspacePath),
-            lib,
-          );
+          const libUri = UriUtils.joinPath(URI.parse(this.workspacePath), lib);
           const entries = await FileSystemProviderInstance.readDir(libUri);
           if (entries.length) {
             for (const dirEntry of entries) {
@@ -466,7 +463,9 @@ export class PluginConfigurationProvider {
    * @param processGroupConfigs List of process group configs loaded from
    *  .pliplugin/proc_grps.json (when present)
    */
-  public async setProcessGroupConfigs(processGroupConfigs: ProcessGroup[]): Promise<void> {
+  public async setProcessGroupConfigs(
+    processGroupConfigs: ProcessGroup[],
+  ): Promise<void> {
     this.processGroupConfigs.clear();
     for (const config of processGroupConfigs) {
       this.processGroupConfigs.set(config.name, config);

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -344,7 +344,9 @@ export class PluginConfigurationProvider {
           );
           const entries = await FileSystemProviderInstance.readDir(libUri);
           if (entries.length) {
-            for (const [fileName, fileType] of entries) {
+            for (const dirEntry of entries) {
+              const fileName = dirEntry.name;
+              const fileType = dirEntry.type;
               if (fileType === 2) {
                 // directory to add for handling
                 libsToProcess.push(`${lib}/${fileName}`);

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -9,7 +9,10 @@
  *
  */
 
-import { FileSystemProviderInstance } from "./file-system-provider";
+import {
+  DirEntryType,
+  FileSystemProviderInstance,
+} from "./file-system-provider";
 import { URI, UriUtils } from "../utils/uri";
 import {
   AbstractCompilerOptions,
@@ -71,14 +74,19 @@ export interface ProcessGroup {
   name: string;
   compilerOptions: string[];
   pliOptions: PliOptions;
+
+  /**
+   * Actual libs as they're loaded from the config on disk.
+   * Feeds into computed libs, not directly used for resolving includes.
+   */
   libs: string[];
 
   /**
-   * Sub directories of libs, populated after reading the configs.
-   * A computed property that is not serialized like regular 'libs',
-   * but is also used to resolve includes.
+   * Computed libs, includes libs from disks & all sub directories of libs.
+   * Populated after reading the configs & not serialized like regular 'libs'.
+   * Used to resolve includes.
    */
-  _subLibs: string[];
+  $computedLibs: string[];
 
   includeExtensions: string[];
   implicitBuiltins: Set<string>;
@@ -95,7 +103,7 @@ export interface ProcessGroup {
 
 /**
  * Deserializes a process group config from a plain object.
- * Generates an empty _subLibs array in the process, but does not populate it
+ * Generates an empty $computedLibs array in the process, but does not populate it
  */
 export function deserializeProcessGroup(
   obj: SerializedProcessGroup,
@@ -112,7 +120,7 @@ export function deserializeProcessGroup(
     compilerOptions: isStringArray(compilerOptions) ? compilerOptions : [],
     pliOptions: isRecordOf(pliOptions, isString) ? pliOptions : {},
     libs: isStringArray(libs) ? libs : [],
-    _subLibs: [],
+    $computedLibs: [],
     includeExtensions: isStringArray(includeExtensions)
       ? includeExtensions
       : [],
@@ -127,7 +135,7 @@ export function deserializeProcessGroup(
 
 /**
  * Serializes a process group config to a plain object.
- * Drops the _subLibs field in the process, to avoid polluting the original config
+ * Drops computed fields in the process (such as $computedLibs)
  */
 export function serializeProcessGroup(
   group: ProcessGroup,
@@ -216,9 +224,9 @@ export class PluginConfigurationProvider {
       wsPrefix += "/";
     }
     for (const processGroup of this.processGroupConfigs.values()) {
-      const allLibs = processGroup.libs.concat(processGroup._subLibs);
+      const computedLibs = processGroup.$computedLibs;
       const extensions = processGroup.includeExtensions;
-      for (let lib of allLibs) {
+      for (let lib of computedLibs) {
         lib = lib.replace(/[\\/]+$/, "");
         for (const ext of extensions) {
           patterns.push(`${wsPrefix}${lib}/*${ext}`);
@@ -344,11 +352,11 @@ export class PluginConfigurationProvider {
 
   /**
    * Go through all process groups & expand libs recursively to ensure all libs are findable when searching
-   * Has a side-effect of adding sub-directories to the _subLibs list of each process group
+   * Populates the $computedLibs property of each process group, which is used to resolve includes
    */
   private async postProcessProcessGroups() {
     for (const processGroup of this.processGroupConfigs.values()) {
-      const allLibs = new Set(processGroup.libs);
+      const computedLibs = new Set(processGroup.libs);
       const libsToProcess = [...processGroup.libs];
       while (libsToProcess.length > 0) {
         const lib = libsToProcess.pop();
@@ -361,17 +369,17 @@ export class PluginConfigurationProvider {
             for (const dirEntry of entries) {
               const fileName = dirEntry.name;
               const fileType = dirEntry.type;
-              if (fileType === 2) {
+              if (fileType === DirEntryType.Directory) {
                 // directory to add for handling
                 libsToProcess.push(`${lib}/${fileName}`);
                 // also add to the full libs list
-                allLibs.add(`${lib}/${fileName}`);
+                computedLibs.add(`${lib}/${fileName}`);
               }
             }
           }
         }
       }
-      processGroup._subLibs = Array.from(allLibs);
+      processGroup.$computedLibs = Array.from(computedLibs);
     }
   }
 
@@ -561,9 +569,7 @@ export class PluginConfigurationProvider {
   public getProcessGroupConfigFromLib(libUri: URI): ProcessGroup | undefined {
     const dirname = UriUtils.basename(UriUtils.dirname(libUri));
     for (const config of this.processGroupConfigs.values()) {
-      if (config.libs?.includes(dirname)) {
-        return config;
-      } else if (config._subLibs?.includes(dirname)) {
+      if (config.$computedLibs?.includes(dirname)) {
         return config;
       }
     }

--- a/packages/language/test/fourslash-harness/execute.test.ts
+++ b/packages/language/test/fourslash-harness/execute.test.ts
@@ -68,7 +68,7 @@ beforeEach(async () => {
     {
       name: "default",
       libs: ["cpy"],
-      _subLibs: [],
+      $computedLibs: [],
       includeExtensions: [".pli"],
       compilerOptions: [],
       implicitBuiltins: new Set(),

--- a/packages/language/test/fourslash-harness/execute.test.ts
+++ b/packages/language/test/fourslash-harness/execute.test.ts
@@ -68,6 +68,7 @@ beforeEach(async () => {
     {
       name: "default",
       libs: ["cpy"],
+      _subLibs: [],
       includeExtensions: [".pli"],
       compilerOptions: [],
       implicitBuiltins: new Set(),

--- a/packages/language/test/fourslash-harness/execute.test.ts
+++ b/packages/language/test/fourslash-harness/execute.test.ts
@@ -64,7 +64,7 @@ beforeEach(async () => {
       pliOptions: {},
     },
   ]);
-  PluginConfigurationProviderInstance.setProcessGroupConfigs([
+  await PluginConfigurationProviderInstance.setProcessGroupConfigs([
     {
       name: "default",
       libs: ["cpy"],
@@ -82,7 +82,7 @@ afterEach(async () => {
   setFileSystemProvider(undefined);
   setPluginConfigurationProvider(undefined);
   PluginConfigurationProviderInstance.setProgramConfigs("", []);
-  PluginConfigurationProviderInstance.setProcessGroupConfigs([]);
+  await PluginConfigurationProviderInstance.setProcessGroupConfigs([]);
 });
 
 function getTestFiles() {

--- a/packages/language/test/fourslash/preprocessor/include/from-lib-path-recursive.ts
+++ b/packages/language/test/fourslash/preprocessor/include/from-lib-path-recursive.ts
@@ -1,0 +1,38 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// trigger a reparsing of the config, so we can pick up the sub libs folder
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////         "name": "default",
+////         "lsp-options": {
+////             "check-margins": true
+////         },
+////         "libs": [
+////             "cpy"
+////         ]
+////         }
+////     ]
+//// }
+
+// @filename: cpy/libs/lib.pli
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: main.pli
+//// %INCLUDE "lib.pli";
+
+preprocessor.expectTokens(`
+  DECLARE LIB_VAR FIXED;
+`);

--- a/packages/language/test/parser/pli-lexer.test.ts
+++ b/packages/language/test/parser/pli-lexer.test.ts
@@ -117,7 +117,7 @@ describe("PL/1 Lexer", () => {
         implicitBuiltins: new Set(),
         includeExtensions: [],
         libs: [],
-        _subLibs: [],
+        $computedLibs: [],
         lspOptions: { checkMargins: false },
         pliOptions: {},
       };
@@ -183,7 +183,7 @@ describe("PL/1 Lexer", () => {
         implicitBuiltins: new Set(),
         includeExtensions: [],
         libs: [],
-        _subLibs: [],
+        $computedLibs: [],
         lspOptions: { checkMargins: false },
         pliOptions: {},
       };

--- a/packages/language/test/parser/pli-lexer.test.ts
+++ b/packages/language/test/parser/pli-lexer.test.ts
@@ -117,6 +117,7 @@ describe("PL/1 Lexer", () => {
         implicitBuiltins: new Set(),
         includeExtensions: [],
         libs: [],
+        _subLibs: [],
         lspOptions: { checkMargins: false },
         pliOptions: {},
       };
@@ -182,6 +183,7 @@ describe("PL/1 Lexer", () => {
         implicitBuiltins: new Set(),
         includeExtensions: [],
         libs: [],
+        _subLibs: [],
         lspOptions: { checkMargins: false },
         pliOptions: {},
       };

--- a/packages/language/test/parser/pli-lexer.test.ts
+++ b/packages/language/test/parser/pli-lexer.test.ts
@@ -94,10 +94,10 @@ describe("PL/1 Lexer", () => {
   });
 
   describe("Compiler Options", () => {
-    afterAll(() => {
+    afterAll(async () => {
       // Reset the plugin configuration state
       PluginConfigurationProviderInstance.setProgramConfigs("", []);
-      PluginConfigurationProviderInstance.setProcessGroupConfigs([]);
+      await PluginConfigurationProviderInstance.setProcessGroupConfigs([]);
     });
 
     test("Inject process group compiler options after *PROCESS directive", async () => {
@@ -126,7 +126,7 @@ describe("PL/1 Lexer", () => {
       PluginConfigurationProviderInstance.setProgramConfigs("/test", [
         programConfig,
       ]);
-      PluginConfigurationProviderInstance.setProcessGroupConfigs([
+      await PluginConfigurationProviderInstance.setProcessGroupConfigs([
         processGroupConfig,
       ]);
 
@@ -192,7 +192,7 @@ describe("PL/1 Lexer", () => {
       PluginConfigurationProviderInstance.setProgramConfigs("/test", [
         programConfig,
       ]);
-      PluginConfigurationProviderInstance.setProcessGroupConfigs([
+      await PluginConfigurationProviderInstance.setProcessGroupConfigs([
         processGroupConfig,
       ]);
 

--- a/packages/language/test/preprocessor/pli-preprocessor.test.ts
+++ b/packages/language/test/preprocessor/pli-preprocessor.test.ts
@@ -40,6 +40,7 @@ async function init(libPath: string) {
     implicitBuiltins: new Set(),
     includeExtensions: [],
     libs: [libPath],
+    _subLibs: [],
     lspOptions: { checkMargins: false },
     pliOptions: {},
   };

--- a/packages/language/test/preprocessor/pli-preprocessor.test.ts
+++ b/packages/language/test/preprocessor/pli-preprocessor.test.ts
@@ -40,7 +40,7 @@ async function init(libPath: string) {
     implicitBuiltins: new Set(),
     includeExtensions: [],
     libs: [libPath],
-    _subLibs: [],
+    $computedLibs: [],
     lspOptions: { checkMargins: false },
     pliOptions: {},
   };

--- a/packages/language/test/preprocessor/pli-preprocessor.test.ts
+++ b/packages/language/test/preprocessor/pli-preprocessor.test.ts
@@ -49,7 +49,7 @@ async function init(libPath: string) {
   PluginConfigurationProviderInstance.setProgramConfigs("/test", [
     programConfig,
   ]);
-  PluginConfigurationProviderInstance.setProcessGroupConfigs([
+  await PluginConfigurationProviderInstance.setProcessGroupConfigs([
     processGroupConfig,
   ]);
 }
@@ -92,11 +92,11 @@ describe("Preprocessor Tests", () => {
     resetDocumentProviders();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     setFileSystemProvider(undefined);
     setPluginConfigurationProvider(undefined);
     PluginConfigurationProviderInstance.setProgramConfigs("", []);
-    PluginConfigurationProviderInstance.setProcessGroupConfigs([]);
+    await PluginConfigurationProviderInstance.setProcessGroupConfigs([]);
   });
 
   // macOS + linux absolute path resolution

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -202,7 +202,7 @@ export class TestBuilder {
       }
     }
 
-    this.configurePluginConfigurationProvider();
+    await this.configurePluginConfigurationProvider();
 
     const [[firstFileUri, firstFile]] = this.files.entries();
     this.output = firstFile.output;
@@ -259,7 +259,7 @@ export class TestBuilder {
     return testBuilder;
   }
 
-  private configurePluginConfigurationProvider() {
+  private async configurePluginConfigurationProvider() {
     // Check if the files contain a program config or process group.
     for (const [uri, file] of this.files) {
       if (uri.endsWith(PluginConfigurationProvider.PROGRAM_CONFIG_FILE)) {
@@ -269,7 +269,7 @@ export class TestBuilder {
         );
       }
       if (uri.endsWith(PluginConfigurationProvider.PROCESS_GROUP_CONFIG_FILE)) {
-        PluginConfigurationProviderInstance.parseProcessGroupConfigs(
+        await PluginConfigurationProviderInstance.parseProcessGroupConfigs(
           file.output,
         );
       }

--- a/packages/language/test/workspace/compilation-unit.test.ts
+++ b/packages/language/test/workspace/compilation-unit.test.ts
@@ -143,6 +143,7 @@ describe("Compilation Unit Tests", () => {
         name: "default",
         compilerOptions: [],
         libs: ["cpy"],
+        _subLibs: [],
         includeExtensions: [".inc"],
         lspOptions: { checkMargins: false },
         pliOptions: {},

--- a/packages/language/test/workspace/compilation-unit.test.ts
+++ b/packages/language/test/workspace/compilation-unit.test.ts
@@ -143,7 +143,7 @@ describe("Compilation Unit Tests", () => {
         name: "default",
         compilerOptions: [],
         libs: ["cpy"],
-        _subLibs: [],
+        $computedLibs: [],
         includeExtensions: [".inc"],
         lspOptions: { checkMargins: false },
         pliOptions: {},

--- a/packages/language/test/workspace/compilation-unit.test.ts
+++ b/packages/language/test/workspace/compilation-unit.test.ts
@@ -15,9 +15,9 @@ import { CompilationUnitHandler } from "../../src/workspace/compilation-unit";
 import { PluginConfigurationProviderInstance } from "../../src/workspace/plugin-configuration-provider";
 
 describe("Compilation Unit Tests", () => {
-  afterEach(() => {
+  afterEach(async () => {
     PluginConfigurationProviderInstance.setProgramConfigs("", []);
-    PluginConfigurationProviderInstance.setProcessGroupConfigs([]);
+    await PluginConfigurationProviderInstance.setProcessGroupConfigs([]);
   });
 
   test("Create", async () => {
@@ -127,7 +127,7 @@ describe("Compilation Unit Tests", () => {
   test("Cannot create compile unit from copybook directly", async () => {
     const ch = new CompilationUnitHandler();
 
-    PluginConfigurationProviderInstance.init("file:///");
+    await PluginConfigurationProviderInstance.init("file:///");
 
     // Simulate a process group 'default' with a cpy folder and include-extensions
     PluginConfigurationProviderInstance.setProgramConfigs("file:///", [
@@ -138,7 +138,7 @@ describe("Compilation Unit Tests", () => {
       },
     ]);
     // Simulate the process group config (normally this would be loaded from a config file)
-    PluginConfigurationProviderInstance.setProcessGroupConfigs([
+    await PluginConfigurationProviderInstance.setProcessGroupConfigs([
       {
         name: "default",
         compilerOptions: [],

--- a/packages/language/test/workspace/compilation-unit.test.ts
+++ b/packages/language/test/workspace/compilation-unit.test.ts
@@ -15,7 +15,6 @@ import { CompilationUnitHandler } from "../../src/workspace/compilation-unit";
 import { PluginConfigurationProviderInstance } from "../../src/workspace/plugin-configuration-provider";
 
 describe("Compilation Unit Tests", () => {
-
   afterEach(() => {
     PluginConfigurationProviderInstance.setProgramConfigs("", []);
     PluginConfigurationProviderInstance.setProcessGroupConfigs([]);

--- a/packages/language/test/workspace/compilation-unit.test.ts
+++ b/packages/language/test/workspace/compilation-unit.test.ts
@@ -9,12 +9,18 @@
  *
  */
 
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test } from "vitest";
 import { URI } from "../../src/utils/uri";
 import { CompilationUnitHandler } from "../../src/workspace/compilation-unit";
 import { PluginConfigurationProviderInstance } from "../../src/workspace/plugin-configuration-provider";
 
 describe("Compilation Unit Tests", () => {
+
+  afterEach(() => {
+    PluginConfigurationProviderInstance.setProgramConfigs("", []);
+    PluginConfigurationProviderInstance.setProcessGroupConfigs([]);
+  });
+
   test("Create", async () => {
     const uri = URI.parse("memory:///test/test.pli");
     const ch = new CompilationUnitHandler();

--- a/packages/vscode-extension/src/common/messages.ts
+++ b/packages/vscode-extension/src/common/messages.ts
@@ -10,6 +10,7 @@
  */
 
 export namespace Messages {
+  export const ReadDir = "fs/readDir";
   export const ReadFile = "fs/readFile";
   export const WriteFile = "fs/writeFile";
   export const FileExists = "fs/fileExists";

--- a/packages/vscode-extension/src/extension/main-browser.ts
+++ b/packages/vscode-extension/src/extension/main-browser.ts
@@ -84,4 +84,13 @@ function registerFileSystemProvider(client: LanguageClient): void {
     const uri = vscode.Uri.parse(uriString);
     await vscode.workspace.fs.writeFile(uri, value);
   });
+  client.onRequest(Messages.ReadDir, async (uriString: string) => {
+    const uri = vscode.Uri.parse(uriString);
+    try {
+      const result = await vscode.workspace.fs.readDirectory(uri);
+      return result;
+    } catch {
+      return [];
+    }
+  });
 }

--- a/packages/vscode-extension/src/language/file-system.ts
+++ b/packages/vscode-extension/src/language/file-system.ts
@@ -12,6 +12,7 @@
 import { FileSystemProvider, SearchOptions, URI } from "pli-language";
 import { Connection } from "vscode-languageserver";
 import { Messages } from "../common/messages";
+import type * as vscode from "vscode";
 
 export class VSCodeFileSystemProvider implements FileSystemProvider {
   private _connection: Connection;
@@ -31,6 +32,23 @@ export class VSCodeFileSystemProvider implements FileSystemProvider {
       return undefined;
     }
   }
+
+  /**
+   * Submits a request to the client to read the contents of a directory.
+   * Returns an array of file and directory names.
+   */
+  async readDir(uri: URI): Promise<Array<[string, vscode.FileType]>> {
+    const result = await this._connection.sendRequest(
+      Messages.ReadDir,
+      uri.toString(),
+    );
+    if (Array.isArray(result)) {
+      return result as Array<[string, vscode.FileType]>;
+    } else {
+      return [];
+    }
+  }
+
   async fileExists(uri: URI): Promise<boolean> {
     const result = await this._connection.sendRequest(
       Messages.FileExists,

--- a/packages/vscode-extension/src/language/file-system.ts
+++ b/packages/vscode-extension/src/language/file-system.ts
@@ -9,10 +9,9 @@
  *
  */
 
-import { FileSystemProvider, SearchOptions, URI } from "pli-language";
+import { DirEntry, FileSystemProvider, SearchOptions, URI } from "pli-language";
 import { Connection } from "vscode-languageserver";
 import { Messages } from "../common/messages";
-import type * as vscode from "vscode";
 
 export class VSCodeFileSystemProvider implements FileSystemProvider {
   private _connection: Connection;
@@ -35,15 +34,15 @@ export class VSCodeFileSystemProvider implements FileSystemProvider {
 
   /**
    * Submits a request to the client to read the contents of a directory.
-   * Returns an array of file and directory names.
+   * Returns an array of directory entries
    */
-  async readDir(uri: URI): Promise<Array<[string, vscode.FileType]>> {
+  async readDir(uri: URI): Promise<DirEntry[]> {
     const result = await this._connection.sendRequest(
       Messages.ReadDir,
       uri.toString(),
     );
     if (Array.isArray(result)) {
-      return result as Array<[string, vscode.FileType]>;
+      return result as DirEntry[];
     } else {
       return [];
     }

--- a/packages/vscode-extension/src/language/main.ts
+++ b/packages/vscode-extension/src/language/main.ts
@@ -27,6 +27,20 @@ class NodeFileSystemProvider implements FileSystemProvider {
   readFile(uri: URI): Promise<string> {
     return fs.promises.readFile(uri.fsPath, "utf8");
   }
+
+  /**
+   * Reads directory contents, returning pairs of file/directory names and their types.
+   * 2 = Directory, 1 = File
+   * @param uri 
+   * @returns 
+   */
+  async readDir(uri: URI): Promise<Array<[string, number]>> {
+    const results = await fs.promises.readdir(uri.fsPath, {
+      withFileTypes: true
+    });
+    return results.map((dirent) => [dirent.name, dirent.isDirectory() ? 2 : 1]);
+  }
+
   async fileExists(uri: URI): Promise<boolean> {
     try {
       await fs.promises.access(uri.fsPath);

--- a/packages/vscode-extension/src/language/main.ts
+++ b/packages/vscode-extension/src/language/main.ts
@@ -19,6 +19,8 @@ import {
   SearchOptions,
   URI,
   setFileSystemProvider,
+  DirEntry,
+  DirEntryType,
 } from "pli-language";
 import * as fs from "fs";
 import * as glob from "glob";
@@ -29,16 +31,18 @@ class NodeFileSystemProvider implements FileSystemProvider {
   }
 
   /**
-   * Reads directory contents, returning pairs of file/directory names and their types.
-   * 2 = Directory, 1 = File
-   * @param uri 
-   * @returns 
+   * Reads directory contents, returning an array of directory entries
    */
-  async readDir(uri: URI): Promise<Array<[string, number]>> {
+  async readDir(uri: URI): Promise<DirEntry[]> {
     const results = await fs.promises.readdir(uri.fsPath, {
       withFileTypes: true
     });
-    return results.map((dirent) => [dirent.name, dirent.isDirectory() ? 2 : 1]);
+    return results.map((dirent) => {
+      return {
+        name: dirent.name,
+        type: dirent.isDirectory() ? DirEntryType.Directory : DirEntryType.File
+      };
+    });
   }
 
   async fileExists(uri: URI): Promise<boolean> {

--- a/packages/vscode-extension/src/language/main.ts
+++ b/packages/vscode-extension/src/language/main.ts
@@ -35,12 +35,12 @@ class NodeFileSystemProvider implements FileSystemProvider {
    */
   async readDir(uri: URI): Promise<DirEntry[]> {
     const results = await fs.promises.readdir(uri.fsPath, {
-      withFileTypes: true
+      withFileTypes: true,
     });
     return results.map((dirent) => {
       return {
         name: dirent.name,
-        type: dirent.isDirectory() ? DirEntryType.Directory : DirEntryType.File
+        type: dirent.isDirectory() ? DirEntryType.Directory : DirEntryType.File,
       };
     });
   }


### PR DESCRIPTION
Closes the 2nd point of #394 by adding support for recursive libs resolution. When your process group config has a libs entry like so: `{libs: ["cpy"]}`, then we resolve all valid libs files contained in any sub directories too. For example, `cpy/folder2/mylib.pli` is resolvable as `%INCLUDE "mylib.pli"` without needing to add `cpy/folder2` explicitly to the config.

When a process group config is loaded or set via the plugin config proivder, we post-process each lib entry to explore & add all sub directories as valid lib entries. This changes from the user supplied `libs` entry to be something that is expanded with all reachable sub directories as well. 