### PR TITLE
Prevent diagnostics pollution of compiler options

### DIFF
--- a/packages/language/src/preprocessor/compiler-options-processor.ts
+++ b/packages/language/src/preprocessor/compiler-options-processor.ts
@@ -74,6 +74,7 @@ export class CompilerOptionsProcessor {
     for (const [index, srcCompilerOpts] of sourceCompilerOptions.entries()) {
       const srcAbstractOptions = parseAbstractCompilerOptions(
         srcCompilerOpts,
+        uri,
         ranges[index].start + CompilerOptionsProcessor.PROCESS_TOKEN_LENGTH,
       );
 

--- a/packages/language/src/preprocessor/compiler-options/parser.ts
+++ b/packages/language/src/preprocessor/compiler-options/parser.ts
@@ -31,6 +31,7 @@ import {
   SyntaxKind,
 } from "../../syntax-tree/ast";
 import { ML_COMMENT, SL_COMMENT, Token } from "../../parser/tokens";
+import { URI } from "../../utils/uri";
 
 const commaToken = createToken({ name: "comma", pattern: "," });
 const semicolonToken = createToken({ name: "semicolon", pattern: ";" });
@@ -273,6 +274,7 @@ export interface AbstractCompilerOptions {
  */
 export function parseAbstractCompilerOptions(
   input: string,
+  uri?: URI,
   offset?: number,
 ): AbstractCompilerOptions {
   // Remove everything after the first ;.
@@ -285,11 +287,17 @@ export function parseAbstractCompilerOptions(
     0,
     semicolonTokenPosition === -1 ? undefined : semicolonTokenPosition,
   ) as Token[];
+  if (uri) {
+    for (const token of tokens) {
+      token.uri = uri;
+    }
+  }
   parser.input = tokens;
   const compilerOptions = parser.compilerOptions();
   const issues: Diagnostic[] = [];
   for (const lexerError of lexerResult.errors) {
     issues.push({
+      uri: uri?.toString(),
       message: lexerError.message,
       range: {
         start: lexerError.offset,
@@ -304,6 +312,7 @@ export function parseAbstractCompilerOptions(
         ? tokens[tokens.length - 1]
         : (parserError.token as Token);
     issues.push({
+      uri: uri?.toString(),
       message: parserError.message,
       range: tokenToRange(errorToken),
       severity: 1,

--- a/packages/language/src/preprocessor/compiler-options/translate.ts
+++ b/packages/language/src/preprocessor/compiler-options/translate.ts
@@ -81,6 +81,7 @@ function parseNestedOptions<T extends CompilerOptionsPP>(
   for (const item of items) {
     const nestedOptions = parseAbstractCompilerOptions(
       item.value as string,
+      item.token?.uri,
       (item.token?.startOffset ?? 0) + 1,
     );
     nestedOptions.options.forEach((option) => ppTranslator.translate(option));

--- a/packages/language/src/validation/validator.ts
+++ b/packages/language/src/validation/validator.ts
@@ -88,22 +88,6 @@ function validateSyntaxNode(
   });
 }
 
-export function filteredDiagnosticsWithUri(
-  diagnostics: Diagnostic[] | undefined,
-  uri: string,
-): Diagnostic[] {
-  if (!diagnostics) {
-    return [];
-  }
-  const filteredDiagnostics: Diagnostic[] = [];
-  for (const issue of diagnostics) {
-    if (issue.range && !isNaN(issue.range.start)) {
-      filteredDiagnostics.push({ ...issue, uri });
-    }
-  }
-  return filteredDiagnostics;
-}
-
 export function parserErrorsToDiagnostics(
   parserErrors: IRecognitionException[],
 ): Diagnostic[] {

--- a/packages/language/src/workspace/lifecycle.ts
+++ b/packages/language/src/workspace/lifecycle.ts
@@ -19,7 +19,6 @@ import {
   generatePreprocessorValidationDiagnostics,
   linkingErrorsToDiagnostics,
   parserErrorsToDiagnostics,
-  filteredDiagnosticsWithUri,
 } from "../validation/validator";
 import { LexerResult, PliLexer } from "../preprocessor/pli-lexer";
 import { assignDebugKinds } from "../utils/debug-kinds";
@@ -75,7 +74,7 @@ export async function tokenize(
   );
   compilationUnit.diagnostics.addAll(
     DiagnosticCategory.CompilerOptions,
-    filteredDiagnosticsWithUri(result.compilerOptions.result?.issues, uri),
+    (result.compilerOptions.result?.issues ?? []).filter((e) => e.uri === uri),
   );
   return result;
 }


### PR DESCRIPTION
Currently, the `filteredDiagnosticsWithUri` function will simply *assign* the current `URI` to any diagnostic generated by the compiler options translator. This is incorrect, and will result in issues assigned to the current file URI, even if it doesn't originate from there. This was apparent when using the `SQL` and `MACRO`, compiler sub options.

This change ensures that only the compiler options from the current file get the `URI` attached to the tokens.

FYI: This change does not contain tests, because I plan to refactor some of the compiler options stuff anyway, which would make any test I write now obsolete.