### PR TITLE
Improve readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # PL/I Language Support
 
-PL/I Language Support enhances the PL/I programming experience on your IDE. The extension leverages the language server protocol to provide syntax highlighting and coloring, and diagnostic features for PL/I code, compiler options, and include files. PL/I Language Support is available as a VS Code extension, and on an interactive [playground](https://zowe.github.io/zowe-pli-language-support/main).
+PL/I Language Support enhances the PL/I programming experience on your IDE. The extension leverages the language server protocol to provide syntax highlighting and coloring, and diagnostic features for PL/I code, compiler options, and include files. PL/I Language Support is available as a VS Code extension, and on an interactive playground ([development](https://zowe.github.io/zowe-pli-language-support/dev) and [main](https://zowe.github.io/zowe-pli-language-support/main) branches).
 
 PL/I Language Support recognizes files with the extension `.pli` and `.pl1` as PL/I files.
 


### PR DESCRIPTION
Adds a link to the vscode marketplace and adds a dev/main distinction for the playground.