### PR TITLE
Stabilize PLIPlugin Initialization in 4Slash Tests

### DIFF
--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -398,7 +398,8 @@ export class PluginConfigurationProvider {
   private async postProcessProcessGroups(): Promise<Diagnostic[]> {
     const diagnostics: Diagnostic[] = [];
     for (const processGroup of this.processGroupConfigs.values()) {
-      const computedLibs: Set<LibsEntry> = new Set();
+      // all computed libs for this group, dirs + ddnames
+      const computedLibsMap: Map<string, LibsEntry> = new Map();
       const libsToProcess = [...processGroup.libs];
       while (libsToProcess.length > 0) {
         const lib = libsToProcess.pop();
@@ -427,14 +428,15 @@ export class PluginConfigurationProvider {
                   // directory to add for handling
                   libsToProcess.push(`${lib}/${fileName}`);
                   // also add to the full libs list
-                  computedLibs.add({
-                    dir: `${lib}/${fileName}`,
+                  const dir = `${lib}/${fileName}`;
+                  computedLibsMap.set(`dir:${dir}`, {
+                    dir,
                   });
                 }
               }
             }
             // add the lib itself, now that we know it exists
-            computedLibs.add({
+            computedLibsMap.set(`dir:${lib}`, {
               dir: lib,
             });
           } catch (e) {
@@ -451,7 +453,7 @@ export class PluginConfigurationProvider {
               for (const entry of parentEntries) {
                 if (ddnamePattern.test(entry)) {
                   // found a ddname-style entry, add full lib & break out, only need one to confirm
-                  computedLibs.add({
+                  computedLibsMap.set(`dd:${lib}`, {
                     ddLib: lib,
                   });
                   matched = true;
@@ -479,11 +481,11 @@ export class PluginConfigurationProvider {
           }
         }
       }
-      const cl = Array.from(computedLibs);
-      processGroup.$computedLibs = cl;
+      const computedLibs = Array.from(computedLibsMap.values());
+      processGroup.$computedLibs = computedLibs;
       // build a lookup set for dir entries only
       processGroup.$computedLibsSet = new Set(
-        cl.filter((e) => isLibsDir(e)).map((e) => e.dir),
+        computedLibs.filter((e) => isLibsDir(e)).map((e) => e.dir),
       );
     }
     return diagnostics;
@@ -542,6 +544,13 @@ export class PluginConfigurationProvider {
     return [abstractOptions, translatedOptions, collectedIssues];
   }
 
+  /**
+   * Attempts to parse program configs from the given text,
+   * and sets them in this provider, overwriting any existing configs.
+   * @param workspacePath Used to build full program config keys
+   * @param text Program config text to parse
+   * @returns Whether or not parsing & setup was successful
+   */
   parseProgramConfigs(workspacePath: string, text: string): boolean {
     try {
       const serializedData: SerializedProgramConfig[] = JSON.parse(text).pgms;
@@ -556,6 +565,7 @@ export class PluginConfigurationProvider {
   /**
    * Sets the program configs of this plugin configuration provider, overwriting any existing configs.
    * The config key is set as the full path relative to the workspace.
+   * Post-processes the program configs after setting them, to ensure abstract options are built.
    * @param workspacePath The full workspace path (used as a prefix for program config keys)
    * @param programConfigs Program configs loaded from .pliplugin/pgm_conf.json (when present)
    */
@@ -569,6 +579,7 @@ export class PluginConfigurationProvider {
       const newPath = UriUtils.joinPath(workspaceUri, config.program);
       this.programConfigs.set(newPath.toString(), config);
     }
+    this.postProcessProgramConfigs();
   }
 
   /**

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -399,6 +399,9 @@ export class PluginConfigurationProvider {
     const diagnostics: Diagnostic[] = [];
     for (const processGroup of this.processGroupConfigs.values()) {
       // all computed libs for this group, dirs + ddnames
+      // @montymxb Using a map here to avoid duplicates over a set, since our entries are objects.
+      //  A set will compare by ref instead of value, seeing each entry as unique, and adding duplicate lib entries.
+      //  That doesn't lead to any issues, but it adds extra entries that we have to look through later on.
       const computedLibsMap: Map<string, LibsEntry> = new Map();
       const libsToProcess = [...processGroup.libs];
       while (libsToProcess.length > 0) {

--- a/packages/language/test/fourslash-harness/execute.test.ts
+++ b/packages/language/test/fourslash-harness/execute.test.ts
@@ -53,30 +53,7 @@ beforeEach(async () => {
   fs = new VirtualFileSystemProvider();
   setFileSystemProvider(fs);
   resetDocumentProviders();
-
-  // Clear the plugin configuration provider and
-  // ensure the 'cpy' directory is always resolvable for includes via config
   setPluginConfigurationProvider(undefined);
-  PluginConfigurationProviderInstance.setProgramConfigs("", [
-    {
-      program: "*.pli",
-      pgroup: "default",
-      pliOptions: {},
-    },
-  ]);
-  await PluginConfigurationProviderInstance.setProcessGroupConfigs([
-    {
-      name: "default",
-      libs: ["cpy"],
-      $computedLibs: [],
-      $computedLibsSet: new Set<string>(),
-      includeExtensions: [".pli"],
-      compilerOptions: [],
-      implicitBuiltins: new Set(),
-      lspOptions: { checkMargins: false },
-      pliOptions: {},
-    },
-  ]);
 });
 
 afterEach(async () => {

--- a/packages/language/test/fourslash/preprocessor/include/from-lib-path-recursive.ts
+++ b/packages/language/test/fourslash/preprocessor/include/from-lib-path-recursive.ts
@@ -11,23 +11,6 @@
 
 /// <reference path="../../framework.ts" />
 
-// trigger a reparsing of the config, so we can pick up the sub libs folder
-// TODO @montymxb Oct 17th, 2025: Replace with a fourslash utility to trigger config reload
-// @filename: .pliplugin/proc_grps.json
-//// {
-////     "pgroups": [
-////         {
-////         "name": "default",
-////         "lsp-options": {
-////             "check-margins": true
-////         },
-////         "libs": [
-////             "cpy"
-////         ]
-////         }
-////     ]
-//// }
-
 // @filename: cpy/libs/lib.pli
 //// DECLARE LIB_VAR FIXED;
 

--- a/packages/language/test/fourslash/preprocessor/include/include-within-copybook.ts
+++ b/packages/language/test/fourslash/preprocessor/include/include-within-copybook.ts
@@ -11,21 +11,6 @@
 
 /// <reference path="../../framework.ts" />
 
-// @filename: .pliplugin/proc_grps.json
-//// {
-////     "pgroups": [
-////         {
-////             "name": "default",
-////             "libs": [
-////                 "cpy"
-////             ],
-////             "include-extensions": [
-////                 ".pli"
-////             ]
-////         }
-////     ]
-//// }
-
 // @filename: cpy/lib.pli
 //// DECLARE LIB_VAR FIXED;
 

--- a/packages/language/test/fourslash/preprocessor/include/test-ddmember-include-recursive.ts
+++ b/packages/language/test/fourslash/preprocessor/include/test-ddmember-include-recursive.ts
@@ -13,22 +13,6 @@
 
 /// <reference path="../../framework.ts" />
 
-// TODO @montymxb Oct 17th, 2025: Replace with a fourslash utility to trigger config reload
-// @filename: .pliplugin/proc_grps.json
-//// {
-////     "pgroups": [
-////         {
-////         "name": "default",
-////         "lsp-options": {
-////             "check-margins": true
-////         },
-////         "libs": [
-////             "cpy"
-////         ]
-////         }
-////     ]
-//// }
-
 // @filename: cpy/MYLIB(m1)
 //// DECLARE LIB_VAR1 FIXED;
 

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -264,20 +264,60 @@ export class TestBuilder {
     return testBuilder;
   }
 
+  /**
+   * Configures the plugin configuration provider based on the test files.
+   * If a file for either the program or process group configuration is found, use it.
+   * If not, provide a default configuration.
+   * Ensures we have a proper config after writing all files to the fs & before parsing,
+   * so that we can build $computedLibs correctly
+   */
   private async configurePluginConfigurationProvider() {
-    // Check if the files contain a program config or process group.
+    let hasProgramConfig = false;
+    let hasProcessGroupConfig = false;
+
+    // check if the files contain a program config or process group.
     for (const [uri, file] of this.files) {
       if (uri.endsWith(PluginConfiguration.PROGRAM_FILE_PATH)) {
-        PluginConfigurationProviderInstance.parseProgramConfigs(
-          "",
-          file.output,
-        );
+        hasProgramConfig =
+          PluginConfigurationProviderInstance.parseProgramConfigs(
+            "",
+            file.output,
+          );
       }
       if (uri.endsWith(PluginConfiguration.PROCESS_GROUP_FILE_PATH)) {
         await PluginConfigurationProviderInstance.parseProcessGroupConfigs(
           file.output,
         );
+        hasProcessGroupConfig = true;
       }
+    }
+
+    // add program config if not present on disc
+    if (!hasProgramConfig) {
+      PluginConfigurationProviderInstance.setProgramConfigs("", [
+        {
+          program: "*.pli",
+          pgroup: "default",
+          pliOptions: {},
+        },
+      ]);
+    }
+
+    // add process group config if not present on disc
+    if (!hasProcessGroupConfig) {
+      await PluginConfigurationProviderInstance.setProcessGroupConfigs([
+        {
+          name: "default",
+          libs: ["cpy"],
+          $computedLibs: [],
+          $computedLibsSet: new Set<string>(),
+          includeExtensions: [".pli"],
+          compilerOptions: [],
+          implicitBuiltins: new Set(),
+          lspOptions: { checkMargins: false },
+          pliOptions: {},
+        },
+      ]);
     }
   }
 

--- a/packages/language/test/workspace/plugin-configuration.test.ts
+++ b/packages/language/test/workspace/plugin-configuration.test.ts
@@ -136,4 +136,46 @@ describe("Plugin Configuration Tests", () => {
     expect(d1.code).toBe("COPC01");
     expect(diagnostics.some((d) => d.message.includes("invalid2"))).toBe(true);
   });
+
+  test("Duplicate Lib Entries are filtered from $computed props", async () => {
+    // ensure that duplicate lib & ddname entries are filtered out from computed props
+    const libs = ["lib1/dir1", "lib1/dir1", "lib2/DDNAME", "lib2/DDNAME"];
+    const uniqueLibs = Array.from(new Set(libs));
+
+    await FileSystemProviderInstance.writeFile(
+      URI.parse("file:///lib1/dir1/p1.pli"),
+      "",
+    );
+    await FileSystemProviderInstance.writeFile(
+      URI.parse("file:///lib2/DDNAME(p2)"),
+      "",
+    );
+
+    // duplicate ddnames should be filtered out in $computedLibDdnamesSet
+    await PluginConfigurationProviderInstance.setProcessGroupConfigs([
+      {
+        name: "default",
+        compilerOptions: [],
+        libs,
+        $computedLibs: [],
+        $computedLibsSet: new Set<string>(),
+        includeExtensions: [".inc"],
+        lspOptions: { checkMargins: false },
+        pliOptions: {},
+        implicitBuiltins: new Set(),
+      },
+    ]);
+
+    // ensure $computedLibs is present w/ only one of each unique entry (2)
+    const processGroup =
+      PluginConfigurationProviderInstance.getProcessGroupConfig("default");
+    expect(processGroup).toBeDefined();
+    expect(processGroup?.$computedLibs).toBeDefined();
+    expect(processGroup?.$computedLibs.length).toBe(uniqueLibs.length);
+
+    // check the generated libs set as well
+    // should be the one dir entry, not the ddname
+    expect(processGroup?.$computedLibsSet.size).toBe(1);
+    expect(processGroup?.$computedLibsSet.has("lib1/dir1")).toBe(true);
+  });
 });


### PR DESCRIPTION
Closes #475 by ensuring the plugin configuration is initialized after we write all test files, and before we parse anything. This resolves a previous issue where the config was setup separately in a beforeEach, which being async sometimes ran before or after we separately wrote files to our VFS. This was especially noticeable when debugging, which would cause a few of these tests to then fail.

Just a sidenote, the original solution in mind was to allow `async` usage in our 4slash tests, but I opted for this way for now, as it fixed the issue more directly. But it wasn't _too_ bad to lift the commands under test into an async context, that worked pretty well. That might still be a helpful change depending on test requirements later on.

The current setup looks to setup the existing default config only when we don't have a user-specified alternative as a file under test. It also modifies the logic in `setProgramConfig` to properly post-process entries, which prevents issues where an already prepared process group config wouldn't update it's associated program config with new compiler options. A bit wordy, but this lead to unexpected test failures after the issue above was fixed, since we didn't have a case that setup just the program config & not the process group right afterwards.

Also patches a small issue in building $computedLibs found while testing, where duplicate lib & ddname entries would be present due to the Set usage w/ separate object refs.