### PR TITLE
Add sql pp compiler options support

### DIFF
--- a/packages/language/src/preprocessor/compiler-options/codes.ts
+++ b/packages/language/src/preprocessor/compiler-options/codes.ts
@@ -1194,4 +1194,22 @@ export const CompilerOptionsCodes = {
       } as ParametricPLICode,
     },
   },
+
+  PPSQL: {
+    Deprecate: {
+      InvalidSubOption: {
+        code: "COPPSQL01",
+        severity: Severity.E,
+        message: (value: string) =>
+          `Expected "STMT" suboption, but received '${value}'.`,
+      } as ParametricPLICode,
+
+      InvalidSubStatement: {
+        code: "COPPSQL02",
+        severity: Severity.E,
+        message: (value: string) =>
+          `Expected "EXPLAIN", "GRANT", "REVOKE", or "SET_CURRENT_SQLID" suboption, but received '${value}'.`,
+      } as ParametricPLICode,
+    },
+  },
 };

--- a/packages/language/src/preprocessor/compiler-options/options-pli.ts
+++ b/packages/language/src/preprocessor/compiler-options/options-pli.ts
@@ -407,7 +407,7 @@ export interface CompilerOptions {
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-ppsql
    */
-  ppSql?: string | false;
+  ppSql?: CompilerOptions.PPValue | false;
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-pptrace
    */

--- a/packages/language/src/preprocessor/compiler-options/options-sql.ts
+++ b/packages/language/src/preprocessor/compiler-options/options-sql.ts
@@ -1,0 +1,40 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+export interface CompilerOptions {
+  ccsid0?: boolean;
+  codepage?: boolean;
+  deprecate?: string[];
+  emptyDbrm?: boolean;
+  hostCopy?: boolean;
+  incOnly?: boolean;
+  line?: CompilerOptions.Line;
+  warnDecp?: boolean;
+}
+
+export namespace CompilerOptions {
+  export type Line = "LINEONLY" | "LINEFILE";
+}
+
+const defaultCompilerOptions: CompilerOptions = {
+  ccsid0: true,
+  codepage: false,
+  deprecate: [],
+  emptyDbrm: false,
+  hostCopy: true,
+  incOnly: false,
+  line: "LINEONLY",
+  warnDecp: false,
+};
+
+export function getDefaultCompilerOptions(): CompilerOptions {
+  return { ...defaultCompilerOptions };
+}

--- a/packages/language/src/preprocessor/compiler-options/options.ts
+++ b/packages/language/src/preprocessor/compiler-options/options.ts
@@ -13,12 +13,17 @@ import { Diagnostic } from "../../language-server/types";
 import { Token } from "../../parser/tokens";
 import * as Pli from "./options-pli";
 import * as Macro from "./options-macro";
+import * as SQL from "./options-sql";
 import { NOT_CHARACTER } from "../../utils/const";
 
-export type CompilerOptionsPP = Pli.CompilerOptions | Macro.CompilerOptions;
+export type CompilerOptionsPP =
+  | Pli.CompilerOptions
+  | Macro.CompilerOptions
+  | SQL.CompilerOptions;
 
 export interface CompilerOptions extends Pli.CompilerOptions {
   macroOptions: Macro.CompilerOptions;
+  sqlOptions: SQL.CompilerOptions;
 }
 
 export interface CompilerOptionResult {
@@ -104,5 +109,6 @@ export function getDefaultCompilerOptions(): CompilerOptions {
   return {
     ...Pli.getDefaultCompilerOptions(),
     macroOptions: Macro.getDefaultCompilerOptions(),
+    sqlOptions: SQL.getDefaultCompilerOptions(),
   };
 }

--- a/packages/language/src/preprocessor/compiler-options/translate.ts
+++ b/packages/language/src/preprocessor/compiler-options/translate.ts
@@ -9,7 +9,7 @@
  *
  */
 
-import { CompilerOptionResult } from "./options";
+import { CompilerOptionResult, CompilerOptionsPP } from "./options";
 import {
   AbstractCompilerOptions,
   parseAbstractCompilerOptions,
@@ -17,14 +17,18 @@ import {
 import { CompilerOption, SyntaxKind } from "../../syntax-tree/ast";
 import { getTranslator as getTranslatorPLI } from "./translator-pli";
 import { getTranslator as getTranslatorMacro } from "./translator-macro";
+import { getTranslator as getTranslatorSQL } from "./translator-sql";
 import {
   CompilerOptions,
   CompilerOptions as CompilerOptionsPLI,
 } from "./options-pli";
 import { CompilerOptions as CompilerOptionsMacro } from "./options-macro";
+import { CompilerOptions as CompilerOptionsSQL } from "./options-sql";
+import { Translator } from "./translator";
 
 const translator = getTranslatorPLI();
 const translatorMacro = getTranslatorMacro();
+const translatorSQL = getTranslatorSQL();
 
 export function translateCompilerOptions(
   input: AbstractCompilerOptions,
@@ -43,32 +47,45 @@ export function translateCompilerOptions(
 
   // Handle nested compiler options that are not yet parsed.
   translatorMacro.clear();
-  const macroItems: CompilerOptions.PPValue[] = [
-    ...(translator.options.ppMacro ? [translator.options.ppMacro] : []),
-    ...(translator.options.pp?.items
-      .filter((item) => item.name === "MACRO" && typeof item.value === "string")
-      .map((item) => ({ value: item.value, token: item.token })) ?? []),
-  ];
-
-  for (const item of macroItems) {
-    const nestedOptions = parseAbstractCompilerOptions(
-      item.value as string,
-      (item.token?.startOffset ?? 0) + 1,
-    );
-    nestedOptions.options.forEach((option) =>
-      translatorMacro.translate(option),
-    );
-    translatorMacro.diagnostics.push(...nestedOptions.issues);
-  }
+  parseNestedOptions(translatorMacro, "MACRO", translator.options.ppMacro);
+  translatorSQL.clear();
+  parseNestedOptions(translatorSQL, "SQL", translator.options.ppSql);
 
   return {
     options: {
       ...(translator.options as CompilerOptionsPLI),
       macroOptions: translatorMacro.options as CompilerOptionsMacro,
+      sqlOptions: translatorSQL.options as CompilerOptionsSQL,
     },
     tokens: input.tokens,
-    issues: [...translator.diagnostics, ...translatorMacro.diagnostics],
+    issues: [
+      ...translator.diagnostics,
+      ...translatorMacro.diagnostics,
+      ...translatorSQL.diagnostics,
+    ],
   };
+}
+
+function parseNestedOptions<T extends CompilerOptionsPP>(
+  ppTranslator: Translator<T>,
+  ppId: string,
+  ppDirectValue: CompilerOptions.PPValue | false | undefined,
+): void {
+  const items: CompilerOptions.PPValue[] = [
+    ...(ppDirectValue ? [ppDirectValue] : []),
+    ...(translator.options.pp?.items
+      .filter((item) => item.name === ppId && typeof item.value === "string")
+      .map((item) => ({ value: item.value, token: item.token })) ?? []),
+  ];
+
+  for (const item of items) {
+    const nestedOptions = parseAbstractCompilerOptions(
+      item.value as string,
+      (item.token?.startOffset ?? 0) + 1,
+    );
+    nestedOptions.options.forEach((option) => ppTranslator.translate(option));
+    ppTranslator.diagnostics.push(...nestedOptions.issues);
+  }
 }
 
 // TODO ssmifi: remove the upper cases from the individual rules.

--- a/packages/language/src/preprocessor/compiler-options/translator-pli.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator-pli.ts
@@ -2249,7 +2249,10 @@ translator.rule(
     ensureArguments(option, 1, 1);
     const value = option.values[0];
     ensureType(value, "string");
-    options.ppSql = value.value;
+    options.ppSql = {
+      value: value.value,
+      token: value.token,
+    };
   },
   ["NOPPSQL"],
   (option, options) => {

--- a/packages/language/src/preprocessor/compiler-options/translator-sql.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator-sql.ts
@@ -1,0 +1,79 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { diagnosticFromCode } from "../../language-server/types";
+import { CompilerOptionsCodes } from "./codes";
+import { CompilerOptions, getDefaultCompilerOptions } from "./options-sql";
+import { ensureArguments, ensureType, Translator } from "./translator";
+
+const translator = new Translator<CompilerOptions>(getDefaultCompilerOptions());
+
+translator.flag("ccsid0", ["CCSID0"], ["NOCCSID0"]);
+
+translator.flag("codepage", ["CODEPAGE"], ["NOCODEPAGE"]);
+
+translator.rule(["DEPRECATE"], (option, options) => {
+  ensureArguments(option, 1);
+  options.deprecate = [];
+  for (const value of option.values) {
+    ensureType(value, "option");
+    if (value.name !== "STMT") {
+      throw diagnosticFromCode(
+        CompilerOptionsCodes.PPSQL.Deprecate.InvalidSubOption,
+        value.token,
+        value.token.image,
+      );
+    }
+
+    // TODO: check STMT().
+    for (const entry of value.values) {
+      ensureType(entry, "plain");
+
+      if (
+        !["EXPLAIN", "GRANT", "REVOKE", "SET_CURRENT_SQLID", ""].includes(
+          entry.value,
+        )
+      ) {
+        throw diagnosticFromCode(
+          CompilerOptionsCodes.PPSQL.Deprecate.InvalidSubStatement,
+          entry.token,
+          entry.value,
+        );
+      }
+      options.deprecate.push(entry.value as string);
+    }
+  }
+});
+
+translator.flag("emptyDbrm", ["EMPTYDBRM"], ["NOEMPTYDBRM"]);
+
+translator.flag("hostCopy", ["HOSTCOPY"], ["NOHOSTCOPY"]);
+
+translator.flag("incOnly", ["INCONLY"], ["NOINCONLY"]);
+
+translator.rule(
+  ["LINEFILE"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.line = "LINEFILE";
+  },
+  ["LINEONLY"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.line = "LINEONLY";
+  },
+);
+
+translator.flag("warnDecp", ["WARNDECP"], ["NOWARNDECP"]);
+
+export function getTranslator(): Translator<CompilerOptions> {
+  return translator;
+}

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/ccsid0.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/ccsid0.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("CCSID0"));
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    ccsid0: true,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/codepage.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/codepage.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("CODEPAGE"));
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    codepage: true,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/deprecate.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/deprecate.ts
@@ -1,0 +1,36 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("DEPRECATE(<|1:LOWER|>)"));
+////*PROCESS PP(SQL("DEPRECATE(<|2:LOWER|>())"));
+////*PROCESS PP(SQL("DEPRECATE(STMT(<|3:INVALID|>))"));
+////*PROCESS PP(SQL("DEPRECATE(STMT(GRANT))"));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedOption.message(""),
+});
+verify.expectDiagnosticsAt(2, {
+  message:
+    code.CompilerOptions.PPSQL.Deprecate.InvalidSubOption.message("LOWER"),
+});
+verify.expectDiagnosticsAt(3, {
+  message:
+    code.CompilerOptions.PPSQL.Deprecate.InvalidSubStatement.message("INVALID"),
+});
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    deprecate: ["GRANT"],
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/emtpydbrm.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/emtpydbrm.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("EMPTYDBRM"));
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    emptyDbrm: true,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/hostcopy.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/hostcopy.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("HOSTCOPY"));
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    hostCopy: true,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/incOnly.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/incOnly.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("INCONLY"));
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    incOnly: true,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/line.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/line.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("LINEFILE"));
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    line: "LINEFILE",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/warndecp.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/warndecp.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("WARNDECP"));
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    warnDecp: true,
+  },
+});


### PR DESCRIPTION
Adding compiler option support for the sql preprocessor as part of https://github.com/zowe/zowe-pli-language-support/issues/472 