### PR TITLE
Improve AST robustness

### DIFF
--- a/packages/language/src/parser/abstract-parser.ts
+++ b/packages/language/src/parser/abstract-parser.ts
@@ -21,6 +21,7 @@ import { LLStarLookaheadStrategy } from "chevrotain-allstar";
 import {
   BinaryOperator,
   Expression,
+  isSyntaxNode,
   SyntaxKind,
   type BinaryExpression,
   type SyntaxNode,
@@ -197,15 +198,15 @@ export class AbstractParser extends EmbeddedActionsParser {
     ruleToCall: ParserMethod<ARGS, R>,
     options: SubruleAssignMethodOpts<ARGS, R>,
   ): void {
-    let value: R;
+    let value: R | undefined | null;
     try {
       value = this.subrule(index, ruleToCall, options);
     } finally {
       this.ACTION(() => {
-        if (value === undefined) {
+        if (!Boolean(value)) {
           value = this.pop();
         }
-        if (value !== undefined) {
+        if (isSyntaxNode(value)) {
           options.assign(value);
         }
       });
@@ -334,9 +335,16 @@ const binaryPrecedence = buildPrecendenceMap([
 export function constructBinaryExpression(
   obj: IntermediateBinaryExpression,
 ): Expression | null {
-  if (obj.items.length === 1) {
+  // If there are no items, that means we have parsed an "empty" expression
+  // Simply return null in this case
+  if (obj.items.length === 0) {
+    return null;
+  }
+  if (obj.items.length === 1 && obj.operators.length === 0) {
     // Captured just a single, non-binary expression
     // Simply return the expression as is.
+    // Note that in some cases there might only be one item, but still more than 0 operators
+    // This usually indicates a parser error, but we still need to handle it gracefully
     return obj.items[0];
   }
   // Find the operator with the lowest precedence (highest value in precedence map)

--- a/packages/language/src/parser/parser-entry.ts
+++ b/packages/language/src/parser/parser-entry.ts
@@ -35,16 +35,13 @@ export function preprocessorParse(
   let index = state.index;
   let token = state.token;
   while (token) {
+    let stmt: ast.Statement | null = null;
     let isTokenStatement = true;
     switch (token.tokenTypeIdx) {
       case t.Percent.tokenTypeIdx:
         isTokenStatement = false;
         // Parse a preprocessor statement
-        const ppStmt = statement(state);
-        if (ppStmt) {
-          recursivelySetContainer(ppStmt);
-          statements.push(ppStmt);
-        }
+        stmt = statement(state);
         break;
       case t.INCLUDE_ALT.tokenTypeIdx:
         isTokenStatement = false;
@@ -53,8 +50,7 @@ export function preprocessorParse(
         const includeAlt = includeAltStatement(state);
         const includeAltStmt = ast.createStatement();
         includeAltStmt.value = includeAlt;
-        recursivelySetContainer(includeAltStmt);
-        statements.push(includeAltStmt);
+        stmt = includeAltStmt;
         break;
       case t.SQL.tokenTypeIdx:
         if (isSqlAttributeStatement(state)) {
@@ -62,16 +58,17 @@ export function preprocessorParse(
           const sqlAttrStmt = sqlAttributeStatement(state);
           const sqlAttrStatement = ast.createStatement();
           sqlAttrStatement.value = sqlAttrStmt;
-          recursivelySetContainer(sqlAttrStatement);
-          statements.push(sqlAttrStatement);
+          stmt = sqlAttrStatement;
         }
         break;
     }
     if (isTokenStatement) {
       // Otherwise construct a token statement
-      const tokenStmt = consumeTokenStatement(state);
-      recursivelySetContainer(tokenStmt);
-      statements.push(tokenStmt);
+      stmt = consumeTokenStatement(state);
+    }
+    if (stmt) {
+      recursivelySetContainer(stmt);
+      statements.push(stmt);
     }
     if (index === state.index) {
       console.error("Parser did not advance at token: " + token.image);

--- a/packages/language/src/syntax-tree/ast-iterator.ts
+++ b/packages/language/src/syntax-tree/ast-iterator.ts
@@ -979,9 +979,7 @@ export function forEachNode(
     case SyntaxKind.SqlAttributeRowId:
       break;
     default:
-      if (node && "kind" in node) {
-        assertUnreachable(node);
-      }
+      assertUnreachable(node);
   }
 }
 


### PR DESCRIPTION
In some rare cases, we received the following error:

```
TypeError: Cannot set properties of null (setting 'container')
```

This change adjusts the `AbstractParser` to ensure that we never call the `assign` function with `null` (we previously only checked for `undefined`). It also improves the computation of erroneous binary expressions like `A + `, which should still generate a `BinaryExpression` element with `right = null`.