### PR TITLE
Avoid infinite loop in tokenizer

### DIFF
--- a/packages/language/src/parser/preprocessor-parser.ts
+++ b/packages/language/src/parser/preprocessor-parser.ts
@@ -1576,15 +1576,13 @@ function stringLiteral(state: ParserState): ast.Literal {
 }
 
 function unpackCharacterValue(literal: string): string {
-  let length = literal.length;
-  // Remove ending quotes if not escaped
-  if (
-    (literal.endsWith('"') || literal.endsWith("'")) &&
-    literal.charAt(length - 2) !== "\\"
-  ) {
-    length--;
+  const type = literal.charAt(0);
+  const content = literal.substring(1, literal.length - 1);
+  if (type === "'") {
+    return content.replace(/''/g, "'");
+  } else {
+    return content.replace(/""/g, '"');
   }
-  return literal.substring(1, length).replace(/""/g, '"');
 }
 
 const XCharCodeLower = "x".charCodeAt(0);

--- a/packages/language/src/parser/preprocessor-parser.ts
+++ b/packages/language/src/parser/preprocessor-parser.ts
@@ -1576,7 +1576,15 @@ function stringLiteral(state: ParserState): ast.Literal {
 }
 
 function unpackCharacterValue(literal: string): string {
-  return literal.substring(1, literal.length - 1).replace(/""/g, '"');
+  let length = literal.length;
+  // Remove ending quotes if not escaped
+  if (
+    (literal.endsWith('"') || literal.endsWith("'")) &&
+    literal.charAt(length - 2) !== "\\"
+  ) {
+    length--;
+  }
+  return literal.substring(1, length).replace(/""/g, '"');
 }
 
 const XCharCodeLower = "x".charCodeAt(0);

--- a/packages/language/src/parser/tokenizer.ts
+++ b/packages/language/src/parser/tokenizer.ts
@@ -268,9 +268,11 @@ function tokenizeString(context: TokenizerContext): tokens.Token | undefined {
     i++;
   }
   context.advance(i - start, false);
+  // Generate the token for the error diagnostic
   const token = context.createTokenInstance(tokens.STRING_TERM);
   context.diagnostics.push(diagnosticFromCode(PLICodes.Severe.IBM3961I, token));
-  return token;
+  // But return undefined to indicate no valid token was created
+  return undefined;
 }
 
 const tokenizeStringInternal = tokenizeRegex(tokens.STRING_TERM, stringRegex);

--- a/packages/language/src/parser/tokenizer.ts
+++ b/packages/language/src/parser/tokenizer.ts
@@ -16,7 +16,12 @@ import {
   CompilerOptions,
   getDefaultCompilerOptions,
 } from "../preprocessor/compiler-options/options";
-import { diagnostic, Diagnostic, fullCode } from "../language-server/types";
+import {
+  diagnostic,
+  Diagnostic,
+  diagnosticFromCode,
+  fullCode,
+} from "../language-server/types";
 import { PLICodes } from "../validation/pli-codes";
 import { NOT_CHARACTER } from "../utils/const";
 
@@ -96,6 +101,7 @@ class TokenizerContext {
   public line: number = 0;
   public column: number = 0;
   public uri: URI | undefined;
+  public diagnostics: Diagnostic[] = [];
 
   private storedIndex: number = 0;
   private storedLine: number = 0;
@@ -246,7 +252,28 @@ function tokenizeRegex(tokenType: TokenType, regex: RegExp): TokenizeFunc {
   };
 }
 
-const tokenizeString = tokenizeRegex(tokens.STRING_TERM, stringRegex);
+function tokenizeString(context: TokenizerContext): tokens.Token | undefined {
+  const result = tokenizeStringInternal(context);
+  if (result) {
+    return result;
+  }
+  // Unterminated string, consume until the end of the line
+  const start = context.index;
+  let i = context.index;
+  while (i < context.length) {
+    const char = context.input[i];
+    if (char === "\n") {
+      break;
+    }
+    i++;
+  }
+  context.advance(i - start, false);
+  const token = context.createTokenInstance(tokens.STRING_TERM);
+  context.diagnostics.push(diagnosticFromCode(PLICodes.Severe.IBM3961I, token));
+  return token;
+}
+
+const tokenizeStringInternal = tokenizeRegex(tokens.STRING_TERM, stringRegex);
 const tokenizeNumber = tokenizeRegex(tokens.NUMBER, numberRegex);
 
 function tokenizeOrSymbol(context: TokenizerContext): tokens.Token | undefined {
@@ -513,7 +540,6 @@ export function tokenize(
   uri: URI | undefined,
 ): TokenizationResult {
   const context = new TokenizerContext(input, uri);
-  const diagnostics: Diagnostic[] = [];
   let previous: tokens.Token | undefined = undefined;
 
   while (context.index < context.length) {
@@ -531,6 +557,7 @@ export function tokenize(
 
     const fn = funcs.get(char);
     if (fn) {
+      const index = context.index;
       const token = fn(context);
       if (token !== undefined) {
         if (previous && previous.endOffset + 1 === token.startOffset) {
@@ -538,6 +565,9 @@ export function tokenize(
         }
         context.tokens.push(token);
         previous = token;
+      } else if (context.index === index) {
+        // No progress made, avoid infinite loop
+        context.index++;
       }
     } else {
       if (uri) {
@@ -551,7 +581,7 @@ export function tokenize(
           uri.toString(),
         );
         issue.code = fullCode(PLICodes.Error.IBM3550I);
-        diagnostics.push(issue);
+        context.diagnostics.push(issue);
       }
       context.index++;
     }
@@ -559,7 +589,7 @@ export function tokenize(
 
   return {
     tokens: context.tokens,
-    diagnostics: diagnostics,
+    diagnostics: context.diagnostics,
   };
 }
 

--- a/packages/language/test/parser/pli-lexer.test.ts
+++ b/packages/language/test/parser/pli-lexer.test.ts
@@ -19,6 +19,9 @@ import {
   ProgramConfig,
 } from "../../src/workspace/plugin-configuration-provider";
 import { TextDocument } from "vscode-languageserver-textdocument";
+import { tokenize } from "../../src/parser/tokenizer";
+import { fullCode } from "../../src/language-server/types";
+import { PLICodes } from "../../src/validation/pli-codes";
 
 type TokenizeFunction = (text: string) => Promise<string[]>;
 
@@ -37,6 +40,13 @@ describe("PL/1 Lexer", () => {
       );
       return diagnostics.map((e) => e.message);
     };
+  });
+
+  test("Avoid infinite loop on unrecognized characters", async () => {
+    const result = tokenize('"test', undefined);
+    expect(result).toBeDefined();
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe(fullCode(PLICodes.Severe.IBM3961I));
   });
 
   test("Preprocessor garbage", async () => {

--- a/packages/language/test/parser/pli-lexer.test.ts
+++ b/packages/language/test/parser/pli-lexer.test.ts
@@ -42,9 +42,10 @@ describe("PL/1 Lexer", () => {
     };
   });
 
-  test("Avoid infinite loop on unrecognized characters", async () => {
+  test("Avoid infinite loop on unterminated string", async () => {
     const result = tokenize('"test', undefined);
     expect(result).toBeDefined();
+    expect(result.tokens).toHaveLength(0);
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].code).toBe(fullCode(PLICodes.Severe.IBM3961I));
   });


### PR DESCRIPTION
Improves our tokenizer to (a) prevent infinite loops (b) to improve lexing of unterminated string literals.