### PR TITLE
Properly await language server startup

### DIFF
--- a/packages/language/src/language-server/connection-handler.ts
+++ b/packages/language/src/language-server/connection-handler.ts
@@ -25,6 +25,7 @@ import {
   Diagnostic,
   Location,
   TextEdit,
+  WorkspaceFolder,
 } from "vscode-languageserver-types";
 import {
   completionItemToLSP,
@@ -54,22 +55,11 @@ export const WorkspaceDidChangePlipluginConfigNotification =
 export function startLanguageServer(connection: Connection): void {
   const compilationUnitHandler = new CompilationUnitHandler();
   compilationUnitHandler.listen(connection);
+  let folders: WorkspaceFolder[] = [];
 
   connection.onInitialize(async (params) => {
     // init the plugin config provider in reverse folder order, last plugin config encountered will take precedence
-    // TODO @montymxb Apr 23rd, 2025: Consider addressing multiple workspaces w/ multiple plugin configs
-    for (const folder of params.workspaceFolders?.reverse() ?? []) {
-      PluginConfigurationProviderInstance.init(folder.uri).then(
-        (diagnostics) => {
-          const ws = PluginConfigurationProviderInstance.getWorkspacePath();
-          const wsPrefix = ws.endsWith("/") ? ws : ws + "/";
-          connection.sendDiagnostics({
-            uri: wsPrefix + PluginConfiguration.PROCESS_GROUP_FILE_PATH,
-            diagnostics,
-          });
-        },
-      );
-    }
+    folders = params.workspaceFolders?.reverse() ?? [];
 
     return {
       capabilities: {
@@ -107,6 +97,25 @@ export function startLanguageServer(connection: Connection): void {
         },
       },
     };
+  });
+  connection.onInitialized(async () => {
+    const promises: Promise<void>[] = [];
+    for (const folder of folders) {
+      promises.push(
+        PluginConfigurationProviderInstance.init(folder.uri).then(
+          (diagnostics) => {
+            const ws = PluginConfigurationProviderInstance.getWorkspacePath();
+            const wsPrefix = ws.endsWith("/") ? ws : ws + "/";
+            connection.sendDiagnostics({
+              uri: wsPrefix + PluginConfiguration.PROCESS_GROUP_FILE_PATH,
+              diagnostics,
+            });
+          },
+        ),
+      );
+    }
+    await Promise.all(promises);
+    compilationUnitHandler.finalize();
   });
   connection.onHover(async (params) => {
     return Mutex.read(async () => {

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -42,7 +42,7 @@ import {
 } from "./plugin-configuration-provider.js";
 import { EvaluationResults } from "../preprocessor/instruction-interpreter.js";
 import { Mutex } from "./mutex.js";
-import { isOperationCancelled } from "../utils/promises.js";
+import { Deferred, isOperationCancelled } from "../utils/promises.js";
 import { InstructionCache } from "../preprocessor/instruction-cache.js";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { FileStore } from "./file-store.js";
@@ -189,6 +189,7 @@ export async function createCompilationUnit(
 export class CompilationUnitHandler {
   private compilationUnits: Map<string, CompilationUnit> = new Map();
   private connection!: Connection;
+  private ready = new Deferred();
 
   getCompilationUnit(uri: URI): CompilationUnit | undefined {
     return this.compilationUnits.get(uri.toString());
@@ -239,7 +240,20 @@ export class CompilationUnitHandler {
     return Array.from(new Set(this.compilationUnits.values()));
   }
 
+  /**
+   * Marks the compilation unit handler as ready to process updates.
+   * **Must** be called if `listen` has been called previously.
+   */
+  finalize(): void {
+    this.ready.resolve();
+  }
+
   listen(connection: Connection): void {
+    // Before we start listening, we need to set up the mutex
+    // to prevent compilation unit updates before we're ready.
+    Mutex.run(async () => {
+      await this.ready.promise;
+    });
     this.connection = connection;
     const textDocuments = EditorDocuments;
     textDocuments.listen(connection);


### PR DESCRIPTION
Closes https://github.com/zowe/zowe-pli-language-support/issues/487, https://github.com/zowe/zowe-pli-language-support/pull/488.

Splits the language server initialization into two phases:

1. `onInitialize` only stores the workspace folders of the client and sends the capabilities back.
2. `onInitialized` reads the plugin configs for each workspace folder and marks the compilation unit handler as "ready"

The compilation unit handler will now **completely block** the compilation if `listen` has been called until `finalize` has been called to ensure that we don't accidentally start compiling code even though the plugin configs haven't been loaded yet.

This also fixes the startup of the web extension. So please test this as well in addition to the linked issue.