### PR TITLE
[Feature] Implement caching for hover

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
     "overrides": {
       "isexe": "3.1.1"
     }
+  },
+  "dependencies": {
+    "lru-cache": "^11.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,8 +33,5 @@
     "overrides": {
       "isexe": "3.1.1"
     }
-  },
-  "dependencies": {
-    "lru-cache": "^11.2.2"
   }
 }

--- a/packages/language/package.json
+++ b/packages/language/package.json
@@ -42,11 +42,12 @@
     "chevrotain": "^11.0.3",
     "chevrotain-allstar": "^0.3.1",
     "lodash-es": "^4.17.21",
+    "lru-cache": "^11.2.2",
+    "minimatch": "^10.0.3",
     "vscode-languageserver": "~9.0.1",
-    "vscode-languageserver-types": "^3.17.5",
     "vscode-languageserver-textdocument": "^1.0.12",
-    "vscode-uri": "^3.1.0",
-    "minimatch": "^10.0.3"
+    "vscode-languageserver-types": "^3.17.5",
+    "vscode-uri": "^3.1.0"
   },
   "devDependencies": {
     "@types/lodash-es": "^4.17.12"

--- a/packages/language/src/language-server/cache/include-cache.ts
+++ b/packages/language/src/language-server/cache/include-cache.ts
@@ -21,7 +21,7 @@ export function getFileContentPreview(
 ) {
   const partialContent = unit.services.includeCache.get(key);
   if (partialContent) {
-    return partialContent.toString();
+    return partialContent;
   }
   // load up the first (LINE_CUTOFF) lines of content from the file (semi-arbitrary cutoff)
   const fileContent = document.getText({

--- a/packages/language/src/language-server/cache/include-cache.ts
+++ b/packages/language/src/language-server/cache/include-cache.ts
@@ -1,0 +1,38 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { CompilationUnit } from "../../workspace/compilation-unit";
+
+const DEFAULT_LINE_CUTOFF = 100;
+
+export function getFileContentPreview(
+  unit: CompilationUnit,
+  key: string,
+  document: TextDocument,
+  lineCutoff = DEFAULT_LINE_CUTOFF,
+) {
+  const partialContent = unit.services.includeCache.get(key);
+  if (partialContent) {
+    return partialContent.toString();
+  }
+  // load up the first (LINE_CUTOFF) lines of content from the file (semi-arbitrary cutoff)
+  const fileContent = document.getText({
+    start: { line: 0, character: 0 },
+    end: { line: lineCutoff, character: 0 },
+  });
+  const partialContentText =
+    document.getText().length > fileContent.length
+      ? fileContent + "\n...\n"
+      : fileContent;
+
+  unit.services.includeCache.set(key, partialContentText);
+  return partialContentText;
+}

--- a/packages/language/src/language-server/hover-request.ts
+++ b/packages/language/src/language-server/hover-request.ts
@@ -37,6 +37,7 @@ import { URI } from "../utils/uri";
 import { retrieveProcedureFromLabelPrefix } from "../validation/utils";
 import { CompilationUnit } from "../workspace/compilation-unit";
 import { HoverResponse, tokenToRange } from "./types";
+import { getFileContentPreview } from "./cache/include-cache";
 
 type MarkupResponse = string | null;
 
@@ -247,31 +248,14 @@ function getIncludeItemRepresentation(
   if (!node.filePath || !node.relativeFilePath) {
     return null;
   }
-
-  // TODO: Don't store the file content in the node itself
-  // Instead, implement a proper caching mechanism
-  let partialContent = node.sourceText;
   const fileUri = URI.parse(node.filePath);
-
-  if (!partialContent) {
-    // load up the first 20 lines of content from the file (semi-arbitrary cutoff)
-    const lineCutoff = 20;
-    const doc = unit.services.files.getDocument(fileUri);
-    if (!doc) {
-      return null;
-    }
-    const fileContent = doc.getText({
-      start: { line: 0, character: 0 },
-      end: { line: lineCutoff + 1, character: 0 },
-    });
-    const lineCount = fileContent.matchAll(/\n/g);
-    partialContent =
-      Array.from(lineCount).length > lineCutoff
-        ? fileContent + "\n...\n"
-        : fileContent;
-    // cache for later requests
-    node.sourceText = partialContent;
+  const doc = unit.services.files.getDocument(fileUri);
+  if (!doc) {
+    return null;
   }
+  const partialContent = getFileContentPreview(unit, node.filePath, doc);
+  if (!partialContent) return null;
+
   return generateIncludeItemMarkup(type, node.relativeFilePath, partialContent);
 }
 

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -53,6 +53,7 @@ import {
   getDefaultCompilerOptions,
 } from "../preprocessor/compiler-options/options.js";
 import { DiagnosticsStore } from "../validation/diagnostics-store.js";
+import { LRUCache } from "lru-cache";
 
 /**
  * A compilation unit is a representation of a PL/I program in the language server.
@@ -90,11 +91,13 @@ export interface CompilationUnit {
 export interface CompilationServices {
   files: FileStore;
   typeCache: TypeCache;
+  includeCache: LRUCache<string, string>;
   inferer: TypeInferer;
 }
 
 const BuiltinFileStart = `${BuiltinsUriSchema}:/`;
 const isBuiltinFile = (uri: URI) => uri.toString().startsWith(BuiltinFileStart);
+const FIVE_MINUTES = 1000 * 60 * 5;
 
 function createBuiltinScopeGetter(builtinDocument: TextDocument) {
   let builtinFileScope: Scope | undefined;
@@ -129,6 +132,10 @@ export async function createCompilationUnit(
   const services: CompilationServices = {
     files: new FileStore(),
     typeCache: new DefaultTypeCache(),
+    includeCache: new LRUCache({
+      max: 500,
+      ttl: FIVE_MINUTES,
+    }),
     inferer: new DefaultTypeInferer(),
   };
   const unit: CompilationUnit = {
@@ -263,6 +270,8 @@ export class CompilationUnitHandler {
       return;
     }
     await this.process(unit, document, this.connection, cancellationToken);
+    // TODO: Wagner Laranjeiras -> includeCache based on changes of a specific file.
+    unit.services.includeCache.clear();
     unit.requestCaches.revalidateAll({ connection: this.connection, unit });
   }
 

--- a/packages/language/test/lsp/include-cache.test.ts
+++ b/packages/language/test/lsp/include-cache.test.ts
@@ -1,0 +1,83 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+import { describe, test, expect, afterEach } from "vitest";
+
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { URI } from "../../src/utils/uri";
+import { getFileContentPreview } from "../../src/language-server/cache/include-cache";
+import { parse } from "../utils";
+
+const mockCode = Array.from(
+  { length: 100 },
+  (_, i) => `DCL Var${i + 1} FIXED;`,
+).join("\n");
+const mockPath = URI.file("/test.pli").toString();
+const mockDocument = TextDocument.create(mockPath, "pli", 1, mockCode);
+const mockUnit = await parse(mockDocument.getText(), { validate: false });
+
+afterEach(() => {
+  mockUnit.services.includeCache.clear();
+});
+
+//
+// ----------------------------------------------------------
+// Include Cache tests
+// ----------------------------------------------------------
+describe("getFileContentPreview", () => {
+  test("Returns full content when file has less than specificied lines", () => {
+    const result = getFileContentPreview(mockUnit, mockPath, mockDocument);
+    expect(result).toBeDefined();
+    expect(result).toBe(mockCode);
+  });
+  test("Returns cached value on second call", () => {
+    expect(mockUnit.services.includeCache.get(mockPath)).toBeUndefined();
+    const result = getFileContentPreview(mockUnit, mockPath, mockDocument, 150);
+    expect(mockUnit.services.includeCache.get(mockPath)).toBeDefined();
+    expect(result).toBe(mockCode);
+  });
+  test("Uses correct cache key", () => {
+    const resultOne = getFileContentPreview(
+      mockUnit,
+      mockPath,
+      mockDocument,
+      150,
+    );
+    expect(mockUnit.services.includeCache.get(mockPath)).toBeDefined();
+    expect(
+      mockUnit.services.includeCache.get(`${mockPath}v02`),
+    ).toBeUndefined();
+    const resultTwo = getFileContentPreview(
+      mockUnit,
+      `${mockPath}v02`,
+      mockDocument,
+      150,
+    );
+    expect(mockUnit.services.includeCache.get(`${mockPath}v02`)).toBeDefined();
+
+    expect(resultOne).toBe(mockCode);
+    expect(resultTwo).toBe(mockCode);
+  });
+
+  test("Returns partial content when not cached / when file has more than specified lines", () => {
+    const result = getFileContentPreview(mockUnit, mockPath, mockDocument, 5);
+    expect(result).toBeDefined();
+    expect(result).toBe(
+      `DCL Var1 FIXED;
+DCL Var2 FIXED;
+DCL Var3 FIXED;
+DCL Var4 FIXED;
+DCL Var5 FIXED;
+
+...
+`,
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,10 @@ overrides:
 importers:
 
   .:
+    dependencies:
+      lru-cache:
+        specifier: ^11.2.2
+        version: 11.2.2
     devDependencies:
       '@types/node':
         specifier: ^18.19.113

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,10 +10,6 @@ overrides:
 importers:
 
   .:
-    dependencies:
-      lru-cache:
-        specifier: ^11.2.2
-        version: 11.2.2
     devDependencies:
       '@types/node':
         specifier: ^18.19.113
@@ -60,6 +56,9 @@ importers:
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
+      lru-cache:
+        specifier: ^11.2.2
+        version: 11.2.2
       minimatch:
         specifier: ^10.0.3
         version: 10.0.3


### PR DESCRIPTION
Issue #450

**Summary**
This PR introduces an in-memory caching layer for include file content previews, improving performance and reducing redundant file reads. The implementation uses an LRUCache with a five-minute TTL to store truncated file content for hover previews and related operations.

**Key Changes**

- Added an LRU cache (includeCache) for storing file preview content.
- Implemented a new utility function getFileContentPreview() that:
- Returns cached preview content if available.
- Reads the first N lines of a file (default: 100) when not cached.
- Automatically stores new entries in the cache.
- Exposed a limited API (includeCacheApi) with only the necessary read/write operations (get, set, has, clear), rather than exporting the entire cache object.
- Added constants for TTL (FIVE_MINUTES) and DEFAULT_LINE_CUTOFF for easier configuration and testing.