### PR TITLE
Add validation for scan attribute repetition

### DIFF
--- a/packages/language/src/validation/compiler/IBM1352IE-declare-item-scan-repetition.ts
+++ b/packages/language/src/validation/compiler/IBM1352IE-declare-item-scan-repetition.ts
@@ -1,0 +1,60 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { diagnosticFromCode } from "../../language-server/types";
+import {
+  ComputationDataAttribute,
+  DeclaredItem,
+  SyntaxKind,
+  DefaultAttribute,
+} from "../../syntax-tree/ast";
+import { PLICodes } from "../pli-codes";
+import { ValidationAcceptor } from "../validator";
+
+// %dcl A(4) FIXED INTERNAL SCAN RESCAN; // throws warning IBM3252I with RESCAN.
+// dcl A FIXED SCAN RESCAN; // throws generic IBM1352I with SCAN.
+
+const scanAttributes = (node: DeclaredItem): ComputationDataAttribute[] =>
+  node.attributes.filter(
+    (attr) =>
+      attr.kind === SyntaxKind.ComputationDataAttribute &&
+      (attr.type === DefaultAttribute.SCAN ||
+        attr.type === DefaultAttribute.RESCAN ||
+        attr.type === DefaultAttribute.NOSCAN),
+  ) as ComputationDataAttribute[];
+
+export function IBM1352IE_declared_item_pp_scan_repetition(
+  node: DeclaredItem,
+  accept: ValidationAcceptor,
+): void {
+  let hasScanAttribute = false;
+
+  scanAttributes(node).forEach((attr) => {
+    if (hasScanAttribute) {
+      const token = attr.typeToken;
+      if (!token) return;
+      accept(diagnosticFromCode(PLICodes.Warning.IBM3252I, token, token.image));
+    } else {
+      hasScanAttribute = true;
+    }
+  });
+}
+
+export function IBM1352IE_declared_item_pli_scan_repetition(
+  node: DeclaredItem,
+  accept: ValidationAcceptor,
+): void {
+  scanAttributes(node).forEach((attr) => {
+    const token = (attr as ComputationDataAttribute).typeToken;
+    if (!token) return;
+    accept(diagnosticFromCode(PLICodes.Error.IBM1352I, token, token.image));
+  });
+}

--- a/packages/language/src/validation/pli-validator.ts
+++ b/packages/language/src/validation/pli-validator.ts
@@ -22,6 +22,7 @@ import { typeCheckDeclareStatement } from "./type-check-validator";
 import { checkImplicitBuiltins } from "./language-server/implicit-builtins";
 import { IBM1376IE_attributes_in_declaration_lists } from "./compiler/IBM1376IE-attributes-in-declaration-lists";
 import { IBM3323I_IBM3324I_check_argument_count } from "./compiler/IBM3323I-IBM3324I-check-argument-count";
+import { IBM1352IE_declared_item_pli_scan_repetition } from "./compiler/IBM1352IE-declare-item-scan-repetition";
 
 /**
  * A function that accepts a diagnostic for PL/I validation
@@ -32,21 +33,22 @@ import { IBM3323I_IBM3324I_check_argument_count } from "./compiler/IBM3323I-IBM3
  */
 export function registerPliValidationChecks(): ValidationChecks {
   return {
+    CallStatement: [IBM3323I_IBM3324I_check_argument_count],
+    DeclaredItem: [IBM1352IE_declared_item_pli_scan_repetition],
+    DeclareStatement: [
+      IBM1376IE_attributes_in_declaration_lists,
+      typeCheckDeclareStatement,
+    ],
+    DoStatement: [IBM2615I_do_loops_execute_once],
     Exports: [IBM1324IE_name_occurs_more_than_once_within_exports_clause],
+    LeaveStatement: [IBM1219I_leave_exits_noniterative_do],
     // TODO @montymxb Mar. 27th, 2025: Needs to have a way to readily access the containing 'document' (SourceFile) to compare the offsets (see def)
     // MemberCall: [IBM1747IS_Function_cannot_be_used_before_the_functions_descriptor_list_has_been_scanned],
     ProcedureStatement: [
       IBM1388IE_NODESCRIPTOR_attribute_is_invalid_when_any_parameter_has_NONCONNECTED_attribute,
       IBM2412I_IBM2410I_IBM2409I_handle_return_stmt_and_returns_att,
     ],
-    CallStatement: [IBM3323I_IBM3324I_check_argument_count],
-    DeclareStatement: [
-      IBM1376IE_attributes_in_declaration_lists,
-      typeCheckDeclareStatement,
-    ],
     ReferenceItem: [checkImplicitBuiltins],
-    DoStatement: [IBM2615I_do_loops_execute_once],
-    LeaveStatement: [IBM1219I_leave_exits_noniterative_do],
     SelectStatement: [IBM1059I_select_without_otherwise],
     // TODO @wagner-laranjeiras -> When adding ReturnStatement to this list, make sure to include comment about IBM2412/10/09I.
   };

--- a/packages/language/src/validation/pp-validator.ts
+++ b/packages/language/src/validation/pp-validator.ts
@@ -4,6 +4,7 @@ import { MACRO_Deprecate } from "./macro/deprecate";
 import { MACRO_NamePrefix } from "./macro/nameprefix";
 import { MACRO_Case } from "./macro/case";
 import { ValidationChecks } from "./validator";
+import { IBM1352IE_declared_item_pp_scan_repetition } from "./compiler/IBM1352IE-declare-item-scan-repetition";
 
 export function registerPreprocessorValidationChecks(): ValidationChecks {
   return {
@@ -11,6 +12,7 @@ export function registerPreprocessorValidationChecks(): ValidationChecks {
       IBM3323I_IBM3324I_check_argument_count,
       IBM3970IS_IBM3971IS_check_pp_call_procedure,
     ],
+    DeclaredItem: [IBM1352IE_declared_item_pp_scan_repetition],
     DeclaredVariable: [MACRO_NamePrefix],
     Program: [MACRO_Case],
     ProcedureStatement: [MACRO_Deprecate, MACRO_NamePrefix],

--- a/packages/language/test/fourslash/validate/IBM1352I-IBM3252/declare-item-multiple-scan.ts
+++ b/packages/language/test/fourslash/validate/IBM1352I-IBM3252/declare-item-multiple-scan.ts
@@ -1,0 +1,24 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %DCL x char SCAN <|1:RESCAN|>;
+//// RGT005: PROCEDURE() OPTIONS(MAIN);
+////   DCL T fixed <|2:scan|> <|3:scan|>;
+//// END RGT005;
+
+verify.expectDiagnosticsAt(1, {
+  message: code.Warning.IBM3252I.message("RESCAN"),
+});
+verify.expectDiagnosticsAt([2, 3], {
+  message: code.Error.IBM1352I.message("SCAN"),
+});


### PR DESCRIPTION
Fixes https://github.com/zowe/zowe-pli-language-support/issues/431 3

The type system changes already covers repeating attributes that influence the type. (Note that the mainframe is actually fine with the repetition.)
This validation adds a check for the scan attribute.