### PR TITLE
Add pp rescan handling

### DIFF
--- a/packages/language/src/parser/tokenizer.ts
+++ b/packages/language/src/parser/tokenizer.ts
@@ -102,15 +102,17 @@ class TokenizerContext {
   public column: number = 0;
   public uri: URI | undefined;
   public diagnostics: Diagnostic[] = [];
+  public caseUpper: boolean;
 
   private storedIndex: number = 0;
   private storedLine: number = 0;
   private storedColumn: number = 0;
 
-  constructor(input: string, uri: URI | undefined) {
+  constructor(input: string, uri: URI | undefined, caseUpper: boolean = true) {
     this.input = input;
     this.length = input.length;
     this.uri = uri;
+    this.caseUpper = caseUpper;
   }
 
   store() {
@@ -203,7 +205,7 @@ function tokenizeIdentifier(
     if (!isIdChar(charCode)) {
       break;
     }
-    if (charCode >= 97 && charCode <= 122) {
+    if (context.caseUpper && charCode >= 97 && charCode <= 122) {
       // Lowercase character, must be uppercased
       charCode &= ~0x20;
     }
@@ -212,7 +214,7 @@ function tokenizeIdentifier(
     i++;
   }
   const originalImage = context.input.substring(start, i);
-  const image = originalImage.toUpperCase();
+  const image = context.caseUpper ? originalImage.toUpperCase() : originalImage;
   const previousToken = context.tokens[context.tokens.length - 1];
   // Specific handling for ExecFragment (likely EXEC SQL or EXEC CICS)
   if (
@@ -540,8 +542,9 @@ export interface TokenizationResult {
 export function tokenize(
   input: string,
   uri: URI | undefined,
+  caseUpper: boolean = true,
 ): TokenizationResult {
-  const context = new TokenizerContext(input, uri);
+  const context = new TokenizerContext(input, uri, caseUpper);
   let previous: tokens.Token | undefined = undefined;
 
   while (context.index < context.length) {

--- a/packages/language/src/preprocessor/compiler-options/options-macro.ts
+++ b/packages/language/src/preprocessor/compiler-options/options-macro.ts
@@ -39,7 +39,8 @@ export namespace CompilerOptions {
 }
 
 const defaultCompilerOptions: CompilerOptions = {
-  case: "ASIS",
+  // Contrary to the spec, our current implementation and tests use UPPER as default for case and rescan.
+  case: "UPPER",
   dbcs: "INEXACT",
   deprecate: new Set(),
   deprecateNext: new Set(),
@@ -49,7 +50,7 @@ const defaultCompilerOptions: CompilerOptions = {
   ignore: false,
   incOnly: false,
   namePrefix: false,
-  rescan: "ASIS",
+  rescan: "UPPER",
 };
 
 export function getDefaultCompilerOptions(): CompilerOptions {

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -1952,7 +1952,10 @@ function replaceTokenWithValue(
   immediateFollow: boolean,
   context: InterpreterContext,
 ): Token[] {
-  const tokens = lex(value);
+  const tokens = lex(
+    value,
+    context.unit.compilerOptions.macroOptions?.rescan !== "ASIS",
+  );
   setImmediateFollowProperty(immediateFollow, tokens);
   return replaceTokensInText(tokens, context);
 }
@@ -1974,8 +1977,8 @@ function generateSyntheticRefItem(
   return refItem;
 }
 
-function lex(text: string): Token[] {
-  return tokenize(text, undefined).tokens;
+function lex(text: string, caseUpper: boolean = true): Token[] {
+  return tokenize(text, undefined, caseUpper).tokens;
 }
 
 function setImmediateFollowProperty(

--- a/packages/language/src/validation/macro/case.ts
+++ b/packages/language/src/validation/macro/case.ts
@@ -27,47 +27,59 @@ export function MACRO_Case(
   acceptor: ValidationAcceptor,
   compilationUnit: CompilationUnit,
 ) {
+  if (!compilationUnit.processGroup?.lspOptions.caseUpperValidation) return;
   if (node !== compilationUnit.preprocessorAst) return;
   if (compilationUnit.compilerOptions.macroOptions.case !== "UPPER") return;
 
-  const tokens = collectPreprocessorTokens(compilationUnit).filter(
-    (token) =>
-      token.tokenType?.tokenTypeIdx !== PreprocessorTokens.String.tokenTypeIdx,
-  );
+  const MAX_DIAGNOSTICS = 100;
+  let diagnosticCount = 0;
 
-  for (const token of tokens) {
-    if (/[a-z]/.test(token.originalImage)) {
-      const diagnostic = diagnosticFromCode(
-        LspCodes.UpperCase,
-        token,
-        token.image,
-      );
-      // Diagnostic data needed for the quickfix
-      diagnostic.data = {
-        uri: diagnostic.uri,
-        text: token.originalImage,
-      };
-      acceptor(diagnostic);
-    }
-  }
-}
-
-function collectPreprocessorTokens(unit: CompilationUnit): Token[] {
-  const tokens: Token[] = [];
   const tokenMap = new MultiMap<AST.SyntaxNode, Token>();
-  for (const token of unit.services.files.getAllTokens()) {
+  for (const token of compilationUnit.services.files.getAllTokens()) {
     if (token.element) {
       tokenMap.add(token.element, token);
     }
   }
 
-  traverseAllNodes(unit.preprocessorAst, (child) => {
-    const nodeTokens = tokenMap.get(child);
-    if (nodeTokens.length > 0) {
-      tokens.push(...nodeTokens);
+  const processedTokens = new Set<Token>();
+
+  traverseAllNodes(compilationUnit.preprocessorAst, (child) => {
+    if (diagnosticCount >= MAX_DIAGNOSTICS) {
+      return TraversalState.Stop;
     }
+
+    const nodeTokens = tokenMap.get(child);
+    for (const token of nodeTokens) {
+      if (processedTokens.has(token)) continue;
+      processedTokens.add(token);
+
+      // Skip string tokens
+      if (
+        token.tokenType?.tokenTypeIdx === PreprocessorTokens.String.tokenTypeIdx
+      ) {
+        continue;
+      }
+
+      if (/[a-z]/.test(token.originalImage)) {
+        if (diagnosticCount >= MAX_DIAGNOSTICS) {
+          return TraversalState.Stop;
+        }
+
+        const diagnostic = diagnosticFromCode(
+          LspCodes.UpperCase,
+          token,
+          token.image,
+        );
+        // Diagnostic data needed for the quickfix
+        diagnostic.data = {
+          uri: diagnostic.uri,
+          text: token.originalImage,
+        };
+        acceptor(diagnostic);
+        diagnosticCount++;
+      }
+    }
+
     return TraversalState.Continue;
   });
-
-  return tokens;
 }

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -106,6 +106,7 @@ export interface ProcessGroup {
   lspOptions: {
     checkMargins: boolean;
     instructionCounterLimit: number;
+    caseUpperValidation: boolean;
   };
 
   /**
@@ -156,6 +157,9 @@ export function deserializeProcessGroup(
       instructionCounterLimit: isNumber(instructionCounterLimit)
         ? instructionCounterLimit
         : MAX_INSTRUCTION_COUNTER,
+      caseUpperValidation: isBoolean(lspOptions["case-upper-validation"])
+        ? lspOptions["case-upper-validation"]
+        : false,
     },
     memberNameValidation: isBoolean(memberNameValidation)
       ? memberNameValidation
@@ -197,6 +201,7 @@ interface SerializedProcessGroup {
   "lsp-options"?: {
     "check-margins"?: boolean;
     "instruction-counter-limit"?: number;
+    "case-upper-validation"?: boolean;
   };
 }
 

--- a/packages/language/test/fourslash/preprocessor/rescan-asis.ts
+++ b/packages/language/test/fourslash/preprocessor/rescan-asis.ts
@@ -1,0 +1,39 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// Example from pg, p. 120.
+
+////*PROCESS PP(MACRO('RESCAN(ASIS)'));
+////
+//// %dcl eins char ext;
+//// %dcl text char ext;
+////
+//// %eins = 'zwei';
+//// %text = 'EINS';
+//// display( text );
+////
+//// %text = 'eins';
+//// display( text );
+
+preprocessor.expectTokens([
+  "DISPLAY",
+  "(",
+  "zwei",
+  ")",
+  ";",
+  "DISPLAY",
+  "(",
+  "eins",
+  ")",
+  ";",
+]);

--- a/packages/language/test/fourslash/preprocessor/rescan-upper.ts
+++ b/packages/language/test/fourslash/preprocessor/rescan-upper.ts
@@ -1,0 +1,31 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// Example from pg, p. 120.
+
+////*PROCESS PP(MACRO('RESCAN(UPPER)'));
+////
+//// %dcl eins char ext;
+//// %dcl text char ext;
+////
+//// %eins = 'zwei';
+//// %text = 'EINS';
+//// display( text );
+////
+//// %text = 'eins';
+//// display( text );
+
+preprocessor.expectTokens(`
+  display( zwei );
+  display( zwei );
+`);

--- a/packages/language/test/fourslash/validate/macro/case-opt-in.ts
+++ b/packages/language/test/fourslash/validate/macro/case-opt-in.ts
@@ -11,6 +11,18 @@
 
 /// <reference path="../../framework.ts" />
 
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////         "name": "default",
+////         "lsp-options": {
+////             "case-upper-validation": true
+////         }
+////         }
+////     ]
+//// }
+
 ////%PROCESS PP(MACRO('CASE(UPPER)'));
 //// %DCL <|1:x|> <|2:char|>;
 //// %DCL Y CHAR;

--- a/packages/language/test/fourslash/validate/macro/case-opt-out.ts
+++ b/packages/language/test/fourslash/validate/macro/case-opt-out.ts
@@ -1,0 +1,30 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////%PROCESS PP(MACRO('CASE(UPPER)'));
+//// %DCL <|1:x|> <|2:char|>;
+//// %DCL Y CHAR;
+//// %X = <|3:"PUT SKIP LIST('Hello, World!');"|>;
+////
+//// %TEST: PROC RETURNS (CHAR);
+////   RETURN (X);
+//// %END;
+////
+//// RGT005: <|3:pROCEDURE|>() OPTIONS(MAIN);
+////   %Y = TEST();
+////   Y
+//// END RGT005;
+
+verify.noDiagnostics(1, code.LspCodes.UpperCase);
+verify.noDiagnostics(2, code.LspCodes.UpperCase);
+verify.noDiagnostics(3, code.LspCodes.UpperCase);

--- a/packages/language/test/parser/pli-lexer.test.ts
+++ b/packages/language/test/parser/pli-lexer.test.ts
@@ -130,7 +130,11 @@ describe("PL/1 Lexer", () => {
         libs: [],
         $computedLibs: [],
         $computedLibsSet: new Set<string>(),
-        lspOptions: { checkMargins: false, instructionCounterLimit: 5000 },
+        lspOptions: {
+          checkMargins: false,
+          instructionCounterLimit: 5000,
+          caseUpperValidation: false,
+        },
         pliOptions: {},
       };
 
@@ -203,6 +207,7 @@ describe("PL/1 Lexer", () => {
         lspOptions: {
           checkMargins: false,
           instructionCounterLimit: 5000,
+          caseUpperValidation: false,
         },
         pliOptions: {},
       };

--- a/packages/language/test/preprocessor/pli-preprocessor.test.ts
+++ b/packages/language/test/preprocessor/pli-preprocessor.test.ts
@@ -44,7 +44,11 @@ async function init(libPath: string): Promise<Diagnostic[]> {
     libs: [libPath],
     $computedLibs: [],
     $computedLibsSet: new Set<string>(),
-    lspOptions: { checkMargins: false, instructionCounterLimit: 5000 },
+    lspOptions: {
+      checkMargins: false,
+      instructionCounterLimit: 5000,
+      caseUpperValidation: false,
+    },
     pliOptions: {},
   };
 

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -314,7 +314,11 @@ export class TestBuilder {
           includeExtensions: [".pli"],
           compilerOptions: [],
           implicitBuiltins: new Set(),
-          lspOptions: { checkMargins: false, instructionCounterLimit: 5000 },
+          lspOptions: {
+            checkMargins: false,
+            instructionCounterLimit: 5000,
+            caseUpperValidation: false,
+          },
           pliOptions: {},
         },
       ]);

--- a/packages/language/test/workspace/compilation-unit.test.ts
+++ b/packages/language/test/workspace/compilation-unit.test.ts
@@ -146,7 +146,11 @@ describe("Compilation Unit Tests", () => {
         $computedLibs: [],
         $computedLibsSet: new Set<string>(),
         includeExtensions: [".inc"],
-        lspOptions: { checkMargins: false, instructionCounterLimit: 5000 },
+        lspOptions: {
+          checkMargins: false,
+          instructionCounterLimit: 5000,
+          caseUpperValidation: false,
+        },
         pliOptions: {},
         implicitBuiltins: new Set(),
       },

--- a/packages/language/test/workspace/plugin-configuration.test.ts
+++ b/packages/language/test/workspace/plugin-configuration.test.ts
@@ -44,7 +44,11 @@ describe("Plugin Configuration Tests", () => {
       $computedLibs: [],
       $computedLibsSet: new Set<string>(),
       includeExtensions: [".inc"],
-      lspOptions: { checkMargins: false, instructionCounterLimit: 5000 },
+      lspOptions: {
+        checkMargins: false,
+        instructionCounterLimit: 5000,
+        caseUpperValidation: false,
+      },
       pliOptions: {},
       implicitBuiltins: new Set(),
     };
@@ -163,6 +167,7 @@ describe("Plugin Configuration Tests", () => {
         lspOptions: {
           checkMargins: false,
           instructionCounterLimit: 5000,
+          caseUpperValidation: false,
         },
         pliOptions: {},
         implicitBuiltins: new Set(),

--- a/packages/vscode-extension/schemas/proc_grps.schema.json
+++ b/packages/vscode-extension/schemas/proc_grps.schema.json
@@ -66,6 +66,10 @@
               "instruction-counter-limit": {
                 "type": "number",
                 "description": "Maximum number of times to run an instructions during preprocessing. The default is 5000."
+              },
+              "case-upper-validation": {
+                "type": "boolean",
+                "description": "Whether to validate the CASE(UPPER) macro option and provide diagnostics for quickfixes."
               }
             }
           }


### PR DESCRIPTION
Concludes https://github.com/zowe/zowe-pli-language-support/issues/441 and hence https://github.com/zowe/zowe-pli-language-support/issues/397

Takes RESCAN(UPPER) as default and handles ASIS as the exception. Please let us discuss if you would like to approach this differently.

The examples are taken from the programming guide.