### PR TITLE
Show error on missing token after include

### DIFF
--- a/packages/language/src/parser/parser-state.ts
+++ b/packages/language/src/parser/parser-state.ts
@@ -20,6 +20,7 @@ import {
   Severity,
 } from "../language-server/types";
 import { PLICodes } from "../validation/messages";
+import { SimplePLICode } from "../validation/messages/pli-codes";
 
 export function preprocessorParserState(tokens: t.Token[]): ParserState {
   return new ParserState(tokens, ParserStateMode.Preprocessor);
@@ -108,17 +109,21 @@ export class ParserState {
    * until a successful consume() happens or the recover() method is called.
    */
   error(
-    message?: string,
+    message?: string | SimplePLICode,
     token = this.token || this.last,
     severity = Severity.S,
   ) {
     if (!this.inError) {
-      const msg =
-        message ??
-        (this.eof
-          ? "Unexpected end of file."
-          : `Unexpected token '${generateTokenErrorName(token)}'.`);
-      this.diagnostics.push(diagnostic(severity, msg, token));
+      if (!message || typeof message === "string") {
+        const msg =
+          message ??
+          (this.eof
+            ? "Unexpected end of file."
+            : `Unexpected token '${generateTokenErrorName(token)}'.`);
+        this.diagnostics.push(diagnostic(severity, msg, token));
+      } else {
+        this.diagnostics.push(diagnosticFromCode(message, token));
+      }
       this.inError = true;
     }
   }
@@ -177,12 +182,17 @@ export class ParserState {
     element: SyntaxNode | undefined,
     kind: CstNodeKind | undefined,
     tokenType: TokenType,
+    code?: SimplePLICode,
   ): t.Token | null {
     const token = this.token;
     if (!token || !this.canConsume(tokenType)) {
       if (!this.inError) {
-        const message = `Expected token "${tokenType.name}", but received ${generateTokenErrorName(token)} instead.`;
-        this.error(message);
+        if (code) {
+          this.error(code);
+        } else {
+          const message = `Expected token "${tokenType.name}", but received ${generateTokenErrorName(token)} instead.`;
+          this.error(message);
+        }
       }
       return null;
     } else {

--- a/packages/language/src/parser/preprocessor-parser.ts
+++ b/packages/language/src/parser/preprocessor-parser.ts
@@ -582,45 +582,58 @@ function labelReference(state: ParserState): ast.LabelReference {
 
 function includeStatement(state: ParserState): ast.IncludeDirective {
   const directive = ast.createIncludeDirective();
-  const token = state.consume(
+  const includeToken = state.consume(
     directive,
     CstNodeKind.IncludeDirective_INCLUDE,
     t.INCLUDE,
   );
-  directive.token = token;
-  directive.idempotent = isXInstruction(token);
+  directive.token = includeToken;
+  directive.idempotent = isXInstruction(includeToken);
+  let parseError = false;
   while (true) {
     const item = ast.createIncludeItem();
-    if (state.canConsume(t.ID)) {
-      // member include
-      const token = state.consume(item, CstNodeKind.IncludeItem_FileID, t.ID);
-      if (token) {
-        const fileName = token.image;
-        item.fileName = fileName;
-        item.token = token;
-      }
-    } else if (state.canConsume(t.STRING_TERM)) {
-      // literal file include (relative, absolute, or lib sourced)
-      const token = state.consume(
+    const idToken = state.tryConsume(
+      item,
+      CstNodeKind.IncludeItem_FileID,
+      t.ID,
+    );
+    if (idToken) {
+      const fileName = idToken.image;
+      item.fileName = fileName;
+      item.token = idToken;
+    } else {
+      const stringToken = state.tryConsume(
         item,
         CstNodeKind.IncludeItem_FileString,
         t.STRING_TERM,
       );
-      if (token) {
-        const file = token.image;
-        const fileName = file.substring(1, file.length - 1);
+      if (stringToken) {
+        const fileName = unpackCharacterValue(stringToken.image);
         item.fileName = fileName;
         item.string = true;
-        item.token = token;
+        item.token = stringToken;
+      } else {
+        // At least one include item is required
+        // If none is found, we will report an error at the end of the statement
+        parseError = directive.items.length === 0;
+        break;
       }
-    } else {
-      break;
     }
     directive.items.push(item);
     // Optional comma
     state.tryConsume(directive, CstNodeKind.IncludeDirective_Comma, t.Comma);
   }
-  state.consume(directive, CstNodeKind.IncludeDirective_Semicolon, t.Semicolon);
+  const semicolon = state.consume(
+    directive,
+    CstNodeKind.IncludeDirective_Semicolon,
+    t.Semicolon,
+    PLICodes.Severe.IBM1618I,
+  );
+  if (parseError && !state.inError) {
+    state.diagnostics.push(
+      diagnosticFromCode(PLICodes.Severe.IBM1620I, semicolon || includeToken),
+    );
+  }
   return directive;
 }
 

--- a/packages/language/test/fourslash/parser/pp/include-invalid-item.ts
+++ b/packages/language/test/fourslash/parser/pp/include-invalid-item.ts
@@ -1,0 +1,17 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// Numbers are not valid include items
+//// %INCLUDE <|123|>;
+
+verify.expectErrorCodesAt("123", code.Severe.IBM1618I.fullCode);

--- a/packages/language/test/fourslash/parser/pp/include-no-item.ts
+++ b/packages/language/test/fourslash/parser/pp/include-no-item.ts
@@ -1,0 +1,16 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %INCLUDE<|;|>
+
+verify.expectErrorCodesAt(";", code.Severe.IBM1620I.fullCode);

--- a/packages/language/test/fourslash/parser/pp/procedure-with-percent-in-body.ts
+++ b/packages/language/test/fourslash/parser/pp/procedure-with-percent-in-body.ts
@@ -12,11 +12,11 @@
 /// <reference path="../../framework.ts" />
 
 //// %TEST: PROC;
-////   <|1:%|>DCL I FIXED;
+////   <|%|>DCL I FIXED;
 //// %END;
 
 // The DCL statement uses an illegal % character, so we expect a parser error
-verify.expectErrorCodesAt("1", code.Severe.IBM3762I.fullCode);
+verify.expectErrorCodesAt("%", code.Severe.IBM3762I.fullCode);
 // But the content of the procedure should still be parsed correctly
 verify.expectPPAst({
   kind: Syntax.ProcedureStatement,

--- a/packages/language/test/fourslash/parser/pp/variable-with-entry.ts
+++ b/packages/language/test/fourslash/parser/pp/variable-with-entry.ts
@@ -11,9 +11,9 @@
 
 /// <reference path="../../framework.ts" />
 
-//// %DCL VAR <|entry:ENTRY|>;
+//// %DCL VAR <|ENTRY|>;
 
-verify.noDiagnostics("entry");
+verify.noDiagnostics("ENTRY");
 
 verify.expectPPAst({
   kind: Syntax.DeclareStatement,

--- a/packages/language/test/utils.ts
+++ b/packages/language/test/utils.ts
@@ -317,6 +317,11 @@ export function replaceNamedIndices(text: string): {
   }[] = [];
 
   const regex =
+    // Regex with named capture groups for:
+    // indexMarker: `<|label>`
+    // rangeStartMarker (alone): `<|`
+    // rangeStartMarker (with label): `<|label:`
+    // rangeEndMarker: `|>`
     /<\|(?<indexMarker>\w+)>|(?<rangeStartMarker><\|)((?<rangeLabel>\w+):)?|\|>/;
 
   let matched = true;

--- a/packages/language/test/utils.ts
+++ b/packages/language/test/utils.ts
@@ -313,10 +313,11 @@ export function replaceNamedIndices(text: string): {
   const ranges: Record<string, Array<[number, number]>> = {};
   const rangeStack: {
     index: number;
-    label: string;
+    label?: string;
   }[] = [];
 
-  const regex = /<\|(?<indexMarker>\w+)>|<\|(?<rangeStartMarker>\w+):|\|>/;
+  const regex =
+    /<\|(?<indexMarker>\w+)>|(?<rangeStartMarker><\|)((?<rangeLabel>\w+):)?|\|>/;
 
   let matched = true;
   let input = text;
@@ -337,10 +338,14 @@ export function replaceNamedIndices(text: string): {
         if (!ranges[label]) {
           ranges[label] = [];
         }
+      } else if (regexMatch.groups.rangeLabel) {
+        rangeStack.push({
+          index: regexMatch.index,
+          label: regexMatch.groups.rangeLabel,
+        });
       } else if (regexMatch.groups.rangeStartMarker) {
         rangeStack.push({
           index: regexMatch.index,
-          label: regexMatch.groups.rangeStartMarker,
         });
       } else {
         const rangeStart = rangeStack.pop();
@@ -348,11 +353,13 @@ export function replaceNamedIndices(text: string): {
           throw new Error("Range start not found");
         }
 
-        if (!ranges[rangeStart.label]) {
-          ranges[rangeStart.label] = [];
+        const label =
+          rangeStart.label ??
+          input.substring(rangeStart.index, regexMatch.index);
+        if (!ranges[label]) {
+          ranges[label] = [];
         }
-
-        ranges[rangeStart.label].push([rangeStart.index, regexMatch.index]);
+        ranges[label].push([rangeStart.index, regexMatch.index]);
       }
 
       const matchedString = regexMatch[0];


### PR DESCRIPTION
Fixes part (1) of https://github.com/zowe/zowe-pli-language-support/issues/445.

Adjusts the test-builder to improve the parsing of test files when lacking a range marker name.