### PR TITLE
Adds Member Name Validation to DDName Style Includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Using the example `pgm_conf.json` file in the section above, the following `proc
       ],
       "include-extensions": [
         ".cpy", ".copy"
-      ]
+      ],
       "member-name-validation": true
     },
     {

--- a/README.md
+++ b/README.md
@@ -123,8 +123,9 @@ Using the example `pgm_conf.json` file in the section above, the following `proc
       "include-extensions": [
         ".cpy", ".copy"
       ]
+      "member-name-validation": true
     },
-{
+    {
       "name": "GROUP2",
       "libs": [
         "lib2",

--- a/code_samples/plugin-example/.pliplugin/proc_grps.json
+++ b/code_samples/plugin-example/.pliplugin/proc_grps.json
@@ -11,6 +11,7 @@
         "SYSTEM": "MVS",
         "MARGINS": "2,72"
       },
+      "member-name-validation": true,
       "libs": [
         "cpy"
       ],

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2313,27 +2313,40 @@ async function resolveIncludeFileUri(
       }
     }
 
-    if (isMemberWithoutDDName && pgroup.memberNameValidation) {
+    /**
+     * Helper to check & validate member names when member name validations are enabled.
+     * Pushes diagnostics to the context when validation fails.
+     * Effectively a noop when member name validation is disabled in the process group.
+     * @param memberName Member to validate, implied to be a member of an existing ddlib entry
+     */
+    function checkToValidateMember(memberName: string): void {
+      if (!pgroup?.memberNameValidation) {
+        return;
+      }
       // apply additional validation to the member name
-      if (fileNameOrPartial.length > 8) {
+      if (memberName.length > 8) {
         // emit diagnostic for member names > 8 characters
         context.diagnostics.push(
-          diagnostic(Severity.E, `Member exceeds 8 characters.`, item.token),
+          diagnostic(Severity.E, "Member exceeds 8 characters.", item.token),
         );
       }
 
       const memberNameRegex = /^[A-Z][A-Z0-9@#_$]*$/i;
-      if (!memberNameRegex.test(fileNameOrPartial)) {
+      if (!memberNameRegex.test(memberName)) {
         // emit a diagnostic for invalid member names
         context.diagnostics.push(
           diagnostic(
             Severity.E,
-            `Member must start with a letter, followed by letters, numbers, @, #, _, or $`,
+            "Member must start with a letter, followed by letters, numbers, @, #, _, or $.",
             item.token,
           ),
         );
       }
     }
+
+    let libMatch: URI | undefined = undefined;
+    // whether a match was found for a member include
+    let needsMemberValidation = isMemberWithoutDDName;
 
     for (const lib of computedLibs) {
       if (isLibsDir(lib)) {
@@ -2344,32 +2357,34 @@ async function resolveIncludeFileUri(
           // This is done to ensure resolution order of libs is maintained as members > files
           // Ex. If we have both `cpy/member.pli` and `cpy/A.B.C(member)`, with `cpy` in the libs list
           // We want to ensure that `A.B.C(member)` is resolved first before falling back to `member.pli`
-          const memberMatch = await FileSystemProviderInstance.search({
+          libMatch = await FileSystemProviderInstance.search({
             dirPath: resolveLibFileUri(lib.dir),
             member: fileNameOrPartial,
           });
-          if (memberMatch) {
-            return memberMatch;
+          if (libMatch) {
+            break;
           }
         }
 
         // perform standard search
-        const match = await FileSystemProviderInstance.search({
+        libMatch = await FileSystemProviderInstance.search({
           path: libFileUri,
           extensions: pgroup.includeExtensions,
         });
-        if (match) {
-          return match;
+        if (libMatch) {
+          // regular file match, no member to validate
+          needsMemberValidation = false;
+          break;
         }
       } else if (isMemberWithoutDDName) {
         // standalone member w/out an explicit ddname, search within ddlib for a match
         const ddLibUri = resolveLibFileUri(lib.ddLib);
-        const ddMemberMatch = await FileSystemProviderInstance.search({
+        libMatch = await FileSystemProviderInstance.search({
           path: URI.parse(ddLibUri.toString(true) + `(${fileNameOrPartial})`),
           extensions: [],
         });
-        if (ddMemberMatch) {
-          return ddMemberMatch;
+        if (libMatch) {
+          break;
         }
       } else if (
         isMemberIncludeItem(item) &&
@@ -2380,16 +2395,23 @@ async function resolveIncludeFileUri(
         const end = lib.ddLib.length - item.ddname.length;
         const libPath = lib.ddLib.substring(0, end);
         const ddLibUri = resolveLibFileUri(libPath, fileNameOrPartial);
-        const ddMemberMatch = await FileSystemProviderInstance.search({
+        libMatch = await FileSystemProviderInstance.search({
           path: ddLibUri,
           extensions: [],
         });
-        if (ddMemberMatch) {
-          return ddMemberMatch;
+        if (libMatch) {
+          break;
         }
       }
     }
+
+    // depending on whether we matched a member, check to apply validation on the name
+    if (needsMemberValidation) {
+      checkToValidateMember(fileNameOrPartial);
+    }
+    return libMatch;
   }
+
   return undefined;
 }
 

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -9,9 +9,23 @@
  *
  */
 
+import { tokenMatcher } from "chevrotain";
 import { TextDocuments } from "../language-server/text-documents";
+import {
+  diagnostic,
+  Diagnostic,
+  diagnosticFromCode,
+  Severity,
+} from "../language-server/types";
+import { preprocessorParse } from "../parser/parser-entry";
+import { preprocessorParserState } from "../parser/parser-state";
+import { tokenize } from "../parser/tokenizer";
 import { Token } from "../parser/tokens";
+import * as ast from "../syntax-tree/ast";
+import { CstNodeKind } from "../syntax-tree/cst";
 import { URI, UriUtils } from "../utils/uri";
+import { LspCodes } from "../validation/lsp-codes";
+import { PLICodes } from "../validation/pli-codes";
 import { CompilationUnit } from "../workspace/compilation-unit";
 import { FileSystemProviderInstance } from "../workspace/file-system-provider";
 import {
@@ -24,17 +38,8 @@ import {
   InstructionGeneratorResult,
 } from "./instruction-generator";
 import * as inst from "./instructions";
-import * as ast from "../syntax-tree/ast";
 import { MarginsProcessor } from "./pli-margins-processor";
-import { CstNodeKind } from "../syntax-tree/cst";
-import { tokenize } from "../parser/tokenizer";
-import { preprocessorParserState } from "../parser/parser-state";
-import { preprocessorParse } from "../parser/parser-entry";
-import { Diagnostic, diagnosticFromCode } from "../language-server/types";
 import { PreprocessorTokens } from "./pli-preprocessor-tokens";
-import { tokenMatcher } from "chevrotain";
-import { PLICodes } from "../validation/pli-codes";
-import { LspCodes } from "../validation/lsp-codes";
 
 interface Variable {
   name: string;
@@ -2305,6 +2310,21 @@ async function resolveIncludeFileUri(
           scheme: context.entryUri.scheme,
         });
         return UriUtils.joinPath(libUri, fileName ?? "");
+      }
+    }
+
+    if (isMemberWithoutDDName && pgroup.memberNameValidation) {
+      // apply additional validation to the member name
+      const memberNameRegex = /^[A-Z][A-Z0-9@#_$]{0,7}$/i;
+      if (!memberNameRegex.test(fileNameOrPartial)) {
+        // emit a non-blocking diagnostic for invalid member names
+        context.diagnostics.push(
+          diagnostic(
+            Severity.E,
+            `(member-name-validation) Member '${fileNameOrPartial}' is invalid. Must be 1 to 8 characters long, starting with [A-Z], followed by only A-Z, 0-9, @, #, _, or $.`,
+            item.token,
+          ),
+        );
       }
     }
 

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2315,13 +2315,20 @@ async function resolveIncludeFileUri(
 
     if (isMemberWithoutDDName && pgroup.memberNameValidation) {
       // apply additional validation to the member name
-      const memberNameRegex = /^[A-Z][A-Z0-9@#_$]{0,7}$/i;
+      if (fileNameOrPartial.length > 8) {
+        // emit diagnostic for member names > 8 characters
+        context.diagnostics.push(
+          diagnostic(Severity.E, `Member exceeds 8 characters.`, item.token),
+        );
+      }
+
+      const memberNameRegex = /^[A-Z][A-Z0-9@#_$]*$/i;
       if (!memberNameRegex.test(fileNameOrPartial)) {
-        // emit a non-blocking diagnostic for invalid member names
+        // emit a diagnostic for invalid member names
         context.diagnostics.push(
           diagnostic(
             Severity.E,
-            `(member-name-validation) Member '${fileNameOrPartial}' is invalid. Must be 1 to 8 characters long, starting with [A-Z], followed by only A-Z, 0-9, @, #, _, or $.`,
+            `Member must start with a letter, followed by letters, numbers, @, #, _, or $`,
             item.token,
           ),
         );

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2344,7 +2344,7 @@ async function resolveIncludeFileUri(
       }
     }
 
-    let libMatch: URI | undefined = undefined;
+    let libMatch: URI | undefined;
     // whether a match was found for a member include
     let needsMemberValidation = isMemberWithoutDDName;
 

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -11,12 +11,7 @@
 
 import { tokenMatcher } from "chevrotain";
 import { TextDocuments } from "../language-server/text-documents";
-import {
-  diagnostic,
-  Diagnostic,
-  diagnosticFromCode,
-  Severity,
-} from "../language-server/types";
+import { Diagnostic, diagnosticFromCode } from "../language-server/types";
 import { preprocessorParse } from "../parser/parser-entry";
 import { preprocessorParserState } from "../parser/parser-state";
 import { tokenize } from "../parser/tokenizer";
@@ -2327,7 +2322,10 @@ async function resolveIncludeFileUri(
       if (memberName.length > 8) {
         // emit diagnostic for member names > 8 characters
         context.diagnostics.push(
-          diagnostic(Severity.E, "Member exceeds 8 characters.", item.token),
+          diagnosticFromCode(
+            LspCodes.MemberValidation.ExceedsMaxLength,
+            item.token,
+          ),
         );
       }
 
@@ -2335,11 +2333,7 @@ async function resolveIncludeFileUri(
       if (!memberNameRegex.test(memberName)) {
         // emit a diagnostic for invalid member names
         context.diagnostics.push(
-          diagnostic(
-            Severity.E,
-            "Member must start with a letter, followed by letters, numbers, @, #, _, or $.",
-            item.token,
-          ),
+          diagnosticFromCode(LspCodes.MemberValidation.InvalidName, item.token),
         );
       }
     }

--- a/packages/language/src/validation/lsp-codes.ts
+++ b/packages/language/src/validation/lsp-codes.ts
@@ -35,7 +35,7 @@ export const LspCodes = {
         "Standalone SKIP directive is not supported by the language server.",
     },
   },
-  
+
   /**
    * Member name validation codes
    */
@@ -57,6 +57,6 @@ export const LspCodes = {
       severity: Severity.E,
       message:
         "Member must start with a letter, followed by letters, numbers, @, #, _, or $.",
-    }
+    },
   },
 };

--- a/packages/language/src/validation/lsp-codes.ts
+++ b/packages/language/src/validation/lsp-codes.ts
@@ -35,4 +35,28 @@ export const LspCodes = {
         "Standalone SKIP directive is not supported by the language server.",
     },
   },
+  
+  /**
+   * Member name validation codes
+   */
+  MemberValidation: {
+    /**
+     * Member name exceeds 8 characters
+     */
+    ExceedsMaxLength: {
+      code: "LSPMV001",
+      severity: Severity.E,
+      message: "Member exceeds 8 characters.",
+    },
+
+    /**
+     * Member name contains invalid characters (when validation is enabled)
+     */
+    InvalidName: {
+      code: "LSPMV002",
+      severity: Severity.E,
+      message:
+        "Member must start with a letter, followed by letters, numbers, @, #, _, or $.",
+    }
+  },
 };

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -111,7 +111,7 @@ export interface ProcessGroup {
   /**
    * Whether member name validation is enabled for this process group.
    * Validation constraints member names to no more than 8 chars, starting with a letter,
-   * and only containing A-Z, 0-9, @abstract, #, _, and $ (case insensitively).
+   * and only containing A-Z, 0-9, @, #, _, and $ (case insensitively).
    */
   memberNameValidation?: boolean;
 

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -109,6 +109,13 @@ export interface ProcessGroup {
   };
 
   /**
+   * Whether member name validation is enabled for this process group.
+   * Validation constraints member names to no more than 8 chars, starting with a letter,
+   * and only containing A-Z, 0-9, @abstract, #, _, and $ (case insensitively).
+   */
+  memberNameValidation?: boolean;
+
+  /**
    * Number of issues found in the compiler options for this process group.
    * Used to avoid duplicate issue reporting later on when running translation in a program context
    */
@@ -130,6 +137,7 @@ export function deserializeProcessGroup(
   const lspOptions = obj["lsp-options"] || {};
   const checkMargins = lspOptions["check-margins"] ?? false;
   const instructionCounterLimit = lspOptions["instruction-counter-limit"];
+  const memberNameValidation = obj["member-name-validation"];
   return {
     name: obj.name,
     compilerOptions: isStringArray(compilerOptions) ? compilerOptions : [],
@@ -149,6 +157,9 @@ export function deserializeProcessGroup(
         ? instructionCounterLimit
         : MAX_INSTRUCTION_COUNTER,
     },
+    memberNameValidation: isBoolean(memberNameValidation)
+      ? memberNameValidation
+      : undefined,
   };
 }
 
@@ -168,6 +179,7 @@ export function serializeProcessGroup(
     "implicit-builtins": Array.from(group.implicitBuiltins).map((b) =>
       b.toLowerCase(),
     ),
+    "member-name-validation": group.memberNameValidation,
     "lsp-options": {
       "check-margins": group.lspOptions.checkMargins,
     },
@@ -181,6 +193,7 @@ interface SerializedProcessGroup {
   libs?: string[];
   "include-extensions"?: string[];
   "implicit-builtins"?: string[];
+  "member-name-validation"?: boolean;
   "lsp-options"?: {
     "check-margins"?: boolean;
     "instruction-counter-limit"?: number;

--- a/packages/language/test/fourslash-harness/harness-interface.ts
+++ b/packages/language/test/fourslash-harness/harness-interface.ts
@@ -9,19 +9,12 @@
  *
  */
 
-import { CompletionKeywords } from "../../src/language-server/completion/keywords";
-import { Diagnostic } from "../../src/language-server/types";
-import { ExpectedCompletion, Label, TestBuilder } from "../test-builder";
-import { type Severity } from "../../src/language-server/types";
 import { SemanticTokenTypes } from "vscode-languageserver-types";
-import { PliMarginsProcessor } from "../../src/preprocessor/pli-margins-processor";
+import { CompletionKeywords } from "../../src/language-server/completion/keywords";
+import { Diagnostic, type Severity } from "../../src/language-server/types";
 import { CompilerOptionsCodes } from "../../src/preprocessor/compiler-options/codes";
 import { CompilerOptions } from "../../src/preprocessor/compiler-options/options";
-import {
-  InternalCodes,
-  TypeSystemCodes,
-} from "../../src/validation/internal-codes";
-import { PLICode, PLICodes } from "../../src/validation/pli-codes";
+import { PliMarginsProcessor } from "../../src/preprocessor/pli-margins-processor";
 import { DefaultAttribute, SyntaxKind } from "../../src/syntax-tree/ast";
 import {
   AccessMode,
@@ -48,7 +41,13 @@ import {
   TypeDescriptions,
   Volatility,
 } from "../../src/typesystem/descriptions";
+import {
+  InternalCodes,
+  TypeSystemCodes,
+} from "../../src/validation/internal-codes";
 import { LspCodes } from "../../src/validation/lsp-codes";
+import { PLICode, PLICodes } from "../../src/validation/pli-codes";
+import { ExpectedCompletion, Label, TestBuilder } from "../test-builder";
 
 type SemanticTokenTypesValues = `${SemanticTokenTypes}`;
 
@@ -326,6 +325,7 @@ export interface HarnessTesterInterface {
         ErrorRight: typeof PliMarginsProcessor.MARGIN_ERROR_MESSAGE_RIGHT;
       };
     };
+    LSP: typeof LspCodes;
     CompilerOptions: typeof CompilerOptionsCodes;
     TypeSystem: typeof TypeSystemCodes;
   };

--- a/packages/language/test/fourslash-harness/implementation/codes.ts
+++ b/packages/language/test/fourslash-harness/implementation/codes.ts
@@ -9,13 +9,15 @@
  *
  */
 
-import { InternalCodes } from "../../../src/validation/internal-codes";
-import { HarnessTesterInterface } from "../harness-interface";
-import { PliMarginsProcessor } from "../../../src/preprocessor/pli-margins-processor";
 import { CompilerOptionsCodes } from "../../../src/preprocessor/compiler-options/codes";
-import { TypeSystemCodes } from "../../../src/validation/internal-codes";
-import { PLICodes } from "../../../src/validation/pli-codes";
+import { PliMarginsProcessor } from "../../../src/preprocessor/pli-margins-processor";
+import {
+  InternalCodes,
+  TypeSystemCodes,
+} from "../../../src/validation/internal-codes";
 import { LspCodes } from "../../../src/validation/lsp-codes";
+import { PLICodes } from "../../../src/validation/pli-codes";
+import { HarnessTesterInterface } from "../harness-interface";
 
 export const HarnessCodes: HarnessTesterInterface["code"] = {
   Severe: PLICodes.Severe,
@@ -30,6 +32,7 @@ export const HarnessCodes: HarnessTesterInterface["code"] = {
       ErrorRight: PliMarginsProcessor.MARGIN_ERROR_MESSAGE_RIGHT,
     },
   },
+  LSP: LspCodes,
   CompilerOptions: CompilerOptionsCodes,
   TypeSystem: TypeSystemCodes,
 };

--- a/packages/language/test/fourslash/preprocessor/include/with-member-validation.ts
+++ b/packages/language/test/fourslash/preprocessor/include/with-member-validation.ts
@@ -54,10 +54,7 @@
 
 // verify 1 diagnostic on the first include only
 verify.expectExclusiveDiagnosticsAt(1, [
-  {
-    severity: constants.Severity.E,
-    message: "Member exceeds 8 characters.",
-  },
+  code.LSP.MemberValidation.ExceedsMaxLength,
 ]);
 // no diagnostics on the second include
 verify.expectExclusiveDiagnosticsAt(2, []);
@@ -67,15 +64,8 @@ verify.expectExclusiveDiagnosticsAt(3, []);
 // verify 2 diagnostics on the 4th include
 // one for invalid starting char, and another for unresolved include
 verify.expectExclusiveDiagnosticsAt(4, [
-  {
-    severity: constants.Severity.E,
-    message:
-      "Member must start with a letter, followed by letters, numbers, @, #, _, or $.",
-  },
-  {
-    severity: constants.Severity.S,
-    message: "The INCLUDE file _A1@# could not be opened.",
-  },
+  code.LSP.MemberValidation.InvalidName,
+  code.Severe.IBM3841I,
 ]);
 
 // lastly verify no diagnostics on the legitimate file include

--- a/packages/language/test/fourslash/preprocessor/include/with-member-validation.ts
+++ b/packages/language/test/fourslash/preprocessor/include/with-member-validation.ts
@@ -37,9 +37,13 @@
 //// // expecting to be valid
 //// DECLARE V2 FIXED;
 
+// @filename: cpy/ddname(A1@#_$)
+//// DECLARE V3 FIXED;
+
 // @filename: main.pli
 //// %INCLUDE <|1:m12345678|>;
 //// %INCLUDE <|2:m1234567|>;
+//// %INCLUDE <|3:A1@#_$|>;
 
 // assert 1 diagnostic on the first include only
 verify.expectExclusiveDiagnosticsAt(1, [
@@ -47,10 +51,14 @@ verify.expectExclusiveDiagnosticsAt(1, [
     severity: constants.Severity.E,
   },
 ]);
+// no diagnostics on the second include
 verify.expectDiagnosticsAt(2, []);
+// no diagnostics on the 3rd include
+verify.expectDiagnosticsAt(3, []);
 
 // still expecting the same tokens as before
 preprocessor.expectTokens(`
   DECLARE V1 FIXED;
   DECLARE V2 FIXED;
+  DECLARE V3 FIXED;
 `);

--- a/packages/language/test/fourslash/preprocessor/include/with-member-validation.ts
+++ b/packages/language/test/fourslash/preprocessor/include/with-member-validation.ts
@@ -1,0 +1,56 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+// Perform an include on a member w/ validation enabled in the plugin config
+
+/// <reference path="../../framework.ts" />
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////             "name": "default",
+////             "libs": [
+////                 "cpy"
+////             ],
+////             "include-extensions": [
+////                 ".pli"
+////             ],
+////             "member-name-validation": true
+////         }
+////     ]
+//// }
+
+// @filename: cpy/ddname(m12345678)
+//// // expecting to be invalid
+//// DECLARE V1 FIXED;
+
+// @filename: cpy/ddname(m1234567)
+//// // expecting to be valid
+//// DECLARE V2 FIXED;
+
+// @filename: main.pli
+//// %INCLUDE <|1:m12345678|>;
+//// %INCLUDE <|2:m1234567|>;
+
+// assert 1 diagnostic on the first include only
+verify.expectExclusiveDiagnosticsAt(1, [
+  {
+    severity: constants.Severity.E,
+  },
+]);
+verify.expectDiagnosticsAt(2, []);
+
+// still expecting the same tokens as before
+preprocessor.expectTokens(`
+  DECLARE V1 FIXED;
+  DECLARE V2 FIXED;
+`);

--- a/packages/language/test/fourslash/preprocessor/include/with-member-validation.ts
+++ b/packages/language/test/fourslash/preprocessor/include/with-member-validation.ts
@@ -40,25 +40,51 @@
 // @filename: cpy/ddname(A1@#_$)
 //// DECLARE V3 FIXED;
 
+// @filename: cpy/__legitimatefile.pli
+//// DECLARE V4 FIXED;
+
 // @filename: main.pli
 //// %INCLUDE <|1:m12345678|>;
 //// %INCLUDE <|2:m1234567|>;
 //// %INCLUDE <|3:A1@#_$|>;
+//// // bad include
+//// %INCLUDE <|4:_A1@#|>;
+//// // legitimate file include
+//// %INCLUDE <|5:__legitimatefile|>;
 
-// assert 1 diagnostic on the first include only
+// verify 1 diagnostic on the first include only
 verify.expectExclusiveDiagnosticsAt(1, [
   {
     severity: constants.Severity.E,
+    message: "Member exceeds 8 characters.",
   },
 ]);
 // no diagnostics on the second include
-verify.expectDiagnosticsAt(2, []);
+verify.expectExclusiveDiagnosticsAt(2, []);
 // no diagnostics on the 3rd include
-verify.expectDiagnosticsAt(3, []);
+verify.expectExclusiveDiagnosticsAt(3, []);
+
+// verify 2 diagnostics on the 4th include
+// one for invalid starting char, and another for unresolved include
+verify.expectExclusiveDiagnosticsAt(4, [
+  {
+    severity: constants.Severity.E,
+    message:
+      "Member must start with a letter, followed by letters, numbers, @, #, _, or $.",
+  },
+  {
+    severity: constants.Severity.S,
+    message: "The INCLUDE file _A1@# could not be opened.",
+  },
+]);
+
+// lastly verify no diagnostics on the legitimate file include
+verify.expectExclusiveDiagnosticsAt(5, []);
 
 // still expecting the same tokens as before
 preprocessor.expectTokens(`
   DECLARE V1 FIXED;
   DECLARE V2 FIXED;
   DECLARE V3 FIXED;
+  DECLARE V4 FIXED;
 `);

--- a/packages/language/test/fourslash/preprocessor/include/with-member-validation.ts
+++ b/packages/language/test/fourslash/preprocessor/include/with-member-validation.ts
@@ -65,7 +65,7 @@ verify.expectExclusiveDiagnosticsAt(3, []);
 // one for invalid starting char, and another for unresolved include
 verify.expectExclusiveDiagnosticsAt(4, [
   code.LSP.MemberValidation.InvalidName,
-  code.Severe.IBM3841I,
+  code.Severe.IBM1848I,
 ]);
 
 // lastly verify no diagnostics on the legitimate file include

--- a/packages/vscode-extension/schemas/proc_grps.schema.json
+++ b/packages/vscode-extension/schemas/proc_grps.schema.json
@@ -51,6 +51,10 @@
               "type": "string"
             }
           },
+          "member-name-validation": {
+            "type": "boolean",
+            "description": "Whether to enable member name validation for this procedure group."
+          },
           "lsp-options": {
             "type": "object",
             "description": "Options for the Language Server Protocol.",


### PR DESCRIPTION
Closes #399 by adding an additional property to the proc groups configuration to enable member name validation. This applies a couple of checks to `%include member` style includes that:
- are longer than 8 chars
- don't start with A-Z and following with either alphanumeric chars or @, #, _ or $.

A diagnostic is emitted for each case separately.

Right now this only adds the diagnostic when we have a member style include that does _not_ resolve to a literal file (like `member.pli`), in all other non-string cases this assumes the include could be a member that needs validation. I've added a longer test case to verify this specific behavior, so we don't get member-focused diagnostics on regular file includes.