### PR TITLE
Fix IF and SELECT pp parser

### DIFF
--- a/packages/language/src/parser/parser-state.ts
+++ b/packages/language/src/parser/parser-state.ts
@@ -259,7 +259,7 @@ export class ParserState {
     }
   }
 
-  canConsumeKeyword(...tokenTypes: TokenType[]): boolean {
+  canPercentConsume(...tokenTypes: TokenType[]): boolean {
     const withPercent = this.canConsume(t.Percent, ...tokenTypes);
     if (this.isInProcedure()) {
       // In a procedure, we should only consume the tokens if there's no percentage sign
@@ -271,25 +271,31 @@ export class ParserState {
     }
   }
 
-  tryConsumeKeyword(
+  tryPercentConsume(
     element: SyntaxNode | undefined,
     kind: CstNodeKind | undefined,
     tokenType: TokenType,
   ): t.Token | null {
-    if (this.canConsumeKeyword(tokenType)) {
-      return this.consumeKeyword(element, kind, tokenType);
+    if (this.canPercentConsume(tokenType)) {
+      return this.percentConsume(element, kind, tokenType);
     } else {
       return null;
     }
   }
 
-  consumeKeyword(
+  /**
+   * Consumes the given token type, handling the optional percent sign.
+   *
+   * Whether a percent sign is expected or not depends on whether the parser
+   * is currently inside a procedure or not.
+   */
+  percentConsume(
     element: SyntaxNode | undefined,
     kind: CstNodeKind | undefined,
     tokenType: TokenType,
   ): t.Token | null {
     if (!this.isInProcedure()) {
-      // If were outside of a procedure, we must have a percent token
+      // If we're outside of a procedure, we must have a percent token
       this.consume(element, CstNodeKind.Percentage, t.Percent);
     } else if (this.canConsume(t.Percent)) {
       // If we're inside a procedure, there shouldn't be a percent token

--- a/packages/language/src/parser/preprocessor-parser.ts
+++ b/packages/language/src/parser/preprocessor-parser.ts
@@ -69,7 +69,7 @@ export function statement(
       return commonStatement(state, {
         withEnd: end,
         endPercent: endP,
-        startPercent: false,
+        startPercent: false, // Percent token already consumed
         labels: true,
       });
     } else {
@@ -80,7 +80,7 @@ export function statement(
     return commonStatement(state, {
       withEnd: end,
       endPercent: endP,
-      startPercent: false,
+      startPercent: false, // Inside of a procedure, percent not required
       labels: true,
     });
   }
@@ -1061,10 +1061,10 @@ function selectStatement(state: ParserState): ast.SelectStatement {
     );
   }
   state.consume(statement, CstNodeKind.SelectStatement_Semicolon0, t.Semicolon);
-  while (state.canConsumeKeyword(t.WHEN)) {
+  while (state.canPercentConsume(t.WHEN)) {
     statement.cases.push(whenStatement(state));
   }
-  if (state.canConsumeKeyword(t.OTHERWISE)) {
+  if (state.canPercentConsume(t.OTHERWISE)) {
     statement.cases.push(otherwiseStatement(state));
   }
   // END statement is preceded by a percent
@@ -1075,7 +1075,7 @@ function selectStatement(state: ParserState): ast.SelectStatement {
 
 function whenStatement(state: ParserState): ast.WhenStatement {
   const when = ast.createWhenStatement();
-  state.consumeKeyword(when, CstNodeKind.WhenStatement_WHEN, t.WHEN);
+  state.percentConsume(when, CstNodeKind.WhenStatement_WHEN, t.WHEN);
   state.consume(when, CstNodeKind.WhenStatement_OpenParen, t.OpenParen);
   let exp = expression(state);
   if (exp) {
@@ -1101,7 +1101,7 @@ function whenStatement(state: ParserState): ast.WhenStatement {
 
 function otherwiseStatement(state: ParserState): ast.OtherwiseStatement {
   const otherwise = ast.createOtherwiseStatement();
-  state.consumeKeyword(
+  state.percentConsume(
     otherwise,
     CstNodeKind.OtherwiseStatement_OTHERWISE,
     t.OTHERWISE,
@@ -1127,7 +1127,15 @@ function ifStatement(state: ParserState): ast.IfStatement {
   const ifStatement = ast.createIfStatement();
   state.consume(ifStatement, CstNodeKind.IfStatement_IF, t.IF);
   ifStatement.expression = expression(state);
-  state.consumeKeyword(ifStatement, CstNodeKind.IfStatement_THEN, t.THEN);
+  if (state.isInProcedure()) {
+    // Inside of procedure: % before THEN is an error
+    state.percentConsume(ifStatement, CstNodeKind.IfStatement_THEN, t.THEN);
+  } else {
+    // Outside of procedure: % before THEN is optional!
+    // NOTE: The language reference requires a % here, but the compiler does not enforce it
+    state.tryConsume(ifStatement, CstNodeKind.Percentage, t.Percent);
+    state.consume(ifStatement, CstNodeKind.IfStatement_THEN, t.THEN);
+  }
   const unitRangeStart = state.token?.startOffset;
   ifStatement.unit = statementAfterCase(state);
   if (unitRangeStart != undefined && state.last) {
@@ -1136,8 +1144,8 @@ function ifStatement(state: ParserState): ast.IfStatement {
       end: state.last.endOffset + 1,
     };
   }
-  if (state.canConsumeKeyword(t.ELSE)) {
-    state.consumeKeyword(ifStatement, CstNodeKind.IfStatement_ELSE, t.ELSE);
+  if (state.canPercentConsume(t.ELSE)) {
+    state.percentConsume(ifStatement, CstNodeKind.IfStatement_ELSE, t.ELSE);
     const elseRangeStart = state.token?.startOffset;
     ifStatement.else = statementAfterCase(state);
     if (elseRangeStart != undefined && state.last) {

--- a/packages/language/src/parser/preprocessor-parser.ts
+++ b/packages/language/src/parser/preprocessor-parser.ts
@@ -66,13 +66,23 @@ export function statement(
   let endP = endPercent ?? false;
   if (!state.isInProcedure()) {
     if (state.tryConsume(undefined, CstNodeKind.Percentage, t.Percent)) {
-      return commonStatement(state, end, endP);
+      return commonStatement(state, {
+        withEnd: end,
+        endPercent: endP,
+        startPercent: false,
+        labels: true,
+      });
     } else {
       return consumeTokenStatement(state);
     }
   } else {
     //state.isInProcedure()
-    return commonStatement(state, end, endP);
+    return commonStatement(state, {
+      withEnd: end,
+      endPercent: endP,
+      startPercent: false,
+      labels: true,
+    });
   }
 }
 
@@ -89,6 +99,25 @@ function labels(state: ParserState): ast.LabelPrefix[] {
   return labels;
 }
 
+interface StatementParseOptions {
+  /**
+   * Whether or not the `END` statement is allowed
+   */
+  withEnd: boolean;
+  /**
+   * Whether or not the `END` statement must be prefixed with a `%` (even in a procedure)
+   */
+  endPercent: boolean;
+  /**
+   * Whether or not the statement is allowed to start with an optional `%` token.
+   */
+  startPercent: boolean;
+  /**
+   * Whether or not the statement is allowed to have labels.
+   */
+  labels: boolean;
+}
+
 /**
  * @param state
  * @param withEnd Whether the `END` statement is allowed
@@ -97,14 +126,25 @@ function labels(state: ParserState): ast.LabelPrefix[] {
  */
 export function commonStatement(
   state: ParserState,
-  withEnd: boolean,
-  endPercent: boolean,
+  options: StatementParseOptions & { withEnd: false },
+): ast.Statement | null;
+export function commonStatement(
+  state: ParserState,
+  options: StatementParseOptions,
+): ast.Statement | ast.EndStatement | null;
+export function commonStatement(
+  state: ParserState,
+  options: StatementParseOptions,
 ): ast.Statement | ast.EndStatement | null {
   const statement = ast.createStatement();
   let startPercent: t.Token | null = null;
-  if (state.isInProcedure()) {
+  if (state.isInProcedure() || options.startPercent) {
     // In some cases, we enter this function with the current token being a `%`
-    // This might be due to errors in the input, or if we are parsing a procedure end statement
+    // This might be due to:
+    // 1. Errors in the input
+    // 2. If we are parsing a procedure end statement
+    // 3. If we are parsing a statement inside of a IF or SELECT statement
+    //    These are not required to have a `%` prefix, but can have one anyway
     // After parsing the "unit" below, we will check if we have a `%END` statement
     // Only then will we actually know whether this token is invalid
     startPercent = state.tryConsume(
@@ -113,8 +153,11 @@ export function commonStatement(
       t.Percent,
     );
   }
-  const stmtLabels = labels(state);
-  statement.labels = stmtLabels;
+  let stmtLabels: ast.LabelPrefix[] = [];
+  if (options.labels) {
+    stmtLabels = labels(state);
+    statement.labels = stmtLabels;
+  }
   let unit: ast.Unit | null = null;
   let endStmt: ast.EndStatement | null = null;
   if (performAssignmentLookahead((la) => state.peek(la))) {
@@ -134,7 +177,7 @@ export function commonStatement(
         unit = doStatement(state);
         break;
       case t.END.tokenTypeIdx:
-        if (withEnd) {
+        if (options.withEnd) {
           endStmt = endStatement(state, stmtLabels);
         }
         break;
@@ -176,7 +219,7 @@ export function commonStatement(
         unit = declareStatement(state);
         break;
       case t.END.tokenTypeIdx:
-        if (withEnd) {
+        if (options.withEnd) {
           endStmt = endStatement(state, stmtLabels);
         }
         break;
@@ -248,7 +291,7 @@ export function commonStatement(
   // Recover at the end of a statement, noop if not in error case
   state.recover();
   if (endStmt) {
-    if (!endPercent && startPercent) {
+    if (!options.endPercent && startPercent) {
       // We have a starting percent, but don't require it for the %END statement
       state.diagnostics.push(
         diagnosticFromCode(PLICodes.Severe.IBM3762I, startPercent),
@@ -264,8 +307,9 @@ export function commonStatement(
         state.token || state.last,
       ),
     );
-  } else if (startPercent) {
-    // We have a starting percent, but didn't parse a %END statement, this is always an error
+  } else if (startPercent && !options.startPercent) {
+    // We have a starting percent, but didn't parse a %END statement
+    // This is an error if we don't allow starting percents
     state.diagnostics.push(
       diagnosticFromCode(PLICodes.Severe.IBM3762I, startPercent),
     );
@@ -1045,7 +1089,7 @@ function whenStatement(state: ParserState): ast.WhenStatement {
   }
   state.consume(when, CstNodeKind.WhenStatement_CloseParen, t.CloseParen);
   const rangeStart = state.token?.startOffset;
-  when.unit = statement(state);
+  when.unit = statementAfterCase(state);
   if (rangeStart != undefined && state.last) {
     when.range = {
       start: rangeStart,
@@ -1063,7 +1107,7 @@ function otherwiseStatement(state: ParserState): ast.OtherwiseStatement {
     t.OTHERWISE,
   );
   const rangeStart = state.token?.startOffset;
-  otherwise.unit = statement(state);
+  otherwise.unit = statementAfterCase(state);
   if (rangeStart != undefined && state.last) {
     otherwise.range = {
       start: rangeStart,
@@ -1085,7 +1129,7 @@ function ifStatement(state: ParserState): ast.IfStatement {
   ifStatement.expression = expression(state);
   state.consumeKeyword(ifStatement, CstNodeKind.IfStatement_THEN, t.THEN);
   const unitRangeStart = state.token?.startOffset;
-  ifStatement.unit = statement(state);
+  ifStatement.unit = statementAfterCase(state);
   if (unitRangeStart != undefined && state.last) {
     ifStatement.unitRange = {
       start: unitRangeStart,
@@ -1095,7 +1139,7 @@ function ifStatement(state: ParserState): ast.IfStatement {
   if (state.canConsumeKeyword(t.ELSE)) {
     state.consumeKeyword(ifStatement, CstNodeKind.IfStatement_ELSE, t.ELSE);
     const elseRangeStart = state.token?.startOffset;
-    ifStatement.else = statement(state);
+    ifStatement.else = statementAfterCase(state);
     if (elseRangeStart != undefined && state.last) {
       ifStatement.elseRange = {
         start: elseRangeStart,
@@ -1104,6 +1148,17 @@ function ifStatement(state: ParserState): ast.IfStatement {
     }
   }
   return ifStatement;
+}
+
+// Statement used after IF, WHEN and OTHERWISE clauses
+// Has special semantics that uses an optional starting percent and prohibits labels
+function statementAfterCase(state: ParserState): ast.Statement | null {
+  return commonStatement(state, {
+    withEnd: false,
+    endPercent: false,
+    startPercent: true, // Can optionally start with a percent
+    labels: false, // Labels are not allowed here
+  });
 }
 
 function deactivateStatement(state: ParserState): ast.DeactivateStatement {

--- a/packages/language/src/parser/preprocessor-parser.ts
+++ b/packages/language/src/parser/preprocessor-parser.ts
@@ -118,12 +118,6 @@ interface StatementParseOptions {
   labels: boolean;
 }
 
-/**
- * @param state
- * @param withEnd Whether the `END` statement is allowed
- * @param endPercent Whether the `END` statement must be prefixed with a `%` (even in a procedure)
- * @returns
- */
 export function commonStatement(
   state: ParserState,
   options: StatementParseOptions & { withEnd: false },

--- a/packages/language/test/fourslash-harness/harness-parser.ts
+++ b/packages/language/test/fourslash-harness/harness-parser.ts
@@ -71,7 +71,7 @@ class HarnessTestParser {
     private context: Context,
   ) {
     // Reverse it for performance reasons, faster to pop than shift
-    this.lines = text.split("\n").toReversed();
+    this.lines = text.split(/\r?\n/).toReversed();
     this.text = text;
   }
 

--- a/packages/language/test/fourslash/preprocessor/array-assignment.ts
+++ b/packages/language/test/fourslash/preprocessor/array-assignment.ts
@@ -21,4 +21,4 @@
 //// %Y = B(1) || B(2) || B(3);
 //// X = Y;
 
-preprocessor.expectTokens(" X = ABC;");
+preprocessor.expectTokens("X = ABC;");

--- a/packages/language/test/fourslash/preprocessor/array-declaration.ts
+++ b/packages/language/test/fourslash/preprocessor/array-declaration.ts
@@ -19,4 +19,4 @@
 //// %Y = A(1) || A(2) || A(3);
 //// X = Y;
 
-preprocessor.expectTokens(" X = ABC;");
+preprocessor.expectTokens("X = ABC;");

--- a/packages/language/test/fourslash/preprocessor/factorized-variables.ts
+++ b/packages/language/test/fourslash/preprocessor/factorized-variables.ts
@@ -16,6 +16,4 @@
 //// %B = 'World';
 //// A%;B = 123;
 
-preprocessor.expectTokens(`
-  HelloWorld = 123;
-`);
+preprocessor.expectTokens("HelloWorld = 123;");

--- a/packages/language/test/fourslash/preprocessor/if-does-not-need-percent.ts
+++ b/packages/language/test/fourslash/preprocessor/if-does-not-need-percent.ts
@@ -11,9 +11,17 @@
 
 /// <reference path="../framework.ts" />
 
-//// %SELECT;
-//// %WHEN (0, 1, 2) DO; X %END;
-//// %OTHERWISE DO Y %END;
-//// %END;
+// @filename: cpy/lib.pli
+//// LIB_VAR
 
-preprocessor.expectTokens("X");
+// @filename: main.pli
+//// %IF 1 %THEN <|INCLUDE|> lib;
+//// %IF 1 %THEN <|%|>INCLUDE lib;
+
+// This asserts that the statement after IF-THEN does not require a percent sign
+// BUT can have one if desired
+preprocessor.expectTokens(`
+  LIB_VAR
+  LIB_VAR
+`);
+verify.noDiagnostics(["%", "INCLUDE"]);

--- a/packages/language/test/fourslash/preprocessor/if-number-comparison-conversion.ts
+++ b/packages/language/test/fourslash/preprocessor/if-number-comparison-conversion.ts
@@ -12,9 +12,11 @@
 /// <reference path="../framework.ts" />
 
 //// %A = 12;
-//// %IF A = "12" %THEN
+//// %IF A = "12" %THEN DO;
 ////   CORRECT
-//// %ELSE
+//// %END;
+//// %ELSE DO;
 ////   ERROR
+//// %END;
 
 preprocessor.expectTokens("CORRECT");

--- a/packages/language/test/fourslash/preprocessor/if-number-comparison-negative.ts
+++ b/packages/language/test/fourslash/preprocessor/if-number-comparison-negative.ts
@@ -12,9 +12,11 @@
 /// <reference path="../framework.ts" />
 
 //// %A = 12;
-//// %IF A = 3 %THEN
+//// %IF A = 3 %THEN DO;
 ////   ERROR
-//// %ELSE
+//// %END;
+//// %ELSE DO;
 ////   CORRECT
+//// %END;
 
 preprocessor.expectTokens("CORRECT");

--- a/packages/language/test/fourslash/preprocessor/if-number-comparison.ts
+++ b/packages/language/test/fourslash/preprocessor/if-number-comparison.ts
@@ -12,9 +12,11 @@
 /// <reference path="../framework.ts" />
 
 //// %A = 12;
-//// %IF A = 12 %THEN
+//// %IF A = 12 %THEN DO;
 ////   CORRECT
-//// %ELSE
+//// %END;
+//// %ELSE DO;
 ////   ERROR
+//// %END;
 
 preprocessor.expectTokens("CORRECT");

--- a/packages/language/test/fourslash/preprocessor/if-string-comparison.ts
+++ b/packages/language/test/fourslash/preprocessor/if-string-comparison.ts
@@ -12,9 +12,11 @@
 /// <reference path="../framework.ts" />
 
 //// %A = "HELLO";
-//// %IF A = "HELLO" %THEN
+//// %IF A = "HELLO" %THEN DO;
 ////   CORRECT
-//// %ELSE
+//// %END;
+//// %ELSE DO;
 ////   ERROR
+//// %END;
 
 preprocessor.expectTokens("CORRECT");

--- a/packages/language/test/fourslash/preprocessor/if-string-not-comparison.ts
+++ b/packages/language/test/fourslash/preprocessor/if-string-not-comparison.ts
@@ -12,9 +12,11 @@
 /// <reference path="../framework.ts" />
 
 //// %A = "HELLO";
-//// %IF A <> "HELLO" %THEN
+//// %IF A <> "HELLO" %THEN DO;
 ////   ERROR
-//// %ELSE
+//// %END;
+//// %ELSE DO;
 ////   CORRECT
+//// %END;
 
 preprocessor.expectTokens("CORRECT");

--- a/packages/language/test/fourslash/preprocessor/if-then-does-not-need-percent copy.ts
+++ b/packages/language/test/fourslash/preprocessor/if-then-does-not-need-percent copy.ts
@@ -1,0 +1,18 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+//// %IF 1 <|THEN|> DO; %END;
+//// %IF 1 <|%|>THEN DO; %END;
+
+// Both "%THEN" and "THEN" are acceptable after an IF
+verify.noDiagnostics(["%", "THEN"]);

--- a/packages/language/test/fourslash/preprocessor/if-with-do-group.ts
+++ b/packages/language/test/fourslash/preprocessor/if-with-do-group.ts
@@ -20,4 +20,4 @@
 //// dcl X fixed;
 //// X = A;
 
-preprocessor.expectTokens(" dcl X fixed; X = 4;");
+preprocessor.expectTokens("dcl X fixed; X = 4;");

--- a/packages/language/test/fourslash/preprocessor/implicit-declaration-can-be-act.ts
+++ b/packages/language/test/fourslash/preprocessor/implicit-declaration-can-be-act.ts
@@ -16,4 +16,4 @@
 //// %ACT A;
 //// DCL A CHARACTER;
 
-preprocessor.expectTokens(" DCL B CHARACTER;");
+preprocessor.expectTokens("DCL B CHARACTER;");

--- a/packages/language/test/fourslash/preprocessor/implicit-declaration-can-be-activated.ts
+++ b/packages/language/test/fourslash/preprocessor/implicit-declaration-can-be-activated.ts
@@ -15,4 +15,4 @@
 //// %ACTIVATE A;
 //// DCL A CHARACTER;
 
-preprocessor.expectTokens(" DCL B CHARACTER;");
+preprocessor.expectTokens("DCL B CHARACTER;");

--- a/packages/language/test/fourslash/preprocessor/implicit-declaration-not-active.ts
+++ b/packages/language/test/fourslash/preprocessor/implicit-declaration-not-active.ts
@@ -15,4 +15,4 @@
 //// DCL A CHARACTER;
 
 /* A is not replaced */
-preprocessor.expectTokens(" DCL A CHARACTER;");
+preprocessor.expectTokens("DCL A CHARACTER;");

--- a/packages/language/test/fourslash/preprocessor/page-directive.ts
+++ b/packages/language/test/fourslash/preprocessor/page-directive.ts
@@ -14,4 +14,4 @@
 //// %PAGE;
 //// dcl A fixed bin(31);
 
-preprocessor.expectTokens(" dcl A fixed bin(31);");
+preprocessor.expectTokens("dcl A fixed bin(31);");

--- a/packages/language/test/fourslash/preprocessor/replace-by-number.ts
+++ b/packages/language/test/fourslash/preprocessor/replace-by-number.ts
@@ -14,4 +14,4 @@
 //// %REPLACE X BY 5;
 //// dcl A fixed bin(X);
 
-preprocessor.expectTokens(" dcl A fixed bin(5);");
+preprocessor.expectTokens("dcl A fixed bin(5);");

--- a/packages/language/test/fourslash/preprocessor/replace-by-string.ts
+++ b/packages/language/test/fourslash/preprocessor/replace-by-string.ts
@@ -15,4 +15,4 @@
 //// DCL A CHAR INIT(X);
 
 // Expect the string to be replaced, including quotation marks
-preprocessor.expectTokens(' DCL A CHAR INIT("HELLO");');
+preprocessor.expectTokens('DCL A CHAR INIT("HELLO");');

--- a/packages/language/test/fourslash/preprocessor/replace-with-number.ts
+++ b/packages/language/test/fourslash/preprocessor/replace-with-number.ts
@@ -14,4 +14,4 @@
 //// %REPLACE X WITH 5;
 //// dcl A fixed bin(X);
 
-preprocessor.expectTokens(" dcl A fixed bin(5);");
+preprocessor.expectTokens("dcl A fixed bin(5);");

--- a/packages/language/test/fourslash/preprocessor/replace-with-string-quotation-marks.ts
+++ b/packages/language/test/fourslash/preprocessor/replace-with-string-quotation-marks.ts
@@ -15,4 +15,4 @@
 //// DCL A CHAR INIT(X);
 
 // Expect the string to be replaced, including quotation marks and escaping of internal quotes
-preprocessor.expectTokens(' DCL A CHAR INIT("HELLO "" WORLD""");');
+preprocessor.expectTokens('DCL A CHAR INIT("HELLO "" WORLD""");');

--- a/packages/language/test/fourslash/preprocessor/replace-with-string.ts
+++ b/packages/language/test/fourslash/preprocessor/replace-with-string.ts
@@ -15,4 +15,4 @@
 //// DCL A CHAR INIT(X);
 
 // Expect the string to be replaced, including quotation marks
-preprocessor.expectTokens(' DCL A CHAR INIT("HELLO");');
+preprocessor.expectTokens('DCL A CHAR INIT("HELLO");');

--- a/packages/language/test/fourslash/preprocessor/rescan-double.ts
+++ b/packages/language/test/fourslash/preprocessor/rescan-double.ts
@@ -17,4 +17,4 @@
 //// %C = 3;
 //// X = A;
 
-preprocessor.expectTokens(" X = 2 + 3;");
+preprocessor.expectTokens("X = 2 + 3;");

--- a/packages/language/test/fourslash/preprocessor/rescan-with-deact-var.ts
+++ b/packages/language/test/fourslash/preprocessor/rescan-with-deact-var.ts
@@ -17,4 +17,4 @@
 //// %DEACT B;
 //// X = A;
 
-preprocessor.expectTokens(" X = B + C;");
+preprocessor.expectTokens("X = B + C;");

--- a/packages/language/test/fourslash/preprocessor/rescan-with-deactivated-var.ts
+++ b/packages/language/test/fourslash/preprocessor/rescan-with-deactivated-var.ts
@@ -17,4 +17,4 @@
 //// %DEACTIVATE B;
 //// X = A;
 
-preprocessor.expectTokens(" X = B + C;");
+preprocessor.expectTokens("X = B + C;");

--- a/packages/language/test/fourslash/preprocessor/rescan.ts
+++ b/packages/language/test/fourslash/preprocessor/rescan.ts
@@ -16,4 +16,4 @@
 //// %B = 2;
 //// X = A;
 
-preprocessor.expectTokens(" X = 2 + C;");
+preprocessor.expectTokens("X = 2 + C;");

--- a/packages/language/test/fourslash/preprocessor/select-statement-does-not-need-percent.ts
+++ b/packages/language/test/fourslash/preprocessor/select-statement-does-not-need-percent.ts
@@ -11,9 +11,12 @@
 
 /// <reference path="../framework.ts" />
 
-//// %IF 1 %THEN
-////   dcl X fixed;
-//// %ELSE
-////   dcl Y fixed;
+//// %FAL = 0;
+//// %TRU = 1;
+//// %SELECT;
+//// %WHEN (FAL) <|%|>DO; X %END;
+//// %WHEN (TRU) <|DO|>; Y %END;
+//// %END;
 
-preprocessor.expectTokens(" dcl X fixed;");
+preprocessor.expectTokens("Y");
+verify.noDiagnostics(["%", "DO"]);

--- a/packages/language/test/fourslash/preprocessor/select-statement-multiple-conditions.ts
+++ b/packages/language/test/fourslash/preprocessor/select-statement-multiple-conditions.ts
@@ -13,7 +13,7 @@
 
 //// %SELECT;
 //// %WHEN (0, 1, 2) DO; X %END;
-//// %OTHERWISE DO Y %END;
+//// %OTHERWISE DO; Y %END;
 //// %END;
 
 preprocessor.expectTokens("X");

--- a/packages/language/test/fourslash/preprocessor/select-statement-otherwise.ts
+++ b/packages/language/test/fourslash/preprocessor/select-statement-otherwise.ts
@@ -12,8 +12,8 @@
 /// <reference path="../framework.ts" />
 
 //// %SELECT;
-//// %WHEN (0) X
-//// %OTHERWISE Y
+//// %WHEN (0) DO; X %END;
+//// %OTHERWISE DO; Y %END;
 //// %END;
 
 preprocessor.expectTokens("Y");

--- a/packages/language/test/fourslash/preprocessor/select-statement-with-value.ts
+++ b/packages/language/test/fourslash/preprocessor/select-statement-with-value.ts
@@ -13,9 +13,9 @@
 
 //// %VAR = 42;
 //// %SELECT (VAR);
-//// %WHEN (21) X
-//// %WHEN (42) Y
-//// %OTHERWISE Z
+//// %WHEN (21) DO; X %END;
+//// %WHEN (42) DO; Y %END;
+//// %OTHERWISE DO; Z %END;
 //// %END;
 
 preprocessor.expectTokens("Y");

--- a/packages/language/test/fourslash/preprocessor/select-statement-without-value.ts
+++ b/packages/language/test/fourslash/preprocessor/select-statement-without-value.ts
@@ -14,8 +14,8 @@
 //// %FAL = 0;
 //// %TRU = 1;
 //// %SELECT;
-//// %WHEN (FAL) X
-//// %WHEN (TRU) Y
+//// %WHEN (FAL) DO; X %END;
+//// %WHEN (TRU) DO; Y %END;
 //// %END;
 
 preprocessor.expectTokens("Y");

--- a/packages/language/test/fourslash/preprocessor/simple-if-else.ts
+++ b/packages/language/test/fourslash/preprocessor/simple-if-else.ts
@@ -11,9 +11,11 @@
 
 /// <reference path="../framework.ts" />
 
-//// %IF 0 %THEN
+//// %IF 0 %THEN DO;
 ////   dcl X fixed;
-//// %ELSE
+//// %END;
+//// %ELSE DO;
 ////   dcl Y fixed;
+//// %END;
 
 preprocessor.expectTokens(" dcl Y fixed;");

--- a/packages/language/test/fourslash/preprocessor/simple-if-else.ts
+++ b/packages/language/test/fourslash/preprocessor/simple-if-else.ts
@@ -11,11 +11,7 @@
 
 /// <reference path="../framework.ts" />
 
-//// %IF 0 %THEN DO;
-////   dcl X fixed;
-//// %END;
-//// %ELSE DO;
-////   dcl Y fixed;
-//// %END;
+//// %IF 0 %THEN DO; X %END;
+//// %ELSE DO; Y %END;
 
-preprocessor.expectTokens(" dcl Y fixed;");
+preprocessor.expectTokens("Y");

--- a/packages/language/test/fourslash/preprocessor/simple-if-then.ts
+++ b/packages/language/test/fourslash/preprocessor/simple-if-then.ts
@@ -11,11 +11,7 @@
 
 /// <reference path="../framework.ts" />
 
-//// %IF 1 %THEN DO;
-////   dcl X fixed;
-//// %END;
-//// %ELSE DO;
-////   dcl Y fixed;
-//// %END;
+//// %IF 1 %THEN DO; X %END;
+//// %ELSE DO; Y %END;
 
-preprocessor.expectTokens(" dcl X fixed;");
+preprocessor.expectTokens("X");

--- a/packages/language/test/fourslash/preprocessor/simple-if-then.ts
+++ b/packages/language/test/fourslash/preprocessor/simple-if-then.ts
@@ -11,9 +11,11 @@
 
 /// <reference path="../framework.ts" />
 
-//// %IF 1 %THEN
+//// %IF 1 %THEN DO;
 ////   dcl X fixed;
-//// %ELSE
+//// %END;
+//// %ELSE DO;
 ////   dcl Y fixed;
+//// %END;
 
 preprocessor.expectTokens(" dcl X fixed;");

--- a/packages/language/test/fourslash/preprocessor/simple-if-with-scan.ts
+++ b/packages/language/test/fourslash/preprocessor/simple-if-with-scan.ts
@@ -11,10 +11,12 @@
 
 /// <reference path="../framework.ts" />
 
-//// %IF 1 %THEN
+//// %IF 1 %THEN DO;
 ////   %A = 123;
-//// %ELSE
+//// %END;
+//// %ELSE DO;
 ////   %A = 456;
+//// %END;
 //// %ACTIVATE A;
 //// dcl X fixed;
 //// X = A;

--- a/packages/language/test/fourslash/preprocessor/simple-if-with-scan.ts
+++ b/packages/language/test/fourslash/preprocessor/simple-if-with-scan.ts
@@ -18,7 +18,6 @@
 ////   %A = 456;
 //// %END;
 //// %ACTIVATE A;
-//// dcl X fixed;
-//// X = A;
+//// A
 
-preprocessor.expectTokens(" dcl X fixed; X = 123;");
+preprocessor.expectTokens("123");

--- a/packages/language/test/fourslash/preprocessor/skipped-code-skipped-otherwise.ts
+++ b/packages/language/test/fourslash/preprocessor/skipped-code-skipped-otherwise.ts
@@ -15,10 +15,10 @@
 //// %DECLARE C fixed;
 //// %C = 42;
 //// %SELECT (C);
-//// %WHEN (1) <|skipped:PUT(1);|>
-//// %WHEN (2) <|skipped:PUT(2);|>
-//// %WHEN (3) <|skipped:PUT(3);|>
-//// %OTHERWISE PUT(4);
+//// %WHEN (1) <|skipped:DO; PUT(1); %END;|>
+//// %WHEN (2) <|skipped:DO; PUT(2); %END;|>
+//// %WHEN (3) <|skipped:DO; PUT(3); %END;|>
+//// %OTHERWISE DO; PUT(4); %END;
 //// %END;
 
 preprocessor.expectSkippedCodeAt("skipped");

--- a/packages/language/test/fourslash/preprocessor/skipped-code-skipped-when-branch.ts
+++ b/packages/language/test/fourslash/preprocessor/skipped-code-skipped-when-branch.ts
@@ -15,10 +15,10 @@
 //// %DECLARE C fixed;
 //// %C = 42;
 //// %SELECT (C);
-//// %WHEN (2) <|skipped:PUT(2);|>
-//// %WHEN (42) PUT(42);
-//// %WHEN (16) <|skipped:PUT(16);|>
-//// %OTHERWISE <|skipped:PUT(1);|>
+//// %WHEN (2) <|skipped:DO; PUT(2); %END;|>
+//// %WHEN (42) DO; PUT(42); %END;
+//// %WHEN (16) <|skipped:DO; PUT(16); %END;|>
+//// %OTHERWISE <|skipped:DO; PUT(1); %END;|>
 //// %END;
 
 preprocessor.expectSkippedCodeAt("skipped");

--- a/packages/language/test/fourslash/preprocessor/skipped-do-select-with-empty-do.ts
+++ b/packages/language/test/fourslash/preprocessor/skipped-do-select-with-empty-do.ts
@@ -14,7 +14,7 @@
 // @wrap: main
 //// %SELECT;
 //// %WHEN (1) <|notSkipped:%DO; %END;|>
-//// %WHEN (2) DCL TEST FIXED;
+//// %WHEN (2) DO; DCL TEST FIXED; %END;
 //// %END;
 
 preprocessor.not.expectSkippedCodeAt("notSkipped");


### PR DESCRIPTION
Closes https://github.com/zowe/zowe-pli-language-support/issues/513

Fixes two main points of our preprocessor parser:
1. "simple" if statements such as `%IF 1 %THEN; <emit some code>` had the wrong semantics. Essentially the `;` after `%THEN` acts as a null-statement, after which normal PLI code is supposed to go. This change adjusts the behavior to only allow "real" preprocessor statements to follow the `%THEN` keyword in the context of the if statement. (this one is difficult to explain)
2. The compiler makes the **first** `%` after the `%THEN` optional. Meaning that `%IF ... %THEN DO; ... %END;` and `%IF ... %THEN %DO; ... %END;` are the same. Adding the `%` is fine with the compiler, but it is not required.