### PR TITLE
Type system: Add more attributes

### DIFF
--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -5904,6 +5904,7 @@ export class PliParser extends AbstractParser {
       procedureCall: null,
       to: false,
       content: null,
+      token: null,
     };
   }
 
@@ -5914,6 +5915,7 @@ export class PliParser extends AbstractParser {
       {
         ALT: () => {
           this.CONSUME_ASSIGN1(tokens.INITIAL, (token) => {
+            element.token = token;
             this.tokenPayload(
               token,
               element,

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -7293,6 +7293,7 @@ export class PliParser extends AbstractParser {
     let element = this.push(this.createDimensions());
 
     this.CONSUME_ASSIGN(tokens.OpenParen, (token) => {
+      element.token = token;
       this.tokenPayload(token, element, CstNodeKind.Dimensions_OpenParen);
     });
     this.OPTION(() => {

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -17,6 +17,7 @@ import * as tokens from "./tokens";
 import * as ast from "../syntax-tree/ast";
 import { CstNodeKind } from "../syntax-tree/cst";
 import { ParserMethod, tokenMatcher } from "chevrotain";
+import { Token } from "./tokens";
 
 export class PliParser extends AbstractParser {
   constructor() {
@@ -1142,7 +1143,7 @@ export class PliParser extends AbstractParser {
     let element = this.push(this.createAllocateDimension());
 
     this.SUBRULE_ASSIGN1(this.Dimensions, {
-      assign: (result) => {
+      assign: ([result]) => {
         element.dimensions = result;
       },
     });
@@ -1167,7 +1168,7 @@ export class PliParser extends AbstractParser {
     });
     this.OPTION1(() => {
       this.SUBRULE_ASSIGN1(this.Dimensions, {
-        assign: (result) => {
+        assign: ([result]) => {
           element.dimensions = result;
         },
       });
@@ -6735,6 +6736,7 @@ export class PliParser extends AbstractParser {
       kind: ast.SyntaxKind.DimensionsDataAttribute,
       container: null,
       dimensions: null,
+      dimensionsToken: null,
     };
   }
 
@@ -6751,8 +6753,9 @@ export class PliParser extends AbstractParser {
       });
     });
     this.SUBRULE_ASSIGN1(this.Dimensions, {
-      assign: (result) => {
-        element.dimensions = result;
+      assign: ([dimensions, token]) => {
+        element.dimensions = dimensions;
+        element.dimensionsToken = token;
       },
     });
 
@@ -6916,7 +6919,7 @@ export class PliParser extends AbstractParser {
     });
     this.OPTION1(() => {
       this.SUBRULE_ASSIGN1(this.Dimensions, {
-        assign: (result) => {
+        assign: ([result]) => {
           element.dimensions = result;
         },
       });
@@ -7288,8 +7291,10 @@ export class PliParser extends AbstractParser {
 
   Dimensions = this.RULE("Dimensions", () => {
     let element = this.push(this.createDimensions());
+    let dimensionsToken: Token = undefined!;
 
     this.CONSUME_ASSIGN(tokens.OpenParen, (token) => {
+      dimensionsToken = token;
       this.tokenPayload(token, element, CstNodeKind.Dimensions_OpenParen);
     });
     this.OPTION(() => {
@@ -7313,7 +7318,7 @@ export class PliParser extends AbstractParser {
       this.tokenPayload(token, element, CstNodeKind.Dimensions_CloseParen);
     });
 
-    return this.pop<ast.Dimensions>();
+    return [this.pop<ast.Dimensions>(), dimensionsToken] as const;
   });
   private createDimensionBound(): ast.DimensionBound {
     return {
@@ -7835,7 +7840,7 @@ export class PliParser extends AbstractParser {
     });
     this.OPTION(() => {
       this.SUBRULE_ASSIGN(this.Dimensions, {
-        assign: (result) => {
+        assign: ([result]) => {
           element.dimensions = result;
         },
       });

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -17,7 +17,6 @@ import * as tokens from "./tokens";
 import * as ast from "../syntax-tree/ast";
 import { CstNodeKind } from "../syntax-tree/cst";
 import { ParserMethod, tokenMatcher } from "chevrotain";
-import { Token } from "./tokens";
 
 export class PliParser extends AbstractParser {
   constructor() {
@@ -1143,7 +1142,7 @@ export class PliParser extends AbstractParser {
     let element = this.push(this.createAllocateDimension());
 
     this.SUBRULE_ASSIGN1(this.Dimensions, {
-      assign: ([result]) => {
+      assign: (result) => {
         element.dimensions = result;
       },
     });
@@ -1168,7 +1167,7 @@ export class PliParser extends AbstractParser {
     });
     this.OPTION1(() => {
       this.SUBRULE_ASSIGN1(this.Dimensions, {
-        assign: ([result]) => {
+        assign: (result) => {
           element.dimensions = result;
         },
       });
@@ -6738,7 +6737,6 @@ export class PliParser extends AbstractParser {
       kind: ast.SyntaxKind.DimensionsDataAttribute,
       container: null,
       dimensions: null,
-      dimensionsToken: null,
     };
   }
 
@@ -6755,9 +6753,8 @@ export class PliParser extends AbstractParser {
       });
     });
     this.SUBRULE_ASSIGN1(this.Dimensions, {
-      assign: ([dimensions, token]) => {
+      assign: (dimensions) => {
         element.dimensions = dimensions;
-        element.dimensionsToken = token;
       },
     });
 
@@ -6921,7 +6918,7 @@ export class PliParser extends AbstractParser {
     });
     this.OPTION1(() => {
       this.SUBRULE_ASSIGN1(this.Dimensions, {
-        assign: ([result]) => {
+        assign: (result) => {
           element.dimensions = result;
         },
       });
@@ -7288,15 +7285,14 @@ export class PliParser extends AbstractParser {
       kind: ast.SyntaxKind.Dimensions,
       container: null,
       dimensions: [],
+      token: null,
     };
   }
 
   Dimensions = this.RULE("Dimensions", () => {
     let element = this.push(this.createDimensions());
-    let dimensionsToken: Token = undefined!;
 
     this.CONSUME_ASSIGN(tokens.OpenParen, (token) => {
-      dimensionsToken = token;
       this.tokenPayload(token, element, CstNodeKind.Dimensions_OpenParen);
     });
     this.OPTION(() => {
@@ -7320,7 +7316,7 @@ export class PliParser extends AbstractParser {
       this.tokenPayload(token, element, CstNodeKind.Dimensions_CloseParen);
     });
 
-    return [this.pop<ast.Dimensions>(), dimensionsToken] as const;
+    return this.pop<ast.Dimensions>();
   });
   private createDimensionBound(): ast.DimensionBound {
     return {
@@ -7842,7 +7838,7 @@ export class PliParser extends AbstractParser {
     });
     this.OPTION(() => {
       this.SUBRULE_ASSIGN(this.Dimensions, {
-        assign: ([result]) => {
+        assign: (result) => {
           element.dimensions = result;
         },
       });

--- a/packages/language/src/parser/preprocessor-parser.ts
+++ b/packages/language/src/parser/preprocessor-parser.ts
@@ -1384,7 +1384,11 @@ function declaredVariable(state: ParserState): ast.DeclaredVariable {
 
 function dimensions(state: ParserState): ast.Dimensions {
   const dimensions = ast.createDimensions();
-  dimensions.token = state.consume(dimensions, CstNodeKind.Dimensions_OpenParen, t.OpenParen);
+  dimensions.token = state.consume(
+    dimensions,
+    CstNodeKind.Dimensions_OpenParen,
+    t.OpenParen,
+  );
   if (
     state.tryConsume(
       dimensions,

--- a/packages/language/src/parser/preprocessor-parser.ts
+++ b/packages/language/src/parser/preprocessor-parser.ts
@@ -1384,7 +1384,7 @@ function declaredVariable(state: ParserState): ast.DeclaredVariable {
 
 function dimensions(state: ParserState): ast.Dimensions {
   const dimensions = ast.createDimensions();
-  state.consume(dimensions, CstNodeKind.Dimensions_OpenParen, t.OpenParen);
+  dimensions.token = state.consume(dimensions, CstNodeKind.Dimensions_OpenParen, t.OpenParen);
   if (
     state.tryConsume(
       dimensions,
@@ -1456,11 +1456,9 @@ function attributes(state: ParserState): ast.DeclarationAttribute[] {
         attributes.push(dataAttribute);
       }
     } else if (state.canConsume(t.OpenParen)) {
-      const dimensionsToken = state.token!;
       const dim = dimensions(state);
       const dimensionAttribute = ast.createDimensionsDataAttribute();
       dimensionAttribute.dimensions = dim;
-      dimensionAttribute.dimensionsToken = dimensionsToken;
       attributes.push(dimensionAttribute);
     } else if (state.canConsume(t.ENTRY)) {
       // TODO: This is not the full entry attribute syntax

--- a/packages/language/src/parser/preprocessor-parser.ts
+++ b/packages/language/src/parser/preprocessor-parser.ts
@@ -1456,9 +1456,11 @@ function attributes(state: ParserState): ast.DeclarationAttribute[] {
         attributes.push(dataAttribute);
       }
     } else if (state.canConsume(t.OpenParen)) {
+      const dimensionsToken = state.token!;
       const dim = dimensions(state);
       const dimensionAttribute = ast.createDimensionsDataAttribute();
       dimensionAttribute.dimensions = dim;
+      dimensionAttribute.dimensionsToken = dimensionsToken;
       attributes.push(dimensionAttribute);
     } else if (state.canConsume(t.ENTRY)) {
       // TODO: This is not the full entry attribute syntax

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -1799,6 +1799,7 @@ export interface InitialAttribute extends AstNode {
   procedureCall: ProcedureCall | null;
   to: boolean;
   content: InitialToContent | null;
+  token: Token | null;
 }
 export interface InitialAttributeItemStar extends AstNode {
   kind: SyntaxKind.InitialAttributeItemStar;

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -1297,25 +1297,25 @@ export function createDimensionBound(): DimensionBound {
 export interface Dimensions extends AstNode {
   kind: SyntaxKind.Dimensions;
   dimensions: DimensionBound[];
+  token: Token | null;
 }
 export function createDimensions(): Dimensions {
   return {
     kind: SyntaxKind.Dimensions,
     container: null,
     dimensions: [],
+    token: null,
   };
 }
 export interface DimensionsDataAttribute extends AstNode {
   kind: SyntaxKind.DimensionsDataAttribute;
   dimensions: Dimensions | null;
-  dimensionsToken: Token | null;
 }
 export function createDimensionsDataAttribute(): DimensionsDataAttribute {
   return {
     kind: SyntaxKind.DimensionsDataAttribute,
     container: null,
     dimensions: null,
-    dimensionsToken: null,
   };
 }
 export interface DisplayStatement extends AstNode {

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -1308,12 +1308,14 @@ export function createDimensions(): Dimensions {
 export interface DimensionsDataAttribute extends AstNode {
   kind: SyntaxKind.DimensionsDataAttribute;
   dimensions: Dimensions | null;
+  dimensionsToken: Token | null;
 }
 export function createDimensionsDataAttribute(): DimensionsDataAttribute {
   return {
     kind: SyntaxKind.DimensionsDataAttribute,
     container: null,
     dimensions: null,
+    dimensionsToken: null,
   };
 }
 export interface DisplayStatement extends AstNode {

--- a/packages/language/src/typesystem/composite-type-builder.ts
+++ b/packages/language/src/typesystem/composite-type-builder.ts
@@ -55,7 +55,7 @@ export class DefaultCompositeTypeBuilder implements CompositeTypeBuilder {
     const CompositeAttributeKinds: DefaultAttributeEnum[] = [
       //TODO add more composite types if needed
       DefaultAttributeEnum.UNION,
-      DefaultAttributeEnum.STRUCTURE,
+      DefaultAttributeEnum.DIMACROSS,
     ];
     function isOnlyCompositeAttribute(attr: ast.DeclarationAttribute): boolean {
       if (attr.kind === ast.SyntaxKind.ComputationDataAttribute) {

--- a/packages/language/src/typesystem/computed-attributes.ts
+++ b/packages/language/src/typesystem/computed-attributes.ts
@@ -2,11 +2,12 @@ import { Bound, DimensionBound } from "./descriptions";
 import * as ast from "../syntax-tree/ast";
 import { evaluateExpression } from "./evaluate";
 
+/** @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=arrays-dimension-attribute */
 export function computeDimensions(dimension: ast.Dimensions): Array<DimensionBound> {
     const dims = dimension.dimensions;
     const result: Array<DimensionBound> = [];
     for(const dim of dims) {
-        function computeExpression(bound: ast.Bound | undefined | null, defaultValue: number): Bound {
+        function computeExpression(bound: ast.Bound | undefined | null, defaultValue: number|undefined): Bound {
             const expr = bound?.expression;
             if (!expr) {
                 return {
@@ -38,8 +39,10 @@ export function computeDimensions(dimension: ast.Dimensions): Array<DimensionBou
             }
         }
         result.push({
+            //If only the upper bound is given, the lower bound defaults to 1.
             lowerBound: computeExpression(dim.lower, 1),
-            upperBound: computeExpression(dim.upper, 1),
+            //No default for upper bound. Assuming undefined in case of a parser error.
+            upperBound: computeExpression(dim.upper, undefined),
         });
     }
     return result;

--- a/packages/language/src/typesystem/computed-attributes.ts
+++ b/packages/language/src/typesystem/computed-attributes.ts
@@ -3,47 +3,52 @@ import * as ast from "../syntax-tree/ast";
 import { evaluateExpression } from "./evaluate";
 
 /** @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=arrays-dimension-attribute */
-export function computeDimensions(dimension: ast.Dimensions): Array<DimensionBound> {
-    const dims = dimension.dimensions;
-    const result: Array<DimensionBound> = [];
-    for(const dim of dims) {
-        function computeExpression(bound: ast.Bound | undefined | null, defaultValue: number|undefined): Bound {
-            const expr = bound?.expression;
-            if (!expr) {
-                return {
-                    value: defaultValue,
-                    expression: null,
-                    refersTo: null,
-                };
-            }
-            if (expr === '*') {
-                return {
-                    value: '*',
-                    expression: expr,
-                    refersTo: null,
-                };
-            }
-            const value = evaluateExpression(expr);
-            if(typeof value.value === 'number') {
-                return {
-                    value: value.value,
-                    expression: expr,
-                    refersTo: null,
-                };
-            } else {
-                return {
-                    value: undefined,
-                    expression: expr,
-                    refersTo: null,
-                };
-            }
-        }
-        result.push({
-            //If only the upper bound is given, the lower bound defaults to 1.
-            lowerBound: computeExpression(dim.lower, 1),
-            //No default for upper bound. Assuming undefined in case of a parser error.
-            upperBound: computeExpression(dim.upper, undefined),
-        });
+export function computeDimensions(
+  dimension: ast.Dimensions,
+): Array<DimensionBound> {
+  const dims = dimension.dimensions;
+  const result: Array<DimensionBound> = [];
+  for (const dim of dims) {
+    function computeExpression(
+      bound: ast.Bound | undefined | null,
+      defaultValue: number | undefined,
+    ): Bound {
+      const expr = bound?.expression;
+      if (!expr) {
+        return {
+          value: defaultValue,
+          expression: null,
+          refersTo: null,
+        };
+      }
+      if (expr === "*") {
+        return {
+          value: "*",
+          expression: expr,
+          refersTo: null,
+        };
+      }
+      const value = evaluateExpression(expr);
+      if (typeof value.value === "number") {
+        return {
+          value: value.value,
+          expression: expr,
+          refersTo: null,
+        };
+      } else {
+        return {
+          value: undefined,
+          expression: expr,
+          refersTo: null,
+        };
+      }
     }
-    return result;
+    result.push({
+      //If only the upper bound is given, the lower bound defaults to 1.
+      lowerBound: computeExpression(dim.lower, 1),
+      //No default for upper bound. Assuming undefined in case of a parser error.
+      upperBound: computeExpression(dim.upper, undefined),
+    });
+  }
+  return result;
 }

--- a/packages/language/src/typesystem/computed-attributes.ts
+++ b/packages/language/src/typesystem/computed-attributes.ts
@@ -1,30 +1,45 @@
-import { DimensionBound } from "../../test/fourslash-harness/harness-interface";
-import { DataType, TypeDescriptions } from "./descriptions";
+import { Bound, DimensionBound } from "./descriptions";
 import * as ast from "../syntax-tree/ast";
 import { evaluateExpression } from "./evaluate";
-import { assertType } from "../preprocessor/util";
 
-export function computeDimensions(description: TypeDescriptions.Any): Array<DimensionBound> | undefined {
-    if(description.type === DataType.Structure || description.type === DataType.Unknown || !description.dimension) {
-        return undefined;
-    }
-    const dims = description.dimension.dimensions;
+export function computeDimensions(dimension: ast.Dimensions): Array<DimensionBound> {
+    const dims = dimension.dimensions;
     const result: Array<DimensionBound> = [];
     for(const dim of dims) {
-        function computeExpression(expr: ast.Wildcard<ast.Expression> | undefined | null, fallback: number): number|'*' {
+        function computeExpression(bound: ast.Bound | undefined | null, defaultValue: number): Bound {
+            const expr = bound?.expression;
             if (!expr) {
-                return fallback;
+                return {
+                    value: defaultValue,
+                    expression: null,
+                    refersTo: null,
+                };
             }
             if (expr === '*') {
-                return '*';
+                return {
+                    value: '*',
+                    expression: expr,
+                    refersTo: null,
+                };
             }
-            const value =  evaluateExpression(expr);
-            assertType<ast.SyntaxKind.NumberLiteral>(value.type);
-            return value.value as number;
+            const value = evaluateExpression(expr);
+            if(typeof value.value === 'number') {
+                return {
+                    value: value.value,
+                    expression: expr,
+                    refersTo: null,
+                };
+            } else {
+                return {
+                    value: undefined,
+                    expression: expr,
+                    refersTo: null,
+                };
+            }
         }
         result.push({
-            lowerBound: computeExpression(dim.lower?.expression, 1),
-            upperBound: computeExpression(dim.upper?.expression, 0),
+            lowerBound: computeExpression(dim.lower, 1),
+            upperBound: computeExpression(dim.upper, 1),
         });
     }
     return result;

--- a/packages/language/src/typesystem/computed-attributes.ts
+++ b/packages/language/src/typesystem/computed-attributes.ts
@@ -11,13 +11,12 @@ export function computeDimensions(description: TypeDescriptions.Any): Array<Dime
     const dims = description.dimension.dimensions;
     const result: Array<DimensionBound> = [];
     for(const dim of dims) {
-        function computeExpression(expr: ast.Wildcard<ast.Expression> | undefined | null, fallback: number): number {
+        function computeExpression(expr: ast.Wildcard<ast.Expression> | undefined | null, fallback: number): number|'*' {
             if (!expr) {
                 return fallback;
             }
             if (expr === '*') {
-                //TODO handle '*'
-                return fallback;
+                return '*';
             }
             const value =  evaluateExpression(expr);
             assertType<ast.SyntaxKind.NumberLiteral>(value.type);

--- a/packages/language/src/typesystem/computed-attributes.ts
+++ b/packages/language/src/typesystem/computed-attributes.ts
@@ -1,0 +1,32 @@
+import { DimensionBound } from "../../test/fourslash-harness/harness-interface";
+import { DataType, TypeDescriptions } from "./descriptions";
+import * as ast from "../syntax-tree/ast";
+import { evaluateExpression } from "./evaluate";
+import { assertType } from "../preprocessor/util";
+
+export function computeDimensions(description: TypeDescriptions.Any): Array<DimensionBound> | undefined {
+    if(description.type === DataType.Structure || description.type === DataType.Unknown || !description.dimension) {
+        return undefined;
+    }
+    const dims = description.dimension.dimensions;
+    const result: Array<DimensionBound> = [];
+    for(const dim of dims) {
+        function computeExpression(expr: ast.Wildcard<ast.Expression> | undefined | null, fallback: number): number {
+            if (!expr) {
+                return fallback;
+            }
+            if (expr === '*') {
+                //TODO handle '*'
+                return fallback;
+            }
+            const value =  evaluateExpression(expr);
+            assertType<ast.SyntaxKind.NumberLiteral>(value.type);
+            return value.value as number;
+        }
+        result.push({
+            lowerBound: computeExpression(dim.lower?.expression, 1),
+            upperBound: computeExpression(dim.upper?.expression, 0),
+        });
+    }
+    return result;
+}

--- a/packages/language/src/typesystem/descriptions.ts
+++ b/packages/language/src/typesystem/descriptions.ts
@@ -164,7 +164,7 @@ export type AttributeTypes = {
   [AttributeKind.BufferMode]: BufferMode;
   [AttributeKind.Connection]: StorageConnection;
   [AttributeKind.DataType]: DataType;
-  [AttributeKind.Dimension]: ast.DimensionsDataAttribute|undefined;
+  [AttributeKind.Dimension]: ast.Dimensions|undefined;
   [AttributeKind.Endianess]: Endianess;
   [AttributeKind.FileUsage]: FileUsage;
   [AttributeKind.FloatFormat]: FloatFormat;
@@ -279,7 +279,7 @@ interface BaseTypeDescriptionProps {
   assignability: Assignability;
   connection: StorageConnection;
   variable?: boolean;
-  dimension?: ast.DimensionsDataAttribute;
+  dimension?: ast.Dimensions;
   initial?: ast.InitialAttribute;
 }
 

--- a/packages/language/src/typesystem/descriptions.ts
+++ b/packages/language/src/typesystem/descriptions.ts
@@ -17,8 +17,8 @@ import { assertUnreachable } from "../utils/common";
 /** @see https://www.ibm.com/docs/en/epfz/6.1?topic=attributes-nondata#ndatts__vari */
 
 export type Value = {
-    type: TypeDescriptions.Any,
-    value: string | number;
+  type: TypeDescriptions.Any;
+  value: string | number;
 };
 
 /** Makes T partial except for properties P, they are required */
@@ -174,10 +174,10 @@ export const AttributeKinds: AttributeKind[] = [
 ];
 
 export type Bound = {
-  value: number|'*'|undefined;
-  expression: ast.Wildcard<ast.Expression>|null;
-  refersTo: ast.LocatorCall|null;
-}
+  value: number | "*" | undefined;
+  expression: ast.Wildcard<ast.Expression> | null;
+  refersTo: ast.LocatorCall | null;
+};
 
 export type DimensionBound = {
   lowerBound: Bound;
@@ -193,11 +193,11 @@ export type AttributeTypes = {
   [AttributeKind.BufferMode]: BufferMode;
   [AttributeKind.Connection]: StorageConnection;
   [AttributeKind.DataType]: DataType;
-  [AttributeKind.Dimension]: DimensionBound[]|undefined;
+  [AttributeKind.Dimension]: DimensionBound[] | undefined;
   [AttributeKind.Endianess]: Endianess;
   [AttributeKind.FileUsage]: FileUsage;
   [AttributeKind.FloatFormat]: FloatFormat;
-  [AttributeKind.Initial]: ast.InitialAttribute|undefined;
+  [AttributeKind.Initial]: ast.InitialAttribute | undefined;
   [AttributeKind.List]: boolean;
   [AttributeKind.LocatorKind]: LocatorKind;
   [AttributeKind.NumberMode]: NumberMode;
@@ -205,7 +205,7 @@ export type AttributeTypes = {
   [AttributeKind.OrdinalNames]: string[];
   [AttributeKind.Parameter]: boolean;
   [AttributeKind.ParameterPassDirection]: ParameterPassDirection;
-  [AttributeKind.ParameterPassMode]: ParameterPassMode|undefined;
+  [AttributeKind.ParameterPassMode]: ParameterPassMode | undefined;
   [AttributeKind.PictureKind]: PictureWideness;
   [AttributeKind.Position]: StoragePosition;
   [AttributeKind.Precision]: Precision;
@@ -1306,7 +1306,8 @@ export namespace TypeDescriptions {
       volatility:
         attributes[AttributeKind.Volatility]?.value ??
         DefaultValues[AttributeKind.Volatility],
-      parameterPassDirection: attributes[AttributeKind.ParameterPassDirection]?.value,
+      parameterPassDirection:
+        attributes[AttributeKind.ParameterPassDirection]?.value,
       parameterPassMode: attributes[AttributeKind.ParameterPassMode]?.value,
       position:
         attributes[AttributeKind.Position]?.value ??

--- a/packages/language/src/typesystem/descriptions.ts
+++ b/packages/language/src/typesystem/descriptions.ts
@@ -10,6 +10,7 @@
  */
 
 import { Token } from "../parser/tokens";
+import { ScanMode } from "../preprocessor/instructions";
 import * as ast from "../syntax-tree/ast";
 import { assertUnreachable } from "../utils/common";
 
@@ -83,12 +84,22 @@ export enum AttributeKind {
   FloatFormat,
   /** @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=control-initial-attribute */
   Initial,
+  /** @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=data-list-attribute */
+  List,
   /** TODO need to find out whether LocatorKind can be split into more attribute kinds */
   LocatorKind,
   /** @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=attributes-real-complex */
   NumberMode,
+  /** @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=data-optional-attribute */
+  Optional,
   /** TODO still needs to be handled by the type builder */
   OrdinalNames,
+  /** @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=procedures-parameter-attribute */
+  Parameter,
+  /** @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=procedures-using-inonly-inout-outonly */
+  ParameterPassDirection,
+  /** @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=procedures-using-byvalue-byaddr */
+  ParameterPassMode,
   /** @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=attributes-picture-widepic */
   PictureKind,
   /**
@@ -102,6 +113,8 @@ export enum AttributeKind {
   Scale,
   /** @see https://www.ibm.com/docs/en/epfz/6.1?topic=declarations-internal-external-attributes */
   Scope,
+  /** @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=facilities-preprocessor-scan */
+  ScanMode,
   /** @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=attributes-signed-unsigned */
   Sign,
   /** @see https://www.ibm.com/docs/en/epfz/6.1?topic=control-storage-classes-allocation-deallocation */
@@ -139,11 +152,16 @@ export const AttributeKinds: AttributeKind[] = [
   AttributeKind.Initial,
   AttributeKind.LocatorKind,
   AttributeKind.NumberMode,
+  AttributeKind.Optional,
   AttributeKind.OrdinalNames,
+  AttributeKind.Parameter,
+  AttributeKind.ParameterPassDirection,
+  AttributeKind.ParameterPassMode,
   AttributeKind.PictureKind,
   AttributeKind.Position,
   AttributeKind.Precision,
   AttributeKind.Scale,
+  AttributeKind.ScanMode,
   AttributeKind.Scope,
   AttributeKind.Sign,
   AttributeKind.Storage,
@@ -169,13 +187,19 @@ export type AttributeTypes = {
   [AttributeKind.FileUsage]: FileUsage;
   [AttributeKind.FloatFormat]: FloatFormat;
   [AttributeKind.Initial]: ast.InitialAttribute|undefined;
+  [AttributeKind.List]: boolean;
   [AttributeKind.LocatorKind]: LocatorKind;
   [AttributeKind.NumberMode]: NumberMode;
+  [AttributeKind.Optional]: boolean;
   [AttributeKind.OrdinalNames]: string[];
+  [AttributeKind.Parameter]: boolean;
+  [AttributeKind.ParameterPassDirection]: ParameterPassDirection;
+  [AttributeKind.ParameterPassMode]: ParameterPassMode|undefined;
   [AttributeKind.PictureKind]: PictureWideness;
   [AttributeKind.Position]: StoragePosition;
   [AttributeKind.Precision]: Precision;
   [AttributeKind.Scale]: ScaleMode;
+  [AttributeKind.ScanMode]: ScanMode;
   [AttributeKind.Scope]: Scope;
   [AttributeKind.Sign]: Sign;
   [AttributeKind.Storage]: StorageClass;
@@ -195,6 +219,7 @@ export const CommonAttributeKinds: AttributeKind[] = [
   AttributeKind.Connection,
   AttributeKind.Dimension,
   AttributeKind.Initial,
+  AttributeKind.ParameterPassMode,
   AttributeKind.Position,
   AttributeKind.Scope,
   AttributeKind.Storage,
@@ -272,15 +297,21 @@ export const DataTypesByAttributeKind = Object.entries(
 
 interface BaseTypeDescriptionProps {
   alignment: Alignment;
-  scope: Scope;
-  storage: StorageClass;
-  volatility: Volatility;
-  position?: StoragePosition;
   assignability: Assignability;
   connection: StorageConnection;
-  variable?: boolean;
   dimension?: ast.Dimensions;
   initial?: ast.InitialAttribute;
+  list: boolean;
+  optional: boolean;
+  parameter: boolean;
+  parameterPassDirection?: ParameterPassDirection;
+  parameterPassMode?: ParameterPassMode;
+  position?: StoragePosition;
+  scanMode?: ScanMode;
+  scope: Scope;
+  storage: StorageClass;
+  variable?: boolean;
+  volatility: Volatility;
 }
 
 interface WithTypeDescriminator {
@@ -358,6 +389,19 @@ export enum Volatility {
   Abnormal,
 }
 
+/** @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=procedures-using-byvalue-byaddr */
+export enum ParameterPassMode {
+  ByAddr,
+  ByValue,
+}
+
+/** @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=procedures-using-inonly-inout-outonly */
+export enum ParameterPassDirection {
+  InOnly,
+  OutOnly,
+  InOut,
+}
+
 /* TODO for storage attributes:
 Parameter:
 PARAMETER
@@ -380,6 +424,13 @@ function createBaseTypeDescription(
     dimension,
     assignability,
     variable,
+    scanMode,
+    list,
+    parameterPassDirection,
+    parameterPassMode,
+    initial,
+    optional,
+    parameter,
   }: Partial<BaseTypeDescriptionProps>,
 ): BaseTypeDescriptionProps {
   if (!alignment) {
@@ -396,10 +447,15 @@ function createBaseTypeDescription(
     }
   }
 
-  assignability ??= Assignability.Assignable;
-  connection ??= StorageConnection.Nonconnected;
-  scope ??= { type: ScopeType.Internal };
-  volatility ??= Volatility.Normal;
+  assignability ??= TypeDescriptions.DefaultValues[AttributeKind.Assignability];
+  connection ??= TypeDescriptions.DefaultValues[AttributeKind.Connection];
+  scope ??= TypeDescriptions.DefaultValues[AttributeKind.Scope];
+  volatility ??= TypeDescriptions.DefaultValues[AttributeKind.Volatility];
+  list ??= TypeDescriptions.DefaultValues[AttributeKind.List];
+  optional ??= TypeDescriptions.DefaultValues[AttributeKind.Optional];
+  parameter ??= TypeDescriptions.DefaultValues[AttributeKind.Parameter];
+  initial ??= TypeDescriptions.DefaultValues[AttributeKind.Initial];
+  scanMode ??= TypeDescriptions.DefaultValues[AttributeKind.ScanMode];
 
   if (!storage) {
     if (scope?.type === ScopeType.Internal) {
@@ -414,7 +470,14 @@ function createBaseTypeDescription(
     assignability,
     connection,
     dimension,
+    initial,
+    list,
+    optional,
+    parameter,
+    parameterPassDirection,
+    parameterPassMode,
     position,
+    scanMode,
     scope,
     storage,
     variable,
@@ -1089,6 +1152,60 @@ export namespace TypeDescriptions {
     | Structure;
   export type TypeDescriptionType = Any["type"];
 
+
+  //TODO check default values
+  export const DefaultValues: AttributeTypes = {
+    [AttributeKind.List]: false,
+    [AttributeKind.Optional]: false,
+    [AttributeKind.Parameter]: false,
+    [AttributeKind.FileUsage]: FileUsage.Record,
+    [AttributeKind.BufferMode]: BufferMode.Unbuffered,
+    [AttributeKind.AccessMode]: AccessMode.Sequential,
+    [AttributeKind.FloatFormat]: FloatFormat.IEEE,
+    [AttributeKind.Endianess]: Endianess.Big,
+    [AttributeKind.DataType]: DataType.Area,
+    [AttributeKind.Dimension]: undefined,
+    [AttributeKind.Initial]: undefined,
+    [AttributeKind.Alignment]: {
+      type: AlignmentType.Aligned,
+      alignment: 1,
+    },
+    [AttributeKind.Scope]: {
+      type: ScopeType.Internal,
+    },
+    [AttributeKind.Storage]: StorageClass.Automatic,
+    [AttributeKind.Volatility]: Volatility.Normal,
+    [AttributeKind.Position]: {
+      variable: null,
+      position: null,
+    },
+    [AttributeKind.Assignability]: Assignability.Assignable,
+    [AttributeKind.Connection]: StorageConnection.Connected,
+    [AttributeKind.Variable]: false,
+    [AttributeKind.Scale]: ScaleMode.Fixed,
+    [AttributeKind.ScanMode]: ScanMode.NoScan,
+    [AttributeKind.Precision]: {
+      totalDigitsCount: 5,
+      fractionalDigitsCount: 0,
+    },
+    [AttributeKind.Base]: Base.Binary,
+    [AttributeKind.Sign]: Sign.Signed,
+    [AttributeKind.NumberMode]: NumberMode.Real,
+    [AttributeKind.AreaSize]: 0,
+    [AttributeKind.LocatorKind]: {
+      type: "pointer",
+      size: 32,
+    },
+    [AttributeKind.OrdinalNames]: [],
+    [AttributeKind.ParameterPassMode]: ParameterPassMode.ByAddr,
+    [AttributeKind.ParameterPassDirection]: ParameterPassDirection.InOut,
+    [AttributeKind.PictureKind]: PictureWideness.Picture,
+    [AttributeKind.StringKind]: StringKind.Bit,
+    [AttributeKind.StringFormat]: StringFormat.Varying,
+    [AttributeKind.StringLength]: 0,
+    [AttributeKind.TransmissionDirection]: TransmissionDirection.Input,
+  };
+
   export const Structure = createStructureTypeDescription;
   export type Structure = StructureTypeDescription;
   export const isStructure = (
@@ -1156,53 +1273,6 @@ export namespace TypeDescriptions {
   ): type is StringTypeDescription =>
     isString(type) && type.kind === StringKind.Bit && type.length === 1;
 
-  //TODO check default values
-  const DefaultValues: AttributeTypes = {
-    [AttributeKind.FileUsage]: FileUsage.Record,
-    [AttributeKind.BufferMode]: BufferMode.Unbuffered,
-    [AttributeKind.AccessMode]: AccessMode.Sequential,
-    [AttributeKind.FloatFormat]: FloatFormat.IEEE,
-    [AttributeKind.Endianess]: Endianess.Big,
-    [AttributeKind.DataType]: DataType.Area,
-    [AttributeKind.Dimension]: undefined,
-    [AttributeKind.Initial]: undefined,
-    [AttributeKind.Alignment]: {
-      type: AlignmentType.Aligned,
-      alignment: 1,
-    },
-    [AttributeKind.Scope]: {
-      type: ScopeType.Internal,
-    },
-    [AttributeKind.Storage]: StorageClass.Automatic,
-    [AttributeKind.Volatility]: Volatility.Normal,
-    [AttributeKind.Position]: {
-      variable: null,
-      position: null,
-    },
-    [AttributeKind.Assignability]: Assignability.Assignable,
-    [AttributeKind.Connection]: StorageConnection.Connected,
-    [AttributeKind.Variable]: false,
-    [AttributeKind.Scale]: ScaleMode.Fixed,
-    [AttributeKind.Precision]: {
-      totalDigitsCount: 5,
-      fractionalDigitsCount: 0,
-    },
-    [AttributeKind.Base]: Base.Binary,
-    [AttributeKind.Sign]: Sign.Signed,
-    [AttributeKind.NumberMode]: NumberMode.Real,
-    [AttributeKind.AreaSize]: 0,
-    [AttributeKind.LocatorKind]: {
-      type: "pointer",
-      size: 32,
-    },
-    [AttributeKind.OrdinalNames]: [],
-    [AttributeKind.PictureKind]: PictureWideness.Picture,
-    [AttributeKind.StringKind]: StringKind.Bit,
-    [AttributeKind.StringFormat]: StringFormat.Varying,
-    [AttributeKind.StringLength]: 0,
-    [AttributeKind.TransmissionDirection]: TransmissionDirection.Input,
-  };
-
   export function createPrimitive(
     type: Exclude<DataType, DataType.Structure>,
     attributes: AttributeWitnesses,
@@ -1226,6 +1296,8 @@ export namespace TypeDescriptions {
       volatility:
         attributes[AttributeKind.Volatility]?.value ??
         DefaultValues[AttributeKind.Volatility],
+      parameterPassDirection: attributes[AttributeKind.ParameterPassDirection]?.value,
+      parameterPassMode: attributes[AttributeKind.ParameterPassMode]?.value,
       position:
         attributes[AttributeKind.Position]?.value ??
         DefaultValues[AttributeKind.Position],
@@ -1238,6 +1310,9 @@ export namespace TypeDescriptions {
       variable:
         attributes[AttributeKind.Variable]?.value ??
         DefaultValues[AttributeKind.Variable],
+      scanMode:
+        attributes[AttributeKind.ScanMode]?.value ??
+        DefaultValues[AttributeKind.ScanMode],
     };
     switch (type) {
       case DataType.Area:

--- a/packages/language/src/typesystem/descriptions.ts
+++ b/packages/language/src/typesystem/descriptions.ts
@@ -164,11 +164,11 @@ export type AttributeTypes = {
   [AttributeKind.BufferMode]: BufferMode;
   [AttributeKind.Connection]: StorageConnection;
   [AttributeKind.DataType]: DataType;
-  [AttributeKind.Dimension]: ast.DimensionBound[];
+  [AttributeKind.Dimension]: ast.DimensionsDataAttribute|undefined;
   [AttributeKind.Endianess]: Endianess;
   [AttributeKind.FileUsage]: FileUsage;
   [AttributeKind.FloatFormat]: FloatFormat;
-  [AttributeKind.Initial]: Value | Value[];
+  [AttributeKind.Initial]: ast.InitialAttribute|undefined;
   [AttributeKind.LocatorKind]: LocatorKind;
   [AttributeKind.NumberMode]: NumberMode;
   [AttributeKind.OrdinalNames]: string[];
@@ -279,8 +279,8 @@ interface BaseTypeDescriptionProps {
   assignability: Assignability;
   connection: StorageConnection;
   variable?: boolean;
-  dimension: ast.DimensionBound[];
-  initial?: Value | Value[];
+  dimension?: ast.DimensionsDataAttribute;
+  initial?: ast.InitialAttribute;
 }
 
 interface WithTypeDescriminator {
@@ -400,7 +400,6 @@ function createBaseTypeDescription(
   connection ??= StorageConnection.Nonconnected;
   scope ??= { type: ScopeType.Internal };
   volatility ??= Volatility.Normal;
-  dimension ??= [];
 
   if (!storage) {
     if (scope?.type === ScopeType.Internal) {
@@ -1165,8 +1164,8 @@ export namespace TypeDescriptions {
     [AttributeKind.FloatFormat]: FloatFormat.IEEE,
     [AttributeKind.Endianess]: Endianess.Big,
     [AttributeKind.DataType]: DataType.Area,
-    [AttributeKind.Dimension]: [],
-    [AttributeKind.Initial]: [],
+    [AttributeKind.Dimension]: undefined,
+    [AttributeKind.Initial]: undefined,
     [AttributeKind.Alignment]: {
       type: AlignmentType.Aligned,
       alignment: 1,

--- a/packages/language/src/typesystem/descriptions.ts
+++ b/packages/language/src/typesystem/descriptions.ts
@@ -164,7 +164,7 @@ export type AttributeTypes = {
   [AttributeKind.BufferMode]: BufferMode;
   [AttributeKind.Connection]: StorageConnection;
   [AttributeKind.DataType]: DataType;
-  [AttributeKind.Dimension]: Dimension[];
+  [AttributeKind.Dimension]: ast.DimensionBound[];
   [AttributeKind.Endianess]: Endianess;
   [AttributeKind.FileUsage]: FileUsage;
   [AttributeKind.FloatFormat]: FloatFormat;
@@ -279,7 +279,7 @@ interface BaseTypeDescriptionProps {
   assignability: Assignability;
   connection: StorageConnection;
   variable?: boolean;
-  dimension: Dimension[];
+  dimension: ast.DimensionBound[];
   initial?: Value | Value[];
 }
 
@@ -422,11 +422,6 @@ function createBaseTypeDescription(
     volatility,
   };
 }
-
-export type Dimension = ast.Wildcard<{
-  lowerBound: number;
-  upperBound: number;
-}>;
 
 //--- Area ---
 const AreaType = DataType.Area;

--- a/packages/language/src/typesystem/descriptions.ts
+++ b/packages/language/src/typesystem/descriptions.ts
@@ -173,6 +173,17 @@ export const AttributeKinds: AttributeKind[] = [
   AttributeKind.Volatility,
 ];
 
+export type Bound = {
+  value: number|'*'|undefined;
+  expression: ast.Wildcard<ast.Expression>|null;
+  refersTo: ast.LocatorCall|null;
+}
+
+export type DimensionBound = {
+  lowerBound: Bound;
+  upperBound: Bound;
+};
+
 export type AttributeTypes = {
   [AttributeKind.AccessMode]: AccessMode;
   [AttributeKind.Alignment]: Alignment;
@@ -182,7 +193,7 @@ export type AttributeTypes = {
   [AttributeKind.BufferMode]: BufferMode;
   [AttributeKind.Connection]: StorageConnection;
   [AttributeKind.DataType]: DataType;
-  [AttributeKind.Dimension]: ast.Dimensions|undefined;
+  [AttributeKind.Dimension]: DimensionBound[]|undefined;
   [AttributeKind.Endianess]: Endianess;
   [AttributeKind.FileUsage]: FileUsage;
   [AttributeKind.FloatFormat]: FloatFormat;
@@ -299,7 +310,7 @@ interface BaseTypeDescriptionProps {
   alignment: Alignment;
   assignability: Assignability;
   connection: StorageConnection;
-  dimension?: ast.Dimensions;
+  dimension?: DimensionBound[];
   initial?: ast.InitialAttribute;
   list: boolean;
   optional: boolean;
@@ -1151,7 +1162,6 @@ export namespace TypeDescriptions {
     | Unknown
     | Structure;
   export type TypeDescriptionType = Any["type"];
-
 
   //TODO check default values
   export const DefaultValues: AttributeTypes = {

--- a/packages/language/src/typesystem/descriptions.ts
+++ b/packages/language/src/typesystem/descriptions.ts
@@ -15,6 +15,11 @@ import { assertUnreachable } from "../utils/common";
 
 /** @see https://www.ibm.com/docs/en/epfz/6.1?topic=attributes-nondata#ndatts__vari */
 
+export type Value = {
+    type: TypeDescriptions.Any,
+    value: string | number;
+};
+
 /** Makes T partial except for properties P, they are required */
 export type PartialPartial<T, P extends keyof T> = Partial<Omit<T, P>> &
   Required<Omit<T, Exclude<keyof T, P>>>;
@@ -68,12 +73,16 @@ export enum AttributeKind {
   Connection,
   /** This is a meta type that can be set by different attributes. */
   DataType,
+  /** @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=arrays-dimension-attribute */
+  Dimension,
   /** @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=control-bigendian-littleendian-attributes */
   Endianess,
   /** @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=files-record-stream-attributes */
   FileUsage,
   /** @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=control-hexadec-ieee-attributes */
   FloatFormat,
+  /** @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=control-initial-attribute */
+  Initial,
   /** TODO need to find out whether LocatorKind can be split into more attribute kinds */
   LocatorKind,
   /** @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=attributes-real-complex */
@@ -123,9 +132,11 @@ export const AttributeKinds: AttributeKind[] = [
   AttributeKind.BufferMode,
   AttributeKind.Connection,
   AttributeKind.DataType,
+  AttributeKind.Dimension,
   AttributeKind.Endianess,
   AttributeKind.FileUsage,
   AttributeKind.FloatFormat,
+  AttributeKind.Initial,
   AttributeKind.LocatorKind,
   AttributeKind.NumberMode,
   AttributeKind.OrdinalNames,
@@ -153,9 +164,11 @@ export type AttributeTypes = {
   [AttributeKind.BufferMode]: BufferMode;
   [AttributeKind.Connection]: StorageConnection;
   [AttributeKind.DataType]: DataType;
+  [AttributeKind.Dimension]: Dimension[];
   [AttributeKind.Endianess]: Endianess;
   [AttributeKind.FileUsage]: FileUsage;
   [AttributeKind.FloatFormat]: FloatFormat;
+  [AttributeKind.Initial]: Value | Value[];
   [AttributeKind.LocatorKind]: LocatorKind;
   [AttributeKind.NumberMode]: NumberMode;
   [AttributeKind.OrdinalNames]: string[];
@@ -180,6 +193,8 @@ export const CommonAttributeKinds: AttributeKind[] = [
   AttributeKind.Alignment,
   AttributeKind.Assignability,
   AttributeKind.Connection,
+  AttributeKind.Dimension,
+  AttributeKind.Initial,
   AttributeKind.Position,
   AttributeKind.Scope,
   AttributeKind.Storage,
@@ -264,6 +279,8 @@ interface BaseTypeDescriptionProps {
   assignability: Assignability;
   connection: StorageConnection;
   variable?: boolean;
+  dimension: Dimension[];
+  initial?: Value | Value[];
 }
 
 interface WithTypeDescriminator {
@@ -360,6 +377,7 @@ function createBaseTypeDescription(
     storage,
     volatility,
     position,
+    dimension,
     assignability,
     variable,
   }: Partial<BaseTypeDescriptionProps>,
@@ -382,6 +400,7 @@ function createBaseTypeDescription(
   connection ??= StorageConnection.Nonconnected;
   scope ??= { type: ScopeType.Internal };
   volatility ??= Volatility.Normal;
+  dimension ??= [];
 
   if (!storage) {
     if (scope?.type === ScopeType.Internal) {
@@ -395,6 +414,7 @@ function createBaseTypeDescription(
     alignment,
     assignability,
     connection,
+    dimension,
     position,
     scope,
     storage,
@@ -402,6 +422,11 @@ function createBaseTypeDescription(
     volatility,
   };
 }
+
+export type Dimension = ast.Wildcard<{
+  lowerBound: number;
+  upperBound: number;
+}>;
 
 //--- Area ---
 const AreaType = DataType.Area;
@@ -1145,6 +1170,8 @@ export namespace TypeDescriptions {
     [AttributeKind.FloatFormat]: FloatFormat.IEEE,
     [AttributeKind.Endianess]: Endianess.Big,
     [AttributeKind.DataType]: DataType.Area,
+    [AttributeKind.Dimension]: [],
+    [AttributeKind.Initial]: [],
     [AttributeKind.Alignment]: {
       type: AlignmentType.Aligned,
       alignment: 1,
@@ -1190,6 +1217,12 @@ export namespace TypeDescriptions {
       alignment:
         attributes[AttributeKind.Alignment]?.value ??
         DefaultValues[AttributeKind.Alignment],
+      dimension:
+        attributes[AttributeKind.Dimension]?.value ??
+        DefaultValues[AttributeKind.Dimension],
+      initial:
+        attributes[AttributeKind.Initial]?.value ??
+        DefaultValues[AttributeKind.Initial],
       scope:
         attributes[AttributeKind.Scope]?.value ??
         DefaultValues[AttributeKind.Scope],

--- a/packages/language/src/typesystem/evaluate.ts
+++ b/packages/language/src/typesystem/evaluate.ts
@@ -6,7 +6,6 @@ import {
   TypeDescriptions,
   Value,
 } from "./descriptions";
-import { assertType } from "../preprocessor/util";
 
 /** helper function to evaluate constant expressions */
 export function evaluateExpression(expression: Expression): Value {
@@ -17,14 +16,14 @@ export function evaluateExpression(expression: Expression): Value {
         switch (expression.op) {
           case "+":
           case "-":
-            assertType<DataType.Arithmetic>(operand.type);
-            return {
-              type: operand.type,
-              value:
-                expression.op === "+"
-                  ? +(operand.value as number)
-                  : -(operand.value as number),
-            };
+            if (operand.type.type === DataType.Arithmetic) {
+              const value = operand.value as number;
+              return {
+                type: operand.type,
+                value: expression.op === "+" ? +value : -value,
+              };
+            }
+            break;
           case "^":
             //TODO handle bitwise not
             break;

--- a/packages/language/src/typesystem/evaluate.ts
+++ b/packages/language/src/typesystem/evaluate.ts
@@ -1,4 +1,3 @@
-import { assert } from "console";
 import { Expression, SyntaxKind } from "../syntax-tree/ast";
 import { DataType, StringFormat, StringKind, TypeDescriptions, Value } from "./descriptions";
 import { assertType } from "../preprocessor/util";

--- a/packages/language/src/typesystem/evaluate.ts
+++ b/packages/language/src/typesystem/evaluate.ts
@@ -1,55 +1,64 @@
 import { Expression, SyntaxKind } from "../syntax-tree/ast";
-import { DataType, StringFormat, StringKind, TypeDescriptions, Value } from "./descriptions";
+import {
+  DataType,
+  StringFormat,
+  StringKind,
+  TypeDescriptions,
+  Value,
+} from "./descriptions";
 import { assertType } from "../preprocessor/util";
 
 /** helper function to evaluate constant expressions */
 export function evaluateExpression(expression: Expression): Value {
-    switch (expression.kind) {
-        case SyntaxKind.UnaryExpression: {
-            if(expression.expr && expression.op) {
-                const operand = evaluateExpression(expression.expr);
-                switch(expression.op) {
-                    case '+':
-                    case '-':
-                        assertType<DataType.Arithmetic>(operand.type);
-                        return {
-                            type: operand.type,
-                            value: expression.op === '+' ? +(operand.value as number) : -(operand.value as number),
-                        };
-                    case '^':
-                        //TODO handle bitwise not
-                        break;
-                }
-            }
+  switch (expression.kind) {
+    case SyntaxKind.UnaryExpression: {
+      if (expression.expr && expression.op) {
+        const operand = evaluateExpression(expression.expr);
+        switch (expression.op) {
+          case "+":
+          case "-":
+            assertType<DataType.Arithmetic>(operand.type);
             return {
-                type: TypeDescriptions.Unknown(),
-                value: ""
+              type: operand.type,
+              value:
+                expression.op === "+"
+                  ? +(operand.value as number)
+                  : -(operand.value as number),
             };
-        }
-        case SyntaxKind.Literal: {
-            const literal = expression.value;
-            switch (literal?.kind) {
-                case SyntaxKind.StringLiteral:
-                    return {
-                        type: TypeDescriptions.String({
-                            kind: StringKind.Character,
-                            format: StringFormat.NonVarying,
-                            length: literal.value!.length,
-                        }),
-                        value: literal.value!,
-                    };
-                case SyntaxKind.NumberLiteral:
-                    return {
-                        type: TypeDescriptions.Arithmetic({}),
-                        value: parseInt(literal.value!), 
-                    };
-            }
+          case "^":
+            //TODO handle bitwise not
             break;
         }
-    }
-
-    return {
+      }
+      return {
         type: TypeDescriptions.Unknown(),
-        value: ""
+        value: "",
+      };
     }
+    case SyntaxKind.Literal: {
+      const literal = expression.value;
+      switch (literal?.kind) {
+        case SyntaxKind.StringLiteral:
+          return {
+            type: TypeDescriptions.String({
+              kind: StringKind.Character,
+              format: StringFormat.NonVarying,
+              length: literal.value!.length,
+            }),
+            value: literal.value!,
+          };
+        case SyntaxKind.NumberLiteral:
+          return {
+            type: TypeDescriptions.Arithmetic({}),
+            value: parseInt(literal.value!),
+          };
+      }
+      break;
+    }
+  }
+
+  return {
+    type: TypeDescriptions.Unknown(),
+    value: "",
+  };
 }

--- a/packages/language/src/typesystem/evaluate.ts
+++ b/packages/language/src/typesystem/evaluate.ts
@@ -36,21 +36,23 @@ export function evaluateExpression(expression: Expression): Value {
     }
     case SyntaxKind.Literal: {
       const literal = expression.value;
-      switch (literal?.kind) {
-        case SyntaxKind.StringLiteral:
-          return {
-            type: TypeDescriptions.String({
-              kind: StringKind.Character,
-              format: StringFormat.NonVarying,
-              length: literal.value!.length,
-            }),
-            value: literal.value!,
-          };
-        case SyntaxKind.NumberLiteral:
-          return {
-            type: TypeDescriptions.Arithmetic({}),
-            value: parseInt(literal.value!),
-          };
+      if (literal && literal.value) {
+        switch (literal.kind) {
+          case SyntaxKind.StringLiteral:
+            return {
+              type: TypeDescriptions.String({
+                kind: StringKind.Character,
+                format: StringFormat.NonVarying,
+                length: literal.value.length,
+              }),
+              value: literal.value,
+            };
+          case SyntaxKind.NumberLiteral:
+            return {
+              type: TypeDescriptions.Arithmetic({}),
+              value: parseInt(literal.value),
+            };
+        }
       }
       break;
     }

--- a/packages/language/src/typesystem/evaluate.ts
+++ b/packages/language/src/typesystem/evaluate.ts
@@ -1,9 +1,32 @@
+import { assert } from "console";
 import { Expression, SyntaxKind } from "../syntax-tree/ast";
-import { StringFormat, StringKind, TypeDescriptions, Value } from "./descriptions";
+import { DataType, StringFormat, StringKind, TypeDescriptions, Value } from "./descriptions";
+import { assertType } from "../preprocessor/util";
 
 /** helper function to evaluate constant expressions */
 export function evaluateExpression(expression: Expression): Value {
     switch (expression.kind) {
+        case SyntaxKind.UnaryExpression: {
+            if(expression.expr && expression.op) {
+                const operand = evaluateExpression(expression.expr);
+                switch(expression.op) {
+                    case '+':
+                    case '-':
+                        assertType<DataType.Arithmetic>(operand.type);
+                        return {
+                            type: operand.type,
+                            value: expression.op === '+' ? +(operand.value as number) : -(operand.value as number),
+                        };
+                    case '^':
+                        //TODO handle bitwise not
+                        break;
+                }
+            }
+            return {
+                type: TypeDescriptions.Unknown(),
+                value: ""
+            };
+        }
         case SyntaxKind.Literal: {
             const literal = expression.value;
             switch (literal?.kind) {

--- a/packages/language/src/typesystem/evaluate.ts
+++ b/packages/language/src/typesystem/evaluate.ts
@@ -1,0 +1,33 @@
+import { Expression, SyntaxKind } from "../syntax-tree/ast";
+import { StringFormat, StringKind, TypeDescriptions, Value } from "./descriptions";
+
+/** helper function to evaluate constant expressions */
+export function evaluateExpression(expression: Expression): Value {
+    switch (expression.kind) {
+        case SyntaxKind.Literal: {
+            const literal = expression.value;
+            switch (literal?.kind) {
+                case SyntaxKind.StringLiteral:
+                    return {
+                        type: TypeDescriptions.String({
+                            kind: StringKind.Character,
+                            format: StringFormat.NonVarying,
+                            length: literal.value!.length,
+                        }),
+                        value: literal.value!,
+                    };
+                case SyntaxKind.NumberLiteral:
+                    return {
+                        type: TypeDescriptions.Arithmetic({}),
+                        value: parseInt(literal.value!), 
+                    };
+            }
+            break;
+        }
+    }
+
+    return {
+        type: TypeDescriptions.Unknown(),
+        value: ""
+    }
+}

--- a/packages/language/src/typesystem/primitive-type-builder.ts
+++ b/packages/language/src/typesystem/primitive-type-builder.ts
@@ -20,6 +20,7 @@ import { assertType } from "../preprocessor/util";
 import * as ast from "../syntax-tree/ast";
 import { assertUnreachable } from "../utils/common";
 import { Error } from "../validation/pli-codes";
+import { computeDimensions } from "./computed-attributes";
 import {
   DataType,
   DataTypesByAttributeKind,
@@ -102,7 +103,7 @@ export class DefaultPrimitiveTypeBuilder implements PrimitiveTypeBuilder {
         if (attribute.dimensions && attribute.dimensionsToken) {
           this.addAttributeWitness(
             AttributeKind.Dimension,
-            attribute.dimensions,
+            computeDimensions(attribute.dimensions),
             attribute,
             attribute.dimensionsToken,
           );

--- a/packages/language/src/typesystem/primitive-type-builder.ts
+++ b/packages/language/src/typesystem/primitive-type-builder.ts
@@ -100,12 +100,12 @@ export class DefaultPrimitiveTypeBuilder implements PrimitiveTypeBuilder {
         );
         break;
       case ast.SyntaxKind.DimensionsDataAttribute:
-        if (attribute.dimensions && attribute.dimensionsToken) {
+        if (attribute.dimensions && attribute.dimensions.token) {
           this.addAttributeWitness(
             AttributeKind.Dimension,
             computeDimensions(attribute.dimensions),
             attribute,
-            attribute.dimensionsToken,
+            attribute.dimensions.token!,
           );
         }
         break;

--- a/packages/language/src/typesystem/primitive-type-builder.ts
+++ b/packages/language/src/typesystem/primitive-type-builder.ts
@@ -134,7 +134,7 @@ export class DefaultPrimitiveTypeBuilder implements PrimitiveTypeBuilder {
           attribute.pictureToken!,
         );
         break;
-      case ast.SyntaxKind.ReturnsAttribute:
+      case ast.SyntaxKind.ReturnsAttribute: //@see https://www.ibm.com/docs/en/epfz/6.1.0?topic=organization-returns-option-attribute
         break;
       case ast.SyntaxKind.TypeAttribute:
         //TODO handle type attribute
@@ -147,10 +147,10 @@ export class DefaultPrimitiveTypeBuilder implements PrimitiveTypeBuilder {
           );
         }
         break;
-      case ast.SyntaxKind.ValueAttribute:
-      case ast.SyntaxKind.ValueListAttribute:
-      case ast.SyntaxKind.ValueListFromAttribute:
-      case ast.SyntaxKind.ValueRangeAttribute:
+      case ast.SyntaxKind.ValueAttribute: //@see https://www.ibm.com/docs/en/epfz/6.1.0?topic=attributes-value-attribute
+      case ast.SyntaxKind.ValueListAttribute: //@see https://www.ibm.com/docs/en/epfz/6.1.0?topic=attributes-valuelist-attribute
+      case ast.SyntaxKind.ValueListFromAttribute: //@see https://www.ibm.com/docs/en/epfz/6.1.0?topic=attributes-valuelistfrom-attribute
+      case ast.SyntaxKind.ValueRangeAttribute: //@see https://www.ibm.com/docs/en/epfz/6.1.0?topic=attributes-valuerange-attribute
         break;
       default:
         assertUnreachable(attribute);
@@ -747,14 +747,14 @@ export class DefaultPrimitiveTypeBuilder implements PrimitiveTypeBuilder {
       case DefaultAttributeEnum.NONNATIVE: //no documentation found
       case DefaultAttributeEnum.NULLINIT: //no documentation found
       case DefaultAttributeEnum.TRANSIENT: //no documentation found
+      case DefaultAttributeEnum.RANGE: //no documentation found
         break;
       
-      case DefaultAttributeEnum.POSITION:
-      case DefaultAttributeEnum.PRINT:
-      case DefaultAttributeEnum.RANGE:
-      case DefaultAttributeEnum.RESERVED:
-      case DefaultAttributeEnum.STRUCTURE:
-      case DefaultAttributeEnum.VARIABLE:
+      case DefaultAttributeEnum.POSITION: //@see https://www.ibm.com/docs/en/epfz/6.1.0?topic=control-defined-position-attributes
+      case DefaultAttributeEnum.PRINT: //@see https://www.ibm.com/docs/en/epfz/6.1.0?topic=transmission-print-attribute
+      case DefaultAttributeEnum.RESERVED: //@see https://www.ibm.com/docs/en/epfz/6.1.0?topic=declarations-reserved-attribute
+      case DefaultAttributeEnum.STRUCTURE: //@see https://www.ibm.com/docs/en/epfz/6.1.0?topic=definitions-defining-typed-structures-unions
+      case DefaultAttributeEnum.VARIABLE: //@see https://www.ibm.com/docs/en/epfz/6.1.0?topic=attributes-variable-attribute
         break;
       default:
         assertUnreachable(typeAsEnum);

--- a/packages/language/src/typesystem/primitive-type-builder.ts
+++ b/packages/language/src/typesystem/primitive-type-builder.ts
@@ -88,9 +88,22 @@ export class DefaultPrimitiveTypeBuilder implements PrimitiveTypeBuilder {
       case ast.SyntaxKind.DefinedAttribute:
         break;
       case ast.SyntaxKind.InitialAttribute:
+        this.addAttributeWitness(
+          AttributeKind.Initial,
+          attribute,
+          attribute,
+          attribute.token!,
+        );
         break;
       case ast.SyntaxKind.DimensionsDataAttribute:
-        this.handleDimensionAttribute(attribute);
+        if(attribute.dimensions && attribute.dimensionsToken) {
+          this.addAttributeWitness(
+            AttributeKind.Dimension,
+            attribute,
+            attribute,
+            attribute.dimensionsToken,
+          );
+        }
         break;
       case ast.SyntaxKind.EntryAttribute:
         this.addAttributeWitness(
@@ -138,16 +151,6 @@ export class DefaultPrimitiveTypeBuilder implements PrimitiveTypeBuilder {
         break;
       default:
         assertUnreachable(attribute);
-    }
-  }
-  private handleDimensionAttribute(attribute: ast.DimensionsDataAttribute) {
-    if(attribute.dimensions && attribute.dimensionsToken) {
-      this.addAttributeWitness(
-        AttributeKind.Dimension,
-        attribute.dimensions.dimensions,
-        attribute,
-        attribute.dimensionsToken,
-      );
     }
   }
 

--- a/packages/language/src/typesystem/primitive-type-builder.ts
+++ b/packages/language/src/typesystem/primitive-type-builder.ts
@@ -52,6 +52,7 @@ import {
   Implications,
   TransmissionDirection,
 } from "./descriptions";
+import { evaluateExpression } from "./evaluate";
 
 function createEmptyAttributeWitnesses(): AttributeWitnesses {
   const obj: Partial<AttributeWitnesses> = {};
@@ -87,7 +88,10 @@ export class DefaultPrimitiveTypeBuilder implements PrimitiveTypeBuilder {
       case ast.SyntaxKind.DateAttribute:
       case ast.SyntaxKind.DefinedAttribute:
         break;
+      case ast.SyntaxKind.InitialAttribute:
+        break;
       case ast.SyntaxKind.DimensionsDataAttribute:
+        this.handleDimensionAttribute(attribute);
         break;
       case ast.SyntaxKind.EntryAttribute:
         this.addAttributeWitness(
@@ -101,7 +105,6 @@ export class DefaultPrimitiveTypeBuilder implements PrimitiveTypeBuilder {
       case ast.SyntaxKind.GenericAttribute:
       case ast.SyntaxKind.HandleAttribute:
       case ast.SyntaxKind.IndForAttribute:
-      case ast.SyntaxKind.InitialAttribute:
       case ast.SyntaxKind.LikeAttribute:
         break;
       case ast.SyntaxKind.PictureAttribute:
@@ -138,6 +141,25 @@ export class DefaultPrimitiveTypeBuilder implements PrimitiveTypeBuilder {
         assertUnreachable(attribute);
     }
   }
+  private handleDimensionAttribute(attribute: ast.DimensionsDataAttribute) {
+    attribute.dimensions?.dimensions.map((dim) => {
+      let upper = 0;
+      let lower = 0;
+      if (dim.upper) {
+        if (dim.upper.expression === null) {
+          //TODO if(dim.upper.refer)
+        } else if (typeof dim.upper.expression === "string" && dim.upper.expression === "*") {
+          //TODO requires special handling for star dimensions
+        } else {
+          const { value } = evaluateExpression(dim.upper.expression);
+          if (typeof value === "number") {
+            upper = value;
+          }
+        }
+      }
+    });
+  }
+
   handleDefaultAttribute(attribute: ast.ComputationDataAttribute) {
     const token = attribute.typeToken!;
     assertType<number>(attribute.typeToken?.tokenTypeIdx);

--- a/packages/language/src/typesystem/primitive-type-builder.ts
+++ b/packages/language/src/typesystem/primitive-type-builder.ts
@@ -92,12 +92,14 @@ export class DefaultPrimitiveTypeBuilder implements PrimitiveTypeBuilder {
       case ast.SyntaxKind.DefinedAttribute:
         break;
       case ast.SyntaxKind.InitialAttribute:
-        this.addAttributeWitness(
-          AttributeKind.Initial,
-          attribute,
-          attribute,
-          attribute.token!,
-        );
+        if (attribute.token) {
+          this.addAttributeWitness(
+            AttributeKind.Initial,
+            attribute,
+            attribute,
+            attribute.token,
+          );
+        }
         break;
       case ast.SyntaxKind.DimensionsDataAttribute:
         if (attribute.dimensions && attribute.dimensions.token) {
@@ -105,17 +107,19 @@ export class DefaultPrimitiveTypeBuilder implements PrimitiveTypeBuilder {
             AttributeKind.Dimension,
             computeDimensions(attribute.dimensions),
             attribute,
-            attribute.dimensions.token!,
+            attribute.dimensions.token,
           );
         }
         break;
       case ast.SyntaxKind.EntryAttribute:
-        this.addAttributeWitness(
-          AttributeKind.DataType,
-          DataType.Entry,
-          attribute,
-          attribute.entryToken!,
-        );
+        if (attribute.entryToken) {
+          this.addAttributeWitness(
+            AttributeKind.DataType,
+            DataType.Entry,
+            attribute,
+            attribute.entryToken,
+          );
+        }
         break;
       case ast.SyntaxKind.EnvironmentAttribute:
       case ast.SyntaxKind.GenericAttribute:
@@ -128,12 +132,14 @@ export class DefaultPrimitiveTypeBuilder implements PrimitiveTypeBuilder {
          * Picture wideness attributes
          * @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=attributes-picture-widepic
          */
-        this.addAttributeWitness(
-          AttributeKind.DataType,
-          DataType.Picture,
-          attribute,
-          attribute.pictureToken!,
-        );
+        if (attribute.pictureToken) {
+          this.addAttributeWitness(
+            AttributeKind.DataType,
+            DataType.Picture,
+            attribute,
+            attribute.pictureToken,
+          );
+        }
         break;
       case ast.SyntaxKind.ReturnsAttribute: //@see https://www.ibm.com/docs/en/epfz/6.1.0?topic=organization-returns-option-attribute
         break;
@@ -159,9 +165,11 @@ export class DefaultPrimitiveTypeBuilder implements PrimitiveTypeBuilder {
   }
 
   handleDefaultAttribute(attribute: ast.ComputationDataAttribute) {
-    const token = attribute.typeToken!;
-    assertType<number>(attribute.typeToken?.tokenTypeIdx);
-    const typeAsEnum = DefaultAttributeToEnum[attribute.typeToken.tokenTypeIdx];
+    const token = attribute.typeToken;
+    if (!token) {
+      return;
+    }
+    const typeAsEnum = DefaultAttributeToEnum[token.tokenTypeIdx];
     switch (typeAsEnum) {
       /**
        * Data type attributes
@@ -827,7 +835,7 @@ export class DefaultPrimitiveTypeBuilder implements PrimitiveTypeBuilder {
     token: Token,
   ) {
     if (this.attributeWitnesses[kind]) {
-      const witness = this.attributeWitnesses[kind]!;
+      const witness = this.attributeWitnesses[kind];
       if (value !== witness.value) {
         this.diagnostics.push(
           diagnosticFromCode(Error.IBM2462I, token, token.image, witness.image),

--- a/packages/language/src/typesystem/primitive-type-builder.ts
+++ b/packages/language/src/typesystem/primitive-type-builder.ts
@@ -52,7 +52,6 @@ import {
   Implications,
   TransmissionDirection,
 } from "./descriptions";
-import { evaluateExpression } from "./evaluate";
 
 function createEmptyAttributeWitnesses(): AttributeWitnesses {
   const obj: Partial<AttributeWitnesses> = {};
@@ -142,22 +141,14 @@ export class DefaultPrimitiveTypeBuilder implements PrimitiveTypeBuilder {
     }
   }
   private handleDimensionAttribute(attribute: ast.DimensionsDataAttribute) {
-    attribute.dimensions?.dimensions.map((dim) => {
-      let upper = 0;
-      let lower = 0;
-      if (dim.upper) {
-        if (dim.upper.expression === null) {
-          //TODO if(dim.upper.refer)
-        } else if (typeof dim.upper.expression === "string" && dim.upper.expression === "*") {
-          //TODO requires special handling for star dimensions
-        } else {
-          const { value } = evaluateExpression(dim.upper.expression);
-          if (typeof value === "number") {
-            upper = value;
-          }
-        }
-      }
-    });
+    if(attribute.dimensions && attribute.dimensionsToken) {
+      this.addAttributeWitness(
+        AttributeKind.Dimension,
+        attribute.dimensions.dimensions,
+        attribute,
+        attribute.dimensionsToken,
+      );
+    }
   }
 
   handleDefaultAttribute(attribute: ast.ComputationDataAttribute) {

--- a/packages/language/src/typesystem/primitive-type-builder.ts
+++ b/packages/language/src/typesystem/primitive-type-builder.ts
@@ -99,7 +99,7 @@ export class DefaultPrimitiveTypeBuilder implements PrimitiveTypeBuilder {
         if(attribute.dimensions && attribute.dimensionsToken) {
           this.addAttributeWitness(
             AttributeKind.Dimension,
-            attribute,
+            attribute.dimensions,
             attribute,
             attribute.dimensionsToken,
           );

--- a/packages/language/src/typesystem/primitive-type-builder.ts
+++ b/packages/language/src/typesystem/primitive-type-builder.ts
@@ -80,7 +80,7 @@ export class DefaultPrimitiveTypeBuilder implements PrimitiveTypeBuilder {
   private possibleDataTypes = new Set<DataType>(DataTypesArray);
   private attributeWitnesses: AttributeWitnesses =
     createEmptyAttributeWitnesses();
-  constructor(private elementName: Token) { }
+  constructor(private elementName: Token) {}
   addAttribute(attribute: ast.DeclarationAttribute): void {
     switch (attribute.kind) {
       case ast.SyntaxKind.ComputationDataAttribute:
@@ -631,7 +631,7 @@ export class DefaultPrimitiveTypeBuilder implements PrimitiveTypeBuilder {
           [DefaultAttributeEnum.SCAN]: ScanMode.Scan,
           [DefaultAttributeEnum.RESCAN]: ScanMode.ReScan,
         };
-        const attributeValue = mapTo[typeAsEnum];;
+        const attributeValue = mapTo[typeAsEnum];
         this.addAttributeWitness(
           AttributeKind.ScanMode,
           attributeValue,
@@ -640,7 +640,6 @@ export class DefaultPrimitiveTypeBuilder implements PrimitiveTypeBuilder {
         );
         break;
       }
-
 
       /**
        * Procedure parameter passing direction attributes
@@ -677,12 +676,7 @@ export class DefaultPrimitiveTypeBuilder implements PrimitiveTypeBuilder {
        * @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=data-list-attribute
        */
       case DefaultAttributeEnum.LIST: {
-        this.addAttributeWitness(
-          AttributeKind.List,
-          true,
-          attribute,
-          token,
-        );
+        this.addAttributeWitness(AttributeKind.List, true, attribute, token);
         break;
       }
 
@@ -718,7 +712,7 @@ export class DefaultPrimitiveTypeBuilder implements PrimitiveTypeBuilder {
         //TODO
         break;
       }
-      
+
       /**
        * Parameter flag attribute
        * @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=procedures-parameter-attribute
@@ -750,7 +744,7 @@ export class DefaultPrimitiveTypeBuilder implements PrimitiveTypeBuilder {
       case DefaultAttributeEnum.TRANSIENT: //no documentation found
       case DefaultAttributeEnum.RANGE: //no documentation found
         break;
-      
+
       case DefaultAttributeEnum.POSITION: //@see https://www.ibm.com/docs/en/epfz/6.1.0?topic=control-defined-position-attributes
       case DefaultAttributeEnum.PRINT: //@see https://www.ibm.com/docs/en/epfz/6.1.0?topic=transmission-print-attribute
       case DefaultAttributeEnum.RESERVED: //@see https://www.ibm.com/docs/en/epfz/6.1.0?topic=declarations-reserved-attribute

--- a/packages/language/src/typesystem/primitive-type-builder.ts
+++ b/packages/language/src/typesystem/primitive-type-builder.ts
@@ -15,6 +15,7 @@ import {
   DefaultAttributeToEnum,
 } from "../parser/token-mappings";
 import { Token } from "../parser/tokens";
+import { ScanMode } from "../preprocessor/instructions";
 import { assertType } from "../preprocessor/util";
 import * as ast from "../syntax-tree/ast";
 import { assertUnreachable } from "../utils/common";
@@ -51,6 +52,8 @@ import {
   AttributeWitness,
   Implications,
   TransmissionDirection,
+  ParameterPassMode,
+  ParameterPassDirection,
 } from "./descriptions";
 
 function createEmptyAttributeWitnesses(): AttributeWitnesses {
@@ -76,7 +79,7 @@ export class DefaultPrimitiveTypeBuilder implements PrimitiveTypeBuilder {
   private possibleDataTypes = new Set<DataType>(DataTypesArray);
   private attributeWitnesses: AttributeWitnesses =
     createEmptyAttributeWitnesses();
-  constructor(private elementName: Token) {}
+  constructor(private elementName: Token) { }
   addAttribute(attribute: ast.DeclarationAttribute): void {
     switch (attribute.kind) {
       case ast.SyntaxKind.ComputationDataAttribute:
@@ -96,7 +99,7 @@ export class DefaultPrimitiveTypeBuilder implements PrimitiveTypeBuilder {
         );
         break;
       case ast.SyntaxKind.DimensionsDataAttribute:
-        if(attribute.dimensions && attribute.dimensionsToken) {
+        if (attribute.dimensions && attribute.dimensionsToken) {
           this.addAttributeWitness(
             AttributeKind.Dimension,
             attribute.dimensions,
@@ -165,12 +168,14 @@ export class DefaultPrimitiveTypeBuilder implements PrimitiveTypeBuilder {
       case DefaultAttributeEnum.TASK:
       case DefaultAttributeEnum.FILE:
       case DefaultAttributeEnum.FORMAT:
+      case DefaultAttributeEnum.LABEL:
       case DefaultAttributeEnum.AREA: {
         const mapTo = {
           [DefaultAttributeEnum.AREA]: DataType.Area,
           [DefaultAttributeEnum.FILE]: DataType.File,
           [DefaultAttributeEnum.FORMAT]: DataType.Format,
           [DefaultAttributeEnum.TASK]: DataType.Task,
+          [DefaultAttributeEnum.LABEL]: DataType.Label,
         };
         const dataType = mapTo[typeAsEnum];
         this.addAttributeWitness(
@@ -593,41 +598,162 @@ export class DefaultPrimitiveTypeBuilder implements PrimitiveTypeBuilder {
         break;
       }
 
-      case DefaultAttributeEnum.BACKWARDS:
+      /**
+       * Procedure parameter passing attributes
+       * @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=procedures-using-byvalue-byaddr
+       */
       case DefaultAttributeEnum.BYADDR:
-      case DefaultAttributeEnum.BYVALUE:
-      case DefaultAttributeEnum.CONDITION:
-      case DefaultAttributeEnum.CONSTANT:
-      case DefaultAttributeEnum.DIMACROSS:
-      case DefaultAttributeEnum.EVENT:
-      case DefaultAttributeEnum.EXCLUSIVE:
-      case DefaultAttributeEnum.GENERIC:
-      case DefaultAttributeEnum.HEX:
-      case DefaultAttributeEnum.INONLY:
-      case DefaultAttributeEnum.INOUT:
-      case DefaultAttributeEnum.IRREDUCIBLE:
-      case DefaultAttributeEnum.KEYED:
-      case DefaultAttributeEnum.LABEL:
-      case DefaultAttributeEnum.LIST:
-      case DefaultAttributeEnum.MEMBER:
-      case DefaultAttributeEnum.NATIVE:
-      case DefaultAttributeEnum.NOINIT:
-      case DefaultAttributeEnum.NONNATIVE:
+      case DefaultAttributeEnum.BYVALUE: {
+        const mapTo = {
+          [DefaultAttributeEnum.BYADDR]: ParameterPassMode.ByAddr,
+          [DefaultAttributeEnum.BYVALUE]: ParameterPassMode.ByValue,
+        };
+        const attributeValue = mapTo[typeAsEnum];
+        this.addAttributeWitness(
+          AttributeKind.ParameterPassMode,
+          attributeValue,
+          attribute,
+          token,
+        );
+        break;
+      }
+
+      /**
+       * Preprocessor scan attributes
+       * @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=facilities-preprocessor-scan
+       */
       case DefaultAttributeEnum.NOSCAN:
-      case DefaultAttributeEnum.NULLINIT:
-      case DefaultAttributeEnum.OPTIONAL:
-      case DefaultAttributeEnum.OPTIONS:
+      case DefaultAttributeEnum.SCAN:
+      case DefaultAttributeEnum.RESCAN: {
+        const mapTo = {
+          [DefaultAttributeEnum.NOSCAN]: ScanMode.NoScan,
+          [DefaultAttributeEnum.SCAN]: ScanMode.Scan,
+          [DefaultAttributeEnum.RESCAN]: ScanMode.ReScan,
+        };
+        const attributeValue = mapTo[typeAsEnum];;
+        this.addAttributeWitness(
+          AttributeKind.ScanMode,
+          attributeValue,
+          attribute,
+          token,
+        );
+        break;
+      }
+
+
+      /**
+       * Procedure parameter passing direction attributes
+       * @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=procedures-using-inonly-inout-outonly
+       */
+      case DefaultAttributeEnum.INONLY:
       case DefaultAttributeEnum.OUTONLY:
-      case DefaultAttributeEnum.PARAMETER:
+      case DefaultAttributeEnum.INOUT: {
+        const mapTo = {
+          [DefaultAttributeEnum.INONLY]: ParameterPassDirection.InOnly,
+          [DefaultAttributeEnum.OUTONLY]: ParameterPassDirection.OutOnly,
+          [DefaultAttributeEnum.INOUT]: ParameterPassDirection.InOut,
+        };
+        const attributeValue = mapTo[typeAsEnum];
+        this.addAttributeWitness(
+          AttributeKind.ParameterPassDirection,
+          attributeValue,
+          attribute,
+          token,
+        );
+        break;
+      }
+
+      /**
+       * @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=conditions-condition-condition
+       */
+      case DefaultAttributeEnum.CONDITION: {
+        //TODO
+        break;
+      }
+
+      /**
+       * List flag attribute
+       * @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=data-list-attribute
+       */
+      case DefaultAttributeEnum.LIST: {
+        this.addAttributeWitness(
+          AttributeKind.List,
+          true,
+          attribute,
+          token,
+        );
+        break;
+      }
+
+      case DefaultAttributeEnum.OPTIONAL: {
+        this.addAttributeWitness(
+          AttributeKind.Optional,
+          true,
+          attribute,
+          token,
+        );
+        break;
+      }
+
+      /**
+       * Options attribute
+       * @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=organization-options-option-attribute
+       */
+      case DefaultAttributeEnum.OPTIONS: {
+        //TODO
+        break;
+      }
+
+      /**
+       * @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=data-generic-attribute
+       */
+      case DefaultAttributeEnum.GENERIC: {
+        //TODO
+        break;
+      }
+
+      /** @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=files-keyed-attribute */
+      case DefaultAttributeEnum.KEYED: {
+        //TODO
+        break;
+      }
+      
+      /**
+       * Parameter flag attribute
+       * @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=procedures-parameter-attribute
+       */
+      case DefaultAttributeEnum.PARAMETER: {
+        this.addAttributeWitness(
+          AttributeKind.Parameter,
+          true,
+          attribute,
+          token,
+        );
+        break;
+      }
+
+      case DefaultAttributeEnum.DIMACROSS: //for composite types only
+      case DefaultAttributeEnum.UNION: //for composite types only
+        break;
+      case DefaultAttributeEnum.BACKWARDS: //no documentation found
+      case DefaultAttributeEnum.CONSTANT: //no documentation found
+      case DefaultAttributeEnum.EVENT: //no documentation found
+      case DefaultAttributeEnum.EXCLUSIVE: //no documentation found
+      case DefaultAttributeEnum.HEX: //a function not an attribute
+      case DefaultAttributeEnum.IRREDUCIBLE: //no documentation found, but @see https://www.ibm.com/support/pages/apar/PI26521
+      case DefaultAttributeEnum.MEMBER: //no documentation found
+      case DefaultAttributeEnum.NATIVE: //no documentation found
+      case DefaultAttributeEnum.NOINIT: //no documentation found
+      case DefaultAttributeEnum.NONNATIVE: //no documentation found
+      case DefaultAttributeEnum.NULLINIT: //no documentation found
+      case DefaultAttributeEnum.TRANSIENT: //no documentation found
+        break;
+      
       case DefaultAttributeEnum.POSITION:
       case DefaultAttributeEnum.PRINT:
       case DefaultAttributeEnum.RANGE:
-      case DefaultAttributeEnum.RESCAN:
       case DefaultAttributeEnum.RESERVED:
-      case DefaultAttributeEnum.SCAN:
       case DefaultAttributeEnum.STRUCTURE:
-      case DefaultAttributeEnum.TRANSIENT:
-      case DefaultAttributeEnum.UNION:
       case DefaultAttributeEnum.VARIABLE:
         break;
       default:

--- a/packages/language/test/fourslash-harness/harness-interface.ts
+++ b/packages/language/test/fourslash-harness/harness-interface.ts
@@ -53,11 +53,16 @@ type SemanticTokenTypesValues = `${SemanticTokenTypes}`;
 
 export type Not<T> = Omit<T, "not">;
 
-type EditComputedAttributes<T extends TypeDescriptions.Any> = Omit<T, "dimension"> & {
-  dimension: {
-    lowerBound: Partial<Bound>;
-    upperBound: Partial<Bound>;
-  }[] | undefined;
+type EditComputedAttributes<T extends TypeDescriptions.Any> = Omit<
+  T,
+  "dimension"
+> & {
+  dimension:
+    | {
+        lowerBound: Partial<Bound>;
+        upperBound: Partial<Bound>;
+      }[]
+    | undefined;
 };
 export type PrimitiveTypeExpectation =
   | EditComputedAttributes<TypeDescriptions.Area>
@@ -70,15 +75,14 @@ export type PrimitiveTypeExpectation =
   | EditComputedAttributes<TypeDescriptions.Ordinal>
   | EditComputedAttributes<TypeDescriptions.Picture>
   | EditComputedAttributes<TypeDescriptions.String>
-  | EditComputedAttributes<TypeDescriptions.Task>
-  ;
+  | EditComputedAttributes<TypeDescriptions.Task>;
 export type TypeExpectation =
   | Partial<PrimitiveTypeExpectation>
   | Partial<TypeDescriptions.Unknown>
   | {
-    type: DataType.Structure;
-    members: Record<string, TypeExpectation>;
-  };
+      type: DataType.Structure;
+      members: Record<string, TypeExpectation>;
+    };
 
 export interface HarnessTesterInterface {
   Syntax: typeof SyntaxKind;

--- a/packages/language/test/fourslash-harness/harness-interface.ts
+++ b/packages/language/test/fourslash-harness/harness-interface.ts
@@ -28,6 +28,7 @@ import {
   Alignments,
   Assignability,
   Base,
+  Bound,
   BufferMode,
   DataType,
   Endianess,
@@ -52,12 +53,11 @@ type SemanticTokenTypesValues = `${SemanticTokenTypes}`;
 
 export type Not<T> = Omit<T, "not">;
 
-export type DimensionBound = {
-  lowerBound: number|'*';
-  upperBound: number|'*';
-};
 type EditComputedAttributes<T extends TypeDescriptions.Any> = Omit<T, "dimension"> & {
-  dimension: DimensionBound[] | undefined;
+  dimension: {
+    lowerBound: Partial<Bound>;
+    upperBound: Partial<Bound>;
+  }[] | undefined;
 };
 export type PrimitiveTypeExpectation =
   | EditComputedAttributes<TypeDescriptions.Area>

--- a/packages/language/test/fourslash-harness/harness-interface.ts
+++ b/packages/language/test/fourslash-harness/harness-interface.ts
@@ -52,12 +52,33 @@ type SemanticTokenTypesValues = `${SemanticTokenTypes}`;
 
 export type Not<T> = Omit<T, "not">;
 
+export type DimensionBound = {
+  lowerBound: number;
+  upperBound: number;
+};
+type EditComputedAttributes<T extends TypeDescriptions.Any> = Omit<T, "dimension"> & {
+  dimension: DimensionBound[] | undefined;
+};
+export type PrimitiveTypeExpectation =
+  | EditComputedAttributes<TypeDescriptions.Area>
+  | EditComputedAttributes<TypeDescriptions.Arithmetic>
+  | EditComputedAttributes<TypeDescriptions.File>
+  | EditComputedAttributes<TypeDescriptions.Format>
+  | EditComputedAttributes<TypeDescriptions.Label>
+  | EditComputedAttributes<TypeDescriptions.Locator>
+  | EditComputedAttributes<TypeDescriptions.Entry>
+  | EditComputedAttributes<TypeDescriptions.Ordinal>
+  | EditComputedAttributes<TypeDescriptions.Picture>
+  | EditComputedAttributes<TypeDescriptions.String>
+  | EditComputedAttributes<TypeDescriptions.Task>
+  ;
 export type TypeExpectation =
-  | Partial<Exclude<TypeDescriptions.Any, TypeDescriptions.Structure>>
+  | Partial<PrimitiveTypeExpectation>
+  | Partial<TypeDescriptions.Unknown>
   | {
-      type: DataType.Structure;
-      members: Record<string, TypeExpectation>;
-    };
+    type: DataType.Structure;
+    members: Record<string, TypeExpectation>;
+  };
 
 export interface HarnessTesterInterface {
   Syntax: typeof SyntaxKind;

--- a/packages/language/test/fourslash-harness/harness-interface.ts
+++ b/packages/language/test/fourslash-harness/harness-interface.ts
@@ -53,8 +53,8 @@ type SemanticTokenTypesValues = `${SemanticTokenTypes}`;
 export type Not<T> = Omit<T, "not">;
 
 export type DimensionBound = {
-  lowerBound: number;
-  upperBound: number;
+  lowerBound: number|'*';
+  upperBound: number|'*';
 };
 type EditComputedAttributes<T extends TypeDescriptions.Any> = Omit<T, "dimension"> & {
   dimension: DimensionBound[] | undefined;

--- a/packages/language/test/fourslash/validate/typesystem/declare/dcl-fixed-dim.ts
+++ b/packages/language/test/fourslash/validate/typesystem/declare/dcl-fixed-dim.ts
@@ -18,7 +18,7 @@ types.expectTypeAt("1", {
   type: types.dataTypes.Arithmetic,
   scale: types.scales.Fixed,
   precision: types.precision.create(5, 0),
-  dimension: [{ lowerBound: 1, upperBound: 10 }],
+  //TODO dimension: [{ lowerBound: 1, upperBound: 10 }],
   mode: types.modes.Real,
 });
 verify.noDiagnostics(undefined, ...code.TypeSystem);

--- a/packages/language/test/fourslash/validate/typesystem/declare/dcl-fixed-dim.ts
+++ b/packages/language/test/fourslash/validate/typesystem/declare/dcl-fixed-dim.ts
@@ -18,7 +18,7 @@ types.expectTypeAt("1", {
   type: types.dataTypes.Arithmetic,
   scale: types.scales.Fixed,
   precision: types.precision.create(5, 0),
-  //TODO dimension: [{ lowerBound: 1, upperBound: 10 }],
+  dimension: [{ lowerBound: 1, upperBound: 10 }],
   mode: types.modes.Real,
 });
 verify.noDiagnostics(undefined, ...code.TypeSystem);

--- a/packages/language/test/fourslash/validate/typesystem/declare/dcl-fixed-dim.ts
+++ b/packages/language/test/fourslash/validate/typesystem/declare/dcl-fixed-dim.ts
@@ -18,7 +18,7 @@ types.expectTypeAt("1", {
   type: types.dataTypes.Arithmetic,
   scale: types.scales.Fixed,
   precision: types.precision.create(5, 0),
-  dimension: [{ lowerBound: 1, upperBound: 10 }],
+  dimension: [{ lowerBound: { value: 1 }, upperBound: { value: 10 } }],
   mode: types.modes.Real,
 });
 verify.noDiagnostics(undefined, ...code.TypeSystem);

--- a/packages/language/test/fourslash/validate/typesystem/declare/dcl-fixed-dim.ts
+++ b/packages/language/test/fourslash/validate/typesystem/declare/dcl-fixed-dim.ts
@@ -1,0 +1,24 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: main
+//// DCL <|1:ANYTHING|> FIXED DIM(10) INITIAL ((10)0);
+
+types.expectTypeAt("1", {
+  type: types.dataTypes.Arithmetic,
+  scale: types.scales.Fixed,
+  precision: types.precision.create(5, 0),
+  dimension: [{ lowerBound: 1, upperBound: 10 }],
+  mode: types.modes.Real,
+});
+verify.noDiagnostics(undefined, ...code.TypeSystem);

--- a/packages/language/test/fourslash/validate/typesystem/declare/dcl-fixed-multi-dim.ts
+++ b/packages/language/test/fourslash/validate/typesystem/declare/dcl-fixed-multi-dim.ts
@@ -19,11 +19,11 @@ types.expectTypeAt("1", {
   scale: types.scales.Fixed,
   precision: types.precision.create(5, 0),
   dimension: [{
-    lowerBound: -1,
-    upperBound: 1
+    lowerBound: { value: -1 },
+    upperBound: { value: 1 }
   }, {
-    lowerBound: 1,
-    upperBound: 5
+    lowerBound: { value: 1 },
+    upperBound: { value: 5 }
   }],
   mode: types.modes.Real,
 });

--- a/packages/language/test/fourslash/validate/typesystem/declare/dcl-fixed-multi-dim.ts
+++ b/packages/language/test/fourslash/validate/typesystem/declare/dcl-fixed-multi-dim.ts
@@ -18,14 +18,13 @@ types.expectTypeAt("1", {
   type: types.dataTypes.Arithmetic,
   scale: types.scales.Fixed,
   precision: types.precision.create(5, 0),
-  //TODO
-  // dimension: [{
-  //   lowerBound: -1,
-  //   upperBound: 1
-  // }, {
-  //   lowerBound: 1,
-  //   upperBound: 5
-  // }],
+  dimension: [{
+    lowerBound: -1,
+    upperBound: 1
+  }, {
+    lowerBound: 1,
+    upperBound: 5
+  }],
   mode: types.modes.Real,
 });
 verify.noDiagnostics(undefined, ...code.TypeSystem);

--- a/packages/language/test/fourslash/validate/typesystem/declare/dcl-fixed-multi-dim.ts
+++ b/packages/language/test/fourslash/validate/typesystem/declare/dcl-fixed-multi-dim.ts
@@ -18,13 +18,16 @@ types.expectTypeAt("1", {
   type: types.dataTypes.Arithmetic,
   scale: types.scales.Fixed,
   precision: types.precision.create(5, 0),
-  dimension: [{
-    lowerBound: { value: -1 },
-    upperBound: { value: 1 }
-  }, {
-    lowerBound: { value: 1 },
-    upperBound: { value: 5 }
-  }],
+  dimension: [
+    {
+      lowerBound: { value: -1 },
+      upperBound: { value: 1 },
+    },
+    {
+      lowerBound: { value: 1 },
+      upperBound: { value: 5 },
+    },
+  ],
   mode: types.modes.Real,
 });
 verify.noDiagnostics(undefined, ...code.TypeSystem);

--- a/packages/language/test/fourslash/validate/typesystem/declare/dcl-fixed-multi-dim.ts
+++ b/packages/language/test/fourslash/validate/typesystem/declare/dcl-fixed-multi-dim.ts
@@ -18,13 +18,14 @@ types.expectTypeAt("1", {
   type: types.dataTypes.Arithmetic,
   scale: types.scales.Fixed,
   precision: types.precision.create(5, 0),
-  dimension: [{
-    lowerBound: -1,
-    upperBound: 1
-  }, {
-    lowerBound: 1,
-    upperBound: 5
-  }],
+  //TODO
+  // dimension: [{
+  //   lowerBound: -1,
+  //   upperBound: 1
+  // }, {
+  //   lowerBound: 1,
+  //   upperBound: 5
+  // }],
   mode: types.modes.Real,
 });
 verify.noDiagnostics(undefined, ...code.TypeSystem);

--- a/packages/language/test/fourslash/validate/typesystem/declare/dcl-fixed-multi-dim.ts
+++ b/packages/language/test/fourslash/validate/typesystem/declare/dcl-fixed-multi-dim.ts
@@ -1,0 +1,30 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: main
+//// DCL <|1:ANYTHING|> FIXED DIM(-1:1, 5) INITIAL ((15)0);
+
+types.expectTypeAt("1", {
+  type: types.dataTypes.Arithmetic,
+  scale: types.scales.Fixed,
+  precision: types.precision.create(5, 0),
+  dimension: [{
+    lowerBound: -1,
+    upperBound: 1
+  }, {
+    lowerBound: 1,
+    upperBound: 5
+  }],
+  mode: types.modes.Real,
+});
+verify.noDiagnostics(undefined, ...code.TypeSystem);

--- a/packages/language/test/fourslash/validate/typesystem/declare/dcl-fixed-star-dim.ts
+++ b/packages/language/test/fourslash/validate/typesystem/declare/dcl-fixed-star-dim.ts
@@ -18,28 +18,32 @@ types.expectTypeAt("1", {
   type: types.dataTypes.Arithmetic,
   scale: types.scales.Fixed,
   precision: types.precision.create(5, 0),
-  dimension: [{
-    lowerBound: {
-      value: 1
+  dimension: [
+    {
+      lowerBound: {
+        value: 1,
+      },
+      upperBound: {
+        value: "*",
+      },
     },
-    upperBound: {
-      value: '*'
-    }
-  }, {
-    lowerBound: {
-      value: 1
+    {
+      lowerBound: {
+        value: 1,
+      },
+      upperBound: {
+        value: "*",
+      },
     },
-    upperBound: {
-      value: '*'
-    }
-  }, {
-    lowerBound: {
-      value: 1
+    {
+      lowerBound: {
+        value: 1,
+      },
+      upperBound: {
+        value: "*",
+      },
     },
-    upperBound: {
-      value: '*'
-    }
-  }],
+  ],
   mode: types.modes.Real,
 });
 verify.noDiagnostics(undefined, ...code.TypeSystem);

--- a/packages/language/test/fourslash/validate/typesystem/declare/dcl-fixed-star-dim.ts
+++ b/packages/language/test/fourslash/validate/typesystem/declare/dcl-fixed-star-dim.ts
@@ -18,7 +18,28 @@ types.expectTypeAt("1", {
   type: types.dataTypes.Arithmetic,
   scale: types.scales.Fixed,
   precision: types.precision.create(5, 0),
-  //TODO dimension: ['*', '*', '*'],
+  dimension: [{
+    lowerBound: {
+      value: 1
+    },
+    upperBound: {
+      value: '*'
+    }
+  }, {
+    lowerBound: {
+      value: 1
+    },
+    upperBound: {
+      value: '*'
+    }
+  }, {
+    lowerBound: {
+      value: 1
+    },
+    upperBound: {
+      value: '*'
+    }
+  }],
   mode: types.modes.Real,
 });
 verify.noDiagnostics(undefined, ...code.TypeSystem);

--- a/packages/language/test/fourslash/validate/typesystem/declare/dcl-fixed-star-dim.ts
+++ b/packages/language/test/fourslash/validate/typesystem/declare/dcl-fixed-star-dim.ts
@@ -18,7 +18,7 @@ types.expectTypeAt("1", {
   type: types.dataTypes.Arithmetic,
   scale: types.scales.Fixed,
   precision: types.precision.create(5, 0),
-  dimension: ['*', '*', '*'],
+  //TODO dimension: ['*', '*', '*'],
   mode: types.modes.Real,
 });
 verify.noDiagnostics(undefined, ...code.TypeSystem);

--- a/packages/language/test/fourslash/validate/typesystem/declare/dcl-fixed-star-dim.ts
+++ b/packages/language/test/fourslash/validate/typesystem/declare/dcl-fixed-star-dim.ts
@@ -1,0 +1,24 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: main
+//// DCL <|1:ANYTHING|> FIXED DIM(*, *, *) INITIAL (1, 2, 3, 4, 5, 6, 7, 8);
+
+types.expectTypeAt("1", {
+  type: types.dataTypes.Arithmetic,
+  scale: types.scales.Fixed,
+  precision: types.precision.create(5, 0),
+  dimension: ['*', '*', '*'],
+  mode: types.modes.Real,
+});
+verify.noDiagnostics(undefined, ...code.TypeSystem);

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -1027,9 +1027,14 @@ export class TestBuilder {
   ) {
     if (expectedType.type === DataType.Structure) {
       //check: is structure?
+      if (!actualType.type) {
+        throw new Error(
+          `Expected type to be a ${TypeDescriptions.Names[DataType.Structure]}, but got undefined`,
+        );
+      }
       if (actualType.type !== DataType.Structure) {
         throw new Error(
-          `Expected type to be a ${TypeDescriptions.Names[DataType.Structure]}, but got ${TypeDescriptions.Names[actualType.type!]}`,
+          `Expected type to be a ${TypeDescriptions.Names[DataType.Structure]}, but got ${TypeDescriptions.Names[actualType.type]}`,
         );
       }
 

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -1010,7 +1010,11 @@ export class TestBuilder {
         );
       }
       const actualType = this.unit.services.inferer.inferType(node, this.unit);
-      if(actualType.type === DataType.Unknown || actualType.type === DataType.Structure || !actualType.dimension) {
+      if (
+        actualType.type === DataType.Unknown ||
+        actualType.type === DataType.Structure ||
+        !actualType.dimension
+      ) {
         this.expectTypeWithStructure(expectedType, actualType as any);
       } else {
         this.expectTypeNoStructure(expectedType, actualType);
@@ -1057,10 +1061,7 @@ export class TestBuilder {
     }
   }
 
-  private expectTypeNoStructure(
-    expectedType: object,
-    actualType: object,
-  ) {
+  private expectTypeNoStructure(expectedType: object, actualType: object) {
     for (const [key, value] of Object.entries(expectedType)) {
       if (typeof value === "object" && value !== null) {
         const field = (actualType as any)[key as keyof typeof actualType];
@@ -1068,10 +1069,7 @@ export class TestBuilder {
           expect(Array.isArray(field)).toEqual(true);
           expect(value.length).toEqual(field.length);
           value.forEach((v, i) => {
-            this.expectTypeNoStructure(
-              v,
-              field[i],
-            );
+            this.expectTypeNoStructure(v, field[i]);
           });
         } else {
           this.expectTypeNoStructure(value, field);

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -49,6 +49,7 @@ import { format } from "util";
 import { DataType, TypeDescriptions } from "../src/typesystem/descriptions";
 import { TypeExpectation } from "./fourslash-harness/harness-interface";
 import { binaryTokenSearch } from "../src/utils/search";
+import { assertType } from "../src/preprocessor/util";
 
 export type Label = string | number | string[] | number[];
 
@@ -1062,7 +1063,19 @@ export class TestBuilder {
   ) {
     for (const [key, value] of Object.entries(expectedType)) {
       if (typeof value === "object" && value !== null) {
-        this.expectTypeNoStructure(value, actualType[key as keyof typeof actualType]);
+        const field = (actualType as any)[key as keyof typeof actualType];
+        if (Array.isArray(value)) {
+          expect(Array.isArray(field)).toEqual(true);
+          expect(value.length).toEqual(field.length);
+          value.forEach((v, i) => {
+            this.expectTypeNoStructure(
+              v,
+              field[i],
+            );
+          });
+        } else {
+          this.expectTypeNoStructure(value, field);
+        }
       } else {
         expect(actualType[key as keyof typeof actualType]).toEqual(value);
       }

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -49,7 +49,6 @@ import { format } from "util";
 import { DataType, TypeDescriptions } from "../src/typesystem/descriptions";
 import { TypeExpectation } from "./fourslash-harness/harness-interface";
 import { binaryTokenSearch } from "../src/utils/search";
-import { assertType } from "../src/preprocessor/util";
 
 export type Label = string | number | string[] | number[];
 

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -49,7 +49,6 @@ import { format } from "util";
 import { DataType, TypeDescriptions } from "../src/typesystem/descriptions";
 import { TypeExpectation } from "./fourslash-harness/harness-interface";
 import { binaryTokenSearch } from "../src/utils/search";
-import { computeDimensions } from "../src/typesystem/computed-attributes";
 
 export type Label = string | number | string[] | number[];
 
@@ -1013,10 +1012,7 @@ export class TestBuilder {
       if(actualType.type === DataType.Unknown || actualType.type === DataType.Structure || !actualType.dimension) {
         this.expectTypeWithStructure(expectedType, actualType as any);
       } else {
-        this.expectTypeNoStructure(expectedType, {
-          ...actualType as any,
-          dimension: computeDimensions(actualType),
-        } as TypeExpectation);
+        this.expectTypeNoStructure(expectedType, actualType);
       }
     }
   }
@@ -1061,14 +1057,12 @@ export class TestBuilder {
   }
 
   private expectTypeNoStructure(
-    expectedType: TypeExpectation,
-    actualType: TypeExpectation,
+    expectedType: object,
+    actualType: object,
   ) {
     for (const [key, value] of Object.entries(expectedType)) {
       if (typeof value === "object" && value !== null) {
-        expect(actualType[key as keyof typeof actualType]).toEqual(
-          expect.objectContaining(value),
-        );
+        this.expectTypeNoStructure(value, actualType[key as keyof typeof actualType]);
       } else {
         expect(actualType[key as keyof typeof actualType]).toEqual(value);
       }

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -49,6 +49,7 @@ import { format } from "util";
 import { DataType, TypeDescriptions } from "../src/typesystem/descriptions";
 import { TypeExpectation } from "./fourslash-harness/harness-interface";
 import { binaryTokenSearch } from "../src/utils/search";
+import { computeDimensions } from "../src/typesystem/computed-attributes";
 
 export type Label = string | number | string[] | number[];
 
@@ -1009,19 +1010,26 @@ export class TestBuilder {
         );
       }
       const actualType = this.unit.services.inferer.inferType(node, this.unit);
-      this.expectTypeWithStructure(expectedType, actualType);
+      if(actualType.type === DataType.Unknown || actualType.type === DataType.Structure || !actualType.dimension) {
+        this.expectTypeWithStructure(expectedType, actualType as any);
+      } else {
+        this.expectTypeNoStructure(expectedType, {
+          ...actualType as any,
+          dimension: computeDimensions(actualType),
+        } as TypeExpectation);
+      }
     }
   }
 
   private expectTypeWithStructure(
     expectedType: TypeExpectation,
-    actualType: TypeDescriptions.Any,
+    actualType: TypeExpectation,
   ) {
     if (expectedType.type === DataType.Structure) {
       //check: is structure?
       if (actualType.type !== DataType.Structure) {
         throw new Error(
-          `Expected type to be a ${TypeDescriptions.Names[DataType.Structure]}, but got ${TypeDescriptions.Names[actualType.type]}`,
+          `Expected type to be a ${TypeDescriptions.Names[DataType.Structure]}, but got ${TypeDescriptions.Names[actualType.type!]}`,
         );
       }
 
@@ -1054,7 +1062,7 @@ export class TestBuilder {
 
   private expectTypeNoStructure(
     expectedType: TypeExpectation,
-    actualType: TypeDescriptions.Any,
+    actualType: TypeExpectation,
   ) {
     for (const [key, value] of Object.entries(expectedType)) {
       if (typeof value === "object" && value !== null) {


### PR DESCRIPTION
I added some of the missing attributes. Especially DIMENSION and INITIAL.

There were also some discussion, how much information we should infer into the type descriptions. The result was, that we can add functionality later, if needed. It makes currently no sense to compute everything when we do not use it for now.

There are also a bunch of attributes that are not listed in the online documentation, but instead mentioned in syntax diagrams or inside th index of the language reference.

I was able to identify some extra attributes for parameter passing and a handful of flag attributes. I will stop adding attributes after this PR. We should add them when they are required. Some attributes are also very complex. I tended to store their AST node into the type description FTM.