### PR TITLE
Support additional SQL preprocessor attributes

### DIFF
--- a/packages/language/src/parser/sql-parser.ts
+++ b/packages/language/src/parser/sql-parser.ts
@@ -61,32 +61,36 @@ export function sqlAttributeStatement(
       state,
       attributeStatement.isXml,
     );
-  } else if (state.canConsume(t.CharOrBinary)) {
+  } else if (state.canConsume(t.BINARY) || state.canConsume(t.CHARACTER)) {
     attributeStatement.body = parseSQLAttributeExplicitLob(
       state,
       attributeStatement.isXml,
     );
   } else if (state.canConsume(t.LOBLocator)) {
-    attributeStatement.body = ast.createSQLAttributeLobLocator();
+    attributeStatement.body = ast.createSqlAttributeLobLocator();
     state.consume(
       attributeStatement.body,
       CstNodeKind.SqlAttributeLobLocator_LOB_LOCATOR,
       t.LOBLocator,
     );
   } else if (state.canConsume(t.LOBFile)) {
-    attributeStatement.body = ast.createSQLAttributeLobFile();
+    attributeStatement.body = ast.createSqlAttributeLobFile();
     state.consume(
       attributeStatement.body,
       CstNodeKind.SqlAttributeLobFile_LOB_FILE,
       t.LOBFile,
     );
   } else if (state.canConsume(t.ROWID)) {
-    attributeStatement.body = ast.createSQLAttributeRowId();
+    attributeStatement.body = ast.createSqlAttributeRowId();
     state.consume(
       attributeStatement.body,
       CstNodeKind.SqlAttributeRowId_ROWID,
       t.ROWID,
     );
+  } else if (state.canConsume(t.TABLE)) {
+    attributeStatement.body = parseSqlTableLocator(state);
+  } else if (state.canConsume(t.RESULT_SET_LOCATOR)) {
+    attributeStatement.body = parseSqlResultSetLocator(state);
   }
   return attributeStatement;
 }
@@ -95,7 +99,7 @@ function parseSQLAttributeBinary(
   state: ParserState,
   isXml: boolean,
 ): ast.SqlAttributeBinary {
-  const binary = ast.createSQLAttributeBinary();
+  const binary = ast.createSqlAttributeBinary();
   let typename = "";
   // Can be BINARY or BINARY VARYING or VARBINARY
   if (state.canConsume(t.BINARY)) {
@@ -130,25 +134,24 @@ function parseSQLAttributeExplicitLob(
   state: ParserState,
   isXml: boolean,
 ): ast.SqlAttributeLob {
-  const lob = ast.createSQLAttributeLob();
-  const typeToken = state.consume(
-    lob,
-    CstNodeKind.SqlAttributeLob_Type,
-    t.CharOrBinary,
-  );
-  state.consume(lob, CstNodeKind.SqlAttributeLob_LARGE, t.LARGE);
-  state.consume(lob, CstNodeKind.SqlAttributeLob_OBJECT, t.OBJECT);
+  const lob = ast.createSqlAttributeLob();
   let typename = "";
-  switch (typeToken?.tokenTypeIdx) {
-    case t.CHARACTER.tokenTypeIdx:
-      lob.type = ast.SQLAttributeLobType.CLOB;
-      typename = "CLOB";
-      break;
-    case t.BINARY.tokenTypeIdx:
+  if (state.tryConsume(lob, CstNodeKind.SqlAttributeLob_Type, t.CHARACTER)) {
+    lob.type = ast.SQLAttributeLobType.CLOB;
+    typename = "CLOB";
+  } else {
+    const binToken = state.consume(
+      lob,
+      CstNodeKind.SqlAttributeLob_Type,
+      t.BINARY,
+    );
+    if (binToken) {
       lob.type = ast.SQLAttributeLobType.BLOB;
       typename = "BLOB";
-      break;
+    }
   }
+  state.consume(lob, CstNodeKind.SqlAttributeLob_LARGE, t.LARGE);
+  state.consume(lob, CstNodeKind.SqlAttributeLob_OBJECT, t.OBJECT);
   parseSQLAttributeLobSize(state, lob, isXml, typename);
   return lob;
 }
@@ -157,7 +160,7 @@ function parseSQLAttributeLob(
   state: ParserState,
   isXml: boolean,
 ): ast.SqlAttributeLob {
-  const lob = ast.createSQLAttributeLob();
+  const lob = ast.createSqlAttributeLob();
   const typeToken = state.consume(lob, CstNodeKind.SqlAttributeLob_Type, t.LOB);
   let typename = "";
   switch (typeToken?.tokenTypeIdx) {
@@ -224,4 +227,45 @@ function parseSQLAttributeLobSize(
     isXml ? Severe.IBM3759I : Severe.IBM3756I,
     typename,
   );
+}
+
+function parseSqlTableLocator(
+  state: ParserState,
+): ast.SqlAttributeTableLocator {
+  const locator = ast.createSqlAttributeTableLocator();
+  state.consume(locator, CstNodeKind.SqlAttributeTableLocator_TABLE, t.TABLE);
+  state.consume(locator, CstNodeKind.SqlAttributeTableLocator_LIKE, t.LIKE);
+  const tableNameToken = state.consume(
+    locator,
+    CstNodeKind.SqlAttributeTableLocator_TableName,
+    t.ID,
+  );
+  if (tableNameToken) {
+    locator.name = tableNameToken.image;
+    locator.nameToken = tableNameToken;
+  }
+  state.consume(locator, CstNodeKind.SqlAttributeTableLocator_AS, t.AS);
+  state.consume(
+    locator,
+    CstNodeKind.SqlAttributeTableLocator_LOCATOR,
+    t.LOCATOR,
+  );
+  return locator;
+}
+
+function parseSqlResultSetLocator(
+  state: ParserState,
+): ast.SqlAttributeResultSetLocator {
+  const locator = ast.createSqlAttributeResultSetLocator();
+  state.consume(
+    locator,
+    CstNodeKind.SqlAttributeResultSetLocator_RESULT_SET_LOCATOR,
+    t.RESULT_SET_LOCATOR,
+  );
+  state.consume(
+    locator,
+    CstNodeKind.SqlAttributeResultSetLocator_VARYING,
+    t.VARYING,
+  );
+  return locator;
 }

--- a/packages/language/src/parser/tokens.ts
+++ b/packages/language/src/parser/tokens.ts
@@ -277,8 +277,6 @@ export const LocateType = registerCombination<ast.LocateType>("LocateType");
 export const OpenOptionType =
   registerCombination<ast.OpenOptionType>("OpenOptionType");
 export const VX = registerCombination<ast.VX>("VX");
-export const CharOrBinary =
-  registerCombination<ast.CharOrBinary>("CharOrBinary");
 export const TypeOrOrdinal =
   registerCombination<ast.TypeOrOrdinal>("TypeOrOrdinal");
 export const BinaryType =
@@ -517,7 +515,6 @@ export const CHARACTER = registerKeyword({
     [DefaultAttribute, ast.DefaultAttribute.CHARACTER],
     [AllocateAttributeType, ast.AllocateAttributeType.CHARACTER],
     [CharType, ast.CharType.CHARACTER],
-    [CharOrBinary, ast.CharOrBinary.CHARACTER],
   ],
 });
 export const DIMACROSS = registerKeyword({
@@ -983,20 +980,15 @@ export const CANCEL = registerKeyword({
   name: "CANCEL",
 });
 export const BINARY = registerKeyword({
-  name: "BINARY",
+  name: ["BINARY", "BIN"],
   categories: [
     [DefaultAttribute, ast.DefaultAttribute.BINARY],
-    [CharOrBinary, ast.CharOrBinary.BINARY],
     [BinaryType, ast.SqlAttributeBinaryType.BINARY],
   ],
 });
 export const VARBINARY = registerKeyword({
   name: "VARBINARY",
   categories: [[BinaryType, ast.SqlAttributeBinaryType.VARBINARY]],
-});
-export const BIN = registerKeyword({
-  name: "BIN",
-  categories: [[DefaultAttribute, ast.DefaultAttribute.BINARY]],
 });
 export const FORMAT = registerKeyword({
   name: "FORMAT",
@@ -1801,6 +1793,15 @@ export const DBCLOB_FILE = registerKeyword({
 });
 export const ROWID = registerKeyword({
   name: "ROWID",
+});
+export const TABLE = registerKeyword({
+  name: "TABLE",
+});
+export const LOCATOR = registerKeyword({
+  name: "LOCATOR",
+});
+export const RESULT_SET_LOCATOR = registerKeyword({
+  name: "RESULT_SET_LOCATOR",
 });
 
 /**

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -508,7 +508,7 @@ function runInstructionSync(
   return undefined;
 }
 
-const LOB_LOCATOR_TYPE = "FIXED BIN(31)";
+const LOCATOR_TYPE = "FIXED BIN(31)";
 const ROWID_TYPE = "CHAR(40) VARYING";
 const LOB_FILE_TYPE = "LIKE SQL_LOB_FILE";
 const LOB_TYPE = (length: number) => `LIKE SQL_LOB${length}`;
@@ -521,8 +521,13 @@ function runSqlAttributeInstruction(
   if (!body) {
     return;
   }
-  if (body.kind === ast.SyntaxKind.SqlAttributeLobLocator) {
-    context.tokens.push(...lex(LOB_LOCATOR_TYPE));
+  if (
+    // All locator types simply generate the same static attributes
+    body.kind === ast.SyntaxKind.SqlAttributeLobLocator ||
+    body.kind === ast.SyntaxKind.SqlAttributeTableLocator ||
+    body.kind === ast.SyntaxKind.SqlAttributeResultSetLocator
+  ) {
+    context.tokens.push(...lex(LOCATOR_TYPE));
   } else if (body.kind === ast.SyntaxKind.SqlAttributeRowId) {
     context.tokens.push(...lex(ROWID_TYPE));
   } else if (body.kind === ast.SyntaxKind.SqlAttributeBinary) {

--- a/packages/language/src/syntax-tree/ast-iterator.ts
+++ b/packages/language/src/syntax-tree/ast-iterator.ts
@@ -977,6 +977,8 @@ export function forEachNode(
     case SyntaxKind.SqlAttributeLobFile:
     case SyntaxKind.SqlAttributeLobLocator:
     case SyntaxKind.SqlAttributeRowId:
+    case SyntaxKind.SqlAttributeTableLocator:
+    case SyntaxKind.SqlAttributeResultSetLocator:
       break;
     default:
       if (node && "kind" in node) {

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -210,6 +210,8 @@ export enum SyntaxKind {
   SqlAttributeLobLocator,
   SqlAttributeLobFile,
   SqlAttributeRowId,
+  SqlAttributeTableLocator,
+  SqlAttributeResultSetLocator,
   TypeAttribute,
   UnaryExpression,
   ValueAttribute,
@@ -435,11 +437,6 @@ export enum CharType {
   CHARACTER,
   WIDECHAR,
   UCHAR,
-}
-
-export enum CharOrBinary {
-  CHARACTER,
-  BINARY,
 }
 
 export enum PutAttribute {
@@ -850,6 +847,8 @@ export type SyntaxNode =
   | SqlAttributeLobLocator
   | SqlAttributeLobFile
   | SqlAttributeRowId
+  | SqlAttributeTableLocator
+  | SqlAttributeResultSetLocator
   | TypeAttribute
   | UnaryExpression
   | ValueAttribute
@@ -2739,7 +2738,7 @@ export interface SqlAttributeBinary extends AstNode {
   size: SQLAttributeLobSize | null;
 }
 
-export function createSQLAttributeBinary(): SqlAttributeBinary {
+export function createSqlAttributeBinary(): SqlAttributeBinary {
   return {
     kind: SyntaxKind.SqlAttributeBinary,
     container: null,
@@ -2768,7 +2767,7 @@ export interface SqlAttributeLob extends AstNode {
   size: SQLAttributeLobSize | null;
 }
 
-export function createSQLAttributeLob(): SqlAttributeLob {
+export function createSqlAttributeLob(): SqlAttributeLob {
   return {
     kind: SyntaxKind.SqlAttributeLob,
     container: null,
@@ -2783,7 +2782,7 @@ export interface SqlAttributeLobLocator extends AstNode {
   type: SQLAttributeLobType | null;
 }
 
-export function createSQLAttributeLobLocator(): SqlAttributeLobLocator {
+export function createSqlAttributeLobLocator(): SqlAttributeLobLocator {
   return {
     kind: SyntaxKind.SqlAttributeLobLocator,
     container: null,
@@ -2796,7 +2795,7 @@ export interface SqlAttributeLobFile extends AstNode {
   type: SQLAttributeLobType | null;
 }
 
-export function createSQLAttributeLobFile(): SqlAttributeLobFile {
+export function createSqlAttributeLobFile(): SqlAttributeLobFile {
   return {
     kind: SyntaxKind.SqlAttributeLobFile,
     container: null,
@@ -2808,9 +2807,35 @@ export interface SqlAttributeRowId extends AstNode {
   kind: SyntaxKind.SqlAttributeRowId;
 }
 
-export function createSQLAttributeRowId(): SqlAttributeRowId {
+export function createSqlAttributeRowId(): SqlAttributeRowId {
   return {
     kind: SyntaxKind.SqlAttributeRowId,
+    container: null,
+  };
+}
+
+export interface SqlAttributeTableLocator extends AstNode {
+  kind: SyntaxKind.SqlAttributeTableLocator;
+  name: string | null;
+  nameToken: Token | null;
+}
+
+export function createSqlAttributeTableLocator(): SqlAttributeTableLocator {
+  return {
+    kind: SyntaxKind.SqlAttributeTableLocator,
+    container: null,
+    name: null,
+    nameToken: null,
+  };
+}
+
+export interface SqlAttributeResultSetLocator extends AstNode {
+  kind: SyntaxKind.SqlAttributeResultSetLocator;
+}
+
+export function createSqlAttributeResultSetLocator(): SqlAttributeResultSetLocator {
+  return {
+    kind: SyntaxKind.SqlAttributeResultSetLocator,
     container: null,
   };
 }
@@ -2820,7 +2845,9 @@ export type SqlAttributeType =
   | SqlAttributeLob
   | SqlAttributeLobLocator
   | SqlAttributeLobFile
-  | SqlAttributeRowId;
+  | SqlAttributeRowId
+  | SqlAttributeTableLocator
+  | SqlAttributeResultSetLocator;
 
 export interface SqlAttributeStatement extends AstNode {
   kind: SyntaxKind.SqlAttributeStatement;

--- a/packages/language/src/syntax-tree/cst.ts
+++ b/packages/language/src/syntax-tree/cst.ts
@@ -706,4 +706,11 @@ export enum CstNodeKind {
   SqlAttributeLob_Length,
   SqlAttributeLob_LengthModifier,
   SqlAttributeLob_CloseParen,
+  SqlAttributeTableLocator_TABLE,
+  SqlAttributeTableLocator_LIKE,
+  SqlAttributeTableLocator_TableName,
+  SqlAttributeTableLocator_AS,
+  SqlAttributeTableLocator_LOCATOR,
+  SqlAttributeResultSetLocator_RESULT_SET_LOCATOR,
+  SqlAttributeResultSetLocator_VARYING,
 }

--- a/packages/language/test/fourslash/hover/pp-generated-procedure.ts
+++ b/packages/language/test/fourslash/hover/pp-generated-procedure.ts
@@ -22,7 +22,7 @@
 //// CALL <|2>P1;
 
 const expectedMarkdown2 = hover.codeBlock(
-  "P1: PROC(A,B) OPTIONS(MAIN) RETURNS(FIXED BIN(15));",
+  "P1: PROC(A,B) OPTIONS(MAIN) RETURNS(FIXED BINARY(15));",
 );
 hover.expectMarkdownAt(1, expectedMarkdown2);
 hover.expectMarkdownAt(2, expectedMarkdown2);

--- a/packages/language/test/fourslash/hover/procedure.ts
+++ b/packages/language/test/fourslash/hover/procedure.ts
@@ -31,11 +31,11 @@
 //// CALL <|3>MyProc2;
 
 const expectedMarkdown = hover.codeBlock(
-  "MYPROC: PROC(A,B,C) OPTIONS(MAIN, ORDER) RECURSIVE REORDER RETURNS(FIXED BIN(31));",
+  "MYPROC: PROC(A,B,C) OPTIONS(MAIN, ORDER) RECURSIVE REORDER RETURNS(FIXED BINARY(31));",
 );
 hover.expectMarkdownAt(1, expectedMarkdown);
 hover.expectMarkdownAt(2, expectedMarkdown);
 hover.expectMarkdownAt(
   3,
-  hover.codeBlock("MYPROC2: PROC(A) RETURNS(FIXED BIN(15));"),
+  hover.codeBlock("MYPROC2: PROC(A) RETURNS(FIXED BINARY(15));"),
 );

--- a/packages/language/test/fourslash/preprocessor/sql/binary-attribute-with-bin.ts
+++ b/packages/language/test/fourslash/preprocessor/sql/binary-attribute-with-bin.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// TEST: PROC;
+////   DCL TEST_SQL SQL TYPE IS BIN(20);
+//// END;
+
+// BINARY and BIN should be exchangable
+preprocessor.expectTokens(`
+TEST: PROC;
+  DCL TEST_SQL CHAR(20) NONVARYING;
+END;
+`);

--- a/packages/language/test/fourslash/preprocessor/sql/result-set-locator.ts
+++ b/packages/language/test/fourslash/preprocessor/sql/result-set-locator.ts
@@ -1,0 +1,22 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// TEST: PROC;
+////   DCL TEST_SQL SQL TYPE IS RESULT_SET_LOCATOR VARYING;
+//// END;
+
+preprocessor.expectTokens(`
+TEST: PROC;
+  DCL TEST_SQL FIXED BIN(31);
+END;
+`);

--- a/packages/language/test/fourslash/preprocessor/sql/table-locator.ts
+++ b/packages/language/test/fourslash/preprocessor/sql/table-locator.ts
@@ -1,0 +1,22 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// TEST: PROC;
+////   DCL TEST_SQL SQL TYPE IS TABLE LIKE TEST_TABLE AS LOCATOR;
+//// END;
+
+preprocessor.expectTokens(`
+TEST: PROC;
+  DCL TEST_SQL FIXED BIN(31);
+END;
+`);


### PR DESCRIPTION
Supports the missing SQL preprocessor attributes from [here](https://www.ibm.com/docs/en/db2-for-zos/13.0.0?topic=pli-host-variables-in). Previously, we only implemented the ones from [this page](https://www.ibm.com/docs/en/db2-for-zos/13.0.0?topic=pli-host-variable-arrays-in).

In total this PR contains changes to:

1. Support the `SQL TYPE IS TABLE LIKE <table-name> AS LOCATOR` syntax
2. Support the `SQL TYPE IS RESULT_SET_LOCATOR VARYING` syntax
3. Remove `BIN` as an individual keyword again. Even though the syntax diagrams never specify it, but `BIN` is ***always*** a valid short version of `BINARY`, even in the SQL preprocessor.