### PR TITLE
Support DD Style Includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ The `proc_grps.json` file is formatted as an array of JSON elements, with one JS
 - **"name":** (string)  
     - Specify a name for the processor group.
 - (Optional) **"libs":** (array)  
-    - Specify local folders that contain include files. Specify local folders as either absolute or relative local paths.
+    - Specify local folders that contain include files. Folders can be either absolute or relative local paths.
+    - Include members by adding ddnames, such as adding `mylibs/a.b.c`, where `a.b.c(member)` is a file in the `mylibs` folder.
 - (Optional) **"include-extensions":** (array)  
     - Specify file extensions that you use for the include files in programs linked with this processor groups.
 - (Optional) **"compiler-options":** (array)  

--- a/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
+++ b/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
@@ -53,7 +53,7 @@ export async function quickFixResolveInclude(
     unresolvedFilePath,
     workspaceFolderUri,
   );
-  if (!parentFolder || procGrpsConfig.$computedLibs.includes(parentFolder)) {
+  if (!parentFolder || procGrpsConfig.$computedLibsSet.has(parentFolder)) {
     return undefined;
   }
 

--- a/packages/language/src/language-server/connection-handler.ts
+++ b/packages/language/src/language-server/connection-handler.ts
@@ -36,7 +36,10 @@ import { renameRequest } from "./rename-request";
 import { getReferenceLocations } from "../linking/resolver";
 import { documentSymbolRequest } from "./document-symbol-request";
 import { workspaceSymbolRequest } from "./workspace-symbol-request";
-import { PluginConfigurationProvider, PluginConfigurationProviderInstance } from "../workspace/plugin-configuration-provider";
+import {
+  PluginConfigurationProvider,
+  PluginConfigurationProviderInstance,
+} from "../workspace/plugin-configuration-provider";
 import { completionRequest } from "./completion/completion-request";
 import { hoverRequest } from "./hover-request";
 import { Mutex } from "../workspace/mutex";
@@ -58,14 +61,17 @@ export function startLanguageServer(connection: Connection): void {
     // init the plugin config provider in reverse folder order, last plugin config encountered will take precedence
     // TODO @montymxb Apr 23rd, 2025: Consider addressing multiple workspaces w/ multiple plugin configs
     for (const folder of params.workspaceFolders?.reverse() ?? []) {
-      PluginConfigurationProviderInstance.init(folder.uri).then((diagnostics) => {
-        const ws = PluginConfigurationProviderInstance.getWorkspacePath();
-        const wsPrefix = ws.endsWith("/") ? ws : ws + "/";
-        connection.sendDiagnostics({
-          uri: wsPrefix + PluginConfigurationProvider.PROCESS_GROUP_CONFIG_FILE,
-          diagnostics,
-        });
-      });
+      PluginConfigurationProviderInstance.init(folder.uri).then(
+        (diagnostics) => {
+          const ws = PluginConfigurationProviderInstance.getWorkspacePath();
+          const wsPrefix = ws.endsWith("/") ? ws : ws + "/";
+          connection.sendDiagnostics({
+            uri:
+              wsPrefix + PluginConfigurationProvider.PROCESS_GROUP_CONFIG_FILE,
+            diagnostics,
+          });
+        },
+      );
     }
 
     return {
@@ -302,14 +308,15 @@ export function startLanguageServer(connection: Connection): void {
     () => {
       Mutex.run(async () => {
         // handle changes to the .pliplugin config folder's contents
-        const diagnostics = await PluginConfigurationProviderInstance.reloadConfigurations();
+        const diagnostics =
+          await PluginConfigurationProviderInstance.reloadConfigurations();
         const ws = PluginConfigurationProviderInstance.getWorkspacePath();
         const wsPrefix = ws.endsWith("/") ? ws : ws + "/";
         connection.sendDiagnostics({
           uri: wsPrefix + PluginConfigurationProvider.PROCESS_GROUP_CONFIG_FILE,
           diagnostics,
         });
-        
+
         // reindex reachable compilation units
         await compilationUnitHandler.reindex(
           connection,

--- a/packages/language/src/language-server/connection-handler.ts
+++ b/packages/language/src/language-server/connection-handler.ts
@@ -36,7 +36,7 @@ import { renameRequest } from "./rename-request";
 import { getReferenceLocations } from "../linking/resolver";
 import { documentSymbolRequest } from "./document-symbol-request";
 import { workspaceSymbolRequest } from "./workspace-symbol-request";
-import { PluginConfigurationProviderInstance } from "../workspace/plugin-configuration-provider";
+import { PluginConfigurationProvider, PluginConfigurationProviderInstance } from "../workspace/plugin-configuration-provider";
 import { completionRequest } from "./completion/completion-request";
 import { hoverRequest } from "./hover-request";
 import { Mutex } from "../workspace/mutex";
@@ -58,7 +58,14 @@ export function startLanguageServer(connection: Connection): void {
     // init the plugin config provider in reverse folder order, last plugin config encountered will take precedence
     // TODO @montymxb Apr 23rd, 2025: Consider addressing multiple workspaces w/ multiple plugin configs
     for (const folder of params.workspaceFolders?.reverse() ?? []) {
-      await PluginConfigurationProviderInstance.init(folder.uri);
+      PluginConfigurationProviderInstance.init(folder.uri).then((diagnostics) => {
+        const ws = PluginConfigurationProviderInstance.getWorkspacePath();
+        const wsPrefix = ws.endsWith("/") ? ws : ws + "/";
+        connection.sendDiagnostics({
+          uri: wsPrefix + PluginConfigurationProvider.PROCESS_GROUP_CONFIG_FILE,
+          diagnostics,
+        });
+      });
     }
 
     return {
@@ -295,7 +302,14 @@ export function startLanguageServer(connection: Connection): void {
     () => {
       Mutex.run(async () => {
         // handle changes to the .pliplugin config folder's contents
-        await PluginConfigurationProviderInstance.reloadConfigurations();
+        const diagnostics = await PluginConfigurationProviderInstance.reloadConfigurations();
+        const ws = PluginConfigurationProviderInstance.getWorkspacePath();
+        const wsPrefix = ws.endsWith("/") ? ws : ws + "/";
+        connection.sendDiagnostics({
+          uri: wsPrefix + PluginConfigurationProvider.PROCESS_GROUP_CONFIG_FILE,
+          diagnostics,
+        });
+        
         // reindex reachable compilation units
         await compilationUnitHandler.reindex(
           connection,

--- a/packages/language/src/language-server/definition-request.ts
+++ b/packages/language/src/language-server/definition-request.ts
@@ -69,7 +69,8 @@ export function definitionRequest(
     ];
   } else if (
     isIncludeItemToken(token.kind) &&
-    (token.element?.kind === SyntaxKind.IncludeItem ||
+    (token.element?.kind === SyntaxKind.IncludeItemFile ||
+      token.element?.kind === SyntaxKind.IncludeItemMember ||
       token.element?.kind === SyntaxKind.InscanDirective)
   ) {
     // allow jumping to the resolved file when present

--- a/packages/language/src/language-server/definition-request.ts
+++ b/packages/language/src/language-server/definition-request.ts
@@ -73,6 +73,8 @@ export function definitionRequest(
       token.element?.kind === SyntaxKind.IncludeItemMember ||
       token.element?.kind === SyntaxKind.InscanDirective)
   ) {
+    // TODO @montymxb Nov 7th, 2025: Highlighting for members is incomplete, only gets the member & not the full ddname.
+    // see: https://github.com/zowe/zowe-pli-language-support/issues/466
     // allow jumping to the resolved file when present
     const filePath = token.element.filePath;
     if (filePath) {

--- a/packages/language/src/language-server/hover-request.ts
+++ b/packages/language/src/language-server/hover-request.ts
@@ -295,7 +295,8 @@ function getNodeRepresentation(
       return getDeclaredVariableRepresentation(unit, node);
     case SyntaxKind.LabelPrefix:
       return getLabelPrefixRepresentation(node);
-    case SyntaxKind.IncludeItem:
+    case SyntaxKind.IncludeItemFile:
+    case SyntaxKind.IncludeItemMember:
       let type = "%INCLUDE";
       const ppInclude = unit.compilerOptions?.pp?.ppInclude?.value;
       if (

--- a/packages/language/src/language-server/semantic-tokens.ts
+++ b/packages/language/src/language-server/semantic-tokens.ts
@@ -162,6 +162,7 @@ function isVariableType(token: Token): boolean {
     case CstNodeKind.HandleAttribute_TypeId1:
     case CstNodeKind.LabelReference_LabelRef:
     case CstNodeKind.IncludeItem_FileID:
+    case CstNodeKind.IncludeItem_MemberID:
       return true;
   }
   return false;

--- a/packages/language/src/linking/tokens.ts
+++ b/packages/language/src/linking/tokens.ts
@@ -75,6 +75,7 @@ export function isIncludeItemToken(kind: CstNodeKind | undefined): boolean {
   switch (kind) {
     case CstNodeKind.IncludeItem_FileString:
     case CstNodeKind.IncludeItem_FileID:
+    case CstNodeKind.IncludeItem_MemberID:
     case CstNodeKind.InscanDirective_INSCAN:
       return true;
   }

--- a/packages/language/src/parser/preprocessor-parser.ts
+++ b/packages/language/src/parser/preprocessor-parser.ts
@@ -596,23 +596,15 @@ function includeStatement(state: ParserState): ast.IncludeDirective {
     // collect all ID tokens that can contribute to a ddname
     const idTokens: t.Token[] = [];
     let nextIdToken: t.Token | null = null;
-    while (true) {
-      nextIdToken = state.tryConsume(
+    while (
+      (nextIdToken = state.tryConsume(
         item,
         CstNodeKind.IncludeItem_FileID,
         t.ID,
-      );
-      if (!nextIdToken) {
-        break;
-      }
+      ))
+    ) {
       idTokens.push(nextIdToken);
-
-      const dotToken = state.tryConsume(
-        item,
-        CstNodeKind.IncludeItem_Dot,
-        t.Dot,
-      );
-      if (!dotToken) {
+      if (!state.tryConsume(item, CstNodeKind.IncludeItem_Dot, t.Dot)) {
         break;
       }
     }

--- a/packages/language/src/parser/preprocessor-parser.ts
+++ b/packages/language/src/parser/preprocessor-parser.ts
@@ -591,7 +591,8 @@ function includeStatement(state: ParserState): ast.IncludeDirective {
   directive.idempotent = isXInstruction(includeToken);
   let parseError = false;
   while (true) {
-    let item: ast.IncludeItemFile | ast.IncludeItemMember | undefined = undefined;
+    let item: ast.IncludeItemFile | ast.IncludeItemMember | undefined =
+      undefined;
     // collect all ID tokens that can contribute to a ddname
     const idTokens: t.Token[] = [];
     let nextIdToken: t.Token | null = null;

--- a/packages/language/src/parser/preprocessor-parser.ts
+++ b/packages/language/src/parser/preprocessor-parser.ts
@@ -591,9 +591,7 @@ function includeStatement(state: ParserState): ast.IncludeDirective {
   directive.idempotent = isXInstruction(includeToken);
   let parseError = false;
   while (true) {
-    const item = ast.createIncludeItem() as
-      | ast.IncludeItemFile
-      | ast.IncludeItemMember;
+    let item: ast.IncludeItemFile | ast.IncludeItemMember | undefined = undefined;
     // collect all ID tokens that can contribute to a ddname
     const idTokens: t.Token[] = [];
     let nextIdToken: t.Token | null = null;
@@ -620,6 +618,11 @@ function includeStatement(state: ParserState): ast.IncludeDirective {
 
     if (idTokens.length > 1) {
       // ddname which requires a parenthesized member portion
+      item = ast.createIncludeItemMember();
+      for (const idToken of idTokens) {
+        idToken.element = item;
+      }
+
       state.consume(item, CstNodeKind.IncludeItem_OpenParen, t.OpenParen);
 
       const memberToken = state.consume(
@@ -628,16 +631,19 @@ function includeStatement(state: ParserState): ast.IncludeDirective {
         t.ID,
       );
 
-      const itemWithMember = item as ast.IncludeItemMember;
-
       state.consume(item, CstNodeKind.IncludeItem_CloseParen, t.CloseParen);
       // joint ddname
-      itemWithMember.ddname = idTokens.map((t) => t.image).join(".");
-      itemWithMember.ddnameTokens = idTokens;
+      item.ddname = idTokens.map((t) => t.image).join(".");
+      item.ddnameTokens = idTokens; // <-- TODO use these tokens to report chained diagnostics, do I already do this?
 
-      itemWithMember.memberName = memberToken?.image ?? null;
-      itemWithMember.token = memberToken;
+      item.memberName = memberToken?.image ?? null;
+      item.token = memberToken;
     } else if (idTokens.length === 1) {
+      item = ast.createIncludeItemMember();
+      for (const idToken of idTokens) {
+        idToken.element = item;
+      }
+
       // either ddname w/ member, or raw member
       const ddnameOrMember = idTokens[0].image;
 
@@ -659,20 +665,22 @@ function includeStatement(state: ParserState): ast.IncludeDirective {
 
         state.consume(item, CstNodeKind.IncludeItem_CloseParen, t.CloseParen);
 
-        const itemWithMember = item as ast.IncludeItemMember;
+        item.ddname = ddnameOrMember;
+        item.ddnameTokens = idTokens;
 
-        itemWithMember.ddname = ddnameOrMember;
-        itemWithMember.ddnameTokens = idTokens;
-
-        itemWithMember.memberName = memberToken?.image ?? null;
-        itemWithMember.token = memberToken;
+        item.memberName = memberToken?.image ?? null;
+        item.token = memberToken;
       } else {
         // member include case
-        const itemWithMember = item as ast.IncludeItemMember;
-        itemWithMember.memberName = ddnameOrMember;
-        itemWithMember.token = nextIdToken;
+        item.memberName = ddnameOrMember;
+        item.token = nextIdToken;
       }
     } else {
+      item = ast.createIncludeItemFile();
+      for (const idToken of idTokens) {
+        idToken.element = item;
+      }
+
       // direct file include, not a member (from string)
       const stringToken = state.tryConsume(
         item,
@@ -680,10 +688,9 @@ function includeStatement(state: ParserState): ast.IncludeDirective {
         t.STRING_TERM,
       );
       if (stringToken) {
-        const itemWithFile = item as ast.IncludeItemFile;
         const fileName = unpackCharacterValue(stringToken.image);
-        itemWithFile.fileName = fileName;
-        itemWithFile.token = stringToken;
+        item.fileName = fileName;
+        item.token = stringToken;
       } else {
         // At least one include item is required
         // If none is found, we will report an error at the end of the statement
@@ -719,7 +726,7 @@ export function includeAltStatement(
     CstNodeKind.IncludeAltDirective_INCLUDE_ALT,
     t.INCLUDE_ALT,
   );
-  const item = ast.createIncludeItem() as ast.IncludeItemFile;
+  const item = ast.createIncludeItemFile();
   const token = state.consume(item, CstNodeKind.IncludeItem_FileID, t.ID);
   const fileName = token?.image ?? null;
   item.fileName = fileName;

--- a/packages/language/src/parser/preprocessor-parser.ts
+++ b/packages/language/src/parser/preprocessor-parser.ts
@@ -591,27 +591,99 @@ function includeStatement(state: ParserState): ast.IncludeDirective {
   directive.idempotent = isXInstruction(includeToken);
   let parseError = false;
   while (true) {
-    const item = ast.createIncludeItem();
-    const idToken = state.tryConsume(
-      item,
-      CstNodeKind.IncludeItem_FileID,
-      t.ID,
-    );
-    if (idToken) {
-      const fileName = idToken.image;
-      item.fileName = fileName;
-      item.token = idToken;
+    const item = ast.createIncludeItem() as
+      | ast.IncludeItemFile
+      | ast.IncludeItemMember;
+    // collect all ID tokens that can contribute to a ddname
+    const idTokens: t.Token[] = [];
+    let nextIdToken: t.Token | null = null;
+    while (true) {
+      nextIdToken = state.tryConsume(
+        item,
+        CstNodeKind.IncludeItem_FileID,
+        t.ID,
+      );
+      if (!nextIdToken) {
+        break;
+      }
+      idTokens.push(nextIdToken);
+
+      const dotToken = state.tryConsume(
+        item,
+        CstNodeKind.IncludeItem_Dot,
+        t.Dot,
+      );
+      if (!dotToken) {
+        break;
+      }
+    }
+
+    if (idTokens.length > 1) {
+      // ddname which requires a parenthesized member portion
+      state.consume(item, CstNodeKind.IncludeItem_OpenParen, t.OpenParen);
+
+      const memberToken = state.consume(
+        item,
+        CstNodeKind.IncludeItem_MemberID,
+        t.ID,
+      );
+
+      const itemWithMember = item as ast.IncludeItemMember;
+
+      state.consume(item, CstNodeKind.IncludeItem_CloseParen, t.CloseParen);
+      // joint ddname
+      itemWithMember.ddname = idTokens.map((t) => t.image).join(".");
+      itemWithMember.ddnameTokens = idTokens;
+
+      itemWithMember.memberName = memberToken?.image ?? null;
+      itemWithMember.token = memberToken;
+    } else if (idTokens.length === 1) {
+      // either ddname w/ member, or raw member
+      const ddnameOrMember = idTokens[0].image;
+
+      // check to see if we have an opening parenthesis for a following member
+      // making this a ddname + member
+      const openParenToken = state.tryConsume(
+        item,
+        CstNodeKind.IncludeItem_OpenParen,
+        t.OpenParen,
+      );
+
+      if (openParenToken) {
+        // ddname(member) case
+        const memberToken = state.consume(
+          item,
+          CstNodeKind.IncludeItem_MemberID,
+          t.ID,
+        );
+
+        state.consume(item, CstNodeKind.IncludeItem_CloseParen, t.CloseParen);
+
+        const itemWithMember = item as ast.IncludeItemMember;
+
+        itemWithMember.ddname = ddnameOrMember;
+        itemWithMember.ddnameTokens = idTokens;
+
+        itemWithMember.memberName = memberToken?.image ?? null;
+        itemWithMember.token = memberToken;
+      } else {
+        // member include case
+        const itemWithMember = item as ast.IncludeItemMember;
+        itemWithMember.memberName = ddnameOrMember;
+        itemWithMember.token = nextIdToken;
+      }
     } else {
+      // direct file include, not a member (from string)
       const stringToken = state.tryConsume(
         item,
         CstNodeKind.IncludeItem_FileString,
         t.STRING_TERM,
       );
       if (stringToken) {
+        const itemWithFile = item as ast.IncludeItemFile;
         const fileName = unpackCharacterValue(stringToken.image);
-        item.fileName = fileName;
-        item.string = true;
-        item.token = stringToken;
+        itemWithFile.fileName = fileName;
+        itemWithFile.token = stringToken;
       } else {
         // At least one include item is required
         // If none is found, we will report an error at the end of the statement
@@ -647,7 +719,7 @@ export function includeAltStatement(
     CstNodeKind.IncludeAltDirective_INCLUDE_ALT,
     t.INCLUDE_ALT,
   );
-  const item = ast.createIncludeItem();
+  const item = ast.createIncludeItem() as ast.IncludeItemFile;
   const token = state.consume(item, CstNodeKind.IncludeItem_FileID, t.ID);
   const fileName = token?.image ?? null;
   item.fileName = fileName;

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2146,8 +2146,8 @@ async function resolveIncludeFileUri(
         // standalone member w/out an explicit ddname, search within ddlib for a match
         const ddLibUri = resolveLibFileUri(lib.ddLib);
         const ddMemberMatch = await FileSystemProviderInstance.search({
-          ddPath: ddLibUri.toString(true),
-          member: fileNameOrPartial,
+          path: URI.parse(ddLibUri.toString(true) + `(${fileNameOrPartial})`),
+          extensions: [],
         });
         if (ddMemberMatch) {
           return ddMemberMatch;

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -1832,6 +1832,7 @@ async function runIncludeInstruction(
         idempotent: instruction.idempotent,
       };
     } else {
+      // not a valid include item (neither member nor fileName is present), skip it
       continue;
     }
 
@@ -1938,12 +1939,15 @@ async function runInclude(
           : item.memberName,
     );
 
+    // check to set optional diagnostic data iff we have a valid fileName/memberName to work with
     if (isFileIncludeItem(item)) {
+      // item w/ valid fileName
       diagnostic.data = {
         unresolvedFile: item.fileName,
         entryUri: context.entryUri.toString(),
       };
     } else if (isMemberIncludeItem(item)) {
+      // item w/ memberName & optional ddname
       diagnostic.data = {
         unresolvedFile: item.ddname
           ? `${item.ddname}(${item.memberName})`
@@ -2022,6 +2026,29 @@ async function runInclude(
 }
 
 /**
+ * Returns the appropriate file name or partial name for an include item.
+ * Partial names refer to member includes that do not have an explicit ddname specified, but can still be resolved
+ * in the context of a known process group lib that may contain the member.
+ * Before checking we can't state whether a pure member name returned here is partial or not, as that depends on the libs.
+ * @returns Relevant fileName or member w/ or w/out a ddname, otherwise undefined when none are found
+ */
+function getFileNameOrPartialName(item: IncludeItem): string | undefined {
+  if (isMemberIncludeItem(item) && item.ddname) {
+    // fully resolvable member w/ ddname
+    return `${item.ddname}(${item.memberName})`;
+  } else if (isMemberIncludeItem(item)) {
+    // pure member w/out a ddname, may be partial depending on libs
+    return item.memberName;
+  } else if (item.fileName) {
+    // literal file include
+    return item.fileName;
+  } else {
+    // no fileName or memberName to work with
+    return undefined;
+  }
+}
+
+/**
  * Attempts to resolve the URI of an include file factoring in process group libs, relative & absolute paths
  *
  * @param item Include item to resolve a URI for
@@ -2060,19 +2087,16 @@ async function resolveIncludeFileUri(
     const computedLibs = pgroup.$computedLibs;
 
     // construct the appropriate file name or partial name for members
-    let fileNameOrPartial: string;
+    // let fileNameOrPartial: string;
     // used to denote whether we're working with a pure member (requires special lookup handling)
-    let isPureMember = false;
-    if (isMemberIncludeItem(item) && item.ddname) {
-      fileNameOrPartial = `${item.ddname}(${item.memberName})`;
-    } else if (isMemberIncludeItem(item)) {
-      isPureMember = true;
-      fileNameOrPartial = item.memberName;
-    } else if (item.fileName) {
-      fileNameOrPartial = item.fileName;
-    } else {
+    const fileNameOrPartial = getFileNameOrPartialName(item);
+    if (!fileNameOrPartial) {
+      // no fileName or memberName to work with, abandon resolution
       return undefined;
     }
+
+    // whether the include item is a pure (standalone) member, no ddname specified
+    const isPureMember = isMemberIncludeItem(item) && !item.ddname;
 
     /**
      * Computes the URI for a lib file based on whether the path is absolute or relative

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -14,7 +14,10 @@ import { Token } from "../parser/tokens";
 import { URI, UriUtils } from "../utils/uri";
 import { CompilationUnit } from "../workspace/compilation-unit";
 import { FileSystemProviderInstance } from "../workspace/file-system-provider";
-import { PluginConfigurationProviderInstance } from "../workspace/plugin-configuration-provider";
+import {
+  isLibsDir,
+  PluginConfigurationProviderInstance,
+} from "../workspace/plugin-configuration-provider";
 import { CompilerOptionResult } from "./compiler-options/options";
 import {
   generateInstructions,
@@ -1813,17 +1816,27 @@ async function runIncludeInstruction(
   context: InterpreterContext,
 ): Promise<void> {
   for (const item of instruction.items) {
-    if (item.fileName) {
-      const filePath = await runInclude(
-        {
-          fileName: item.fileName,
-          idempotent: instruction.idempotent,
-          token: item.token,
-        },
-        context,
-      );
-      setFilePath(item, filePath, context);
+    let includeItem: IncludeItem;
+    if (ast.isIncludeItemFile(item)) {
+      includeItem = {
+        fileName: item.fileName,
+        token: item.token,
+        idempotent: instruction.idempotent,
+      };
+    } else if (ast.isIncludeItemMember(item)) {
+      includeItem = {
+        memberName: item.memberName,
+        ddname: item.ddname,
+        ddnameTokens: item.ddnameTokens,
+        token: item.token,
+        idempotent: instruction.idempotent,
+      };
+    } else {
+      continue;
     }
+
+    const filePath = await runInclude(includeItem, context);
+    setFilePath(item, filePath, context);
   }
 }
 
@@ -1861,10 +1874,48 @@ function setFilePath(
   }
 }
 
-interface IncludeItem {
+/**
+ * Represents an include item to be processed
+ * Either by fileName or member
+ */
+type IncludeItem = FileIncludeItem | MemberIncludeItem;
+
+/**
+ * Literal file include
+ */
+interface FileIncludeItem {
   fileName: string;
   token?: Token | null;
   idempotent: boolean;
+}
+
+/**
+ * Include by member item, possibly with a ddname to further clarify
+ */
+interface MemberIncludeItem {
+  memberName: string;
+  ddname: string | null;
+  ddnameTokens: Token[] | null;
+  token?: Token | null;
+  idempotent: boolean;
+}
+
+function isFileIncludeItem(obj: any): obj is FileIncludeItem {
+  return (
+    obj &&
+    typeof obj === "object" &&
+    "fileName" in obj &&
+    typeof obj.fileName === "string"
+  );
+}
+
+function isMemberIncludeItem(obj: any): obj is MemberIncludeItem {
+  return (
+    obj &&
+    typeof obj === "object" &&
+    "memberName" in obj &&
+    typeof obj.memberName === "string"
+  );
 }
 
 async function runInclude(
@@ -1880,13 +1931,26 @@ async function runInclude(
     const diagnostic = diagnosticFromCode(
       PLICodes.Severe.IBM3841I,
       item.token,
-      item.fileName,
+      isFileIncludeItem(item)
+        ? item.fileName
+        : item.ddname
+          ? `${item.ddname}(${item.memberName})`
+          : item.memberName,
     );
-    if (item.fileName)
+
+    if (isFileIncludeItem(item)) {
       diagnostic.data = {
         unresolvedFile: item.fileName,
         entryUri: context.entryUri.toString(),
       };
+    } else if (isMemberIncludeItem(item)) {
+      diagnostic.data = {
+        unresolvedFile: item.ddname
+          ? `${item.ddname}(${item.memberName})`
+          : item.memberName,
+        entryUri: context.entryUri.toString(),
+      };
+    }
     context.diagnostics.push(diagnostic);
   }
 
@@ -1968,7 +2032,7 @@ async function resolveIncludeFileUri(
   item: IncludeItem,
   context: InterpreterContext,
 ): Promise<URI | undefined> {
-  if (!context.entryUri || !item.fileName) {
+  if (!context.entryUri || (!isFileIncludeItem(item) && !item.memberName)) {
     return undefined;
   }
   const pgroup =
@@ -1993,31 +2057,96 @@ async function resolveIncludeFileUri(
 
   if (pgroup) {
     // lib file as either a string or a member from a known process group
-    const absPathRegex = /^(?:\/|\\|[A-Z]:)/i;
     const computedLibs = pgroup.$computedLibs;
-    for (const lib of computedLibs) {
-      let libFileUri: URI;
-      if (!absPathRegex.test(lib)) {
+
+    // construct the appropriate file name or partial name for members
+    let fileNameOrPartial: string;
+    // used to denote whether we're working with a pure member (requires special lookup handling)
+    let isPureMember = false;
+    if (isMemberIncludeItem(item) && item.ddname) {
+      fileNameOrPartial = `${item.ddname}(${item.memberName})`;
+    } else if (isMemberIncludeItem(item)) {
+      isPureMember = true;
+      fileNameOrPartial = item.memberName;
+    } else if (item.fileName) {
+      fileNameOrPartial = item.fileName;
+    } else {
+      return undefined;
+    }
+
+    /**
+     * Computes the URI for a lib file based on whether the path is absolute or relative
+     * Relative paths are combined w/ the workspace path
+     * @path Lib path from the process group
+     * @fileName Optional file name to append to the lib path (generally the include file name)
+     */
+    function resolveLibFileUri(path: string, fileName?: string): URI {
+      const absPathRegex = /^(?:\/|\\|[A-Z]:)/i;
+      if (!absPathRegex.test(path)) {
         // relative lib path, combine w/ workspace
-        libFileUri = UriUtils.joinPath(
+        return UriUtils.joinPath(
           URI.parse(PluginConfigurationProviderInstance.getWorkspacePath()),
-          lib,
-          item.fileName,
+          path,
+          fileName ?? "",
         );
       } else {
         // use lib path over workspace
-        const libUri = URI.file(lib).with({
+        const libUri = URI.file(path).with({
           scheme: context.entryUri.scheme,
         });
-        libFileUri = UriUtils.joinPath(libUri, item.fileName);
+        return UriUtils.joinPath(libUri, fileName ?? "");
       }
+    }
 
-      const match = await FileSystemProviderInstance.search({
-        path: libFileUri,
-        extensions: pgroup.includeExtensions,
-      });
-      if (match) {
-        return match;
+    for (const lib of computedLibs) {
+      if (isLibsDir(lib)) {
+        const libFileUri = resolveLibFileUri(lib.dir, fileNameOrPartial);
+
+        if (isPureMember) {
+          // attempt an early resolution for any DDName that introduces this member
+          const memberMatch = await FileSystemProviderInstance.search({
+            dirPath: resolveLibFileUri(lib.dir),
+            member: fileNameOrPartial,
+          });
+          if (memberMatch) {
+            return memberMatch;
+          }
+        }
+
+        // perform standard search
+        const match = await FileSystemProviderInstance.search({
+          path: libFileUri,
+          extensions: pgroup.includeExtensions,
+        });
+        if (match) {
+          return match;
+        }
+      } else if (isPureMember) {
+        // pure member, search within ddlib for a match
+        const ddLibUri = resolveLibFileUri(lib.ddLib);
+        const ddMemberMatch = await FileSystemProviderInstance.search({
+          ddPath: ddLibUri.toString(true),
+          member: fileNameOrPartial,
+        });
+        if (ddMemberMatch) {
+          return ddMemberMatch;
+        }
+      } else if (
+        isMemberIncludeItem(item) &&
+        item.ddname &&
+        lib.ddLib.toLowerCase().endsWith(item.ddname.toLowerCase())
+      ) {
+        // member w/ ddname, search for an exact match using ddlib
+        const end = lib.ddLib.length - item.ddname.length;
+        const libPath = lib.ddLib.substring(0, end);
+        const ddLibUri = resolveLibFileUri(libPath, fileNameOrPartial);
+        const ddMemberMatch = await FileSystemProviderInstance.search({
+          path: ddLibUri,
+          extensions: [],
+        });
+        if (ddMemberMatch) {
+          return ddMemberMatch;
+        }
       }
     }
   }

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2029,7 +2029,7 @@ async function runInclude(
  * Returns the appropriate file name or partial name for an include item.
  * Partial names refer to member includes that do not have an explicit ddname specified, but can still be resolved
  * in the context of a known process group lib that may contain the member.
- * Before checking we can't state whether a pure member name returned here is partial or not, as that depends on the libs.
+ * Before checking we can't state whether a standalone member returned here is partial or not, as that depends on the libs.
  * @returns Relevant fileName or member w/ or w/out a ddname, otherwise undefined when none are found
  */
 function getFileNameOrPartialName(item: IncludeItem): string | undefined {
@@ -2037,7 +2037,7 @@ function getFileNameOrPartialName(item: IncludeItem): string | undefined {
     // fully resolvable member w/ ddname
     return `${item.ddname}(${item.memberName})`;
   } else if (isMemberIncludeItem(item)) {
-    // pure member w/out a ddname, may be partial depending on libs
+    // standalone member w/out a ddname, may be partial depending on libs
     return item.memberName;
   } else if (item.fileName) {
     // literal file include
@@ -2088,15 +2088,16 @@ async function resolveIncludeFileUri(
 
     // construct the appropriate file name or partial name for members
     // let fileNameOrPartial: string;
-    // used to denote whether we're working with a pure member (requires special lookup handling)
     const fileNameOrPartial = getFileNameOrPartialName(item);
     if (!fileNameOrPartial) {
       // no fileName or memberName to work with, abandon resolution
       return undefined;
     }
 
-    // whether the include item is a pure (standalone) member, no ddname specified
-    const isPureMember = isMemberIncludeItem(item) && !item.ddname;
+    // whether the include item is a standalone member, no ddname specified
+    // in such cases this member may be the suffix of an a ddname entry in the libs, (ex. `A.B.C(member)`)
+    // corresponding to mainframe behavior, if `cpy/A.B.C` or `cpy` is in libs, we should be able to resolve `member`
+    const isMemberWithoutDDName = isMemberIncludeItem(item) && !item.ddname;
 
     /**
      * Computes the URI for a lib file based on whether the path is absolute or relative
@@ -2126,7 +2127,7 @@ async function resolveIncludeFileUri(
       if (isLibsDir(lib)) {
         const libFileUri = resolveLibFileUri(lib.dir, fileNameOrPartial);
 
-        if (isPureMember) {
+        if (isMemberWithoutDDName) {
           // attempt to first resolve for any DDName that introduces this member
           // This is done to ensure resolution order of libs is maintained as members > files
           // Ex. If we have both `cpy/member.pli` and `cpy/A.B.C(member)`, with `cpy` in the libs list
@@ -2148,8 +2149,8 @@ async function resolveIncludeFileUri(
         if (match) {
           return match;
         }
-      } else if (isPureMember) {
-        // pure member, search within ddlib for a match
+      } else if (isMemberWithoutDDName) {
+        // standalone member w/out an explicit ddname, search within ddlib for a match
         const ddLibUri = resolveLibFileUri(lib.ddLib);
         const ddMemberMatch = await FileSystemProviderInstance.search({
           ddPath: ddLibUri.toString(true),

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -1932,7 +1932,7 @@ async function runInclude(
     const diagnostic = diagnosticFromCode(
       PLICodes.Severe.IBM3841I,
       item.token,
-      getFileNameOrPartialName(item)!
+      getFileNameOrPartialName(item)!,
     );
 
     // check to set optional diagnostic data iff we have a valid fileName/memberName to work with

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -1932,11 +1932,7 @@ async function runInclude(
     const diagnostic = diagnosticFromCode(
       PLICodes.Severe.IBM3841I,
       item.token,
-      isFileIncludeItem(item)
-        ? item.fileName
-        : item.ddname
-          ? `${item.ddname}(${item.memberName})`
-          : item.memberName,
+      getFileNameOrPartialName(item)!
     );
 
     // check to set optional diagnostic data iff we have a valid fileName/memberName to work with
@@ -1949,9 +1945,7 @@ async function runInclude(
     } else if (isMemberIncludeItem(item)) {
       // item w/ memberName & optional ddname
       diagnostic.data = {
-        unresolvedFile: item.ddname
-          ? `${item.ddname}(${item.memberName})`
-          : item.memberName,
+        unresolvedFile: getFileNameOrPartialName(item)!,
         entryUri: context.entryUri.toString(),
       };
     }
@@ -2087,7 +2081,6 @@ async function resolveIncludeFileUri(
     const computedLibs = pgroup.$computedLibs;
 
     // construct the appropriate file name or partial name for members
-    // let fileNameOrPartial: string;
     const fileNameOrPartial = getFileNameOrPartialName(item);
     if (!fileNameOrPartial) {
       // no fileName or memberName to work with, abandon resolution

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2103,7 +2103,10 @@ async function resolveIncludeFileUri(
         const libFileUri = resolveLibFileUri(lib.dir, fileNameOrPartial);
 
         if (isPureMember) {
-          // attempt an early resolution for any DDName that introduces this member
+          // attempt to first resolve for any DDName that introduces this member
+          // This is done to ensure resolution order of libs is maintained as members > files
+          // Ex. If we have both `cpy/member.pli` and `cpy/A.B.C(member)`, with `cpy` in the libs list
+          // We want to ensure that `A.B.C(member)` is resolved first before falling back to `member.pli`
           const memberMatch = await FileSystemProviderInstance.search({
             dirPath: resolveLibFileUri(lib.dir),
             member: fileNameOrPartial,

--- a/packages/language/src/preprocessor/instructions.ts
+++ b/packages/language/src/preprocessor/instructions.ts
@@ -370,12 +370,12 @@ export function createDeclareInstruction(
 
 export interface IncludeInstruction {
   kind: InstructionKind.Include;
-  items: ast.IncludeItem[];
+  items: Array<ast.IncludeItemFile | ast.IncludeItemMember>;
   idempotent: boolean;
 }
 
 export function createIncludeInstruction(
-  items: ast.IncludeItem[],
+  items: Array<ast.IncludeItemFile | ast.IncludeItemMember>,
   idempotent: boolean,
 ): IncludeInstruction {
   return {

--- a/packages/language/src/preprocessor/pli-lexer.ts
+++ b/packages/language/src/preprocessor/pli-lexer.ts
@@ -138,7 +138,7 @@ function generateIncAfterInstruction(
   }
   // Generate a synthetic include item here
   // This allows us to perform LSP operations to jump to the included file
-  const includeItem = ast.createIncludeItem() as ast.IncludeItemFile;
+  const includeItem = ast.createIncludeItemFile();
   includeItem.fileName = incAfter.process;
   includeItem.token = incAfter.token || null;
   if (incAfter.token) {

--- a/packages/language/src/preprocessor/pli-lexer.ts
+++ b/packages/language/src/preprocessor/pli-lexer.ts
@@ -138,7 +138,7 @@ function generateIncAfterInstruction(
   }
   // Generate a synthetic include item here
   // This allows us to perform LSP operations to jump to the included file
-  const includeItem = ast.createIncludeItem();
+  const includeItem = ast.createIncludeItem() as ast.IncludeItemFile;
   includeItem.fileName = incAfter.process;
   includeItem.token = incAfter.token || null;
   if (incAfter.token) {

--- a/packages/language/src/syntax-tree/ast-iterator.ts
+++ b/packages/language/src/syntax-tree/ast-iterator.ts
@@ -544,7 +544,9 @@ export function forEachNode(
     case SyntaxKind.IncludeAltDirective:
       node.items.forEach(action);
       break;
-    case SyntaxKind.IncludeItem:
+    case SyntaxKind.IncludeItemFile:
+      break;
+    case SyntaxKind.IncludeItemMember:
       break;
     case SyntaxKind.InscanDirective:
       if (node.item) {

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -117,7 +117,8 @@ export enum SyntaxKind {
   IfStatement,
   IncludeDirective,
   IncludeAltDirective,
-  IncludeItem,
+  IncludeItemMember,
+  IncludeItemFile,
   InscanDirective,
   IndForAttribute,
   InitAcrossExpression,
@@ -373,7 +374,8 @@ export type SyntaxNode =
   | IfStatement
   | IncludeDirective
   | IncludeAltDirective
-  | IncludeItem
+  | IncludeItemMember
+  | IncludeItemFile
   | InscanDirective
   | IndForAttribute
   | InitAcrossExpression
@@ -1614,31 +1616,35 @@ export function createIncludeAltDirective(): IncludeAltDirective {
   };
 }
 
-interface IncludeItem extends AstNode {
-  kind: SyntaxKind.IncludeItem;
-
-  /**
-   * Token shared by either fileName | member
-   */
+/**
+ * Include item by file name
+ */
+// TODO break this up into it's own AST node type
+export interface IncludeItemFile extends AstNode {
+  kind: SyntaxKind.IncludeItemFile;
   token: Token | null;
 
   // Properties filled by the preprocessor
   filePath: string | null;
   relativeFilePath: string | null;
   sourceText: string | null;
-}
 
-/**
- * Include item by file name
- */
-export type IncludeItemFile = IncludeItem & {
   fileName: string | null;
 };
 
 /**
  * Include item by member name + optional ddname
  */
-export type IncludeItemMember = IncludeItem & {
+// TODO break this up into it's own AST node type
+export interface IncludeItemMember extends AstNode {
+  kind: SyntaxKind.IncludeItemMember;
+  token: Token | null;
+
+  // Properties filled by the preprocessor
+  filePath: string | null;
+  relativeFilePath: string | null;
+  sourceText: string | null;
+
   /**
    * Member name of the include, if present
    */
@@ -1659,30 +1665,52 @@ export type IncludeItemMember = IncludeItem & {
  * Type guard for an IncludeItemFile w/ fileName prop
  */
 export function isIncludeItemFile(
-  item: IncludeItem,
+  item: unknown,
 ): item is IncludeItemFile & { fileName: string } {
-  return !!(item as IncludeItemFile).fileName;
+  return typeof item === "object" &&
+    item !== null &&
+    'fileName' in item &&
+    typeof (item as any).fileName === 'string';
 }
 
 /**
  * Type guard for an IncludeItemMember w/ memberName prop
  */
 export function isIncludeItemMember(
-  item: IncludeItem,
+  item: unknown,
 ): item is IncludeItemMember & { memberName: string } {
-  return !!(item as IncludeItemMember).memberName;
+  return typeof item === "object" &&
+    item !== null &&
+    'memberName' in item &&
+    typeof (item as any).memberName === 'string';
 }
 
-export function createIncludeItem(): IncludeItem {
+export function createIncludeItemFile(): IncludeItemFile {
   return {
-    kind: SyntaxKind.IncludeItem,
+    kind: SyntaxKind.IncludeItemFile,
     container: null,
     filePath: null,
     relativeFilePath: null,
     token: null,
     sourceText: null,
+    fileName: null,
   };
 }
+
+export function createIncludeItemMember(): IncludeItemMember {
+  return {
+    kind: SyntaxKind.IncludeItemMember,
+    container: null,
+    filePath: null,
+    relativeFilePath: null,
+    token: null,
+    sourceText: null,
+    memberName: null,
+    ddname: null,
+    ddnameTokens: null,
+  };
+}
+
 export interface InscanDirective extends AstNode {
   kind: SyntaxKind.InscanDirective;
   token: Token | null;

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -1584,7 +1584,7 @@ export interface IncludeDirective extends AstNode {
   kind: SyntaxKind.IncludeDirective;
   idempotent: boolean;
   token: Token | null;
-  items: IncludeItem[];
+  items: Array<IncludeItemFile | IncludeItemMember>;
 }
 export function createIncludeDirective(): IncludeDirective {
   return {
@@ -1602,7 +1602,7 @@ export interface IncludeAltDirective extends AstNode {
   kind: SyntaxKind.IncludeAltDirective;
   idempotent: boolean;
   token: Token | null;
-  items: IncludeItem[];
+  items: Array<IncludeItemFile | IncludeItemMember>;
 }
 export function createIncludeAltDirective(): IncludeAltDirective {
   return {
@@ -1613,24 +1613,64 @@ export function createIncludeAltDirective(): IncludeAltDirective {
     items: [],
   };
 }
-export interface IncludeItem extends AstNode {
+
+interface IncludeItem extends AstNode {
   kind: SyntaxKind.IncludeItem;
-  fileName: string | null;
-  string: boolean;
-  ddname: string | null;
+
+  /**
+   * Token shared by either fileName | member
+   */
   token: Token | null;
+
   // Properties filled by the preprocessor
   filePath: string | null;
   relativeFilePath: string | null;
   sourceText: string | null;
 }
+
+/**
+ * Include item by file name
+ */
+export type IncludeItemFile = IncludeItem & {
+  fileName: string | null;
+};
+
+/**
+ * Include item by member name + optional ddname
+ */
+export type IncludeItemMember = IncludeItem & {
+  /**
+   * Member name of the include, if present
+   */
+  memberName: string | null;
+
+  /**
+   * Explicit ddname for resolving the member within
+   */
+  ddname: string | null;
+
+  /**
+   * Contributing tokens for ddname components
+   */
+  ddnameTokens: Token[] | null;
+};
+
+export function isIncludeItemFile(
+  item: IncludeItem,
+): item is IncludeItemFile & { fileName: string } {
+  return !!(item as IncludeItemFile).fileName;
+}
+
+export function isIncludeItemMember(
+  item: IncludeItem,
+): item is IncludeItemMember & { memberName: string } {
+  return !!(item as IncludeItemMember).memberName;
+}
+
 export function createIncludeItem(): IncludeItem {
   return {
     kind: SyntaxKind.IncludeItem,
     container: null,
-    fileName: null,
-    string: false,
-    ddname: null,
     filePath: null,
     relativeFilePath: null,
     token: null,

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -1619,7 +1619,6 @@ export function createIncludeAltDirective(): IncludeAltDirective {
 /**
  * Include item by file name
  */
-// TODO break this up into it's own AST node type
 export interface IncludeItemFile extends AstNode {
   kind: SyntaxKind.IncludeItemFile;
   token: Token | null;
@@ -1635,7 +1634,6 @@ export interface IncludeItemFile extends AstNode {
 /**
  * Include item by member name + optional ddname
  */
-// TODO break this up into it's own AST node type
 export interface IncludeItemMember extends AstNode {
   kind: SyntaxKind.IncludeItemMember;
   token: Token | null;

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -1629,7 +1629,7 @@ export interface IncludeItemFile extends AstNode {
   sourceText: string | null;
 
   fileName: string | null;
-};
+}
 
 /**
  * Include item by member name + optional ddname
@@ -1657,7 +1657,7 @@ export interface IncludeItemMember extends AstNode {
    * Contributing tokens for ddname components
    */
   ddnameTokens: Token[] | null;
-};
+}
 
 /**
  * Type guard for an IncludeItemFile w/ fileName prop
@@ -1665,10 +1665,12 @@ export interface IncludeItemMember extends AstNode {
 export function isIncludeItemFile(
   item: unknown,
 ): item is IncludeItemFile & { fileName: string } {
-  return typeof item === "object" &&
+  return (
+    typeof item === "object" &&
     item !== null &&
-    'fileName' in item &&
-    typeof (item as any).fileName === 'string';
+    "fileName" in item &&
+    typeof (item as any).fileName === "string"
+  );
 }
 
 /**
@@ -1677,10 +1679,12 @@ export function isIncludeItemFile(
 export function isIncludeItemMember(
   item: unknown,
 ): item is IncludeItemMember & { memberName: string } {
-  return typeof item === "object" &&
+  return (
+    typeof item === "object" &&
     item !== null &&
-    'memberName' in item &&
-    typeof (item as any).memberName === 'string';
+    "memberName" in item &&
+    typeof (item as any).memberName === "string"
+  );
 }
 
 export function createIncludeItemFile(): IncludeItemFile {

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -1655,12 +1655,18 @@ export type IncludeItemMember = IncludeItem & {
   ddnameTokens: Token[] | null;
 };
 
+/**
+ * Type guard for an IncludeItemFile w/ fileName prop
+ */
 export function isIncludeItemFile(
   item: IncludeItem,
 ): item is IncludeItemFile & { fileName: string } {
   return !!(item as IncludeItemFile).fileName;
 }
 
+/**
+ * Type guard for an IncludeItemMember w/ memberName prop
+ */
 export function isIncludeItemMember(
   item: IncludeItem,
 ): item is IncludeItemMember & { memberName: string } {

--- a/packages/language/src/syntax-tree/cst.ts
+++ b/packages/language/src/syntax-tree/cst.ts
@@ -390,6 +390,8 @@ export enum CstNodeKind {
   IncludeAltDirective_Semicolon,
   IncludeItem_FileString,
   IncludeItem_FileID,
+  IncludeItem_MemberID,
+  IncludeItem_Dot,
   IncludeItem_DDName,
   IncludeItem_OpenParen,
   IncludeItem_CloseParen,

--- a/packages/language/src/workspace/file-system-provider.ts
+++ b/packages/language/src/workspace/file-system-provider.ts
@@ -11,9 +11,7 @@
 
 import { URI } from "../utils/uri";
 
-export type SearchOptions =
-  | PathSearch
-  | MemberSearchInDir;
+export type SearchOptions = PathSearch | MemberSearchInDir;
 
 /**
  * Search by full path with optional extensions.
@@ -52,7 +50,6 @@ export function isPathSearch(obj: any): obj is PathSearch {
     Array.isArray(obj.extensions)
   );
 }
-
 
 /**
  * File or directory stats

--- a/packages/language/src/workspace/file-system-provider.ts
+++ b/packages/language/src/workspace/file-system-provider.ts
@@ -53,28 +53,22 @@ export function isPathSearch(obj: any): obj is PathSearch {
   );
 }
 
-/**
- * Directory entry types, used in readDir results
- */
-export enum DirEntryType {
-  File = 1,
-  Directory = 2,
-}
 
 /**
- * Directory entry, used in readDir results
+ * File or directory stats
  */
-export interface DirEntry {
-  name: string;
-  type: DirEntryType;
+export interface Stats {
+  isFile: boolean;
+  isDirectory: boolean;
 }
 
 export interface FileSystemProvider {
   readFile(uri: URI): Promise<string | undefined>;
   /**
-   * Reads the contents of a directory. The result is an array of directory entries w/ types
+   * Reads the contents of a directory.
+   * The result is an array of file & directory names as strings
    */
-  readDir(uri: URI): Promise<DirEntry[]>;
+  readDir(uri: URI): Promise<string[]>;
   fileExists(uri: URI): Promise<boolean>;
   writeFile(uri: URI, value: string): Promise<void>;
   deleteFile(uri: URI): Promise<void>;
@@ -83,6 +77,13 @@ export interface FileSystemProvider {
    * Returns a singular URI if found, otherwise undefined.
    */
   search(options: SearchOptions): Promise<URI | undefined>;
+
+  /**
+   * Retrieve file or directory stats.
+   * @param uri Of file or directory to stat
+   * @returns Stats object
+   */
+  stat(uri: URI): Promise<Stats>;
 }
 
 /**
@@ -93,7 +94,7 @@ class _EmptyFileSystemProvider implements FileSystemProvider {
     return Promise.resolve("");
   }
 
-  readDir(_uri: URI): Promise<DirEntry[]> {
+  readDir(_uri: URI): Promise<string[]> {
     return Promise.resolve([]);
   }
 
@@ -111,6 +112,13 @@ class _EmptyFileSystemProvider implements FileSystemProvider {
 
   search(_options: SearchOptions): Promise<URI | undefined> {
     return Promise.resolve(undefined);
+  }
+
+  stat(_uri: URI): Promise<Stats> {
+    return Promise.resolve({
+      isFile: false,
+      isDirectory: false,
+    });
   }
 }
 
@@ -145,12 +153,12 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
 
   /**
    * Reads the contents of a directory in the virtualized file system.
-   * The result is an array of directory entries w/ types.
+   * The result is an array of file & directory names as strings.
    * Directories are virtual in this case, only existing if there are files with matching prefixes.
    * If no matching directory entry is found (i.e. no entries), an exception is thrown
    * If the file system is empty, an empty array is returned (assuming uninitialized)
    */
-  async readDir(uri: URI): Promise<DirEntry[]> {
+  async readDir(uri: URI): Promise<string[]> {
     if (this.files.size === 0) {
       // not populated yet
       return [];
@@ -160,23 +168,13 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
     if (!path.endsWith("/")) {
       path += "/";
     }
-    const entries: DirEntry[] = [];
+    const entries: string[] = [];
     for (const filePath of this.files.keys()) {
       if (filePath.startsWith(path)) {
         const relativePath = filePath.substring(path.length);
         const parts = relativePath.split("/").filter((p) => p.length > 0);
-        if (parts.length === 1) {
-          // file
-          entries.push({
-            name: parts[0],
-            type: DirEntryType.File,
-          });
-        } else {
-          // directory
-          entries.push({
-            name: parts[0],
-            type: DirEntryType.Directory,
-          });
+        if (parts.length > 0) {
+                    entries.push(parts[0]);
         }
       }
     }
@@ -257,6 +255,33 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
     }
 
     return undefined;
+  }
+
+  /**
+   * Retrieve file or directory stats for the virtual file system.
+   * Folders are virtual, so we check for any files that start with the given path + "/" to indicate
+   * their presence
+   * @param uri URI of file or directory to stat
+   * @returns Stats object
+   */
+  async stat(uri: URI): Promise<Stats> {
+    const path = uri.toString(true).toLowerCase();
+    const isFile = this.files.has(path);
+    let isDirectory = false;
+    if (!isFile) {
+      // check if any files start with this path + "/"
+      const dirPath = path.endsWith("/") ? path : path + "/";
+      for (const filePath of this.files.keys()) {
+        if (filePath.startsWith(dirPath)) {
+          isDirectory = true;
+          break;
+        }
+      }
+    }
+    return {
+      isFile,
+      isDirectory,
+    };
   }
 }
 

--- a/packages/language/src/workspace/file-system-provider.ts
+++ b/packages/language/src/workspace/file-system-provider.ts
@@ -13,8 +13,7 @@ import { URI } from "../utils/uri";
 
 export type SearchOptions =
   | PathSearch
-  | MemberSearchInDir
-  | MemberSearchWithDDPath;
+  | MemberSearchInDir;
 
 /**
  * Search by full path with optional extensions.
@@ -44,24 +43,6 @@ interface MemberSearchInDir {
   member: string;
 }
 
-/**
- * Search by member name w/ a path up to & including the ddname.
- * Combined with the member, we can construct a complete path to search.
- * The search implementation determines how best to combine the two.
- */
-interface MemberSearchWithDDPath {
-  /**
-   * Partial path that corresponds to a common ddname
-   * Ex. entries like A.B.C(m1) & A.B.C(m2) would result in ddPath 'A.B.C'
-   */
-  ddPath: string;
-
-  /**
-   * Member we're looking for
-   */
-  member: string;
-}
-
 export function isPathSearch(obj: any): obj is PathSearch {
   return (
     obj &&
@@ -69,28 +50,6 @@ export function isPathSearch(obj: any): obj is PathSearch {
     "path" in obj &&
     "extensions" in obj &&
     Array.isArray(obj.extensions)
-  );
-}
-
-export function isMemberSearchInDir(obj: any): obj is MemberSearchInDir {
-  return (
-    obj &&
-    typeof obj === "object" &&
-    "dirPath" in obj &&
-    "member" in obj &&
-    typeof obj.member === "string"
-  );
-}
-
-export function isMemberSearchWithDDPath(
-  obj: any,
-): obj is MemberSearchWithDDPath {
-  return (
-    obj &&
-    typeof obj === "object" &&
-    "ddPath" in obj &&
-    "member" in obj &&
-    typeof obj.member === "string"
   );
 }
 
@@ -283,7 +242,7 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
           }
         }
       }
-    } else if (isMemberSearchInDir(options)) {
+    } else {
       // perform a search by a member w/ candidate dir path
       const memberPart = `(${options.member})`.toLowerCase();
       for (const [filePath] of this.files) {
@@ -292,15 +251,6 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
           fpl.endsWith(memberPart) &&
           fpl.startsWith(options.dirPath.toString(true).toLowerCase())
         ) {
-          return URI.parse(filePath);
-        }
-      }
-    } else {
-      // member search w/ full path
-      const memberPart = `(${options.member})`.toLowerCase();
-      const searchPath = options.ddPath.toLowerCase() + memberPart;
-      for (const [filePath] of this.files) {
-        if (filePath.toLowerCase() === searchPath) {
           return URI.parse(filePath);
         }
       }

--- a/packages/language/src/workspace/file-system-provider.ts
+++ b/packages/language/src/workspace/file-system-provider.ts
@@ -125,7 +125,9 @@ class _EmptyFileSystemProvider implements FileSystemProvider {
 export const EmptyFileSystemProvider = new _EmptyFileSystemProvider();
 
 /**
- * Virtualized file system, internally represented as a flat map of files
+ * Virtualized file system, internally represented as a flat map of files.
+ * Files & Directories are represented in a case-insensitive manner in this implementation,
+ * by opting to store all paths in lower-case form, and perform all lookups in lower-case as well.
  */
 export class VirtualFileSystemProvider implements FileSystemProvider {
   /**
@@ -171,7 +173,7 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
         const relativePath = filePath.substring(path.length);
         const parts = relativePath.split("/").filter((p) => p.length > 0);
         if (parts.length > 0) {
-                    entries.push(parts[0]);
+          entries.push(parts[0]);
         }
       }
     }

--- a/packages/language/src/workspace/file-system-provider.ts
+++ b/packages/language/src/workspace/file-system-provider.ts
@@ -11,10 +11,87 @@
 
 import { URI } from "../utils/uri";
 
-export interface SearchOptions {
+export type SearchOptions =
+  | PathSearch
+  | MemberSearchInDir
+  | MemberSearchWithDDPath;
+
+/**
+ * Search by full path with optional extensions.
+ * Global option indicates whether to perform a global lookup or not
+ */
+interface PathSearch {
   path: URI;
   extensions: string[];
   global?: boolean;
+}
+
+/**
+ * Search by member name in given directory
+ * We don't know the ddname up front, but we know the member.
+ * So we'll need to perform a search in the given directory for any file matching the member
+ * Ex. a/b/c ... m1, where we search for any file in a/b/c that ends with (m1)
+ */
+interface MemberSearchInDir {
+  /**
+   * Path to candidate directory, which may contain this member under a ddname
+   */
+  dirPath: URI;
+
+  /**
+   * Member we're looking for
+   */
+  member: string;
+}
+
+/**
+ * Search by member name w/ a path up to & including the ddname.
+ * Combined with the member, we can construct a complete path to search.
+ * The search implementation determines how best to combine the two.
+ */
+interface MemberSearchWithDDPath {
+  /**
+   * Partial path that corresponds to a common ddname
+   * Ex. entries like A.B.C(m1) & A.B.C(m2) would result in ddPath 'A.B.C'
+   */
+  ddPath: string;
+
+  /**
+   * Member we're looking for
+   */
+  member: string;
+}
+
+export function isPathSearch(obj: any): obj is PathSearch {
+  return (
+    obj &&
+    typeof obj === "object" &&
+    "path" in obj &&
+    "extensions" in obj &&
+    Array.isArray(obj.extensions)
+  );
+}
+
+export function isMemberSearchInDir(obj: any): obj is MemberSearchInDir {
+  return (
+    obj &&
+    typeof obj === "object" &&
+    "dirPath" in obj &&
+    "member" in obj &&
+    typeof obj.member === "string"
+  );
+}
+
+export function isMemberSearchWithDDPath(
+  obj: any,
+): obj is MemberSearchWithDDPath {
+  return (
+    obj &&
+    typeof obj === "object" &&
+    "ddPath" in obj &&
+    "member" in obj &&
+    typeof obj.member === "string"
+  );
 }
 
 /**
@@ -96,7 +173,7 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
    * Write a file to the virtualized file system
    */
   async writeFile(uri: URI, value: string): Promise<void> {
-    this.files.set(uri.toString().toLowerCase(), value);
+    this.files.set(uri.toString(true).toLowerCase(), value);
   }
 
   /**
@@ -104,18 +181,26 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
    * If the file does not exist, undefined is returned.
    */
   async readFile(uri: URI): Promise<string | undefined> {
-    return this.files.get(uri.toString().toLowerCase());
+    return this.files.get(uri.toString(true).toLowerCase());
   }
 
   /**
    * Reads the contents of a directory in the virtualized file system.
    * The result is an array of directory entries w/ types.
    * Directories are virtual in this case, only existing if there are files with matching prefixes.
-   * If no entries are found, an empty array is returned.
+   * If no matching directory entry is found (i.e. no entries), an exception is thrown
+   * If the file system is empty, an empty array is returned (assuming uninitialized)
    */
   async readDir(uri: URI): Promise<DirEntry[]> {
+    if (this.files.size === 0) {
+      // not populated yet
+      return [];
+    }
     // collect all entries which start with the given path
-    const path = uri.toString().toLowerCase();
+    let path = uri.toString(true).toLowerCase();
+    if (!path.endsWith("/")) {
+      path += "/";
+    }
     const entries: DirEntry[] = [];
     for (const filePath of this.files.keys()) {
       if (filePath.startsWith(path)) {
@@ -136,6 +221,11 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
         }
       }
     }
+    if (entries.length === 0) {
+      // when no files are found, we assume the directory does not exist
+      // as we don't currently support creating empty dirs in the vfs
+      throw new Error(`Directory not found: ${uri.toString(true)}`);
+    }
     return entries;
   }
 
@@ -143,14 +233,14 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
    * Checks if a file exists in the virtualized file system
    */
   async fileExists(uri: URI): Promise<boolean> {
-    return this.files.has(uri.toString().toLowerCase());
+    return this.files.has(uri.toString(true).toLowerCase());
   }
 
   /**
    * Deletes a file from the virtualized file system
    */
   async deleteFile(uri: URI): Promise<void> {
-    this.files.delete(uri.toString().toLowerCase());
+    this.files.delete(uri.toString(true).toLowerCase());
   }
 
   /**
@@ -160,33 +250,58 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
    * @returns First match, or undefined if no match found
    */
   async search(options: SearchOptions): Promise<URI | undefined> {
-    const searchPath = options.path
-      .toString()
-      .toLowerCase()
-      .replace(/\\/g, "/");
-    const extensions = options.extensions ?? [];
+    if (isPathSearch(options)) {
+      // perform a search with a uri
+      const searchPath = options.path
+        .toString(true)
+        .toLowerCase()
+        .replace(/\\/g, "/");
+      const extensions = options.extensions ?? [];
 
-    if (!options.global) {
-      if (this.files.has(searchPath)) {
-        return options.path;
-      }
-      for (const ext of extensions) {
-        const fullPath = searchPath + (ext.startsWith(".") ? ext : `.${ext}`);
-        if (this.files.has(fullPath)) {
-          return URI.parse(fullPath).with({ scheme: options.path.scheme });
-        }
-      }
-    } else {
-      // @wagner-laranjeiras. TODO: Optimize this matching pattern.
-      for (const [filePath] of this.files) {
-        if (filePath.endsWith(searchPath)) {
-          return URI.parse(filePath);
+      if (!options.global) {
+        if (this.files.has(searchPath)) {
+          return options.path;
         }
         for (const ext of extensions) {
           const fullPath = searchPath + (ext.startsWith(".") ? ext : `.${ext}`);
-          if (filePath.endsWith(fullPath)) {
-            return URI.parse(filePath).with({ scheme: options.path.scheme });
+          if (this.files.has(fullPath)) {
+            return URI.parse(fullPath).with({ scheme: options.path.scheme });
           }
+        }
+      } else {
+        // @wagner-laranjeiras. TODO: Optimize this matching pattern.
+        for (const [filePath] of this.files) {
+          if (filePath.endsWith(searchPath)) {
+            return URI.parse(filePath);
+          }
+          for (const ext of extensions) {
+            const fullPath =
+              searchPath + (ext.startsWith(".") ? ext : `.${ext}`);
+            if (filePath.endsWith(fullPath)) {
+              return URI.parse(filePath).with({ scheme: options.path.scheme });
+            }
+          }
+        }
+      }
+    } else if (isMemberSearchInDir(options)) {
+      // perform a search by a member w/ candidate dir path
+      const memberPart = `(${options.member})`.toLowerCase();
+      for (const [filePath] of this.files) {
+        const fpl = filePath.toLowerCase();
+        if (
+          fpl.endsWith(memberPart) &&
+          fpl.startsWith(options.dirPath.toString(true).toLowerCase())
+        ) {
+          return URI.parse(filePath);
+        }
+      }
+    } else {
+      // member search w/ full path
+      const memberPart = `(${options.member})`.toLowerCase();
+      const searchPath = options.ddPath.toLowerCase() + memberPart;
+      for (const [filePath] of this.files) {
+        if (filePath.toLowerCase() === searchPath) {
+          return URI.parse(filePath);
         }
       }
     }

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -19,9 +19,7 @@ import {
 import { translateCompilerOptions } from "../preprocessor/compiler-options/translate";
 import { isBoolean, isRecordOf, isString, isStringArray } from "../utils/types";
 import { URI, UriUtils } from "../utils/uri";
-import {
-  FileSystemProviderInstance,
-} from "./file-system-provider";
+import { FileSystemProviderInstance } from "./file-system-provider";
 
 /**
  * Pli options are effectively macros to set w/ the given values
@@ -238,7 +236,7 @@ export class PluginConfigurationProvider {
 
   /**
    * Initializes the plugin configuration provider with a workspace path, using any plugin configs present in the workspace.
-   * 
+   *
    * @param workspacePath The full path to the workspace to load plugin configurations from
    * @returns List of diagnostics encountered during loading & processing
    */
@@ -297,7 +295,7 @@ export class PluginConfigurationProvider {
 
   /**
    * Reloads plugin configurations from the existing workspace path.
-   * 
+   *
    * @returns List of diagnostics encountered during loading & processing
    */
   public async reloadConfigurations(): Promise<Diagnostic[]> {
@@ -307,7 +305,7 @@ export class PluginConfigurationProvider {
 
   /**
    * Loads the plugin configurations from the workspace path, overwriting any existing configs.
-   * 
+   *
    * @returns List of diagnostics encountered during loading & processing
    */
   private async loadConfigurations(): Promise<Diagnostic[]> {
@@ -366,7 +364,7 @@ export class PluginConfigurationProvider {
    * @returns List of diagnostics encountered during loading & processing
    */
   private async loadProcessGroupConfig(
-    processGroupConfigUri: URI
+    processGroupConfigUri: URI,
   ): Promise<Diagnostic[]> {
     if (await FileSystemProviderInstance.fileExists(processGroupConfigUri)) {
       const processGrpConfig = await FileSystemProviderInstance.readFile(
@@ -376,7 +374,8 @@ export class PluginConfigurationProvider {
       if (processGrpConfig !== undefined) {
         try {
           // process & set configs, also triggers post-processing of process groups
-          const diagnostics = await this.parseProcessGroupConfigs(processGrpConfig);
+          const diagnostics =
+            await this.parseProcessGroupConfigs(processGrpConfig);
           this.postProcessProgramConfigs();
           return diagnostics;
         } catch (e) {
@@ -423,7 +422,9 @@ export class PluginConfigurationProvider {
             const entries = await FileSystemProviderInstance.readDir(libUri);
             if (entries.length) {
               for (const fileName of entries) {
-                const stats = await FileSystemProviderInstance.stat(UriUtils.joinPath(libUri, fileName));
+                const stats = await FileSystemProviderInstance.stat(
+                  UriUtils.joinPath(libUri, fileName),
+                );
                 if (stats.isDirectory) {
                   // directory to add for handling
                   libsToProcess.push(`${lib}/${fileName}`);
@@ -467,14 +468,14 @@ export class PluginConfigurationProvider {
             } catch (parentError) {
               // parent directory also failed to read, skip this lib & collect diagnostic
               diagnostics.push({
-                severity: 1, // err 
+                severity: 1, // err
                 message: `Plugin Configuration failed to resolve library entry '${lib}'`,
                 code: "COPC01",
                 source: "PL/I",
                 range: {
                   start: { line: 0, character: 0 },
                   end: { line: 0, character: 1 },
-                }
+                },
               });
             }
           }

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -9,18 +9,19 @@
  *
  */
 
-import {
-    FileSystemProviderInstance,
-} from "./file-system-provider";
-import { URI, UriUtils } from "../utils/uri";
+import { minimatch } from "minimatch";
+import { Diagnostic } from "vscode-languageserver-types";
+import { CompilerOptionResult } from "../preprocessor/compiler-options/options";
 import {
   AbstractCompilerOptions,
   parseAbstractCompilerOptions,
 } from "../preprocessor/compiler-options/parser";
 import { translateCompilerOptions } from "../preprocessor/compiler-options/translate";
-import { minimatch } from "minimatch";
-import { CompilerOptionResult } from "../preprocessor/compiler-options/options";
 import { isBoolean, isRecordOf, isString, isStringArray } from "../utils/types";
+import { URI, UriUtils } from "../utils/uri";
+import {
+  FileSystemProviderInstance,
+} from "./file-system-provider";
 
 /**
  * Pli options are effectively macros to set w/ the given values
@@ -237,10 +238,13 @@ export class PluginConfigurationProvider {
 
   /**
    * Initializes the plugin configuration provider with a workspace path, using any plugin configs present in the workspace.
+   * 
+   * @param workspacePath The full path to the workspace to load plugin configurations from
+   * @returns List of diagnostics encountered during loading & processing
    */
-  public async init(workspacePath: string): Promise<void> {
+  public async init(workspacePath: string): Promise<Diagnostic[]> {
     this.workspacePath = workspacePath;
-    await this.loadConfigurations();
+    return this.loadConfigurations();
   }
 
   /**
@@ -293,16 +297,20 @@ export class PluginConfigurationProvider {
 
   /**
    * Reloads plugin configurations from the existing workspace path.
+   * 
+   * @returns List of diagnostics encountered during loading & processing
    */
-  public async reloadConfigurations(): Promise<void> {
+  public async reloadConfigurations(): Promise<Diagnostic[]> {
     console.log("Reloading .pliplugin configurations...");
-    await this.loadConfigurations();
+    return this.loadConfigurations();
   }
 
   /**
    * Loads the plugin configurations from the workspace path, overwriting any existing configs.
+   * 
+   * @returns List of diagnostics encountered during loading & processing
    */
-  private async loadConfigurations(): Promise<void> {
+  private async loadConfigurations(): Promise<Diagnostic[]> {
     const workspaceUri = URI.parse(this.workspacePath);
 
     // load configs
@@ -310,9 +318,10 @@ export class PluginConfigurationProvider {
       UriUtils.joinPath(workspaceUri, ".pliplugin", "pgm_conf.json"),
     );
 
-    await this.loadProcessGroupConfig(
+    const diagnostics = await this.loadProcessGroupConfig(
       UriUtils.joinPath(workspaceUri, ".pliplugin", "proc_grps.json"),
     );
+    return diagnostics;
   }
 
   /**
@@ -354,10 +363,11 @@ export class PluginConfigurationProvider {
   /**
    * Loads the process group config from the given path, and sets it in this provider.
    * @param processGroupConfigUri URI to the process group config file
+   * @returns List of diagnostics encountered during loading & processing
    */
   private async loadProcessGroupConfig(
-    processGroupConfigUri: URI,
-  ): Promise<void> {
+    processGroupConfigUri: URI
+  ): Promise<Diagnostic[]> {
     if (await FileSystemProviderInstance.fileExists(processGroupConfigUri)) {
       const processGrpConfig = await FileSystemProviderInstance.readFile(
         processGroupConfigUri,
@@ -365,10 +375,10 @@ export class PluginConfigurationProvider {
 
       if (processGrpConfig !== undefined) {
         try {
-          await this.parseProcessGroupConfigs(processGrpConfig);
+          // process & set configs, also triggers post-processing of process groups
+          const diagnostics = await this.parseProcessGroupConfigs(processGrpConfig);
           this.postProcessProgramConfigs();
-          await this.postProcessProcessGroups();
-          return;
+          return diagnostics;
         } catch (e) {
           console.error("Failed to load process group config, skipping:", e);
         }
@@ -382,13 +392,16 @@ export class PluginConfigurationProvider {
     console.warn(
       "No process group config found, clearing existing configurations.",
     );
+    return [];
   }
 
   /**
    * Go through all process groups & expand libs recursively to ensure all libs are findable when searching
    * Populates the $computedLibs property of each process group, which is used to resolve includes
+   * @returns List of diagnostics encountered during processing
    */
-  private async postProcessProcessGroups() {
+  private async postProcessProcessGroups(): Promise<Diagnostic[]> {
+    const diagnostics: Diagnostic[] = [];
     for (const processGroup of this.processGroupConfigs.values()) {
       const computedLibs: Set<LibsEntry> = new Set();
       const libsToProcess = [...processGroup.libs];
@@ -397,7 +410,15 @@ export class PluginConfigurationProvider {
         if (lib) {
           // read all files in this lib path
           // add any contained directories to the libs list, as well as the toProcess list
-          const libUri = UriUtils.joinPath(URI.parse(this.workspacePath), lib);
+          let libUri: URI;
+          const absPathRegex = /^\/|[A-Z]:|~/i;
+          if (absPathRegex.test(lib)) {
+            // absolute path, use as-is
+            libUri = URI.file(lib);
+          } else {
+            libUri = UriUtils.joinPath(URI.parse(this.workspacePath), lib);
+          }
+
           try {
             const entries = await FileSystemProviderInstance.readDir(libUri);
             if (entries.length) {
@@ -427,18 +448,34 @@ export class PluginConfigurationProvider {
               const parentEntries =
                 await FileSystemProviderInstance.readDir(parentUri);
               const ddnamePattern = new RegExp(`^${libName}\\(`, "i");
+              let matched = false;
               for (const entry of parentEntries) {
                 if (ddnamePattern.test(entry)) {
                   // found a ddname-style entry, add full lib & break out, only need one to confirm
                   computedLibs.add({
                     ddLib: lib,
                   });
+                  matched = true;
                   break;
                 }
               }
+
+              if (!matched) {
+                // no matches found, rethrow to generate diagnostic
+                throw e;
+              }
             } catch (parentError) {
-              // parent directory also failed to read, skip this lib
-              console.warn(`Failed to resolve library entry "${lib}"`);
+              // parent directory also failed to read, skip this lib & collect diagnostic
+              diagnostics.push({
+                severity: 1, // err 
+                message: `Plugin Configuration failed to resolve library entry '${lib}'`,
+                code: "COPC01",
+                source: "PL/I",
+                range: {
+                  start: { line: 0, character: 0 },
+                  end: { line: 0, character: 1 },
+                }
+              });
             }
           }
         }
@@ -450,6 +487,7 @@ export class PluginConfigurationProvider {
         cl.filter((e) => isLibsDir(e)).map((e) => e.dir),
       );
     }
+    return diagnostics;
   }
 
   /**
@@ -537,36 +575,38 @@ export class PluginConfigurationProvider {
   /**
    * Parses & sets the process group configs of this plugin configuration provider, overwriting any existing configs.
    * @param text Raw text content of .pliplugin/proc_grps.json to parse
-   * @returns Whether parsing was successful
+   * @returns List of diagnostics encountered during loading & processing
    */
-  public async parseProcessGroupConfigs(text: string): Promise<boolean> {
+  public async parseProcessGroupConfigs(text: string): Promise<Diagnostic[]> {
     try {
       const serializedData: SerializedProcessGroup[] = JSON.parse(text).pgroups;
       const groupConfigs = serializedData.map(deserializeProcessGroup);
-      await this.setProcessGroupConfigs(groupConfigs);
+      const diagnostics = await this.setProcessGroupConfigs(groupConfigs);
       this.postProcessProgramConfigs();
-      return true;
+      return diagnostics;
     } catch {
-      return false;
+      return [];
     }
   }
 
   /**
    * Sets the process group configs of this plugin configuration provider, overwriting any existing configs.
-   * Also invalidates the saved library file patterns.
+   * Also invalidates the saved library file patterns & post-processes program configs.
    * @param processGroupConfigs List of process group configs loaded from
    *  .pliplugin/proc_grps.json (when present)
+   * @returns List of diagnostics encountered during loading & processing
    */
   public async setProcessGroupConfigs(
     processGroupConfigs: ProcessGroup[],
-  ): Promise<void> {
+  ): Promise<Diagnostic[]> {
     this.processGroupConfigs.clear();
     for (const config of processGroupConfigs) {
       this.processGroupConfigs.set(config.name, config);
     }
     this.postProcessProgramConfigs();
-    await this.postProcessProcessGroups();
+    const diagnostics = await this.postProcessProcessGroups();
     this.libFileGlobPatterns = undefined;
+    return diagnostics;
   }
 
   /**

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -422,6 +422,8 @@ export class PluginConfigurationProvider {
             const entries = await FileSystemProviderInstance.readDir(libUri);
             if (entries.length) {
               for (const fileName of entries) {
+                // TODO @montymxb Nov. 7th, 2025: Handle stat checks in parallel to avoid blocking so long,
+                // see https://github.com/zowe/zowe-pli-language-support/issues/465
                 const stats = await FileSystemProviderInstance.stat(
                   UriUtils.joinPath(libUri, fileName),
                 );

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -10,8 +10,7 @@
  */
 
 import {
-  DirEntryType,
-  FileSystemProviderInstance,
+    FileSystemProviderInstance,
 } from "./file-system-provider";
 import { URI, UriUtils } from "../utils/uri";
 import {
@@ -402,10 +401,9 @@ export class PluginConfigurationProvider {
           try {
             const entries = await FileSystemProviderInstance.readDir(libUri);
             if (entries.length) {
-              for (const dirEntry of entries) {
-                const fileName = dirEntry.name;
-                const fileType = dirEntry.type;
-                if (fileType === DirEntryType.Directory) {
+              for (const fileName of entries) {
+                const stats = await FileSystemProviderInstance.stat(UriUtils.joinPath(libUri, fileName));
+                if (stats.isDirectory) {
                   // directory to add for handling
                   libsToProcess.push(`${lib}/${fileName}`);
                   // also add to the full libs list
@@ -430,7 +428,7 @@ export class PluginConfigurationProvider {
                 await FileSystemProviderInstance.readDir(parentUri);
               const ddnamePattern = new RegExp(`^${libName}\\(`, "i");
               for (const entry of parentEntries) {
-                if (ddnamePattern.test(entry.name)) {
+                if (ddnamePattern.test(entry)) {
                   // found a ddname-style entry, add full lib & break out, only need one to confirm
                   computedLibs.add({
                     ddLib: lib,

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -82,11 +82,19 @@ export interface ProcessGroup {
   libs: string[];
 
   /**
-   * Computed libs, includes libs from disks & all sub directories of libs.
-   * Populated after reading the configs & not serialized like regular 'libs'.
+   * Computed libs, includes libs from discs, sub dirs of libs, & dd names.
+   * DD name entries are derived from files like `abc(member)`, which produce a ddname of `abc`.
+   * This is populated after reading the configs, not serialized like regular 'libs'.
    * Used to resolve includes.
    */
-  $computedLibs: string[];
+  $computedLibs: LibsEntry[];
+
+  /**
+   * Set of computed libs for fast lookup.
+   * Only contains directory entries, not DD name entries, which are partial.
+   * Used to find process groups from a lib URI
+   */
+  $computedLibsSet: Set<string>;
 
   includeExtensions: string[];
   implicitBuiltins: Set<string>;
@@ -121,6 +129,7 @@ export function deserializeProcessGroup(
     pliOptions: isRecordOf(pliOptions, isString) ? pliOptions : {},
     libs: isStringArray(libs) ? libs : [],
     $computedLibs: [],
+    $computedLibsSet: new Set<string>(),
     includeExtensions: isStringArray(includeExtensions)
       ? includeExtensions
       : [],
@@ -165,6 +174,29 @@ interface SerializedProcessGroup {
   "lsp-options"?: {
     "check-margins"?: boolean;
   };
+}
+
+/**
+ * Library entry, either a directory or a DD entry
+ */
+export type LibsEntry = LibsDirEntry | LibsDDEntry;
+
+/**
+ * Library directory entry
+ */
+export interface LibsDirEntry {
+  dir: string;
+}
+
+/**
+ * Library DD name entry
+ */
+export interface LibsDDEntry {
+  ddLib: string;
+}
+
+export function isLibsDir(entry: LibsEntry): entry is LibsDirEntry {
+  return (entry as LibsDirEntry).dir !== undefined;
 }
 
 /**
@@ -214,6 +246,7 @@ export class PluginConfigurationProvider {
 
   /**
    * Builds and saves the glob patterns for library file matching.
+   * Omits DD entries, only includes directory-based libs.
    * Patterns are prefixed with the workspace path and are intended to match full file paths.
    */
   private buildLibFileGlobPatterns(): void {
@@ -227,9 +260,11 @@ export class PluginConfigurationProvider {
       const computedLibs = processGroup.$computedLibs;
       const extensions = processGroup.includeExtensions;
       for (let lib of computedLibs) {
-        lib = lib.replace(/[\\/]+$/, "");
-        for (const ext of extensions) {
-          patterns.push(`${wsPrefix}${lib}/*${ext}`);
+        if (isLibsDir(lib)) {
+          const entry = lib.dir.replace(/[\\/]+$/, "");
+          for (const ext of extensions) {
+            patterns.push(`${wsPrefix}${entry}/*${ext}`);
+          }
         }
       }
     }
@@ -356,7 +391,7 @@ export class PluginConfigurationProvider {
    */
   private async postProcessProcessGroups() {
     for (const processGroup of this.processGroupConfigs.values()) {
-      const computedLibs = new Set(processGroup.libs);
+      const computedLibs: Set<LibsEntry> = new Set();
       const libsToProcess = [...processGroup.libs];
       while (libsToProcess.length > 0) {
         const lib = libsToProcess.pop();
@@ -364,22 +399,58 @@ export class PluginConfigurationProvider {
           // read all files in this lib path
           // add any contained directories to the libs list, as well as the toProcess list
           const libUri = UriUtils.joinPath(URI.parse(this.workspacePath), lib);
-          const entries = await FileSystemProviderInstance.readDir(libUri);
-          if (entries.length) {
-            for (const dirEntry of entries) {
-              const fileName = dirEntry.name;
-              const fileType = dirEntry.type;
-              if (fileType === DirEntryType.Directory) {
-                // directory to add for handling
-                libsToProcess.push(`${lib}/${fileName}`);
-                // also add to the full libs list
-                computedLibs.add(`${lib}/${fileName}`);
+          try {
+            const entries = await FileSystemProviderInstance.readDir(libUri);
+            if (entries.length) {
+              for (const dirEntry of entries) {
+                const fileName = dirEntry.name;
+                const fileType = dirEntry.type;
+                if (fileType === DirEntryType.Directory) {
+                  // directory to add for handling
+                  libsToProcess.push(`${lib}/${fileName}`);
+                  // also add to the full libs list
+                  computedLibs.add({
+                    dir: `${lib}/${fileName}`,
+                  });
+                }
               }
+            }
+            // add the lib itself, now that we know it exists
+            computedLibs.add({
+              dir: lib,
+            });
+          } catch (e) {
+            // could not read, try again to retrieve & read the parent directory
+            // take its entries to see if our lib exists as a file or directory
+            // if so, add it as a ddLib entry instead
+            const parentUri = UriUtils.dirname(libUri);
+            const libName = UriUtils.basename(libUri);
+            try {
+              const parentEntries =
+                await FileSystemProviderInstance.readDir(parentUri);
+              const ddnamePattern = new RegExp(`^${libName}\\(`, "i");
+              for (const entry of parentEntries) {
+                if (ddnamePattern.test(entry.name)) {
+                  // found a ddname-style entry, add full lib & break out, only need one to confirm
+                  computedLibs.add({
+                    ddLib: lib,
+                  });
+                  break;
+                }
+              }
+            } catch (parentError) {
+              // parent directory also failed to read, skip this lib
+              console.warn(`Failed to resolve library entry "${lib}"`);
             }
           }
         }
       }
-      processGroup.$computedLibs = Array.from(computedLibs);
+      const cl = Array.from(computedLibs);
+      processGroup.$computedLibs = cl;
+      // build a lookup set for dir entries only
+      processGroup.$computedLibsSet = new Set(
+        cl.filter((e) => isLibsDir(e)).map((e) => e.dir),
+      );
     }
   }
 
@@ -569,7 +640,7 @@ export class PluginConfigurationProvider {
   public getProcessGroupConfigFromLib(libUri: URI): ProcessGroup | undefined {
     const dirname = UriUtils.basename(UriUtils.dirname(libUri));
     for (const config of this.processGroupConfigs.values()) {
-      if (config.$computedLibs.includes(dirname)) {
+      if (config.$computedLibsSet.has(dirname)) {
         return config;
       }
     }

--- a/packages/language/test/fourslash-harness/execute.test.ts
+++ b/packages/language/test/fourslash-harness/execute.test.ts
@@ -69,6 +69,7 @@ beforeEach(async () => {
       name: "default",
       libs: ["cpy"],
       $computedLibs: [],
+      $computedLibsSet: new Set<string>(),
       includeExtensions: [".pli"],
       compilerOptions: [],
       implicitBuiltins: new Set(),

--- a/packages/language/test/fourslash-harness/harness-interface.ts
+++ b/packages/language/test/fourslash-harness/harness-interface.ts
@@ -97,7 +97,7 @@ export interface HarnessTesterInterface {
 
   verify: {
     /**
-     * Expect that the given label has only the given error codes.
+     * Expect that the given label has _only_ the given error codes.
      * @param label The label to expect the error codes at.
      * @param codes The only error codes to expect.
      */
@@ -109,7 +109,7 @@ export interface HarnessTesterInterface {
      */
     expectErrorCodesAt(label: Label, codes: string[] | string): void;
     /**
-     * Expect that the given label has only the given diagnostics.
+     * Expect that the given label has _only_ the given diagnostics.
      * @param label The label to expect the diagnostics at.
      * @param diagnostics The only diagnostics to expect.
      */

--- a/packages/language/test/fourslash-harness/harness-interface.ts
+++ b/packages/language/test/fourslash-harness/harness-interface.ts
@@ -97,9 +97,9 @@ export interface HarnessTesterInterface {
 
   verify: {
     /**
-     * Expect that the given label has the given error codes.
+     * Expect that the given label has only the given error codes.
      * @param label The label to expect the error codes at.
-     * @param codes The error codes to expect.
+     * @param codes The only error codes to expect.
      */
     expectExclusiveErrorCodesAt(label: Label, codes: string[] | string): void;
     /**
@@ -109,9 +109,9 @@ export interface HarnessTesterInterface {
      */
     expectErrorCodesAt(label: Label, codes: string[] | string): void;
     /**
-     * Expect that the given label has the given diagnostics.
+     * Expect that the given label has only the given diagnostics.
      * @param label The label to expect the diagnostics at.
-     * @param diagnostics The diagnostics to expect.
+     * @param diagnostics The only diagnostics to expect.
      */
     expectExclusiveDiagnosticsAt(
       label: Label,

--- a/packages/language/test/fourslash/preprocessor/include/test-ddmember-include-members.ts
+++ b/packages/language/test/fourslash/preprocessor/include/test-ddmember-include-members.ts
@@ -9,7 +9,13 @@
  *
  */
 
-// Tests including a ddname(member) by its member
+// Tests including a ddname(member) by its member (mainframe-style include)
+// This is a special case that requires looking up the member within known ddname libs
+// Ex. We have `%include m2;` and in the proc_grps.json we have `cpy2/A.B.C` in the libs
+// The preprocessor should be able to resolve m2 as a member of A.B.C from cpy2
+// The same should work if only `cpy2` is in the libs, since we resolve libs recursively
+// This mimics mainframe behavior, which sees ddnames akin to directories containing members (ex. A/B/C/m2)
+// Effectively this tests that language support for mainframe-style includes works as expected alongside regular includes
 
 /// <reference path="../../framework.ts" />
 

--- a/packages/language/test/fourslash/preprocessor/include/test-ddmember-include-members.ts
+++ b/packages/language/test/fourslash/preprocessor/include/test-ddmember-include-members.ts
@@ -9,10 +9,10 @@
  *
  */
 
+// Tests including a ddname(member) by its member
+
 /// <reference path="../../framework.ts" />
 
-// trigger a reparsing of the config, so we can pick up the sub libs folder
-// TODO @montymxb Oct 17th, 2025: Replace with a fourslash utility to trigger config reload
 // @filename: .pliplugin/proc_grps.json
 //// {
 ////     "pgroups": [
@@ -22,18 +22,24 @@
 ////             "check-margins": true
 ////         },
 ////         "libs": [
-////             "cpy"
+////             "cpy2/MYLIB",
+////             "cpy2/A.B.C"
 ////         ]
 ////         }
 ////     ]
 //// }
 
-// @filename: cpy/libs/lib.pli
-//// DECLARE LIB_VAR FIXED;
+// @filename: cpy2/MYLIB(m1)
+//// DECLARE LIB_VAR1 FIXED;
+
+// @filename: cpy2/A.B.C(m2)
+//// DECLARE LIB_VAR2 FIXED;
 
 // @filename: main.pli
-//// %INCLUDE "lib.pli";
+//// %INCLUDE m1;
+//// %INCLUDE m2;
 
 preprocessor.expectTokens(`
-  DECLARE LIB_VAR FIXED;
+  DECLARE LIB_VAR1 FIXED;
+  DECLARE LIB_VAR2 FIXED;
 `);

--- a/packages/language/test/fourslash/preprocessor/include/test-ddmember-include-recursive.ts
+++ b/packages/language/test/fourslash/preprocessor/include/test-ddmember-include-recursive.ts
@@ -9,9 +9,10 @@
  *
  */
 
+// Tests including a ddname(member) by its member
+
 /// <reference path="../../framework.ts" />
 
-// trigger a reparsing of the config, so we can pick up the sub libs folder
 // TODO @montymxb Oct 17th, 2025: Replace with a fourslash utility to trigger config reload
 // @filename: .pliplugin/proc_grps.json
 //// {
@@ -28,12 +29,17 @@
 ////     ]
 //// }
 
-// @filename: cpy/libs/lib.pli
-//// DECLARE LIB_VAR FIXED;
+// @filename: cpy/MYLIB(m1)
+//// DECLARE LIB_VAR1 FIXED;
+
+// @filename: cpy/A.B.C(m2)
+//// DECLARE LIB_VAR2 FIXED;
 
 // @filename: main.pli
-//// %INCLUDE "lib.pli";
+//// %INCLUDE m1;
+//// %INCLUDE m2;
 
 preprocessor.expectTokens(`
-  DECLARE LIB_VAR FIXED;
+  DECLARE LIB_VAR1 FIXED;
+  DECLARE LIB_VAR2 FIXED;
 `);

--- a/packages/language/test/fourslash/preprocessor/include/test-ddmember-includes-registered-libs.ts
+++ b/packages/language/test/fourslash/preprocessor/include/test-ddmember-includes-registered-libs.ts
@@ -40,9 +40,11 @@
 //// %INCLUDE m1;
 //// %INCLUDE <|1:m2|>;
 
-verify.expectExclusiveDiagnosticsAt(1, [{
+verify.expectExclusiveDiagnosticsAt(1, [
+  {
     message: code.Severe.IBM3841I.message("M2"),
-}]);
+  },
+]);
 
 preprocessor.expectTokens(`
   DECLARE LIB_VAR1 FIXED;

--- a/packages/language/test/fourslash/preprocessor/include/test-ddmember-includes-registered-libs.ts
+++ b/packages/language/test/fourslash/preprocessor/include/test-ddmember-includes-registered-libs.ts
@@ -9,10 +9,12 @@
  *
  */
 
+// Tests including a ddname(member) by its member
+// Should only include members from registered libs
+// ex. cpy2/MYLIB, but not cpy2/A.B.C
+
 /// <reference path="../../framework.ts" />
 
-// trigger a reparsing of the config, so we can pick up the sub libs folder
-// TODO @montymxb Oct 17th, 2025: Replace with a fourslash utility to trigger config reload
 // @filename: .pliplugin/proc_grps.json
 //// {
 ////     "pgroups": [
@@ -22,18 +24,22 @@
 ////             "check-margins": true
 ////         },
 ////         "libs": [
-////             "cpy"
+////             "cpy2/MYLIB"
 ////         ]
 ////         }
 ////     ]
 //// }
 
-// @filename: cpy/libs/lib.pli
-//// DECLARE LIB_VAR FIXED;
+// @filename: cpy2/MYLIB(m1)
+//// DECLARE LIB_VAR1 FIXED;
+
+// @filename: cpy2/A.B.C(m2)
+//// DECLARE LIB_VAR2 FIXED;
 
 // @filename: main.pli
-//// %INCLUDE "lib.pli";
+//// %INCLUDE m1;
+//// %INCLUDE m2;
 
 preprocessor.expectTokens(`
-  DECLARE LIB_VAR FIXED;
+  DECLARE LIB_VAR1 FIXED;
 `);

--- a/packages/language/test/fourslash/preprocessor/include/test-ddmember-includes-registered-libs.ts
+++ b/packages/language/test/fourslash/preprocessor/include/test-ddmember-includes-registered-libs.ts
@@ -38,7 +38,11 @@
 
 // @filename: main.pli
 //// %INCLUDE m1;
-//// %INCLUDE m2;
+//// %INCLUDE <|1:m2|>;
+
+verify.expectDiagnosticsAt(1, [{
+    message: code.Severe.IBM3841I.message("M2"),
+}]);
 
 preprocessor.expectTokens(`
   DECLARE LIB_VAR1 FIXED;

--- a/packages/language/test/fourslash/preprocessor/include/test-ddmember-includes-registered-libs.ts
+++ b/packages/language/test/fourslash/preprocessor/include/test-ddmember-includes-registered-libs.ts
@@ -40,7 +40,7 @@
 //// %INCLUDE m1;
 //// %INCLUDE <|1:m2|>;
 
-verify.expectDiagnosticsAt(1, [{
+verify.expectExclusiveDiagnosticsAt(1, [{
     message: code.Severe.IBM3841I.message("M2"),
 }]);
 

--- a/packages/language/test/fourslash/preprocessor/include/test-ddname-include.ts
+++ b/packages/language/test/fourslash/preprocessor/include/test-ddname-include.ts
@@ -1,0 +1,24 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+// Tests including a ddname(member) directly.
+
+/// <reference path="../../framework.ts" />
+
+// @filename: cpy/MYLIB(member)
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: main.pli
+//// %INCLUDE MYLIB(member);
+
+preprocessor.expectTokens(`
+  DECLARE LIB_VAR FIXED;
+`);

--- a/packages/language/test/fourslash/preprocessor/include/test-ddname-string-include.ts
+++ b/packages/language/test/fourslash/preprocessor/include/test-ddname-string-include.ts
@@ -1,0 +1,26 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+// Tests including a ddname(member) directly as a string literal.
+// TODO @montymxb this feature may be dropped later on, potential issue since
+// ddname(member) shouldn't be importable directly as a file, not the intended use case.
+
+/// <reference path="../../framework.ts" />
+
+// @filename: cpy/MYLIB(member)
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: main.pli
+//// %INCLUDE "MYLIB(member)";
+
+preprocessor.expectTokens(`
+  DECLARE LIB_VAR FIXED;
+`);

--- a/packages/language/test/parser/pli-lexer.test.ts
+++ b/packages/language/test/parser/pli-lexer.test.ts
@@ -118,6 +118,7 @@ describe("PL/1 Lexer", () => {
         includeExtensions: [],
         libs: [],
         $computedLibs: [],
+        $computedLibsSet: new Set<string>(),
         lspOptions: { checkMargins: false },
         pliOptions: {},
       };
@@ -184,6 +185,7 @@ describe("PL/1 Lexer", () => {
         includeExtensions: [],
         libs: [],
         $computedLibs: [],
+        $computedLibsSet: new Set<string>(),
         lspOptions: { checkMargins: false },
         pliOptions: {},
       };

--- a/packages/language/test/parser/pli-lexer.test.ts
+++ b/packages/language/test/parser/pli-lexer.test.ts
@@ -127,9 +127,11 @@ describe("PL/1 Lexer", () => {
       PluginConfigurationProviderInstance.setProgramConfigs("/test", [
         programConfig,
       ]);
-      await PluginConfigurationProviderInstance.setProcessGroupConfigs([
+      const diagnostics = await PluginConfigurationProviderInstance.setProcessGroupConfigs([
         processGroupConfig,
       ]);
+
+      expect(diagnostics).toHaveLength(0);
 
       const { compilerOptions } = await lexer.tokenize(
         await createCompilationUnit(uri),

--- a/packages/language/test/parser/pli-lexer.test.ts
+++ b/packages/language/test/parser/pli-lexer.test.ts
@@ -127,9 +127,10 @@ describe("PL/1 Lexer", () => {
       PluginConfigurationProviderInstance.setProgramConfigs("/test", [
         programConfig,
       ]);
-      const diagnostics = await PluginConfigurationProviderInstance.setProcessGroupConfigs([
-        processGroupConfig,
-      ]);
+      const diagnostics =
+        await PluginConfigurationProviderInstance.setProcessGroupConfigs([
+          processGroupConfig,
+        ]);
 
       expect(diagnostics).toHaveLength(0);
 

--- a/packages/language/test/preprocessor/pli-preprocessor.test.ts
+++ b/packages/language/test/preprocessor/pli-preprocessor.test.ts
@@ -126,7 +126,7 @@ describe("Preprocessor Tests", () => {
     },
   );
 
-  // tets win absolute path resolution w/ a drive letter
+  // tests win absolute path resolution w/ a drive letter
   test.runIf(process.platform === "win32")(
     "Windows path resolution",
     async () => {
@@ -139,7 +139,7 @@ describe("Preprocessor Tests", () => {
       );
 
       // lib path should now exist, re-init to check for no diagnostics
-      const diagnostics = await init("/test/libs");
+      const diagnostics = await init("c:/test/libs");
       expect(diagnostics).toHaveLength(0);
     },
   );

--- a/packages/language/test/preprocessor/pli-preprocessor.test.ts
+++ b/packages/language/test/preprocessor/pli-preprocessor.test.ts
@@ -41,6 +41,7 @@ async function init(libPath: string) {
     includeExtensions: [],
     libs: [libPath],
     $computedLibs: [],
+    $computedLibsSet: new Set<string>(),
     lspOptions: { checkMargins: false },
     pliOptions: {},
   };

--- a/packages/language/test/preprocessor/pli-preprocessor.test.ts
+++ b/packages/language/test/preprocessor/pli-preprocessor.test.ts
@@ -24,11 +24,12 @@ import {
   VirtualFileSystemProvider,
 } from "../../src/workspace/file-system-provider";
 import { resetDocumentProviders } from "../../src/language-server/text-documents";
+import { Diagnostic } from "vscode-languageserver-types";
 
 /**
  * Helper to modify the program config & process group w/ a given lib for each os-specific test
  */
-async function init(libPath: string) {
+async function init(libPath: string): Promise<Diagnostic[]> {
   const programConfig: ProgramConfig = {
     program: "test.pli",
     pgroup: "testGroup",
@@ -50,9 +51,16 @@ async function init(libPath: string) {
   PluginConfigurationProviderInstance.setProgramConfigs("/test", [
     programConfig,
   ]);
-  await PluginConfigurationProviderInstance.setProcessGroupConfigs([
+  return await PluginConfigurationProviderInstance.setProcessGroupConfigs([
     processGroupConfig,
   ]);
+}
+
+/**
+ * Helper for writing library files to the vfs
+ */
+async function writeLibFile(path: string, content: string): Promise<void> {
+  await FileSystemProviderInstance.writeFile(URI.file(path), content);
 }
 
 /**
@@ -70,7 +78,7 @@ async function expectTokensForWorkspace(
   expectedTokens: string[],
 ): Promise<void> {
   for (const [path, content] of libFiles) {
-    await FileSystemProviderInstance.writeFile(URI.file(path), content);
+    await writeLibFile(path, content);
   }
 
   // parse the main program
@@ -111,6 +119,10 @@ describe("Preprocessor Tests", () => {
         [["/test/libs/lib.pli", ` DECLARE LIB_VAR FIXED;`]],
         ["DECLARE", "LIB_VAR", "FIXED", ";"],
       );
+
+      // lib path should now exist, re-init to check for no diagnostics
+      const diagnostics = await init("/test/libs");
+      expect(diagnostics).toHaveLength(0);
     },
   );
 
@@ -125,6 +137,10 @@ describe("Preprocessor Tests", () => {
         [["C:/test/libs/lib.pli", ` DECLARE LIB_VAR FIXED;`]],
         ["DECLARE", "LIB_VAR", "FIXED", ";"],
       );
+
+      // lib path should now exist, re-init to check for no diagnostics
+      const diagnostics = await init("/test/libs");
+      expect(diagnostics).toHaveLength(0);
     },
   );
 });

--- a/packages/language/test/workspace/compilation-unit.test.ts
+++ b/packages/language/test/workspace/compilation-unit.test.ts
@@ -144,6 +144,7 @@ describe("Compilation Unit Tests", () => {
         compilerOptions: [],
         libs: ["cpy"],
         $computedLibs: [],
+        $computedLibsSet: new Set<string>(),
         includeExtensions: [".inc"],
         lspOptions: { checkMargins: false },
         pliOptions: {},

--- a/packages/language/test/workspace/plugin-configuration.test.ts
+++ b/packages/language/test/workspace/plugin-configuration.test.ts
@@ -1,0 +1,130 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { URI } from "../../src/utils/uri";
+import {
+  FileSystemProviderInstance,
+    setFileSystemProvider,
+    VirtualFileSystemProvider,
+} from "../../src/workspace/file-system-provider";
+import {
+    PluginConfigurationProviderInstance,
+    ProcessGroup,
+} from "../../src/workspace/plugin-configuration-provider";
+
+describe("Plugin Configuration Tests", () => {
+  beforeEach(() => {
+    const vfs: VirtualFileSystemProvider = new VirtualFileSystemProvider();
+    setFileSystemProvider(vfs);
+  });
+
+  afterEach(async () => {
+    PluginConfigurationProviderInstance.setProgramConfigs("", []);
+    await PluginConfigurationProviderInstance.setProcessGroupConfigs([]);
+    setFileSystemProvider(undefined);
+  });
+
+  /**
+   * Helper function to create a process group configuration with default values
+   */
+  function createProcessGroup(
+    name: string,
+    libs: string[],
+  ): ProcessGroup {
+    return {
+      name,
+      compilerOptions: [],
+      libs,
+      $computedLibs: [],
+      $computedLibsSet: new Set<string>(),
+      includeExtensions: [".inc"],
+      lspOptions: { checkMargins: false },
+      pliOptions: {},
+      implicitBuiltins: new Set()
+    };
+  }
+
+  test("No libs produce no diagnostics", async () => {
+    await PluginConfigurationProviderInstance.init("file:///");
+
+    // set up a process group with no libs
+    const diagnostics =
+      await PluginConfigurationProviderInstance.setProcessGroupConfigs([
+        createProcessGroup("default", []),
+      ]);
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test("Valid libs produce no diagnostics", async () => {
+    await PluginConfigurationProviderInstance.init("file:///");
+
+    // create a virtual directory to satisfy the subsequent libs check
+    await FileSystemProviderInstance.writeFile(URI.parse("file:///libs/existing/dummy.pli"), "");
+
+    // set up a process group w/ a libs entry that exists
+    const diagnostics =
+      await PluginConfigurationProviderInstance.setProcessGroupConfigs([
+        createProcessGroup("default", ["libs/existing"]),
+      ]);
+    
+    expect(diagnostics).toEqual([]);
+  });
+
+  test("Invalid libs produce diagnostics", async () => {
+    await PluginConfigurationProviderInstance.init("file:///");
+
+    // populate the virtual file system with at least one file so it's not empty
+    await FileSystemProviderInstance.writeFile(URI.parse("file:///dummy.pli"), "");
+
+    // set up a process group with a libs entry that does not exist
+    const diagnostics =
+      await PluginConfigurationProviderInstance.setProcessGroupConfigs([
+        createProcessGroup("default", ["nonexistent-libs"]),
+      ]);
+
+    // should generate a diagnostic for the non-existing lib
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].code).toBe("COPC01");
+    expect(diagnostics[0].message).toContain("nonexistent-libs");
+    expect(diagnostics[0].severity).toBe(1); // err
+  });
+
+  test("Only invalid libs produce diagnostics, not valid ones", async () => {
+    await PluginConfigurationProviderInstance.init("file:///");
+
+    await FileSystemProviderInstance.writeFile(URI.parse("file:///libs/existing1/p1.pli"), "");
+    await FileSystemProviderInstance.writeFile(URI.parse("file:///libs/existing2/p2.pli"), "");
+
+    const diagnostics =
+      await PluginConfigurationProviderInstance.setProcessGroupConfigs([
+        createProcessGroup("default", [
+          "libs/existing1",
+          "libs/existing2",
+
+          "invalid1",
+          "invalid2",
+        ]),
+      ]);
+
+    // expect diagnostics for the 2 invalid libs only
+    expect(diagnostics).toHaveLength(2);
+    
+    const d0 = diagnostics[0];
+    expect(d0.code).toBe("COPC01");
+    expect(diagnostics.some(d => d.message.includes("invalid1"))).toBe(true);
+
+    const d1 = diagnostics[1];
+    expect(d1.code).toBe("COPC01");
+    expect(diagnostics.some(d => d.message.includes("invalid2"))).toBe(true);
+  });
+});

--- a/packages/language/test/workspace/plugin-configuration.test.ts
+++ b/packages/language/test/workspace/plugin-configuration.test.ts
@@ -13,12 +13,12 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { URI } from "../../src/utils/uri";
 import {
   FileSystemProviderInstance,
-    setFileSystemProvider,
-    VirtualFileSystemProvider,
+  setFileSystemProvider,
+  VirtualFileSystemProvider,
 } from "../../src/workspace/file-system-provider";
 import {
-    PluginConfigurationProviderInstance,
-    ProcessGroup,
+  PluginConfigurationProviderInstance,
+  ProcessGroup,
 } from "../../src/workspace/plugin-configuration-provider";
 
 describe("Plugin Configuration Tests", () => {
@@ -36,10 +36,7 @@ describe("Plugin Configuration Tests", () => {
   /**
    * Helper function to create a process group configuration with default values
    */
-  function createProcessGroup(
-    name: string,
-    libs: string[],
-  ): ProcessGroup {
+  function createProcessGroup(name: string, libs: string[]): ProcessGroup {
     return {
       name,
       compilerOptions: [],
@@ -49,7 +46,7 @@ describe("Plugin Configuration Tests", () => {
       includeExtensions: [".inc"],
       lspOptions: { checkMargins: false },
       pliOptions: {},
-      implicitBuiltins: new Set()
+      implicitBuiltins: new Set(),
     };
   }
 
@@ -69,14 +66,17 @@ describe("Plugin Configuration Tests", () => {
     await PluginConfigurationProviderInstance.init("file:///");
 
     // create a virtual directory to satisfy the subsequent libs check
-    await FileSystemProviderInstance.writeFile(URI.parse("file:///libs/existing/dummy.pli"), "");
+    await FileSystemProviderInstance.writeFile(
+      URI.parse("file:///libs/existing/dummy.pli"),
+      "",
+    );
 
     // set up a process group w/ a libs entry that exists
     const diagnostics =
       await PluginConfigurationProviderInstance.setProcessGroupConfigs([
         createProcessGroup("default", ["libs/existing"]),
       ]);
-    
+
     expect(diagnostics).toEqual([]);
   });
 
@@ -84,7 +84,10 @@ describe("Plugin Configuration Tests", () => {
     await PluginConfigurationProviderInstance.init("file:///");
 
     // populate the virtual file system with at least one file so it's not empty
-    await FileSystemProviderInstance.writeFile(URI.parse("file:///dummy.pli"), "");
+    await FileSystemProviderInstance.writeFile(
+      URI.parse("file:///dummy.pli"),
+      "",
+    );
 
     // set up a process group with a libs entry that does not exist
     const diagnostics =
@@ -102,8 +105,14 @@ describe("Plugin Configuration Tests", () => {
   test("Only invalid libs produce diagnostics, not valid ones", async () => {
     await PluginConfigurationProviderInstance.init("file:///");
 
-    await FileSystemProviderInstance.writeFile(URI.parse("file:///libs/existing1/p1.pli"), "");
-    await FileSystemProviderInstance.writeFile(URI.parse("file:///libs/existing2/p2.pli"), "");
+    await FileSystemProviderInstance.writeFile(
+      URI.parse("file:///libs/existing1/p1.pli"),
+      "",
+    );
+    await FileSystemProviderInstance.writeFile(
+      URI.parse("file:///libs/existing2/p2.pli"),
+      "",
+    );
 
     const diagnostics =
       await PluginConfigurationProviderInstance.setProcessGroupConfigs([
@@ -118,13 +127,13 @@ describe("Plugin Configuration Tests", () => {
 
     // expect diagnostics for the 2 invalid libs only
     expect(diagnostics).toHaveLength(2);
-    
+
     const d0 = diagnostics[0];
     expect(d0.code).toBe("COPC01");
-    expect(diagnostics.some(d => d.message.includes("invalid1"))).toBe(true);
+    expect(diagnostics.some((d) => d.message.includes("invalid1"))).toBe(true);
 
     const d1 = diagnostics[1];
     expect(d1.code).toBe("COPC01");
-    expect(diagnostics.some(d => d.message.includes("invalid2"))).toBe(true);
+    expect(diagnostics.some((d) => d.message.includes("invalid2"))).toBe(true);
   });
 });

--- a/packages/vscode-extension/src/common/file-search.ts
+++ b/packages/vscode-extension/src/common/file-search.ts
@@ -11,12 +11,28 @@
 
 import { isPathSearch, SearchOptions } from "pli-language";
 
+/**
+ * Searches for a file based on the provided search options & readDir function.
+ * Will perform this search in a _case-insensitive_ manner by default.
+ * @param options Search options to use, extended with a caseSensitive flag
+ * @param readDir Helper function to read directory contents
+ * @returns Matching file path if found, undefined otherwise
+ */
 export async function searchFiles(
-  options: SearchOptions,
+  options: SearchOptions & { caseSensitive?: boolean },
   readDir: (path: string) => Promise<string[]>,
 ): Promise<string | undefined> {
   function readDirSafe(path: string): Promise<string[]> {
     return readDir(path).catch(() => []);
+  }
+
+  const caseSensitive = options.caseSensitive ?? false;
+
+  /**
+   * Helper for performing case-sensitive/insensitive comparison
+   */
+  function compare(a: string, b: string): boolean {
+    return caseSensitive ? a === b : a.toLowerCase() === b.toLowerCase();
   }
 
   if (isPathSearch(options)) {
@@ -35,9 +51,7 @@ export async function searchFiles(
     for (let i = 0; i < segments.length - 1; i++) {
       const dir = await readDirSafe(start);
       const segment = segments[i];
-      const fsSegment = dir.find(
-        (d) => d.toLowerCase() === segment.toLowerCase(),
-      );
+      const fsSegment = dir.find((d) => compare(d, segment));
       if (!fsSegment) {
         return undefined;
       }
@@ -45,18 +59,17 @@ export async function searchFiles(
     }
 
     // find the last segment accounting for possible extensions
-    const lastSegment = segments[segments.length - 1].toLowerCase();
+    const lastSegment = segments[segments.length - 1];
     const dir = await readDirSafe(start);
     for (const file of dir) {
-      const fileLower = file.toLowerCase();
-      if (fileLower === lastSegment) {
+      if (compare(file, lastSegment)) {
         return start + file;
       }
       if (isPathSearch(options)) {
         for (const ext of options.extensions) {
           const fullName =
-            lastSegment + (ext.startsWith(".") ? ext : `.${ext}`).toLowerCase();
-          if (fileLower === fullName) {
+            lastSegment + (ext.startsWith(".") ? ext : `.${ext}`);
+          if (compare(file, fullName)) {
             return start + file;
           }
         }
@@ -67,6 +80,17 @@ export async function searchFiles(
     const member = `\\(${options.member}\\)`;
 
     /**
+     * Helper for performing case-sensitive/insensitive endsWith check
+     */
+    function endsWith(str: string, suffix: string): boolean {
+      if (caseSensitive) {
+        return str.endsWith(suffix);
+      } else {
+        return str.toLowerCase().endsWith(suffix.toLowerCase());
+      }
+    }
+
+    /**
      * Helper to await the recursive search
      */
     async function searchDir(currentPath: string): Promise<string | undefined> {
@@ -75,7 +99,7 @@ export async function searchFiles(
         const entryPath = currentPath.endsWith("/")
           ? currentPath + entry
           : currentPath + "/" + entry;
-        if (entry.toLowerCase().endsWith(member.toLowerCase())) {
+        if (endsWith(entry, member)) {
           return entryPath;
         }
       }

--- a/packages/vscode-extension/src/common/file-search.ts
+++ b/packages/vscode-extension/src/common/file-search.ts
@@ -9,10 +9,7 @@
  *
  */
 
-import {
-  isPathSearch,
-  SearchOptions
-} from "pli-language";
+import { isPathSearch, SearchOptions } from "pli-language";
 
 export async function searchFiles(
   options: SearchOptions,

--- a/packages/vscode-extension/src/common/file-search.ts
+++ b/packages/vscode-extension/src/common/file-search.ts
@@ -9,7 +9,12 @@
  *
  */
 
-import { SearchOptions } from "pli-language";
+import {
+  isMemberSearchWithDDPath,
+  isPathSearch,
+  SearchOptions,
+  URI,
+} from "pli-language";
 
 export async function searchFiles(
   options: SearchOptions,
@@ -18,39 +23,92 @@ export async function searchFiles(
   function readDirSafe(path: string): Promise<string[]> {
     return readDir(path).catch(() => []);
   }
-  const string = options.path.path.substring(1);
-  const segments = string.split("/");
-  let start = "";
-  if (string.charAt(1) === ":") {
-    start = segments.shift() + "/";
-  } else {
-    start = "/";
-  }
-  for (let i = 0; i < segments.length - 1; i++) {
+
+  if (isPathSearch(options) || isMemberSearchWithDDPath(options)) {
+    let subPath: string;
+    if (isPathSearch(options)) {
+      // get the path string without the starting / or drive letter
+      subPath = options.path.path.substring(1);
+    } else {
+      // same from ddPath + member case
+      const memberUri = URI.parse(`${options.ddPath}(${options.member}))`);
+      subPath = memberUri.path.substring(1);
+    }
+
+    // construct starting point, accounting for windows drive letters
+    const segments = subPath.split("/");
+    let start = "";
+    if (subPath.charAt(1) === ":") {
+      start = segments.shift() + "/";
+    } else {
+      start = "/";
+    }
+
+    // iterate through segments except last to find correct casing for each
+    for (let i = 0; i < segments.length - 1; i++) {
+      const dir = await readDirSafe(start);
+      const segment = segments[i];
+      const fsSegment = dir.find(
+        (d) => d.toLowerCase() === segment.toLowerCase(),
+      );
+      if (!fsSegment) {
+        return undefined;
+      }
+      start += fsSegment + "/";
+    }
+
+    // find the last segment accounting for possible extensions
+    const lastSegment = segments[segments.length - 1].toLowerCase();
     const dir = await readDirSafe(start);
-    const segment = segments[i];
-    const fsSegment = dir.find(
-      (d) => d.toLowerCase() === segment.toLowerCase(),
-    );
-    if (!fsSegment) {
-      return undefined;
-    }
-    start += fsSegment + "/";
-  }
-  const lastSegment = segments[segments.length - 1].toLowerCase();
-  const dir = await readDirSafe(start);
-  for (const file of dir) {
-    const fileLower = file.toLowerCase();
-    if (fileLower === lastSegment) {
-      return start + file;
-    }
-    for (const ext of options.extensions) {
-      const fullName =
-        lastSegment + (ext.startsWith(".") ? ext : `.${ext}`).toLowerCase();
-      if (fileLower === fullName) {
+    for (const file of dir) {
+      const fileLower = file.toLowerCase();
+      if (fileLower === lastSegment) {
         return start + file;
       }
+      if (isPathSearch(options)) {
+        for (const ext of options.extensions) {
+          const fullName =
+            lastSegment + (ext.startsWith(".") ? ext : `.${ext}`).toLowerCase();
+          if (fileLower === fullName) {
+            return start + file;
+          }
+        }
+      }
     }
+  } else {
+    // member search w/ dirPath
+    const member = `\\(${options.member}\\)`;
+
+    /**
+     * Helper to await the recursive search
+     */
+    async function searchDir(currentPath: string): Promise<string | undefined> {
+      const entries = await readDirSafe(currentPath);
+      for (const entry of entries) {
+        const entryPath = currentPath.endsWith("/")
+          ? currentPath + entry
+          : currentPath + "/" + entry;
+        if (entry.toLowerCase().endsWith(member.toLowerCase())) {
+          return entryPath;
+        }
+      }
+      // recurse into subdirs
+      for (const entry of entries) {
+        const entryPath = currentPath.endsWith("/")
+          ? currentPath + entry
+          : currentPath + "/" + entry;
+        // attempt readDir into entryPath; if it fails, it's not a directory
+        const subEntries = await readDirSafe(entryPath);
+        if (subEntries.length > 0) {
+          const found = await searchDir(entryPath);
+          if (found) {
+            return found;
+          }
+        }
+      }
+      return undefined;
+    }
+    return searchDir(options.dirPath.path);
   }
   return undefined;
 }

--- a/packages/vscode-extension/src/common/file-search.ts
+++ b/packages/vscode-extension/src/common/file-search.ts
@@ -10,10 +10,8 @@
  */
 
 import {
-  isMemberSearchWithDDPath,
   isPathSearch,
-  SearchOptions,
-  URI,
+  SearchOptions
 } from "pli-language";
 
 export async function searchFiles(
@@ -24,16 +22,8 @@ export async function searchFiles(
     return readDir(path).catch(() => []);
   }
 
-  if (isPathSearch(options) || isMemberSearchWithDDPath(options)) {
-    let subPath: string;
-    if (isPathSearch(options)) {
-      // get the path string without the starting / or drive letter
-      subPath = options.path.path.substring(1);
-    } else {
-      // same from ddPath + member case
-      const memberUri = URI.parse(`${options.ddPath}(${options.member}))`);
-      subPath = memberUri.path.substring(1);
-    }
+  if (isPathSearch(options)) {
+    const subPath = options.path.path.substring(1);
 
     // construct starting point, accounting for windows drive letters
     const segments = subPath.split("/");

--- a/packages/vscode-extension/src/common/messages.ts
+++ b/packages/vscode-extension/src/common/messages.ts
@@ -15,4 +15,5 @@ export namespace Messages {
   export const WriteFile = "fs/writeFile";
   export const FileExists = "fs/fileExists";
   export const Search = "fs/search";
+  export const Stat = "fs/stat";
 }

--- a/packages/vscode-extension/src/extension/main-browser.ts
+++ b/packages/vscode-extension/src/extension/main-browser.ts
@@ -85,6 +85,14 @@ function registerFileSystemProvider(client: LanguageClient): void {
       return result.map((r) => r[0]);
     });
   });
+  client.onRequest(Messages.Stat, async (uriString: string) => {
+    const uri = vscode.Uri.parse(uriString);
+    const stat = await vscode.workspace.fs.stat(uri);
+    return {
+      isFile: stat.type === vscode.FileType.File,
+      isDirectory: stat.type === vscode.FileType.Directory
+    };
+  });
   client.onRequest(Messages.WriteFile, async (uriString, value) => {
     const uri = vscode.Uri.parse(uriString);
     await vscode.workspace.fs.writeFile(uri, value);

--- a/packages/vscode-extension/src/extension/main-browser.ts
+++ b/packages/vscode-extension/src/extension/main-browser.ts
@@ -90,7 +90,7 @@ function registerFileSystemProvider(client: LanguageClient): void {
     const stat = await vscode.workspace.fs.stat(uri);
     return {
       isFile: stat.type === vscode.FileType.File,
-      isDirectory: stat.type === vscode.FileType.Directory
+      isDirectory: stat.type === vscode.FileType.Directory,
     };
   });
   client.onRequest(Messages.WriteFile, async (uriString, value) => {

--- a/packages/vscode-extension/src/extension/main-browser.ts
+++ b/packages/vscode-extension/src/extension/main-browser.ts
@@ -15,7 +15,7 @@ import { LanguageClient } from "vscode-languageclient/browser.js";
 import { BuiltinFileSystemProvider } from "./builtin-files";
 import { Messages } from "../common/messages";
 import { searchFiles } from "../common/file-search";
-import { isMemberSearchInDir, isPathSearch, SearchOptions } from "pli-language";
+import { isPathSearch, SearchOptions } from "pli-language";
 
 let client: LanguageClient;
 
@@ -78,10 +78,8 @@ function registerFileSystemProvider(client: LanguageClient): void {
       let uri;
       if (isPathSearch(options)) {
         uri = options.path.with({ path });
-      } else if (isMemberSearchInDir(options)) {
-        uri = options.dirPath.with({ path });
       } else {
-        uri = vscode.Uri.parse(options.ddPath).with({ path });
+        uri = options.dirPath.with({ path });
       }
       const result = await vscode.workspace.fs.readDirectory(uri);
       return result.map((r) => r[0]);

--- a/packages/vscode-extension/src/extension/main-browser.ts
+++ b/packages/vscode-extension/src/extension/main-browser.ts
@@ -15,7 +15,7 @@ import { LanguageClient } from "vscode-languageclient/browser.js";
 import { BuiltinFileSystemProvider } from "./builtin-files";
 import { Messages } from "../common/messages";
 import { searchFiles } from "../common/file-search";
-import { SearchOptions } from "pli-language";
+import { isMemberSearchInDir, isPathSearch, SearchOptions } from "pli-language";
 
 let client: LanguageClient;
 
@@ -75,7 +75,14 @@ function registerFileSystemProvider(client: LanguageClient): void {
   });
   client.onRequest(Messages.Search, (options: SearchOptions) => {
     return searchFiles(options, async (path) => {
-      const uri = options.path.with({ path });
+      let uri;
+      if (isPathSearch(options)) {
+        uri = options.path.with({ path });
+      } else if (isMemberSearchInDir(options)) {
+        uri = options.dirPath.with({ path });
+      } else {
+        uri = vscode.Uri.parse(options.ddPath).with({ path });
+      }
       const result = await vscode.workspace.fs.readDirectory(uri);
       return result.map((r) => r[0]);
     });

--- a/packages/vscode-extension/src/extension/main-browser.ts
+++ b/packages/vscode-extension/src/extension/main-browser.ts
@@ -74,7 +74,7 @@ function registerFileSystemProvider(client: LanguageClient): void {
     }
   });
   client.onRequest(Messages.Search, (options: SearchOptions) => {
-    return searchFiles(options, async (path) => {
+    return searchFiles({ ...options, caseSensitive: true }, async (path) => {
       let uri;
       if (isPathSearch(options)) {
         uri = options.path.with({ path });

--- a/packages/vscode-extension/src/language/file-system.ts
+++ b/packages/vscode-extension/src/language/file-system.ts
@@ -10,10 +10,10 @@
  */
 
 import {
-  DirEntry,
   FileSystemProvider,
   isPathSearch,
   SearchOptions,
+  Stats,
   URI,
 } from "pli-language";
 import { Connection } from "vscode-languageserver";
@@ -40,15 +40,15 @@ export class VSCodeFileSystemProvider implements FileSystemProvider {
 
   /**
    * Submits a request to the client to read the contents of a directory.
-   * Returns an array of directory entries
+   * Returns an array of file & directory names as strings
    */
-  async readDir(uri: URI): Promise<DirEntry[]> {
+  async readDir(uri: URI): Promise<string[]> {
     const result = await this._connection.sendRequest(
       Messages.ReadDir,
       uri.toString(),
     );
     if (Array.isArray(result)) {
-      return result as DirEntry[];
+      return result as string[];
     } else {
       return [];
     }
@@ -77,6 +77,15 @@ export class VSCodeFileSystemProvider implements FileSystemProvider {
       return undefined;
     }
   }
+
+  async stat(uri: URI): Promise<Stats> {
+    const result = await this._connection.sendRequest(
+      Messages.Stat,
+      uri.toString(),
+    );
+    return result as Stats;
+  }
+
   async writeFile(uri: URI, value: string): Promise<void> {
     const stringUri = uri.toString();
     await this._connection.sendRequest(Messages.WriteFile, {

--- a/packages/vscode-extension/src/language/file-system.ts
+++ b/packages/vscode-extension/src/language/file-system.ts
@@ -9,7 +9,13 @@
  *
  */
 
-import { DirEntry, FileSystemProvider, SearchOptions, URI } from "pli-language";
+import {
+  DirEntry,
+  FileSystemProvider,
+  isPathSearch,
+  SearchOptions,
+  URI,
+} from "pli-language";
 import { Connection } from "vscode-languageserver";
 import { Messages } from "../common/messages";
 
@@ -61,7 +67,12 @@ export class VSCodeFileSystemProvider implements FileSystemProvider {
       options,
     )) as string | undefined;
     if (result) {
-      return options.path.with({ path: result });
+      if (isPathSearch(options)) {
+        return options.path.with({ path: result });
+      } else {
+        // not a path, take result as full URI
+        return URI.parse(result);
+      }
     } else {
       return undefined;
     }

--- a/packages/vscode-extension/src/language/main.ts
+++ b/packages/vscode-extension/src/language/main.ts
@@ -21,6 +21,8 @@ import {
   setFileSystemProvider,
   DirEntry,
   DirEntryType,
+  isPathSearch,
+  isMemberSearchInDir,
 } from "pli-language";
 import * as fs from "fs";
 import * as glob from "glob";
@@ -60,19 +62,49 @@ class NodeFileSystemProvider implements FileSystemProvider {
     throw new Error("Not supported.");
   }
   async search(options: SearchOptions): Promise<URI | undefined> {
-    const GLOBAL_PATTERN = "**";
-    const path = options.path.fsPath.replace(/\\/g, "/");
-    const pattern = options.global
-      ? `${GLOBAL_PATTERN}${path}{,${options.extensions.join(",")}}`
-      : `${path}{,${options.extensions.join(",")}}`;
-    const files = await glob.glob(pattern, {
-      nodir: true,
-      absolute: true,
-      nocase: true,
-    });
-    if (!files.length) return undefined;
+    let files: string[] = [];
+    if (isPathSearch(options)) {
+      // uri lookup
+      const GLOBAL_PATTERN = "**";
+      const path = options.path.fsPath.replace(/\\/g, "/");
+      const pattern = options.global
+        ? `${GLOBAL_PATTERN}${path}{,${options.extensions.join(",")}}`
+        : `${path}{,${options.extensions.join(",")}}`;
+      files = await glob.glob(pattern, {
+        nodir: true,
+        absolute: true,
+        nocase: true,
+      });
+    } else if (isMemberSearchInDir(options)) {
+      // member lookup w/ dir path
+      files = await glob.glob(
+        `${options.dirPath.fsPath}**/*\\(${options.member}\\)`,
+        {
+          nodir: true,
+          absolute: true,
+          nocase: true,
+        },
+      );
+    } else {
+      // member lookup w/ dd path (partial lib file as entry)
+      const uri = URI.parse(options.ddPath + `(${options.member})`);
+      const exists = await fs.promises
+        .access(uri.fsPath)
+        .then(() => true)
+        .catch(() => false);
+      if (exists) {
+        files.push(uri.path);
+      }
+    }
+
+    // return first match when present
+    if (!files.length) {
+      return undefined;
+    }
     const result = URI.file(files[0]);
-    if (!result) return undefined;
+    if (!result) {
+      return undefined;
+    }
     return result;
   }
 }

--- a/packages/vscode-extension/src/language/main.ts
+++ b/packages/vscode-extension/src/language/main.ts
@@ -88,13 +88,12 @@ class NodeFileSystemProvider implements FileSystemProvider {
     } else {
       // member lookup w/ dd path (partial lib file as entry)
       const uri = URI.parse(options.ddPath + `(${options.member})`);
-      const exists = await fs.promises
-        .access(uri.fsPath)
-        .then(() => true)
-        .catch(() => false);
-      if (exists) {
-        files.push(uri.path);
-      }
+      const path = uri.fsPath.replace(/\\/g, "/");
+      files = await glob.glob(path, {
+        nodir: true,
+        absolute: true,
+        nocase: true,
+      });
     }
 
     // return first match when present

--- a/packages/vscode-extension/src/language/main.ts
+++ b/packages/vscode-extension/src/language/main.ts
@@ -20,7 +20,7 @@ import {
   URI,
   setFileSystemProvider,
   isPathSearch,
-  Stats
+  Stats,
 } from "pli-language";
 import * as fs from "fs";
 import * as glob from "glob";

--- a/packages/vscode-extension/src/language/main.ts
+++ b/packages/vscode-extension/src/language/main.ts
@@ -19,9 +19,8 @@ import {
   SearchOptions,
   URI,
   setFileSystemProvider,
-  DirEntry,
-  DirEntryType,
-  isPathSearch
+  isPathSearch,
+  Stats
 } from "pli-language";
 import * as fs from "fs";
 import * as glob from "glob";
@@ -32,18 +31,10 @@ class NodeFileSystemProvider implements FileSystemProvider {
   }
 
   /**
-   * Reads directory contents, returning an array of directory entries
+   * Reads directory contents, returning an array of file & directory names
    */
-  async readDir(uri: URI): Promise<DirEntry[]> {
-    const results = await fs.promises.readdir(uri.fsPath, {
-      withFileTypes: true,
-    });
-    return results.map((dirent) => {
-      return {
-        name: dirent.name,
-        type: dirent.isDirectory() ? DirEntryType.Directory : DirEntryType.File,
-      };
-    });
+  async readDir(uri: URI): Promise<string[]> {
+    return fs.promises.readdir(uri.fsPath);
   }
 
   async fileExists(uri: URI): Promise<boolean> {
@@ -95,6 +86,26 @@ class NodeFileSystemProvider implements FileSystemProvider {
       return undefined;
     }
     return result;
+  }
+
+  /**
+   * Stats for file or directory
+   * @param uri URI of file or directory to stat
+   * @returns Stats object. If stat fails, returns a stats object with both isFile and isDirectory false.
+   */
+  async stat(uri: URI): Promise<Stats> {
+    try {
+      const stat = await fs.promises.stat(uri.fsPath);
+      return {
+        isFile: stat.isFile(),
+        isDirectory: stat.isDirectory(),
+      };
+    } catch {
+      return {
+        isFile: false,
+        isDirectory: false,
+      };
+    }
   }
 }
 

--- a/packages/vscode-extension/src/language/main.ts
+++ b/packages/vscode-extension/src/language/main.ts
@@ -21,8 +21,7 @@ import {
   setFileSystemProvider,
   DirEntry,
   DirEntryType,
-  isPathSearch,
-  isMemberSearchInDir,
+  isPathSearch
 } from "pli-language";
 import * as fs from "fs";
 import * as glob from "glob";
@@ -75,7 +74,7 @@ class NodeFileSystemProvider implements FileSystemProvider {
         absolute: true,
         nocase: true,
       });
-    } else if (isMemberSearchInDir(options)) {
+    } else {
       // member lookup w/ dir path
       files = await glob.glob(
         `${options.dirPath.fsPath}**/*\\(${options.member}\\)`,
@@ -85,15 +84,6 @@ class NodeFileSystemProvider implements FileSystemProvider {
           nocase: true,
         },
       );
-    } else {
-      // member lookup w/ dd path (partial lib file as entry)
-      const uri = URI.parse(options.ddPath + `(${options.member})`);
-      const path = uri.fsPath.replace(/\\/g, "/");
-      files = await glob.glob(path, {
-        nodir: true,
-        absolute: true,
-        nocase: true,
-      });
     }
 
     // return first match when present


### PR DESCRIPTION
Closes the last of #394 by:

- supporting `%INCLUDE ddname(member);` includes, that resolve within libs
- adding parser support for segmented ddnames in includes, ex. `%include a.b.c(member)`
- `%include member;` includes that resolve within the first matching `ddname(member)` entry that is reachable from libs
- adding ddname style lib entries, such as `cpy/a.b.c`, where one or more `a.b.c(...)` files exist within `cpy`. Collectively they constitute a single ddname entry that members can be resolved within
    - these, along with recursive lib resolution, are what allow `%include member` to work
- supporting resolution of ddnames in recursive libs
- updating search to support member resolution with & without a ddname
- refactor existing IncludeItem types to split up member & file cases
- support process group lib resolution without tripping on ddnames
- numerous other changes to support these includes across the stack

The later case is in supplement to our existing file resolution strategy, where `%include abc` would resolve to a file named `abc` with one of the supported extensions. This is still the case, but we'll first attempt to match to a member of an existing ddname entry before trying files.

This does _not_ add:
- quick fix support for resolving unresolved `%include ddname(member);` or `%include member` entries, but the existing quick fix support for files works as is
- proper range for unresolved `ddname(member)` diagnostics (diagnostic is still on the member at the moment). The regular `member` case works as expected.

There's a _lot_ of changes here for a relatively small feature, so I'm very open to feedback for issues, improvements, thoughts, etc.. I've done my best to try and document new additions & logic clearly to make it clear why changes were made at various stages, but feel free to make further suggestions if there's anything else that's missing or unclear in terms of documented behavior.

Some other notes:
- Noticed syntax highlighting needs to be improved for some ddname includes, such as `%INCLUDE D.E.F`. This should be spun out into a separate issue, could benefit from semantic highlighting support.