### PR TITLE
False-Positive-Fix: FILE-typed variables with INPUT

### DIFF
--- a/packages/language/src/typesystem/descriptions.ts
+++ b/packages/language/src/typesystem/descriptions.ts
@@ -103,6 +103,8 @@ export enum AttributeKind {
   StringKind,
   /** TODO belongs to StringKind, maybe refactor later */
   StringLength,
+  /** @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=files-input-output-update-attributes */
+  TransmissionDirection,
   /**
    * TODO still needs to be handled by the type builder
    * @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=attributes-variable-attribute
@@ -137,6 +139,7 @@ export const AttributeKinds: AttributeKind[] = [
   AttributeKind.StringFormat,
   AttributeKind.StringKind,
   AttributeKind.StringLength,
+  AttributeKind.TransmissionDirection,
   AttributeKind.Variable,
   AttributeKind.Volatility,
 ];
@@ -166,6 +169,7 @@ export type AttributeTypes = {
   [AttributeKind.StringFormat]: StringFormat;
   [AttributeKind.StringKind]: StringKind;
   [AttributeKind.StringLength]: number;
+  [AttributeKind.TransmissionDirection]: TransmissionDirection;
   [AttributeKind.Variable]: boolean;
   [AttributeKind.Volatility]: Volatility;
 };
@@ -206,6 +210,7 @@ export const AttributeKindsByDataType: Record<DataType, AttributeKind[]> = {
     AttributeKind.AccessMode,
     AttributeKind.BufferMode,
     AttributeKind.FileUsage,
+    AttributeKind.TransmissionDirection,
   ],
   [DataType.Format]: [...CommonAttributeKinds],
   [DataType.Label]: [...CommonAttributeKinds],
@@ -585,9 +590,16 @@ export enum FileUsage {
   Stream,
 }
 
+export enum TransmissionDirection {
+  Input,
+  Output,
+  Update,
+}
+
 interface FileTypeDescriptionProps extends BaseTypeDescriptionProps {
   accessMode: AccessMode;
   bufferMode: BufferMode;
+  transmissionDirection: TransmissionDirection;
   usage: FileUsage;
 }
 
@@ -603,6 +615,7 @@ function createFileTypeDescription({
   bufferMode = accessMode === AccessMode.Sequential
     ? BufferMode.Buffered
     : BufferMode.Unbuffered,
+  transmissionDirection = TransmissionDirection.Input,
   ...base
 }: Partial<FileTypeDescriptionProps>): FileTypeDescription {
   return {
@@ -610,6 +623,7 @@ function createFileTypeDescription({
     ...createBaseTypeDescription(FileType, base),
     accessMode,
     bufferMode,
+    transmissionDirection,
     usage,
   };
 }
@@ -1017,6 +1031,9 @@ export const Implications: Partial<Implications> = {
   [AttributeKind.StringLength]: {
     [AttributeKind.DataType]: () => DataType.String,
   },
+  [AttributeKind.TransmissionDirection]: {
+    [AttributeKind.DataType]: () => DataType.File,
+  },
   [AttributeKind.Variable]: undefined,
   [AttributeKind.Volatility]: undefined,
 };
@@ -1162,6 +1179,7 @@ export namespace TypeDescriptions {
     [AttributeKind.StringKind]: StringKind.Bit,
     [AttributeKind.StringFormat]: StringFormat.Varying,
     [AttributeKind.StringLength]: 0,
+    [AttributeKind.TransmissionDirection]: TransmissionDirection.Input,
   };
 
   export function createPrimitive(
@@ -1236,6 +1254,9 @@ export namespace TypeDescriptions {
           bufferMode:
             attributes[AttributeKind.BufferMode]?.value ??
             DefaultValues[AttributeKind.BufferMode],
+          transmissionDirection:
+            attributes[AttributeKind.TransmissionDirection]?.value ??
+            DefaultValues[AttributeKind.TransmissionDirection],
           usage:
             attributes[AttributeKind.FileUsage]?.value ??
             DefaultValues[AttributeKind.FileUsage],

--- a/packages/language/src/typesystem/primitive-type-builder.ts
+++ b/packages/language/src/typesystem/primitive-type-builder.ts
@@ -50,6 +50,7 @@ import {
   Precisions,
   AttributeWitness,
   Implications,
+  TransmissionDirection,
 } from "./descriptions";
 
 function createEmptyAttributeWitnesses(): AttributeWitnesses {
@@ -553,14 +554,22 @@ export class DefaultPrimitiveTypeBuilder implements PrimitiveTypeBuilder {
         break;
       }
 
+      /**
+       * File transmission direction attributes
+       * @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=files-input-output-update-attributes
+       */
       case DefaultAttributeEnum.INPUT:
       case DefaultAttributeEnum.UPDATE:
       case DefaultAttributeEnum.OUTPUT: {
-        //TODO add a attribute kind for transmission direction
-        //https://www.ibm.com/docs/en/epfz/6.1.0?topic=files-input-output-update-attributes
+        const mapTo = {
+          [DefaultAttributeEnum.INPUT]: TransmissionDirection.Input,
+          [DefaultAttributeEnum.OUTPUT]: TransmissionDirection.Output,
+          [DefaultAttributeEnum.UPDATE]: TransmissionDirection.Update,
+        };
+        const attributeValue = mapTo[typeAsEnum];
         this.addAttributeWitness(
-          AttributeKind.DataType,
-          DataType.File,
+          AttributeKind.TransmissionDirection,
+          attributeValue,
           attribute,
           token,
         );

--- a/packages/language/test/fourslash-harness/harness-interface.ts
+++ b/packages/language/test/fourslash-harness/harness-interface.ts
@@ -43,6 +43,7 @@ import {
   StorageConnection,
   StringFormat,
   StringKind,
+  TransmissionDirection,
   TypeDescriptions,
   Volatility,
 } from "../../src/typesystem/descriptions";
@@ -92,6 +93,7 @@ export interface HarnessTesterInterface {
     storageClasses: typeof StorageClass;
     stringFormats: typeof StringFormat;
     stringKinds: typeof StringKind;
+    transmissionDirections: typeof TransmissionDirection;
     volatilities: typeof Volatility;
   };
 

--- a/packages/language/test/fourslash-harness/implementation/type-atttributes.ts
+++ b/packages/language/test/fourslash-harness/implementation/type-atttributes.ts
@@ -18,6 +18,7 @@ import {
   StorageConnection,
   StringFormat,
   StringKind,
+  TransmissionDirection,
   Volatility,
 } from "../../../src/typesystem/descriptions";
 import { HarnessTesterInterface } from "../harness-interface";
@@ -48,5 +49,6 @@ export const HarnessTypeAttributes: Omit<
   storageClasses: StorageClass,
   stringFormats: StringFormat,
   stringKinds: StringKind,
+  transmissionDirections: TransmissionDirection,
   volatilities: Volatility,
 };

--- a/packages/language/test/fourslash/validate/typesystem/declare/dcl-file-input-output-triggers-error.ts
+++ b/packages/language/test/fourslash/validate/typesystem/declare/dcl-file-input-output-triggers-error.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: main
+//// DCL <|1:ANYTHING|> FILE INPUT <|OUTPUT|>;
+
+verify.expectDiagnosticsAt('OUTPUT', code.Error.IBM2462I);
+types.expectTypeAt(1, {
+  type: types.dataTypes.File,
+  transmissionDirection: types.transmissionDirections.Input,
+});

--- a/packages/language/test/fourslash/validate/typesystem/declare/dcl-file-input-output-triggers-error.ts
+++ b/packages/language/test/fourslash/validate/typesystem/declare/dcl-file-input-output-triggers-error.ts
@@ -14,7 +14,7 @@
 // @wrap: main
 //// DCL <|1:ANYTHING|> FILE INPUT <|OUTPUT|>;
 
-verify.expectDiagnosticsAt('OUTPUT', code.Error.IBM2462I);
+verify.expectDiagnosticsAt("OUTPUT", code.Error.IBM2462I);
 types.expectTypeAt(1, {
   type: types.dataTypes.File,
   transmissionDirection: types.transmissionDirections.Input,

--- a/packages/language/test/fourslash/validate/typesystem/declare/dcl-file-input.ts
+++ b/packages/language/test/fourslash/validate/typesystem/declare/dcl-file-input.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: main
+//// DCL <|1:ANYTHING|> FILE INPUT;
+
+verify.noDiagnostics(undefined, ...code.TypeSystem);
+types.expectTypeAt(1, {
+  type: types.dataTypes.File,
+  transmissionDirection: types.transmissionDirections.Input,
+});


### PR DESCRIPTION
`INPUT` / `OUTPUT` / `UPDATE` are transmission direction attributes.
Before this change they were only taking care that the variable becomes `FILE`-typed, which caused a false positive when the variable was already declared as `FILE` (it was flagged as a duplicated attribute).