### PR TITLE
Use full include member range for definition

### DIFF
--- a/packages/language/src/language-server/connection-handler.ts
+++ b/packages/language/src/language-server/connection-handler.ts
@@ -24,6 +24,7 @@ import {
   CodeAction,
   Diagnostic,
   Location,
+  LocationLink,
   TextEdit,
 } from "vscode-languageserver-types";
 import {
@@ -162,14 +163,19 @@ export function startLanguageServer(connection: Connection): void {
       if (textDocument && compilationUnit) {
         const offset = textDocument.offsetAt(position);
         const definition = definitionRequest(compilationUnit, uri, offset);
-        const lspDefinitions: Location[] = [];
+        const lspDefinitions: LocationLink[] = [];
         for (const def of definition) {
           const doc = compilationUnit?.services.files.getDocument(def.uri);
           if (doc) {
             const range = rangeToLSP(doc, def.range);
+            const sourceRange = def.source
+              ? rangeToLSP(textDocument, def.source)
+              : undefined;
             lspDefinitions.push({
-              uri: def.uri,
-              range,
+              targetUri: def.uri,
+              targetRange: range,
+              targetSelectionRange: range,
+              originSelectionRange: sourceRange,
             });
           }
         }

--- a/packages/language/src/language-server/definition-request.ts
+++ b/packages/language/src/language-server/definition-request.ts
@@ -11,7 +11,7 @@
 
 import { CompilationUnit } from "../workspace/compilation-unit";
 import { binaryTokenSearch } from "../utils/search";
-import { Location } from "./types";
+import { Location, tokenToRange } from "./types";
 import {
   getNameToken,
   getReference,
@@ -65,6 +65,7 @@ export function definitionRequest(
           start: nameToken.startOffset,
           end: nameToken.endOffset + 1,
         },
+        source: tokenToRange(token),
       },
     ];
   } else if (
@@ -73,8 +74,13 @@ export function definitionRequest(
       token.element?.kind === SyntaxKind.IncludeItemMember ||
       token.element?.kind === SyntaxKind.InscanDirective)
   ) {
-    // TODO @montymxb Nov 7th, 2025: Highlighting for members is incomplete, only gets the member & not the full ddname.
-    // see: https://github.com/zowe/zowe-pli-language-support/issues/466
+    let sourceRange = tokenToRange(token);
+    if (
+      token.element.kind !== SyntaxKind.InscanDirective &&
+      token.element.range
+    ) {
+      sourceRange = token.element.range;
+    }
     // allow jumping to the resolved file when present
     const filePath = token.element.filePath;
     if (filePath) {
@@ -85,6 +91,7 @@ export function definitionRequest(
             start: 0,
             end: 0,
           },
+          source: sourceRange,
         },
       ];
     }

--- a/packages/language/src/language-server/hover-request.ts
+++ b/packages/language/src/language-server/hover-request.ts
@@ -237,7 +237,6 @@ function decodeBound(bound: Bound | null): string | null {
 }
 
 interface IncludeItemNode {
-  sourceText: string | null;
   filePath: string | null;
   relativeFilePath: string | null;
 }

--- a/packages/language/src/language-server/types.ts
+++ b/packages/language/src/language-server/types.ts
@@ -27,6 +27,7 @@ export type Offset = number;
 export interface Location {
   uri: string;
   range: Range;
+  source?: Range;
 }
 
 export interface Range {

--- a/packages/language/src/parser/preprocessor-parser.ts
+++ b/packages/language/src/parser/preprocessor-parser.ts
@@ -22,7 +22,9 @@ import { TokenType } from "chevrotain";
 import {
   diagnostic,
   diagnosticFromCode,
+  Range,
   Severity,
+  tokenToRange,
 } from "../language-server/types";
 import { PLICodes } from "../validation/pli-codes";
 
@@ -602,6 +604,7 @@ function includeStatement(state: ParserState): ast.IncludeDirective {
   directive.token = includeToken;
   directive.idempotent = isXInstruction(includeToken);
   let parseError = false;
+  let range: Range | null = null;
   while (true) {
     let item: ast.IncludeItemFile | ast.IncludeItemMember | undefined =
       undefined;
@@ -622,6 +625,10 @@ function includeStatement(state: ParserState): ast.IncludeDirective {
     }
 
     if (idTokens.length > 1) {
+      range = {
+        start: idTokens[0].startOffset,
+        end: NaN,
+      };
       // ddname which requires a parenthesized member portion
       item = ast.createIncludeItemMember();
       for (const idToken of idTokens) {
@@ -636,7 +643,14 @@ function includeStatement(state: ParserState): ast.IncludeDirective {
         t.ID,
       );
 
-      state.consume(item, CstNodeKind.IncludeItem_CloseParen, t.CloseParen);
+      const endToken = state.consume(
+        item,
+        CstNodeKind.IncludeItem_CloseParen,
+        t.CloseParen,
+      );
+      if (endToken && range) {
+        range.end = endToken.endOffset + 1;
+      }
       // joint ddname
       item.ddname = idTokens.map((t) => t.image).join(".");
       item.ddnameTokens = idTokens; // <-- TODO use these tokens to report chained diagnostics, do I already do this?
@@ -645,12 +659,12 @@ function includeStatement(state: ParserState): ast.IncludeDirective {
       item.token = memberToken;
     } else if (idTokens.length === 1) {
       item = ast.createIncludeItemMember();
-      for (const idToken of idTokens) {
-        idToken.element = item;
-      }
+      const idToken = idTokens[0];
+      idToken.element = item;
+      range = tokenToRange(idToken);
 
       // either ddname w/ member, or raw member
-      const ddnameOrMember = idTokens[0].image;
+      const ddnameOrMember = idToken.image;
 
       // check to see if we have an opening parenthesis for a following member
       // making this a ddname + member
@@ -693,6 +707,7 @@ function includeStatement(state: ParserState): ast.IncludeDirective {
         t.STRING_TERM,
       );
       if (stringToken) {
+        range = tokenToRange(stringToken);
         const fileName = unpackCharacterValue(stringToken.image);
         item.fileName = fileName;
         item.token = stringToken;
@@ -703,6 +718,7 @@ function includeStatement(state: ParserState): ast.IncludeDirective {
         break;
       }
     }
+    item.range = range;
     directive.items.push(item);
     // Optional comma
     state.tryConsume(directive, CstNodeKind.IncludeDirective_Comma, t.Comma);

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -1843,7 +1843,7 @@ export interface IncludeDirective extends AstNode {
   kind: SyntaxKind.IncludeDirective;
   idempotent: boolean;
   token: Token | null;
-  items: Array<IncludeItemFile | IncludeItemMember>;
+  items: IncludeItem[];
 }
 export function createIncludeDirective(): IncludeDirective {
   return {
@@ -1861,7 +1861,7 @@ export interface IncludeAltDirective extends AstNode {
   kind: SyntaxKind.IncludeAltDirective;
   idempotent: boolean;
   token: Token | null;
-  items: Array<IncludeItemFile | IncludeItemMember>;
+  items: IncludeItem[];
 }
 export function createIncludeAltDirective(): IncludeAltDirective {
   return {
@@ -1873,17 +1873,19 @@ export function createIncludeAltDirective(): IncludeAltDirective {
   };
 }
 
+export type IncludeItem = IncludeItemFile | IncludeItemMember;
+
 /**
  * Include item by file name
  */
 export interface IncludeItemFile extends AstNode {
   kind: SyntaxKind.IncludeItemFile;
   token: Token | null;
+  range: Range | null;
 
   // Properties filled by the preprocessor
   filePath: string | null;
   relativeFilePath: string | null;
-  sourceText: string | null;
 
   fileName: string | null;
 }
@@ -1894,11 +1896,11 @@ export interface IncludeItemFile extends AstNode {
 export interface IncludeItemMember extends AstNode {
   kind: SyntaxKind.IncludeItemMember;
   token: Token | null;
+  range: Range | null;
 
   // Properties filled by the preprocessor
   filePath: string | null;
   relativeFilePath: string | null;
-  sourceText: string | null;
 
   /**
    * Member name of the include, if present
@@ -1922,12 +1924,7 @@ export interface IncludeItemMember extends AstNode {
 export function isIncludeItemFile(
   item: unknown,
 ): item is IncludeItemFile & { fileName: string } {
-  return (
-    typeof item === "object" &&
-    item !== null &&
-    "fileName" in item &&
-    typeof (item as any).fileName === "string"
-  );
+  return isObject<IncludeItemFile>(item) && typeof item.fileName === "string";
 }
 
 /**
@@ -1937,10 +1934,7 @@ export function isIncludeItemMember(
   item: unknown,
 ): item is IncludeItemMember & { memberName: string } {
   return (
-    typeof item === "object" &&
-    item !== null &&
-    "memberName" in item &&
-    typeof (item as any).memberName === "string"
+    isObject<IncludeItemMember>(item) && typeof item.memberName === "string"
   );
 }
 
@@ -1948,10 +1942,10 @@ export function createIncludeItemFile(): IncludeItemFile {
   return {
     kind: SyntaxKind.IncludeItemFile,
     container: null,
+    range: null,
     filePath: null,
     relativeFilePath: null,
     token: null,
-    sourceText: null,
     fileName: null,
   };
 }
@@ -1960,10 +1954,10 @@ export function createIncludeItemMember(): IncludeItemMember {
   return {
     kind: SyntaxKind.IncludeItemMember,
     container: null,
+    range: null,
     filePath: null,
     relativeFilePath: null,
     token: null,
-    sourceText: null,
     memberName: null,
     ddname: null,
     ddnameTokens: null,

--- a/packages/language/test/lsp/definition-source.test.ts
+++ b/packages/language/test/lsp/definition-source.test.ts
@@ -1,0 +1,107 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { describe, expect, test } from "vitest";
+import {
+  setFileSystemProvider,
+  VirtualFileSystemProvider,
+} from "../../src/workspace/file-system-provider";
+import {
+  deserializeProcessGroup,
+  PluginConfigurationProvider,
+  setPluginConfigurationProvider,
+} from "../../src/workspace/plugin-configuration-provider";
+import { URI } from "../../src/utils/uri";
+import { parseAndLink } from "../utils";
+import { definitionRequest } from "../../src/language-server/definition-request";
+
+let vfs: VirtualFileSystemProvider;
+let pluginConfig: PluginConfigurationProvider;
+
+async function setupIncludes(path: string, libEntry: string): Promise<void> {
+  vfs = new VirtualFileSystemProvider();
+  pluginConfig = new PluginConfigurationProvider();
+  setFileSystemProvider(vfs);
+  setPluginConfigurationProvider(pluginConfig);
+
+  const pathUri = URI.file(path);
+  await vfs.writeFile(pathUri, "");
+
+  await pluginConfig.init("/workspace");
+
+  // Base config setup
+  const processGroup = deserializeProcessGroup({
+    name: "default",
+    "include-extensions": [".pli"],
+    libs: [libEntry],
+  });
+
+  await pluginConfig.setProcessGroupConfigs([processGroup]);
+  pluginConfig.setProgramConfigs("/workspace", [
+    { program: "*.pli", pgroup: "default", pliOptions: {} },
+  ]);
+}
+
+describe("Definition Source Ranges", () => {
+  test("Include source range on strings", async () => {
+    await setupIncludes("/workspace/lib/included.pli", "/workspace/lib/");
+    const code = ' %INCLUDE "included.pli";';
+    const index = code.indexOf("included.pli");
+    const uri = URI.file("/workspace/main.pli");
+    const unit = await parseAndLink(code, {
+      uri,
+    });
+    const definitions = definitionRequest(unit, uri, index);
+    expect(definitions).toHaveLength(1);
+    const def = definitions[0];
+    expect(def.source).toBeDefined();
+    // Should start with the opening quote character
+    expect(def.source?.start).toBe(index - 1);
+    // Should end with the closing quote character
+    expect(def.source?.end).toBe(index + "included.pli".length + 1);
+  });
+
+  test("Include source range on members", async () => {
+    await setupIncludes("/workspace/lib/A.B.C(test).pli", "/workspace/lib");
+    const code = " %INCLUDE A.B.C(test);";
+    const index = code.indexOf("A.B.C(test)");
+    const uri = URI.file("/workspace/main.pli");
+    const unit = await parseAndLink(code, {
+      uri,
+    });
+    const definitions = definitionRequest(unit, uri, index);
+    expect(definitions).toHaveLength(1);
+    const def = definitions[0];
+    expect(def.source).toBeDefined();
+    // Should start at the beginning of the member
+    expect(def.source?.start).toBe(index);
+    // Should end at the end of the member
+    expect(def.source?.end).toBe(index + "A.B.C(test)".length);
+  });
+
+  test("Include source range on simple names", async () => {
+    await setupIncludes("/workspace/lib/simple.pli", "/workspace/lib/");
+    const code = " %INCLUDE simple;";
+    const index = code.indexOf("simple");
+    const uri = URI.file("/workspace/main.pli");
+    const unit = await parseAndLink(code, {
+      uri,
+    });
+    const definitions = definitionRequest(unit, uri, index);
+    expect(definitions).toHaveLength(1);
+    const def = definitions[0];
+    expect(def.source).toBeDefined();
+    // Should start at the beginning of the name
+    expect(def.source?.start).toBe(index);
+    // Should end at the end of the name
+    expect(def.source?.end).toBe(index + "simple".length);
+  });
+});


### PR DESCRIPTION
Closes #466

Adds the full range of the respective include item to the AST node. Uses this information to calculate the `sourceRange` for the definition request to fix this issue at hand.