### PR TITLE
Support `INITIAL` attribute in preprocessor

### DIFF
--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -5917,24 +5917,8 @@ export class PliParser extends AbstractParser {
     return this.pop<ast.WriteStatementOption>();
   });
 
-  private createInitialAttribute(): ast.InitialAttribute {
-    return {
-      kind: ast.SyntaxKind.InitialAttribute,
-      container: null,
-      across: false,
-      expressions: [],
-      direct: false,
-      items: [],
-      call: false,
-      procedureCall: null,
-      to: false,
-      content: null,
-      token: null,
-    };
-  }
-
   InitialAttribute = this.RULE("InitialAttribute", () => {
-    let element = this.push(this.createInitialAttribute());
+    let element = this.push(ast.createInitialAttribute());
 
     this.OR1([
       {

--- a/packages/language/src/parser/preprocessor-parser.ts
+++ b/packages/language/src/parser/preprocessor-parser.ts
@@ -1480,6 +1480,44 @@ function attributes(state: ParserState): ast.DeclarationAttribute[] {
         t.ENTRY,
       );
       attributes.push(entryAttribute);
+    } else if (state.canConsume(t.INITIAL)) {
+      const initialAttribute = ast.createInitialAttribute();
+      state.consume(
+        initialAttribute,
+        CstNodeKind.InitialAttribute_INITIAL,
+        t.INITIAL,
+      );
+      state.consume(
+        initialAttribute,
+        CstNodeKind.InitialAttribute_OpenParenDirect,
+        t.OpenParen,
+      );
+      const firstExpr = expression(state);
+      if (firstExpr) {
+        const spec = ast.createInitialAttributeSpecification();
+        spec.expression = firstExpr;
+        initialAttribute.items.push(spec);
+      }
+      while (
+        state.tryConsume(
+          initialAttribute,
+          CstNodeKind.InitialAttribute_CommaDirect,
+          t.Comma,
+        )
+      ) {
+        const expr = expression(state);
+        if (expr) {
+          const spec = ast.createInitialAttributeSpecification();
+          spec.expression = expr;
+          initialAttribute.items.push(spec);
+        }
+      }
+      state.consume(
+        initialAttribute,
+        CstNodeKind.InitialAttribute_CloseParenDirect,
+        t.CloseParen,
+      );
+      attributes.push(initialAttribute);
     } else {
       break;
     }

--- a/packages/language/src/preprocessor/instruction-generator.ts
+++ b/packages/language/src/preprocessor/instruction-generator.ts
@@ -358,6 +358,7 @@ function generateDeclareInstruction(
       continue; // Skip variables without a name
     }
     const dimensions = getDimensions(item);
+    const initial = getInitial(item);
     // Generate an instruction for each declared variable
     const attributes = getAttributes(item);
     let type: inst.DeclaredType = inst.DeclaredType.Character;
@@ -370,7 +371,7 @@ function generateDeclareInstruction(
     } else if (attributes.includes("NOSCAN")) {
       scanMode = ast.ScanMode.NOSCAN;
     }
-    let visibility: inst.VariableVisibility | null = null;
+    let visibility: inst.VariableVisibility | undefined;
     if (attributes.includes("INTERNAL")) {
       visibility = inst.VariableVisibility.Internal;
     } else if (attributes.includes("EXTERNAL")) {
@@ -382,6 +383,7 @@ function generateDeclareInstruction(
         dimensions,
         type,
         scanMode,
+        initial,
         visibility,
         item,
       ),
@@ -396,26 +398,19 @@ function generateReplaceInstruction(
   // A replace instruction is a combination of a declare and an assignment
   const instructions: inst.Instruction[] = [];
   if (statement.name && statement.nameToken && statement.literal) {
+    const literal = generateExpressionInstruction(statement.literal, true);
+    const initial = literal ? [literal] : undefined;
     instructions.push(
       inst.createDeclareInstruction(
         statement.name,
         undefined,
         inst.DeclaredType.Character,
         ast.ScanMode.RESCAN,
-        null,
+        initial,
+        undefined,
         statement,
       ),
     );
-    const literal = generateExpressionInstruction(statement.literal, true);
-    if (literal) {
-      instructions.push(
-        inst.createAssignmentInstruction(
-          [inst.createReferenceItemInstruction(statement.name, null, [])],
-          ast.AssignmentOperator.Equals,
-          literal,
-        ),
-      );
-    }
   }
   return inst.createCompoundInstruction(instructions);
 }
@@ -470,6 +465,33 @@ function getDimensions(
     });
   }
   return instructions;
+}
+
+function getInitial(
+  item: ast.DeclaredVariable,
+): inst.ExpressionInstruction[] | undefined {
+  let container = item.container;
+  while (container?.kind === ast.SyntaxKind.DeclaredItem) {
+    for (const attribute of container.attributes) {
+      if (attribute.kind === ast.SyntaxKind.InitialAttribute) {
+        const initialExpressions: inst.ExpressionInstruction[] = [];
+        for (const item of attribute.items) {
+          if (
+            item.kind === ast.SyntaxKind.InitialAttributeSpecification &&
+            item.expression
+          ) {
+            const expr = generateExpressionInstruction(item.expression);
+            if (expr) {
+              initialExpressions.push(expr);
+            }
+          }
+        }
+        return initialExpressions;
+      }
+    }
+    container = container.container;
+  }
+  return undefined;
 }
 
 function generateSelectInstructionFromIf(

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -223,6 +223,24 @@ function generateVariableValue(
       };
     }
   }
+  if (instruction.initial) {
+    // Currently only supports scalar initial values for simple arrays or scalar variables
+    if (isArrayValue(value)) {
+      for (
+        let i = 0;
+        i < value.array.length && i < instruction.initial.length;
+        i++
+      ) {
+        const expr = instruction.initial[i];
+        const evaluated = evaluateExpression(expr, context);
+        value.array[i] = evaluated;
+      }
+    } else if (instruction.initial.length > 0) {
+      const expr = instruction.initial[0];
+      const evaluated = evaluateExpression(expr, context);
+      value = evaluated;
+    }
+  }
   return value;
 }
 

--- a/packages/language/src/preprocessor/instructions.ts
+++ b/packages/language/src/preprocessor/instructions.ts
@@ -330,19 +330,20 @@ export enum VariableVisibility {
 export interface DeclareInstruction {
   kind: InstructionKind.Declare;
   name: string;
-  node: ast.SyntaxNode | null;
+  node?: ast.SyntaxNode;
   /**
    * If defined, it contains the lower and upper bounds of the n-dimensional array
    */
-  dimensions: DimensionBoundsInstruction[] | undefined;
+  dimensions?: DimensionBoundsInstruction[];
   type: DeclaredType;
   mode: ScanMode;
+  initial?: ExpressionInstruction[];
   /**
    * If defined, it indicates whether the variable is part of a PROCEDURE or not.
    *
    * However, this information is not used in the preprocessor, it is only used for error reporting.
    */
-  visibility: VariableVisibility | null;
+  visibility?: VariableVisibility;
 }
 
 export function createDeclareInstruction(
@@ -350,8 +351,9 @@ export function createDeclareInstruction(
   dimensions: DimensionBoundsInstruction[] | undefined,
   type: DeclaredType,
   mode: ScanMode,
-  visibility?: VariableVisibility | null,
-  node: ast.SyntaxNode | null = null,
+  initial: ExpressionInstruction[] | undefined,
+  visibility: VariableVisibility | undefined,
+  node: ast.SyntaxNode | undefined,
 ): DeclareInstruction {
   return {
     kind: InstructionKind.Declare,
@@ -360,7 +362,8 @@ export function createDeclareInstruction(
     type,
     mode,
     node,
-    visibility: visibility ?? null,
+    initial,
+    visibility,
   };
 }
 

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -2014,6 +2014,21 @@ export interface InitialAttribute extends AstNode {
   content: InitialToContent | null;
   token: Token | null;
 }
+export function createInitialAttribute(): InitialAttribute {
+  return {
+    kind: SyntaxKind.InitialAttribute,
+    container: null,
+    across: false,
+    expressions: [],
+    direct: false,
+    items: [],
+    call: false,
+    procedureCall: null,
+    to: false,
+    content: null,
+    token: null,
+  };
+}
 export interface InitialAttributeItemStar extends AstNode {
   kind: SyntaxKind.InitialAttributeItemStar;
 }
@@ -2022,6 +2037,15 @@ export interface InitialAttributeSpecification extends AstNode {
   star: boolean;
   item: InitialAttributeSpecificationIteration | null;
   expression: Expression | null;
+}
+export function createInitialAttributeSpecification(): InitialAttributeSpecification {
+  return {
+    kind: SyntaxKind.InitialAttributeSpecification,
+    container: null,
+    star: false,
+    item: null,
+    expression: null,
+  };
 }
 export interface InitialAttributeSpecificationIterationValue extends AstNode {
   kind: SyntaxKind.InitialAttributeSpecificationIterationValue;

--- a/packages/language/test/fourslash/preprocessor/initial/array-char-not-full.ts
+++ b/packages/language/test/fourslash/preprocessor/initial/array-char-not-full.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %DECLARE A(4) CHAR INIT("a", "b", "c");
+//// %A1 = A(1);
+//// %A2 = A(2);
+//// %A3 = A(3);
+//// %A4 = A(4);
+//// %ACT A1, A2, A3, A4;
+//// A1 A2 A3 A4
+
+// Should initialize missing values to an empty string
+preprocessor.expectTokens("a b c");

--- a/packages/language/test/fourslash/preprocessor/initial/array-number-not-full.ts
+++ b/packages/language/test/fourslash/preprocessor/initial/array-number-not-full.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %DECLARE A(4) FIXED INIT(10, 20, 30);
+//// %A1 = A(1);
+//// %A2 = A(2);
+//// %A3 = A(3);
+//// %A4 = A(4);
+//// %ACT A1, A2, A3, A4;
+//// A1 A2 A3 A4
+
+// Should initialize missing values to 0
+preprocessor.expectTokens("10 20 30 0");

--- a/packages/language/test/fourslash/preprocessor/initial/array-number.ts
+++ b/packages/language/test/fourslash/preprocessor/initial/array-number.ts
@@ -1,0 +1,22 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %DECLARE A(4) FIXED INIT(10, 20, 30, 40);
+//// %A1 = A(1);
+//// %A2 = A(2);
+//// %A3 = A(3);
+//// %A4 = A(4);
+//// %ACT A1, A2, A3, A4;
+//// A1 A2 A3 A4
+
+preprocessor.expectTokens("10 20 30 40");

--- a/packages/language/test/fourslash/preprocessor/initial/expression-number.ts
+++ b/packages/language/test/fourslash/preprocessor/initial/expression-number.ts
@@ -1,0 +1,17 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %DECLARE A FIXED INIT(4 * 10 + 2);
+//// A
+
+preprocessor.expectTokens("42");

--- a/packages/language/test/fourslash/preprocessor/initial/expression-var-complex.ts
+++ b/packages/language/test/fourslash/preprocessor/initial/expression-var-complex.ts
@@ -1,0 +1,18 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %DECLARE A FIXED INIT(40);
+//// %DCL B FIXED INIT(A + 2);
+//// B
+
+preprocessor.expectTokens("42");

--- a/packages/language/test/fourslash/preprocessor/initial/expression-var-reference.ts
+++ b/packages/language/test/fourslash/preprocessor/initial/expression-var-reference.ts
@@ -1,0 +1,18 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %DECLARE A FIXED INIT(42);
+//// %DCL B FIXED INIT(A);
+//// B
+
+preprocessor.expectTokens("42");

--- a/packages/language/test/fourslash/preprocessor/initial/simple-character.ts
+++ b/packages/language/test/fourslash/preprocessor/initial/simple-character.ts
@@ -1,0 +1,17 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %DECLARE A CHAR INIT("Y");
+//// A
+
+preprocessor.expectTokens("Y");

--- a/packages/language/test/fourslash/preprocessor/initial/simple-multiple-number.ts
+++ b/packages/language/test/fourslash/preprocessor/initial/simple-multiple-number.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %DECLARE A FIXED INIT(1, 2, 3, 4, 5);
+//// A
+
+// It should only pick the first one
+// TODO: Consider showing a warning for multiple initial values
+preprocessor.expectTokens("1");

--- a/packages/language/test/fourslash/preprocessor/initial/simple-number.ts
+++ b/packages/language/test/fourslash/preprocessor/initial/simple-number.ts
@@ -1,0 +1,17 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %DECLARE A FIXED INIT(42);
+//// A
+
+preprocessor.expectTokens("42");


### PR DESCRIPTION
This attempts to add support for the `INITIAL` attribute of the `DECLARE` statement. Even though the attribute is not supported in the language reference, the compiler accepts the attribute and sets the initial values as expected when using it.

There is one major feature of this still missing, mainly because the AST structure doesn't support this case well:

```
DCL A(2) CHAR INIT((2)"a");
```

We can add this later in a separate PR.