### PR TITLE
Macro pp effects

### DIFF
--- a/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
+++ b/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
@@ -16,6 +16,7 @@ import {
   CodeAction,
   CodeActionKind,
   Diagnostic,
+  TextEdit,
 } from "vscode-languageserver-types";
 import {
   PluginConfigurationProviderInstance,
@@ -115,6 +116,31 @@ export async function quickFixCreateConfig(
   return action;
 }
 
+export function quickFixUppercaseText(
+  diagnostic: Diagnostic,
+): CodeAction | undefined {
+  const range = diagnostic.range;
+  if (!diagnostic.data || !diagnostic.data.text || !diagnostic.data.uri) {
+    console.error("Diagnostic data is missing for quick fix uppercase text.");
+    return undefined;
+  }
+  const text = diagnostic.data.text;
+  const uri = diagnostic.data.uri;
+
+  const action: CodeAction = {
+    title: `Convert to uppercase`,
+    kind: CodeActionKind.QuickFix,
+    diagnostics: [diagnostic],
+    edit: {
+      changes: {
+        [uri]: [TextEdit.replace(range, text.toUpperCase())],
+      },
+    },
+  };
+
+  return action;
+}
+
 export async function applyQuickFixes(
   diagnostics: Diagnostic[],
 ): Promise<CodeAction[] | undefined> {
@@ -124,6 +150,7 @@ export async function applyQuickFixes(
   const CODE_MISSING_CONFIG = fullCode(
     LspCodes.IncludeResolution.MissingConfiguration,
   ); // "Could not resolve include directive. Plugin configuration is missing"
+  const CODE_MACRO_CASE = fullCode(LspCodes.UpperCase);
 
   for (const diagnostic of diagnostics) {
     if (!diagnostic.code) {
@@ -137,6 +164,10 @@ export async function applyQuickFixes(
         break;
       case CODE_MISSING_CONFIG:
         action = await quickFixCreateConfig(diagnostic);
+        if (action) actions.push(action);
+        break;
+      case CODE_MACRO_CASE:
+        action = quickFixUppercaseText(diagnostic);
         if (action) actions.push(action);
         break;
     }

--- a/packages/language/src/language-server/code-actions/apply-source-actions.ts
+++ b/packages/language/src/language-server/code-actions/apply-source-actions.ts
@@ -1,0 +1,106 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import {
+  CodeAction,
+  CodeActionKind,
+  Diagnostic,
+  TextEdit,
+} from "vscode-languageserver-types";
+import { URI } from "../../utils/uri";
+import { CompilationUnitHandler } from "../../workspace/compilation-unit";
+import { diagnosticToLSP, fullCode } from "../types";
+import { LspCodes } from "../../validation/lsp-codes";
+
+export function sourceActionUppercaseAllText(
+  caseDiagnostics: Diagnostic[],
+): CodeAction {
+  // Group diagnostics by URI
+  const diagnosticsByUri: { [uri: string]: Diagnostic[] } = {};
+
+  for (const diagnostic of caseDiagnostics) {
+    if (!diagnostic.data || !diagnostic.data.uri) {
+      console.error(
+        "Diagnostic data is missing for source action uppercase all text.",
+      );
+      continue;
+    }
+    const uri = diagnostic.data.uri;
+    if (!diagnosticsByUri[uri]) {
+      diagnosticsByUri[uri] = [];
+    }
+    diagnosticsByUri[uri].push(diagnostic);
+  }
+
+  // Create text edits for each file
+  const changes: { [uri: string]: TextEdit[] } = {};
+
+  for (const [uri, diagnostics] of Object.entries(diagnosticsByUri)) {
+    changes[uri] = diagnostics
+      .filter((d) => d.range && d.data?.text)
+      .map((diagnostic) =>
+        TextEdit.replace(
+          diagnostic.range!,
+          (diagnostic.data?.text || "").toUpperCase(),
+        ),
+      );
+  }
+
+  const action: CodeAction = {
+    title: `Convert all to uppercase (${caseDiagnostics.length} instances)`,
+    kind: CodeActionKind.SourceFixAll,
+    diagnostics: caseDiagnostics,
+    edit: {
+      changes,
+    },
+  };
+
+  return action;
+}
+
+export function getCaseDiagnosticsFromCompilationUnit(
+  uri: string,
+  compilationUnitHandler: CompilationUnitHandler,
+): Diagnostic[] {
+  try {
+    const unit = compilationUnitHandler.getCompilationUnit(URI.parse(uri));
+    if (!unit) return [];
+
+    const caseDiagnostics = unit.diagnostics
+      .getAll()
+      .filter((d) => d.code === fullCode(LspCodes.UpperCase));
+
+    return caseDiagnostics
+      .map((d) => diagnosticToLSP(unit, d))
+      .filter((d) => d !== undefined) as Diagnostic[];
+  } catch (error) {
+    return [];
+  }
+}
+
+export async function applySourceActions(
+  uri: string,
+  compilationUnitHandler: CompilationUnitHandler,
+): Promise<CodeAction[] | undefined> {
+  const actions: CodeAction[] = [];
+
+  const caseDiagnostics = getCaseDiagnosticsFromCompilationUnit(
+    uri,
+    compilationUnitHandler,
+  );
+  if (caseDiagnostics.length > 0) {
+    const fixAllAction = sourceActionUppercaseAllText(caseDiagnostics);
+    actions.push(fixAllAction);
+  }
+
+  if (!actions.length) return undefined;
+  return actions;
+}

--- a/packages/language/src/language-server/connection-handler.ts
+++ b/packages/language/src/language-server/connection-handler.ts
@@ -21,7 +21,7 @@ import { definitionRequest } from "./definition-request";
 import { referencesRequest } from "./references-request";
 import { semanticTokenLegend, semanticTokens } from "./semantic-tokens";
 import {
-  CodeAction,
+  CodeActionKind,
   Diagnostic,
   Location,
   TextEdit,
@@ -41,6 +41,7 @@ import { completionRequest } from "./completion/completion-request";
 import { hoverRequest } from "./hover-request";
 import { Mutex } from "../workspace/mutex";
 import { applyQuickFixes } from "./code-actions/apply-quick-fixes";
+import { applySourceActions } from "./code-actions/apply-source-actions";
 import { commandCreateConfig, commandResolveInclude } from "./commands";
 import { Commands, PluginConfiguration } from "./constants";
 export { PluginConfiguration } from "./constants";
@@ -90,7 +91,12 @@ export function startLanguageServer(connection: Connection): void {
         renameProvider: true,
         definitionProvider: true,
         referencesProvider: true,
-        codeActionProvider: true,
+        codeActionProvider: {
+          codeActionKinds: [
+            CodeActionKind.QuickFix,
+            CodeActionKind.SourceFixAll,
+          ],
+        },
         executeCommandProvider: {
           commands: [Commands.RESOLVE_INCLUDE, Commands.CREATE_CONFIG],
         },
@@ -325,13 +331,24 @@ export function startLanguageServer(connection: Connection): void {
 
   connection.onCodeAction(async (params) => {
     return Mutex.read(async () => {
-      const diagnostics = params.context.diagnostics as Diagnostic[];
-      if (!diagnostics.length) return;
-      const actions: CodeAction[] | undefined =
-        await applyQuickFixes(diagnostics);
-      if (!actions) return;
+      const requestedKinds = params.context.only;
+      const isSourceActionRequest =
+        requestedKinds?.includes(CodeActionKind.SourceFixAll) ||
+        requestedKinds?.includes(CodeActionKind.Source);
 
-      return actions;
+      if (isSourceActionRequest) {
+        const sourceActions = await applySourceActions(
+          params.textDocument.uri,
+          compilationUnitHandler,
+        );
+        return sourceActions || [];
+      } else {
+        const diagnostics = params.context.diagnostics as Diagnostic[];
+        if (!diagnostics || !diagnostics.length) return [];
+
+        const actions = await applyQuickFixes(diagnostics);
+        return actions || [];
+      }
     });
   });
 

--- a/packages/language/src/preprocessor/compiler-options/codes.ts
+++ b/packages/language/src/preprocessor/compiler-options/codes.ts
@@ -117,6 +117,13 @@ export const CompilerOptionsCodes = {
       `Expected one of '${values.splice(1).join("', '")}', but received '${values[0]}'.`,
   } as ParametricPLICode,
 
+  OptionNotSupported: {
+    code: "COOP13",
+    severity: Severity.W,
+    message: (option: string) =>
+      `The compiler option '${option}' is recognized but not supported by this preprocessor.`,
+  } as ParametricPLICode,
+
   Assert: {
     InvalidParameter: {
       code: "COAS01",

--- a/packages/language/src/preprocessor/compiler-options/options-macro.ts
+++ b/packages/language/src/preprocessor/compiler-options/options-macro.ts
@@ -12,8 +12,8 @@
 export interface CompilerOptions {
   case?: CompilerOptions.Case;
   dbcs?: CompilerOptions.Dbcs;
-  deprecate?: string[];
-  deprecateNext?: string[];
+  deprecate?: Set<string>;
+  deprecateNext?: Set<string>;
   eolComm?: boolean;
   fixed?: CompilerOptions.Fixed;
   id?: string;
@@ -41,8 +41,8 @@ export namespace CompilerOptions {
 const defaultCompilerOptions: CompilerOptions = {
   case: "ASIS",
   dbcs: "INEXACT",
-  deprecate: [],
-  deprecateNext: [],
+  deprecate: new Set(),
+  deprecateNext: new Set(),
   eolComm: true,
   fixed: "DECIMAL",
   id: "",

--- a/packages/language/src/preprocessor/compiler-options/translator-macro.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator-macro.ts
@@ -33,7 +33,7 @@ translator.rule(["CASE"], (option, options) => {
   );
 });
 
-translator.rule(["DBCS"], (option, options) => {
+translator.rule(["DBCS"], (option, options, acceptor) => {
   ensureArguments(option, 1, 1);
   const value = option.values[0];
   ensureType(value, "plain");
@@ -42,11 +42,18 @@ translator.rule(["DBCS"], (option, options) => {
     CompilerOptionsCodes.PPMacro.Dbcs.InvalidParameter,
     ["EXACT", "INEXACT"],
   );
+  acceptor(
+    diagnosticFromCode(
+      CompilerOptionsCodes.OptionNotSupported,
+      option.token,
+      "DBCS",
+    ),
+  );
 });
 
 translator.rule(["DEPRECATE"], (option, options) => {
   ensureArguments(option, 1);
-  options.deprecate = [];
+  options.deprecate = new Set<string>();
   for (const value of option.values) {
     ensureType(value, "option");
     if (value.name !== "ENTRY") {
@@ -60,14 +67,14 @@ translator.rule(["DEPRECATE"], (option, options) => {
     // ENTRY() is valid.
     for (const entry of value.values) {
       ensureType(entry, "plain");
-      options.deprecate.push(entry.value as string);
+      options.deprecate.add(entry.value as string);
     }
   }
 });
 
 translator.rule(["DEPRECATENEXT"], (option, options) => {
   ensureArguments(option, 1);
-  options.deprecateNext = [];
+  options.deprecateNext = new Set<string>();
   for (const value of option.values) {
     ensureType(value, "option");
     if (value.name !== "ENTRY") {
@@ -81,12 +88,18 @@ translator.rule(["DEPRECATENEXT"], (option, options) => {
     // ENTRY() is valid.
     for (const entry of value.values) {
       ensureType(entry, "plain");
-      options.deprecateNext.push(entry.value as string);
+      options.deprecateNext.add(entry.value as string);
     }
   }
 });
 
-translator.flag("eolComm", ["EOLCOMM"], ["NOEOLCOMM"]);
+translator.flag("eolComm", ["EOLCOMM"], ["NOEOLCOMM"], (option) => {
+  throw diagnosticFromCode(
+    CompilerOptionsCodes.OptionNotSupported,
+    option.token,
+    "EOLCOMM",
+  );
+});
 
 translator.rule(["FIXED"], (option, options) => {
   ensureArguments(option, 1, 1);
@@ -127,7 +140,13 @@ translator.rule(
   },
 );
 
-translator.flag("incOnly", ["INCONLY"], ["NOINCONLY"]);
+translator.flag("incOnly", ["INCONLY"], ["NOINCONLY"], (option) => {
+  throw diagnosticFromCode(
+    CompilerOptionsCodes.OptionNotSupported,
+    option.token,
+    "INCONLY",
+  );
+});
 
 translator.rule(
   ["NAMEPREFIX"],

--- a/packages/language/src/preprocessor/compiler-options/translator.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator.ts
@@ -81,17 +81,24 @@ export class Translator<T extends CompilerOptionsPP = CompilerOptionsPP> {
     });
   }
 
-  flag(key: keyof T, positive: string[], negative: string[]) {
+  flag(
+    key: keyof T,
+    positive: string[],
+    negative: string[],
+    callback?: (option: CompilerOption, options: T) => void,
+  ) {
     this.rules.push({
       positive,
       positiveTranslate: (option, options) => {
         ensureArguments(option, 0, 0);
         (options as any)[key] = true;
+        callback?.(option, options);
       },
       negative,
       negativeTranslate: (option, options) => {
         ensureArguments(option, 0, 0);
         (options as any)[key] = false;
+        callback?.(option, options);
       },
     });
   }

--- a/packages/language/src/validation/lsp-codes.ts
+++ b/packages/language/src/validation/lsp-codes.ts
@@ -10,7 +10,7 @@
  */
 
 import { Severity } from "../language-server/types";
-import { SimplePLICode } from "./pli-codes";
+import { ParametricPLICode, SimplePLICode } from "./pli-codes";
 
 export const LspCodes = {
   IncludeResolution: {
@@ -21,4 +21,10 @@ export const LspCodes = {
         "Could not resolve include directive. Plugin configuration is missing",
     } as SimplePLICode,
   },
+
+  UpperCase: {
+    code: "LSPUC001",
+    severity: Severity.W,
+    message: (token: any) => `Input text "${token}" must be uppercase.`,
+  } as ParametricPLICode,
 };

--- a/packages/language/src/validation/macro/case.ts
+++ b/packages/language/src/validation/macro/case.ts
@@ -1,0 +1,73 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { diagnosticFromCode } from "../../language-server/types";
+import * as AST from "../../syntax-tree/ast";
+import { ValidationAcceptor } from "../validator";
+import { CompilationUnit } from "../../workspace/compilation-unit";
+import { Token } from "../../parser/tokens";
+import {
+  TraversalState,
+  traverseAllNodes,
+} from "../../syntax-tree/ast-iterator";
+import { PreprocessorTokens } from "../../preprocessor/pli-preprocessor-tokens";
+import { MultiMap } from "../../utils/collections";
+import { LspCodes } from "../lsp-codes";
+
+export function MACRO_Case(
+  node: AST.Program,
+  acceptor: ValidationAcceptor,
+  compilationUnit: CompilationUnit,
+) {
+  if (node !== compilationUnit.preprocessorAst) return;
+  if (compilationUnit.compilerOptions.macroOptions.case !== "UPPER") return;
+
+  const tokens = collectPreprocessorTokens(compilationUnit).filter(
+    (token) =>
+      token.tokenType?.tokenTypeIdx !== PreprocessorTokens.String.tokenTypeIdx,
+  );
+
+  for (const token of tokens) {
+    if (/[a-z]/.test(token.originalImage)) {
+      const diagnostic = diagnosticFromCode(
+        LspCodes.UpperCase,
+        token,
+        token.image,
+      );
+      // Diagnostic data needed for the quickfix
+      diagnostic.data = {
+        uri: diagnostic.uri,
+        text: token.originalImage,
+      };
+      acceptor(diagnostic);
+    }
+  }
+}
+
+function collectPreprocessorTokens(unit: CompilationUnit): Token[] {
+  const tokens: Token[] = [];
+  const tokenMap = new MultiMap<AST.SyntaxNode, Token>();
+  for (const token of unit.services.files.getAllTokens()) {
+    if (token.element) {
+      tokenMap.add(token.element, token);
+    }
+  }
+
+  traverseAllNodes(unit.preprocessorAst, (child) => {
+    const nodeTokens = tokenMap.get(child);
+    if (nodeTokens.length > 0) {
+      tokens.push(...nodeTokens);
+    }
+    return TraversalState.Continue;
+  });
+
+  return tokens;
+}

--- a/packages/language/src/validation/macro/deprecate.ts
+++ b/packages/language/src/validation/macro/deprecate.ts
@@ -1,0 +1,62 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { diagnosticFromCode } from "../../language-server/types";
+import * as AST from "../../syntax-tree/ast";
+import { ValidationAcceptor } from "../validator";
+import { CompilationUnit } from "../../workspace/compilation-unit";
+import { PLICodes } from "../pli-codes";
+
+export function MACRO_Deprecate(
+  node: AST.ProcedureStatement,
+  acceptor: ValidationAcceptor,
+  compilationUnit: CompilationUnit,
+) {
+  if (
+    !compilationUnit.compilerOptions.macroOptions.deprecate &&
+    !compilationUnit.compilerOptions.macroOptions.deprecateNext
+  ) {
+    return;
+  }
+
+  if (
+    compilationUnit.compilerOptions.macroOptions.deprecate?.size === 0 &&
+    compilationUnit.compilerOptions.macroOptions.deprecateNext?.size === 0
+  ) {
+    return;
+  }
+
+  const nameTokens =
+    node.container?.kind === AST.SyntaxKind.Statement
+      ? node.container.labels
+          ?.map((label) => label.nameToken)
+          .filter((token) => token !== null) || []
+      : [];
+
+  if (!nameTokens.length) return;
+
+  for (const nameToken of nameTokens) {
+    const name = nameToken.image;
+
+    if (
+      compilationUnit.compilerOptions.macroOptions.deprecate &&
+      compilationUnit.compilerOptions.macroOptions.deprecate.has(name)
+    ) {
+      acceptor(diagnosticFromCode(PLICodes.Error.IBM3660I, nameToken, name));
+    }
+    if (
+      compilationUnit.compilerOptions.macroOptions.deprecateNext &&
+      compilationUnit.compilerOptions.macroOptions.deprecateNext.has(name)
+    ) {
+      acceptor(diagnosticFromCode(PLICodes.Warning.IBM3334I, nameToken, name));
+    }
+  }
+}

--- a/packages/language/src/validation/macro/nameprefix.ts
+++ b/packages/language/src/validation/macro/nameprefix.ts
@@ -1,0 +1,58 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { diagnosticFromCode } from "../../language-server/types";
+import * as AST from "../../syntax-tree/ast";
+import { ValidationAcceptor } from "../validator";
+import { CompilationUnit } from "../../workspace/compilation-unit";
+import { Token } from "../../parser/tokens";
+import { PLICodes } from "../pli-codes";
+
+export function MACRO_NamePrefix(
+  node: AST.ProcedureStatement | AST.DeclaredVariable,
+  acceptor: ValidationAcceptor,
+  compilationUnit: CompilationUnit,
+) {
+  if (!compilationUnit.compilerOptions.macroOptions.namePrefix) {
+    return;
+  }
+
+  let nameTokens: Token[];
+  let name;
+
+  if (node.kind === AST.SyntaxKind.DeclaredVariable) {
+    nameTokens = node.nameToken !== null ? [node.nameToken] : [];
+  } else {
+    nameTokens =
+      node.container?.kind === AST.SyntaxKind.Statement
+        ? node.container.labels
+            ?.map((label) => label.nameToken)
+            .filter((token) => token !== null) || []
+        : [];
+  }
+
+  if (!nameTokens.length) return;
+
+  for (const nameToken of nameTokens) {
+    name = nameToken.originalImage;
+    if (
+      !nameToken ||
+      !name ||
+      name.startsWith(
+        compilationUnit.compilerOptions.macroOptions.namePrefix.character,
+      )
+    ) {
+      continue;
+    }
+
+    acceptor(diagnosticFromCode(PLICodes.Error.IBM3518I, nameToken, name));
+  }
+}

--- a/packages/language/src/validation/pp-validator.ts
+++ b/packages/language/src/validation/pp-validator.ts
@@ -1,5 +1,8 @@
 import { IBM3323I_IBM3324I_check_argument_count } from "./compiler/IBM3323I-IBM3324I-check-argument-count";
 import { IBM3970IS_IBM3971IS_check_pp_call_procedure } from "./compiler/IBM3970-IBM3971-call-procedure";
+import { MACRO_Deprecate } from "./macro/deprecate";
+import { MACRO_NamePrefix } from "./macro/nameprefix";
+import { MACRO_Case } from "./macro/case";
 import { ValidationChecks } from "./validator";
 
 export function registerPreprocessorValidationChecks(): ValidationChecks {
@@ -8,5 +11,8 @@ export function registerPreprocessorValidationChecks(): ValidationChecks {
       IBM3323I_IBM3324I_check_argument_count,
       IBM3970IS_IBM3971IS_check_pp_call_procedure,
     ],
+    DeclaredVariable: [MACRO_NamePrefix],
+    Program: [MACRO_Case],
+    ProcedureStatement: [MACRO_Deprecate, MACRO_NamePrefix],
   };
 }

--- a/packages/language/src/workspace/file-store.ts
+++ b/packages/language/src/workspace/file-store.ts
@@ -31,6 +31,12 @@ export class FileStore {
     return this.get(uri)?.tokens;
   }
 
+  *getAllTokens(): IterableIterator<Token> {
+    for (const file of this.map.values()) {
+      yield* file.tokens;
+    }
+  }
+
   getDocument(uri: URI | string): TextDocument | undefined {
     // Builtin documents are not stored on the compilation unit
     // To respond to LSP requests, we need to return them anyway

--- a/packages/language/test/fourslash-harness/harness-interface.ts
+++ b/packages/language/test/fourslash-harness/harness-interface.ts
@@ -48,6 +48,7 @@ import {
   TypeDescriptions,
   Volatility,
 } from "../../src/typesystem/descriptions";
+import { LspCodes } from "../../src/validation/lsp-codes";
 
 type SemanticTokenTypesValues = `${SemanticTokenTypes}`;
 
@@ -324,6 +325,7 @@ export interface HarnessTesterInterface {
       };
     };
     CompilerOptions: typeof CompilerOptionsCodes;
+    LspCodes: typeof LspCodes;
     TypeSystem: typeof TypeSystemCodes;
   };
 

--- a/packages/language/test/fourslash-harness/implementation/codes.ts
+++ b/packages/language/test/fourslash-harness/implementation/codes.ts
@@ -15,6 +15,7 @@ import { PliMarginsProcessor } from "../../../src/preprocessor/pli-margins-proce
 import { CompilerOptionsCodes } from "../../../src/preprocessor/compiler-options/codes";
 import { TypeSystemCodes } from "../../../src/validation/internal-codes";
 import { PLICodes } from "../../../src/validation/pli-codes";
+import { LspCodes } from "../../../src/validation/lsp-codes";
 
 export const HarnessCodes: HarnessTesterInterface["code"] = {
   Severe: PLICodes.Severe,
@@ -29,5 +30,6 @@ export const HarnessCodes: HarnessTesterInterface["code"] = {
     },
   },
   CompilerOptions: CompilerOptionsCodes,
+  LspCodes: LspCodes,
   TypeSystem: TypeSystemCodes,
 };

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-macro/deprecatenext.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-macro/deprecatenext.ts
@@ -27,6 +27,6 @@ verify.expectDiagnosticsAt(2, {
 
 verify.expectCompilerOptions({
   macroOptions: {
-    deprecateNext: ["OLD3", "OLD4"],
+    deprecateNext: new Set(["OLD3", "OLD4"]),
   },
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-macro/not-supported.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-macro/not-supported.ts
@@ -12,21 +12,16 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(MACRO("DEPRECATE(<|1:LOWER|>)"));
-////*PROCESS PP(MACRO("DEPRECATE(<|2:LOWER|>())"));
-////*PROCESS PP(MACRO("DEPRECATE(ENTRY(OLD1, OLD2))"));
-////*PROCESS PP(MACRO("DEPRECATE(ENTRY(OLD3, OLD4))"));
+////*PROCESS PP(MACRO("<|1:NOEOLCOMM|>"));
+////*PROCESS PP(MACRO("<|2:INCONLY|>"));
+////*PROCESS PP(MACRO("<|3:DBCS|>(EXACT)"));
 
 verify.expectDiagnosticsAt(1, {
-  message: code.CompilerOptions.ExpectedOption.message(""),
+  message: code.CompilerOptions.OptionNotSupported.message("EOLCOMM"),
 });
 verify.expectDiagnosticsAt(2, {
-  message:
-    code.CompilerOptions.PPMacro.Deprecate.InvalidSubOption.message("LOWER"),
+  message: code.CompilerOptions.OptionNotSupported.message("INCONLY"),
 });
-
-verify.expectCompilerOptions({
-  macroOptions: {
-    deprecate: new Set(["OLD3", "OLD4"]),
-  },
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.OptionNotSupported.message("DBCS"),
 });

--- a/packages/language/test/fourslash/validate/macro/case.ts
+++ b/packages/language/test/fourslash/validate/macro/case.ts
@@ -1,0 +1,30 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////%PROCESS PP(MACRO('CASE(UPPER)'));
+//// %DCL <|1:x|> <|2:char|>;
+//// %DCL Y CHAR;
+//// %X = <|3:"PUT SKIP LIST('Hello, World!');"|>;
+////
+//// %TEST: PROC RETURNS (CHAR);
+////   RETURN (X);
+//// %END;
+////
+//// RGT005: <|3:pROCEDURE|>() OPTIONS(MAIN);
+////   %Y = TEST();
+////   Y
+//// END RGT005;
+
+verify.expectDiagnosticsAt(1, code.LspCodes.UpperCase);
+verify.expectDiagnosticsAt(2, code.LspCodes.UpperCase);
+verify.noDiagnostics(3, code.LspCodes.UpperCase);

--- a/packages/language/test/fourslash/validate/macro/deprecate-multiple-labels.ts
+++ b/packages/language/test/fourslash/validate/macro/deprecate-multiple-labels.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////%PROCESS PP(MACRO('DEPRECATE(ENTRY(TEST))'));
+//// %X: <|1:TEST|>: PROC RETURNS (CHAR);
+////   RETURN (X);
+//// %END;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM3660I);

--- a/packages/language/test/fourslash/validate/macro/deprecate-onlypp.ts
+++ b/packages/language/test/fourslash/validate/macro/deprecate-onlypp.ts
@@ -1,0 +1,18 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////%PROCESS PP(MACRO('DEPRECATE(ENTRY(TEST))'));
+//// <|1:TEST|>: PROCEDURE() OPTIONS(MAIN);
+//// END TEST;
+
+verify.noDiagnostics(1, code.Error.IBM3660I);

--- a/packages/language/test/fourslash/validate/macro/deprecate.ts
+++ b/packages/language/test/fourslash/validate/macro/deprecate.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////%PROCESS PP(MACRO('DEPRECATE(ENTRY(TEST))'));
+//// %<|1:TEST|>: PROC RETURNS (CHAR);
+////   RETURN (X);
+//// %END;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM3660I);

--- a/packages/language/test/fourslash/validate/macro/deprecatenext.ts
+++ b/packages/language/test/fourslash/validate/macro/deprecatenext.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////%PROCESS PP(MACRO('DEPRECATENEXT(ENTRY(TEST))'));
+//// %<|1:TEST|>: PROC RETURNS (CHAR);
+////   RETURN (X);
+//// %END;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM3334I);

--- a/packages/language/test/fourslash/validate/macro/nameprefix-multiple-labels.ts
+++ b/packages/language/test/fourslash/validate/macro/nameprefix-multiple-labels.ts
@@ -1,0 +1,31 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////%PROCESS PP(MACRO('NAMEPREFIX(X)'));
+//// %DCL x char;
+//// %DCL <|1:Y|> CHAR;
+//// %X = "PUT SKIP LIST('Hello, World!');";
+////
+//// %<|2:TEST|>: <|3:TEST2|>: PROC RETURNS (CHAR);
+////   RETURN (X);
+//// %END;
+////
+//// <|4:RGT005|>: PROCEDURE() OPTIONS(MAIN);
+////   %Y = TEST();
+////   Y
+//// END RGT005;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM3518I);
+verify.expectDiagnosticsAt(2, code.Error.IBM3518I);
+verify.expectDiagnosticsAt(3, code.Error.IBM3518I);
+verify.noDiagnostics(4, code.Error.IBM3518I);

--- a/packages/language/test/fourslash/validate/macro/nameprefix.ts
+++ b/packages/language/test/fourslash/validate/macro/nameprefix.ts
@@ -1,0 +1,30 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////%PROCESS PP(MACRO('NAMEPREFIX(X)'));
+//// %DCL x char;
+//// %DCL <|1:Y|> CHAR;
+//// %X = "PUT SKIP LIST('Hello, World!');";
+////
+//// %<|2:TEST|>: PROC RETURNS (CHAR);
+////   RETURN (X);
+//// %END;
+////
+//// <|3:RGT005|>: PROCEDURE() OPTIONS(MAIN);
+////   %Y = TEST();
+////   Y
+//// END RGT005;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM3518I);
+verify.expectDiagnosticsAt(2, code.Error.IBM3518I);
+verify.noDiagnostics(3, code.Error.IBM3518I);

--- a/packages/language/test/lsp/apply-quick-fixes.test.ts
+++ b/packages/language/test/lsp/apply-quick-fixes.test.ts
@@ -232,3 +232,72 @@ describe("applyQuickFixes", () => {
     expect(result).toHaveLength(2);
   });
 });
+
+describe("applyQuickFixes with case diagnostics", () => {
+  test("should return individual code actions for MACRO0003W diagnostics", async () => {
+    const diagnostics = [
+      {
+        code: "LSPUC001W",
+        data: { uri: "file:///test.pli", text: "hello" },
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 5 },
+        },
+      } as Diagnostic,
+    ];
+
+    const result = await applyQuickFixes.applyQuickFixes(diagnostics);
+
+    expect(result).toHaveLength(1);
+    expect(result![0].title).toBe("Convert to uppercase");
+    expect(result![0].kind).toBe("quickfix");
+  });
+
+  test("should return individual actions for multiple MACRO0003W diagnostics", async () => {
+    const diagnostics = [
+      {
+        code: "LSPUC001W",
+        data: { uri: "file:///test.pli", text: "hello" },
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 5 },
+        },
+      } as Diagnostic,
+      {
+        code: "LSPUC001W",
+        data: { uri: "file:///test.pli", text: "world" },
+        range: {
+          start: { line: 0, character: 6 },
+          end: { line: 0, character: 11 },
+        },
+      } as Diagnostic,
+    ];
+
+    const result = await applyQuickFixes.applyQuickFixes(diagnostics);
+
+    // Should return 2 individual actions (Fix All is now handled by source actions)
+    expect(result).toHaveLength(2);
+    expect(result![0].title).toBe("Convert to uppercase");
+    expect(result![0].kind).toBe("quickfix");
+    expect(result![0].edit?.changes?.["file:///test.pli"]).toEqual([
+      {
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 5 },
+        },
+        newText: "HELLO",
+      },
+    ]);
+    expect(result![1].title).toBe("Convert to uppercase");
+    expect(result![1].kind).toBe("quickfix");
+    expect(result![1].edit?.changes?.["file:///test.pli"]).toEqual([
+      {
+        range: {
+          start: { line: 0, character: 6 },
+          end: { line: 0, character: 11 },
+        },
+        newText: "WORLD",
+      },
+    ]);
+  });
+});

--- a/packages/language/test/lsp/apply-source-actions.test.ts
+++ b/packages/language/test/lsp/apply-source-actions.test.ts
@@ -1,0 +1,86 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { test, expect, describe } from "vitest";
+import { Diagnostic } from "vscode-languageserver-types";
+import * as applySourceActions from "../../src/language-server/code-actions/apply-source-actions";
+
+describe("sourceActionUppercaseAllText", () => {
+  test("should create a source action for multiple case diagnostics", () => {
+    const diagnostics: Diagnostic[] = [
+      {
+        code: "LSPUC001W",
+        message: "Input text must be uppercase.",
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 5 },
+        },
+        data: {
+          uri: "file:///test.pli",
+          text: "hello",
+        },
+      },
+      {
+        code: "LSPUC001W",
+        message: "Input text must be uppercase.",
+        range: {
+          start: { line: 0, character: 6 },
+          end: { line: 0, character: 11 },
+        },
+        data: {
+          uri: "file:///test.pli",
+          text: "world",
+        },
+      },
+    ];
+
+    const result = applySourceActions.sourceActionUppercaseAllText(diagnostics);
+
+    expect(result).toBeDefined();
+    expect(result.title).toBe("Convert all to uppercase (2 instances)");
+    expect(result.kind).toBe("source.fixAll");
+    expect(result.diagnostics).toEqual(diagnostics);
+    expect(result.edit).toBeDefined();
+    expect(result.edit!.changes).toBeDefined();
+    expect(result.edit!.changes!["file:///test.pli"]).toHaveLength(2);
+    expect(result.edit!.changes!["file:///test.pli"][0].newText).toBe("HELLO");
+    expect(result.edit!.changes!["file:///test.pli"][1].newText).toBe("WORLD");
+  });
+
+  test("should handle multiple files", () => {
+    const diagnostics: Diagnostic[] = [
+      {
+        code: "LSPUC001W",
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 5 },
+        },
+        data: { uri: "file:///test1.pli", text: "hello" },
+      } as Diagnostic,
+      {
+        code: "LSPUC001W",
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: 5 },
+        },
+        data: { uri: "file:///test2.pli", text: "world" },
+      } as Diagnostic,
+    ];
+
+    const result = applySourceActions.sourceActionUppercaseAllText(diagnostics);
+
+    expect(result).toBeDefined();
+    expect(result.edit!.changes!["file:///test1.pli"]).toHaveLength(1);
+    expect(result.edit!.changes!["file:///test1.pli"][0].newText).toBe("HELLO");
+    expect(result.edit!.changes!["file:///test2.pli"]).toHaveLength(1);
+    expect(result.edit!.changes!["file:///test2.pli"][0].newText).toBe("WORLD");
+  });
+});


### PR DESCRIPTION
Implements https://github.com/zowe/zowe-pli-language-support/issues/441

* Implements macro pp validations for DEPRECATE, DEPRECATENEXT, NAMEPREFIX and CASE.
* Provides quickfix and source action for CASE.
* Adds a "not supported" message for DBCS, EOLCOMM, and INCONLY.

The Macro PP diagnostics use internal codes until we can verify the official codes on the mainframe. Afterwards they should be replaced with the official ones provided they carry the same information. 