### PR TITLE
New diagnostic for unresolved INCLUDE

### DIFF
--- a/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
+++ b/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
@@ -26,6 +26,7 @@ import {
 import { Commands, PluginConfiguration } from "../constants";
 import { LspCodes } from "../../validation/lsp-codes";
 import { fullCode } from "../types";
+import { PLICodes } from "../../validation/pli-codes";
 
 export async function quickFixResolveInclude(
   diagnostic: Diagnostic,
@@ -145,9 +146,7 @@ export async function applyQuickFixes(
 ): Promise<CodeAction[] | undefined> {
   const actions: CodeAction[] = [];
   // PLI CODES LIST
-  const CODE_UNRESOLVED_INCLUDE = fullCode(
-    LspCodes.IncludeResolution.FileNotFound,
-  ); // The INCLUDE file could not be found
+  const CODE_UNRESOLVED_INCLUDE = fullCode(PLICodes.Severe.IBM1848I); // The INCLUDE file could not be found
   const CODE_MISSING_CONFIG = fullCode(
     LspCodes.IncludeResolution.MissingConfiguration,
   ); // "Could not resolve include directive. Plugin configuration is missing"

--- a/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
+++ b/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
@@ -24,7 +24,6 @@ import {
 } from "../../workspace/plugin-configuration-provider";
 
 import { Commands, PluginConfiguration } from "../constants";
-import { PLICodes } from "../../validation/pli-codes";
 import { LspCodes } from "../../validation/lsp-codes";
 import { fullCode } from "../types";
 
@@ -146,7 +145,9 @@ export async function applyQuickFixes(
 ): Promise<CodeAction[] | undefined> {
   const actions: CodeAction[] = [];
   // PLI CODES LIST
-  const CODE_UNRESOLVED_INCLUDE = fullCode(PLICodes.Severe.IBM3841I); // The INCLUDE file could not be found, or if found, it could not be opened.
+  const CODE_UNRESOLVED_INCLUDE = fullCode(
+    LspCodes.IncludeResolution.FileNotFound,
+  ); // The INCLUDE file could not be found
   const CODE_MISSING_CONFIG = fullCode(
     LspCodes.IncludeResolution.MissingConfiguration,
   ); // "Could not resolve include directive. Plugin configuration is missing"

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2104,7 +2104,7 @@ async function runInclude(
       );
     } else {
       diagnostic = diagnosticFromCode(
-        LspCodes.IncludeResolution.FileNotFound,
+        PLICodes.Severe.IBM1848I,
         item.token,
         getFileNameOrPartialName(item)!,
       );

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2104,7 +2104,7 @@ async function runInclude(
       );
     } else {
       diagnostic = diagnosticFromCode(
-        PLICodes.Severe.IBM3841I,
+        LspCodes.IncludeResolution.FileNotFound,
         item.token,
         getFileNameOrPartialName(item)!,
       );

--- a/packages/language/src/validation/lsp-codes.ts
+++ b/packages/language/src/validation/lsp-codes.ts
@@ -19,12 +19,6 @@ export const LspCodes = {
       message:
         "Could not resolve include directive. Plugin configuration is missing",
     },
-    // FileNotFound: {
-    //   code: "LSPIR002",
-    //   severity: Severity.S,
-    //   message: (includefilename: string) =>
-    //     `INCLUDE file "${includefilename}" not found.`,
-    // },
   },
 
   UpperCase: {

--- a/packages/language/src/validation/lsp-codes.ts
+++ b/packages/language/src/validation/lsp-codes.ts
@@ -19,12 +19,12 @@ export const LspCodes = {
       message:
         "Could not resolve include directive. Plugin configuration is missing",
     },
-    FileNotFound: {
-      code: "LSPIR002",
-      severity: Severity.S,
-      message: (includefilename: string) =>
-        `INCLUDE file "${includefilename}" not found.`,
-    },
+    // FileNotFound: {
+    //   code: "LSPIR002",
+    //   severity: Severity.S,
+    //   message: (includefilename: string) =>
+    //     `INCLUDE file "${includefilename}" not found.`,
+    // },
   },
 
   UpperCase: {

--- a/packages/language/src/validation/lsp-codes.ts
+++ b/packages/language/src/validation/lsp-codes.ts
@@ -19,6 +19,12 @@ export const LspCodes = {
       message:
         "Could not resolve include directive. Plugin configuration is missing",
     },
+    FileNotFound: {
+      code: "LSPIR002",
+      severity: Severity.S,
+      message: (includefilename: string) =>
+        `INCLUDE file "${includefilename}" not found.`,
+    },
   },
 
   UpperCase: {

--- a/packages/language/test/fourslash/preprocessor/include/test-ddmember-includes-registered-libs.ts
+++ b/packages/language/test/fourslash/preprocessor/include/test-ddmember-includes-registered-libs.ts
@@ -42,7 +42,7 @@
 
 verify.expectExclusiveDiagnosticsAt(1, [
   {
-    message: code.LspCodes.IncludeResolution.FileNotFound.message("M2"),
+    message: code.Severe.IBM1848I.message("M2"),
   },
 ]);
 

--- a/packages/language/test/fourslash/preprocessor/include/test-ddmember-includes-registered-libs.ts
+++ b/packages/language/test/fourslash/preprocessor/include/test-ddmember-includes-registered-libs.ts
@@ -42,7 +42,7 @@
 
 verify.expectExclusiveDiagnosticsAt(1, [
   {
-    message: code.Severe.IBM3841I.message("M2"),
+    message: code.LspCodes.IncludeResolution.FileNotFound.message("M2"),
   },
 ]);
 

--- a/packages/language/test/lsp/apply-quick-fixes.test.ts
+++ b/packages/language/test/lsp/apply-quick-fixes.test.ts
@@ -163,7 +163,7 @@ describe("applyQuickFixes", () => {
 
     const diagnostics = [
       {
-        code: fullCode(PLICodes.Severe.IBM3841I),
+        code: fullCode(LspCodes.IncludeResolution.FileNotFound),
         data: { unresolvedFile: "file1.inc", entryUri: "/workspace/main.pli" },
       },
       {
@@ -172,7 +172,7 @@ describe("applyQuickFixes", () => {
         data: {},
       },
       {
-        code: fullCode(PLICodes.Severe.IBM3841I),
+        code: fullCode(LspCodes.IncludeResolution.FileNotFound),
         data: { unresolvedFile: "file2.inc", entryUri: "/workspace/main.pli" },
       },
     ] as Diagnostic[];
@@ -211,7 +211,7 @@ describe("applyQuickFixes", () => {
 
     const diagnostics = [
       {
-        code: fullCode(PLICodes.Severe.IBM3841I),
+        code: fullCode(LspCodes.IncludeResolution.FileNotFound),
         data: {
           unresolvedFile: "missing.inc",
           entryUri: "/workspace/main.pli",

--- a/packages/language/test/lsp/apply-quick-fixes.test.ts
+++ b/packages/language/test/lsp/apply-quick-fixes.test.ts
@@ -163,7 +163,7 @@ describe("applyQuickFixes", () => {
 
     const diagnostics = [
       {
-        code: fullCode(LspCodes.IncludeResolution.FileNotFound),
+        code: fullCode(PLICodes.Severe.IBM1848I),
         data: { unresolvedFile: "file1.inc", entryUri: "/workspace/main.pli" },
       },
       {
@@ -172,7 +172,7 @@ describe("applyQuickFixes", () => {
         data: {},
       },
       {
-        code: fullCode(LspCodes.IncludeResolution.FileNotFound),
+        code: fullCode(PLICodes.Severe.IBM1848I),
         data: { unresolvedFile: "file2.inc", entryUri: "/workspace/main.pli" },
       },
     ] as Diagnostic[];
@@ -211,7 +211,7 @@ describe("applyQuickFixes", () => {
 
     const diagnostics = [
       {
-        code: fullCode(LspCodes.IncludeResolution.FileNotFound),
+        code: fullCode(PLICodes.Severe.IBM1848I),
         data: {
           unresolvedFile: "missing.inc",
           entryUri: "/workspace/main.pli",

--- a/packages/language/test/validating.test.ts
+++ b/packages/language/test/validating.test.ts
@@ -386,7 +386,7 @@ describe("Validating", () => {
         END EP;
       `);
       assertDiagnostic(doc, {
-        message: 'The INCLUDE file for nonexistent.pli could not be found.',
+        message: "The INCLUDE file for nonexistent.pli could not be found.",
         severity: Severity.S,
       });
       setPluginConfigurationProvider(undefined);

--- a/packages/language/test/validating.test.ts
+++ b/packages/language/test/validating.test.ts
@@ -386,7 +386,7 @@ describe("Validating", () => {
         END EP;
       `);
       assertDiagnostic(doc, {
-        message: "The INCLUDE file nonexistent.pli could not be opened.",
+        message: 'INCLUDE file "nonexistent.pli" not found.',
         severity: Severity.S,
       });
       setPluginConfigurationProvider(undefined);

--- a/packages/language/test/validating.test.ts
+++ b/packages/language/test/validating.test.ts
@@ -386,7 +386,7 @@ describe("Validating", () => {
         END EP;
       `);
       assertDiagnostic(doc, {
-        message: 'INCLUDE file "nonexistent.pli" not found.',
+        message: 'The INCLUDE file for nonexistent.pli could not be found.',
         severity: Severity.S,
       });
       setPluginConfigurationProvider(undefined);


### PR DESCRIPTION
### List of Changes

* Introduced new diagnostic:

  ```ts
  FileNotFound: {
    code: "LSPIR002",
    severity: Severity.S,
    message: (includefilename: string) =>
      `INCLUDE file "${includefilename}" not found.`,
  },
  ```

* Replaced the previous diagnostic:

  ```ts
  /**
   * The INCLUDE file could not be found, or if found, it could not be opened.
   * (see page 171)
   */
  IBM3841I: {
    code: "IBM3841I",
    severity: Severity.S,
    message: (includefilename: string) =>
      `The INCLUDE file ${includefilename} could not be opened.`,
  },
  ```

* Updated all relevant tests to reflect the new diagnostic:

  * Expected code changed from `IBM3841I` → `LSPIR002`
  * Updated expected error message text
  * Updated tests accordingly
