### PR TITLE
Add config option for configurable instruction counter limit

### DIFF
--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -265,6 +265,7 @@ interface InterpreterContext {
    * It is invalid to invoke MACNAME outside of a preprocessor procedure.
    */
   macname: string;
+  instructionCounterLimit: number;
 }
 
 interface SqlAttributeCache {
@@ -296,6 +297,8 @@ export interface InterpreterOptions {
   compilerOptions: CompilerOptionResult | undefined;
   marginsProcessor: MarginsProcessor;
 }
+
+export const MAX_INSTRUCTION_COUNTER = 5000;
 
 export async function runInstructions(
   unit: CompilationUnit,
@@ -334,6 +337,9 @@ export async function runInstructions(
       entries: new Map(),
     },
     macname: "",
+    instructionCounterLimit:
+      unit.processGroup?.lspOptions.instructionCounterLimit ??
+      MAX_INSTRUCTION_COUNTER,
   };
   for (const [key, value] of instruction.procedures.entries()) {
     context.procedures.set(key, value);
@@ -349,8 +355,6 @@ export async function runInstructions(
   };
 }
 
-const MAX_INSTRUCTION_COUNTER = 5000;
-
 async function doRunInstructions(
   context: InterpreterContext,
   start: inst.InstructionNode,
@@ -359,7 +363,7 @@ async function doRunInstructions(
   while (currentNode) {
     const value = context.counter.get(currentNode) || 0;
     // Prevent infinite loops by limiting the number of iterations
-    if (value > MAX_INSTRUCTION_COUNTER) {
+    if (value > context.instructionCounterLimit) {
       console.log("Long running preprocessor code detected. Stopping.");
       return;
     }

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -17,9 +17,16 @@ import {
   parseAbstractCompilerOptions,
 } from "../preprocessor/compiler-options/parser";
 import { translateCompilerOptions } from "../preprocessor/compiler-options/translate";
-import { isBoolean, isRecordOf, isString, isStringArray } from "../utils/types";
+import {
+  isBoolean,
+  isNumber,
+  isRecordOf,
+  isString,
+  isStringArray,
+} from "../utils/types";
 import { URI, UriUtils } from "../utils/uri";
 import { FileSystemProviderInstance } from "./file-system-provider";
+import { MAX_INSTRUCTION_COUNTER } from "../preprocessor/instruction-interpreter";
 
 /**
  * Pli options are effectively macros to set w/ the given values
@@ -98,6 +105,7 @@ export interface ProcessGroup {
   implicitBuiltins: Set<string>;
   lspOptions: {
     checkMargins: boolean;
+    instructionCounterLimit: number;
   };
 
   /**
@@ -121,6 +129,7 @@ export function deserializeProcessGroup(
   const libs = obj.libs || [];
   const lspOptions = obj["lsp-options"] || {};
   const checkMargins = lspOptions["check-margins"] ?? false;
+  const instructionCounterLimit = lspOptions["instruction-counter-limit"];
   return {
     name: obj.name,
     compilerOptions: isStringArray(compilerOptions) ? compilerOptions : [],
@@ -136,6 +145,9 @@ export function deserializeProcessGroup(
       : new Set(),
     lspOptions: {
       checkMargins: isBoolean(checkMargins) ? checkMargins : false,
+      instructionCounterLimit: isNumber(instructionCounterLimit)
+        ? instructionCounterLimit
+        : MAX_INSTRUCTION_COUNTER,
     },
   };
 }
@@ -171,6 +183,7 @@ interface SerializedProcessGroup {
   "implicit-builtins"?: string[];
   "lsp-options"?: {
     "check-margins"?: boolean;
+    "instruction-counter-limit"?: number;
   };
 }
 

--- a/packages/language/test/fourslash-harness/harness-interface.ts
+++ b/packages/language/test/fourslash-harness/harness-interface.ts
@@ -305,6 +305,7 @@ export interface HarnessTesterInterface {
      * If a string is provided, it is piped through the lexer and the resulting tokens are expected.
      */
     expectTokens(textOrTokens: string | string[]): void;
+    containsTokens(textOrTokens: string | string[]): void;
     /**
      * Expect that the code is skipped at the given range.
      * @param label The label to expect the skipped code at.

--- a/packages/language/test/fourslash-harness/harness.test.ts
+++ b/packages/language/test/fourslash-harness/harness.test.ts
@@ -85,9 +85,11 @@ async function createTestingHarnessImplementation(
     preprocessor: {
       not: {
         expectTokens: listen("preprocessor.not.expectTokens"),
+        containsTokens: listen("preprocessor.not.containsTokens"),
         expectSkippedCodeAt: listen("preprocessor.not.expectSkippedCodeAt"),
       },
       expectTokens: listen("preprocessor.expectTokens"),
+      containsTokens: listen("preprocessor.containsTokens"),
       expectSkippedCodeAt: listen("preprocessor.expectSkippedCodeAt"),
     },
     code: HarnessCodes,

--- a/packages/language/test/fourslash-harness/implementation/test-builder.ts
+++ b/packages/language/test/fourslash-harness/implementation/test-builder.ts
@@ -91,10 +91,13 @@ export function createTestBuilderHarnessImplementation(
     preprocessor: {
       not: {
         expectTokens: (text) => testBuilder.not.expectPreprocessorTokens(text),
+        containsTokens: (text) =>
+          testBuilder.not.containsPreprocessorTokens(text),
         expectSkippedCodeAt: (label) =>
           testBuilder.not.expectSkippedCode(label.toString()),
       },
       expectTokens: (text) => testBuilder.expectPreprocessorTokens(text),
+      containsTokens: (text) => testBuilder.containsPreprocessorTokens(text),
       expectSkippedCodeAt: (label) =>
         testBuilder.expectSkippedCode(label.toString()),
     },

--- a/packages/language/test/fourslash/preprocessor/configurable-instruction-counter-limit-fail.ts
+++ b/packages/language/test/fourslash/preprocessor/configurable-instruction-counter-limit-fail.ts
@@ -1,0 +1,22 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+//// %DCL X FIXED;
+//// %X = 1;
+//// %DO
+////   WHILE(X <= 10000);
+////     DCL Variable%;X FIXED;
+////     %X = X + 1;
+//// %END;
+
+preprocessor.not.containsTokens("Variable10000");

--- a/packages/language/test/fourslash/preprocessor/configurable-instruction-counter-limit-increased.ts
+++ b/packages/language/test/fourslash/preprocessor/configurable-instruction-counter-limit-increased.ts
@@ -1,0 +1,35 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////         "name": "default",
+////         "lsp-options": {
+////             "instruction-counter-limit": 10000
+////         }
+////         }
+////     ]
+//// }
+
+// @filename: main.pli
+//// %DCL X FIXED;
+//// %X = 1;
+//// %DO
+////   WHILE(X <= 10000);
+////     DCL Variable%;X FIXED;
+////     %X = X + 1;
+//// %END;
+
+preprocessor.containsTokens("Variable10000");

--- a/packages/language/test/fourslash/preprocessor/configurable-instruction-counter-limit.ts
+++ b/packages/language/test/fourslash/preprocessor/configurable-instruction-counter-limit.ts
@@ -1,0 +1,22 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+//// %DCL X FIXED;
+//// %X = 1;
+//// %DO
+////   WHILE(X <= 1000);
+////     DCL Variable%;X FIXED;
+////     %X = X + 1;
+//// %END;
+
+preprocessor.containsTokens("Variable1000");

--- a/packages/language/test/parser/pli-lexer.test.ts
+++ b/packages/language/test/parser/pli-lexer.test.ts
@@ -119,7 +119,7 @@ describe("PL/1 Lexer", () => {
         libs: [],
         $computedLibs: [],
         $computedLibsSet: new Set<string>(),
-        lspOptions: { checkMargins: false },
+        lspOptions: { checkMargins: false, instructionCounterLimit: 5000 },
         pliOptions: {},
       };
 
@@ -189,7 +189,10 @@ describe("PL/1 Lexer", () => {
         libs: [],
         $computedLibs: [],
         $computedLibsSet: new Set<string>(),
-        lspOptions: { checkMargins: false },
+        lspOptions: {
+          checkMargins: false,
+          instructionCounterLimit: 5000,
+        },
         pliOptions: {},
       };
 

--- a/packages/language/test/preprocessor/pli-preprocessor.test.ts
+++ b/packages/language/test/preprocessor/pli-preprocessor.test.ts
@@ -44,7 +44,7 @@ async function init(libPath: string): Promise<Diagnostic[]> {
     libs: [libPath],
     $computedLibs: [],
     $computedLibsSet: new Set<string>(),
-    lspOptions: { checkMargins: false },
+    lspOptions: { checkMargins: false, instructionCounterLimit: 5000 },
     pliOptions: {},
   };
 

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -314,7 +314,7 @@ export class TestBuilder {
           includeExtensions: [".pli"],
           compilerOptions: [],
           implicitBuiltins: new Set(),
-          lspOptions: { checkMargins: false },
+          lspOptions: { checkMargins: false, instructionCounterLimit: 5000 },
           pliOptions: {},
         },
       ]);
@@ -484,6 +484,25 @@ export class TestBuilder {
       exp = exp.not;
     }
     exp.toEqual(expectedTokens);
+  }
+
+  containsPreprocessorTokens(textOrTokens: string | string[]): void {
+    const actualTokens = this.unit.tokens.map((e) => e.image);
+    let expectedTokens: string[] = [];
+    if (Array.isArray(textOrTokens)) {
+      expectedTokens = textOrTokens;
+    } else {
+      expectedTokens = tokenize(textOrTokens, undefined).tokens.map(
+        (e) => e.image,
+      );
+    }
+    let exp = expect(actualTokens);
+    if (this.options.not) {
+      exp = exp.not;
+    }
+    for (const token of expectedTokens) {
+      exp.toContain(token);
+    }
   }
 
   /**

--- a/packages/language/test/workspace/compilation-unit.test.ts
+++ b/packages/language/test/workspace/compilation-unit.test.ts
@@ -146,7 +146,7 @@ describe("Compilation Unit Tests", () => {
         $computedLibs: [],
         $computedLibsSet: new Set<string>(),
         includeExtensions: [".inc"],
-        lspOptions: { checkMargins: false },
+        lspOptions: { checkMargins: false, instructionCounterLimit: 5000 },
         pliOptions: {},
         implicitBuiltins: new Set(),
       },

--- a/packages/language/test/workspace/plugin-configuration.test.ts
+++ b/packages/language/test/workspace/plugin-configuration.test.ts
@@ -44,7 +44,7 @@ describe("Plugin Configuration Tests", () => {
       $computedLibs: [],
       $computedLibsSet: new Set<string>(),
       includeExtensions: [".inc"],
-      lspOptions: { checkMargins: false },
+      lspOptions: { checkMargins: false, instructionCounterLimit: 5000 },
       pliOptions: {},
       implicitBuiltins: new Set(),
     };
@@ -160,7 +160,10 @@ describe("Plugin Configuration Tests", () => {
         $computedLibs: [],
         $computedLibsSet: new Set<string>(),
         includeExtensions: [".inc"],
-        lspOptions: { checkMargins: false },
+        lspOptions: {
+          checkMargins: false,
+          instructionCounterLimit: 5000,
+        },
         pliOptions: {},
         implicitBuiltins: new Set(),
       },

--- a/packages/vscode-extension/schemas/proc_grps.schema.json
+++ b/packages/vscode-extension/schemas/proc_grps.schema.json
@@ -36,7 +36,12 @@
             "description": "List of file extensions to treat as include files.",
             "items": {
               "type": "string",
-              "enum": [".pli", ".pl1", ".cpy", ".inc"]
+              "enum": [
+                ".pli",
+                ".pl1",
+                ".cpy",
+                ".inc"
+              ]
             }
           },
           "implicit-builtins": {
@@ -53,16 +58,23 @@
               "check-margins": {
                 "type": "boolean",
                 "description": "Whether to check for margins in the PL/I code."
+              },
+              "instruction-counter-limit": {
+                "type": "number",
+                "description": "Maximum number of times to run an instructions during preprocessing. The default is 5000."
               }
             }
           }
         },
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "additionalProperties": false
       }
     }
   },
-  "required": ["pgroups"],
+  "required": [
+    "pgroups"
+  ],
   "additionalProperties": false
 }
-  


### PR DESCRIPTION
Suggestion for adding a variable instruction counter limit for the preprocessor interpreter, which came up during todays meeting. Configurable on process groups to make it customizable per project.