### PR TITLE
Stabilize Include Resolution Ordering

### DIFF
--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2238,7 +2238,7 @@ function getFileNameOrPartialName(item: IncludeItem): string | undefined {
  * Attempts to resolve the URI of an include file factoring in process group libs, relative & absolute paths
  *
  * @param item Include item to resolve a URI for
- * @param state Current PP state, used to resolve relative paths, program configs, and report errors
+ * @param context Interpreter context used for resolution & diagnostic collection
  * @returns URI of the included file if found, otherwise undefined
  */
 async function resolveIncludeFileUri(
@@ -2254,6 +2254,11 @@ async function resolveIncludeFileUri(
       context.currentUri,
     );
 
+  if (!pgroup) {
+    // no process group to resolve libs from
+    return undefined;
+  }
+
   // TODO @montymxb Jun 24th, 2025: Disabled relative & absolute pathing per request, however mainframe tests do show this works w/ the right JCL config
   // temporarily retaining here until we know we won't need this going forward, or we decide to re-enable it based on some configuration setting
   /*
@@ -2268,148 +2273,145 @@ async function resolveIncludeFileUri(
   } else ....
   */
 
-  if (pgroup) {
-    // lib file as either a string or a member from a known process group
-    const computedLibs = pgroup.$computedLibs;
+  // lib file as either a string or a member from a known process group
+  const computedLibs = pgroup.$computedLibs;
 
-    // construct the appropriate file name or partial name for members
-    const fileNameOrPartial = getFileNameOrPartialName(item);
-    if (!fileNameOrPartial) {
-      // no fileName or memberName to work with, abandon resolution
-      return undefined;
-    }
-
-    // whether the include item is a standalone member, no ddname specified
-    // in such cases this member may be the suffix of an a ddname entry in the libs, (ex. `A.B.C(member)`)
-    // corresponding to mainframe behavior, if `cpy/A.B.C` or `cpy` is in libs, we should be able to resolve `member`
-    const isMemberWithoutDDName = isMemberIncludeItem(item) && !item.ddname;
-
-    /**
-     * Computes the URI for a lib file based on whether the path is absolute or relative
-     * Relative paths are combined w/ the workspace path
-     * @path Lib path from the process group
-     * @fileName Optional file name to append to the lib path (generally the include file name)
-     */
-    function resolveLibFileUri(path: string, fileName?: string): URI {
-      const absPathRegex = /^(?:\/|\\|[A-Z]:)/i;
-      if (!absPathRegex.test(path)) {
-        // relative lib path, combine w/ workspace
-        return UriUtils.joinPath(
-          URI.parse(PluginConfigurationProviderInstance.getWorkspacePath()),
-          path,
-          fileName ?? "",
-        );
-      } else {
-        // use lib path over workspace
-        const libUri = URI.file(path).with({
-          scheme: context.entryUri.scheme,
-        });
-        return UriUtils.joinPath(libUri, fileName ?? "");
-      }
-    }
-
-    // what constitutes a valid member name, whether it's a member or file include
-    const memberNameRegex = /^[A-Z][A-Z0-9@#_$]*$/i;
-
-    /**
-     * Helper to check & validate member names when member name validations are enabled.
-     * Pushes diagnostics to the context when validation fails.
-     * Effectively a noop when member name validation is disabled in the process group.
-     * @param memberName Member to validate, implied to be a member of an existing ddlib entry
-     */
-    function checkToValidateMember(memberName: string): void {
-      if (!pgroup?.memberNameValidation) {
-        return;
-      }
-      // apply additional validation to the member name
-      if (memberName.length > 8) {
-        // emit diagnostic for member names > 8 characters
-        context.diagnostics.push(
-          diagnosticFromCode(
-            LspCodes.MemberValidation.ExceedsMaxLength,
-            item.token,
-          ),
-        );
-      }
-
-      if (!memberNameRegex.test(memberName)) {
-        // emit a diagnostic for invalid member names
-        context.diagnostics.push(
-          diagnosticFromCode(LspCodes.MemberValidation.InvalidName, item.token),
-        );
-      }
-    }
-
-    let libMatch: URI | undefined;
-    // whether a match was found for a member include
-    let needsMemberValidation = isMemberWithoutDDName;
-
-    for (const lib of computedLibs) {
-      if (isLibsDir(lib)) {
-        const libFileUri = resolveLibFileUri(lib.dir, fileNameOrPartial);
-
-        if (memberNameRegex.test(fileNameOrPartial)) {
-          // attempt to first resolve for any DDName that may introduce a member by this name
-          // This is done to ensure resolution order of libs is maintained as members > files
-          // Same applies for both member & file includes, to ensure behavior is consistent.
-          // Ex. If we have both `cpy/member.pli` and `cpy/A.B.C(member)`, with `cpy` in the libs list
-          // We want to ensure that `A.B.C(member)` is resolved first before falling back to `member.pli`
-          libMatch = await FileSystemProviderInstance.search({
-            dirPath: resolveLibFileUri(lib.dir),
-            member: fileNameOrPartial,
-          });
-          if (libMatch) {
-            break;
-          }
-        }
-
-        // perform standard search
-        libMatch = await FileSystemProviderInstance.search({
-          path: libFileUri,
-          extensions: pgroup.includeExtensions,
-        });
-        if (libMatch) {
-          // regular file match, no member to validate
-          needsMemberValidation = false;
-          break;
-        }
-      } else if (isMemberWithoutDDName) {
-        // standalone member w/out an explicit ddname, search within ddlib for a match
-        const ddLibUri = resolveLibFileUri(lib.ddLib);
-        libMatch = await FileSystemProviderInstance.search({
-          path: URI.parse(ddLibUri.toString(true) + `(${fileNameOrPartial})`),
-          extensions: [],
-        });
-        if (libMatch) {
-          break;
-        }
-      } else if (
-        isMemberIncludeItem(item) &&
-        item.ddname &&
-        lib.ddLib.toLowerCase().endsWith(item.ddname.toLowerCase())
-      ) {
-        // member w/ ddname, search for an exact match using ddlib
-        const end = lib.ddLib.length - item.ddname.length;
-        const libPath = lib.ddLib.substring(0, end);
-        const ddLibUri = resolveLibFileUri(libPath, fileNameOrPartial);
-        libMatch = await FileSystemProviderInstance.search({
-          path: ddLibUri,
-          extensions: [],
-        });
-        if (libMatch) {
-          break;
-        }
-      }
-    }
-
-    // depending on whether we matched a member, check to apply validation on the name
-    if (needsMemberValidation) {
-      checkToValidateMember(fileNameOrPartial);
-    }
-    return libMatch;
+  // construct the appropriate file name or partial name for members
+  const fileNameOrPartial = getFileNameOrPartialName(item);
+  if (!fileNameOrPartial) {
+    // no fileName or memberName to work with, abandon resolution
+    return undefined;
   }
 
-  return undefined;
+  // whether the include item is a standalone member, no ddname specified
+  // in such cases this member may be the suffix of an a ddname entry in the libs, (ex. `A.B.C(member)`)
+  // corresponding to mainframe behavior, if `cpy/A.B.C` or `cpy` is in libs, we should be able to resolve `member`
+  const isMemberWithoutDDName = isMemberIncludeItem(item) && !item.ddname;
+
+  /**
+   * Computes the URI for a lib file based on whether the path is absolute or relative.
+   * Relative paths are combined w/ the workspace path.
+   *
+   * @param path Lib path from the process group
+   * @param fileName Optional file name to append to the lib path (generally the include file name)
+   */
+  function resolveLibFileUri(path: string, fileName?: string): URI {
+    const absPathRegex = /^(?:\/|\\|[A-Z]:)/i;
+    if (!absPathRegex.test(path)) {
+      // relative lib path, combine w/ workspace
+      return UriUtils.joinPath(
+        URI.parse(PluginConfigurationProviderInstance.getWorkspacePath()),
+        path,
+        fileName ?? "",
+      );
+    } else {
+      // use lib path over workspace
+      const libUri = URI.file(path).with({
+        scheme: context.entryUri.scheme,
+      });
+      return UriUtils.joinPath(libUri, fileName ?? "");
+    }
+  }
+
+  // what constitutes a valid member name, whether it's a member or file include
+  const memberNameRegex = /^[A-Z][A-Z0-9@#_$]*$/i;
+
+  /**
+   * Helper to check & validate member names when member name validations are enabled.
+   * Pushes diagnostics to the context when validation fails.
+   * Effectively a noop when member name validation is disabled in the process group.
+   * @param memberName Member to validate, implied to be a member of an existing ddlib entry
+   */
+  function checkToValidateMember(memberName: string): void {
+    if (!pgroup?.memberNameValidation) {
+      return;
+    }
+    // apply additional validation to the member name
+    if (memberName.length > 8) {
+      // emit diagnostic for member names > 8 characters
+      context.diagnostics.push(
+        diagnosticFromCode(
+          LspCodes.MemberValidation.ExceedsMaxLength,
+          item.token,
+        ),
+      );
+    }
+
+    if (!memberNameRegex.test(memberName)) {
+      // emit a diagnostic for invalid member names
+      context.diagnostics.push(
+        diagnosticFromCode(LspCodes.MemberValidation.InvalidName, item.token),
+      );
+    }
+  }
+
+  let libMatch: URI | undefined;
+  // whether a match was found for a member include
+  let needsMemberValidation = isMemberWithoutDDName;
+
+  for (const lib of computedLibs) {
+    if (isLibsDir(lib)) {
+      const libFileUri = resolveLibFileUri(lib.dir, fileNameOrPartial);
+
+      if (memberNameRegex.test(fileNameOrPartial)) {
+        // attempt to first resolve for any DDName that may introduce a member by this name
+        // This is done to ensure resolution order of libs is maintained as members > files
+        // Same applies for both member & file includes, to ensure behavior is consistent.
+        // Ex. If we have both `cpy/member.pli` and `cpy/A.B.C(member)`, with `cpy` in the libs list
+        // We want to ensure that `A.B.C(member)` is resolved first before falling back to `member.pli`
+        libMatch = await FileSystemProviderInstance.search({
+          dirPath: resolveLibFileUri(lib.dir),
+          member: fileNameOrPartial,
+        });
+        if (libMatch) {
+          break;
+        }
+      }
+
+      // perform standard search
+      libMatch = await FileSystemProviderInstance.search({
+        path: libFileUri,
+        extensions: pgroup.includeExtensions,
+      });
+      if (libMatch) {
+        // regular file match, no member to validate
+        needsMemberValidation = false;
+        break;
+      }
+    } else if (isMemberWithoutDDName) {
+      // standalone member w/out an explicit ddname, search within ddlib for a match
+      const ddLibUri = resolveLibFileUri(lib.ddLib);
+      libMatch = await FileSystemProviderInstance.search({
+        path: URI.parse(ddLibUri.toString(true) + `(${fileNameOrPartial})`),
+        extensions: [],
+      });
+      if (libMatch) {
+        break;
+      }
+    } else if (
+      isMemberIncludeItem(item) &&
+      item.ddname &&
+      lib.ddLib.toLowerCase().endsWith(item.ddname.toLowerCase())
+    ) {
+      // member w/ ddname, search for an exact match using ddlib
+      const end = lib.ddLib.length - item.ddname.length;
+      const libPath = lib.ddLib.substring(0, end);
+      const ddLibUri = resolveLibFileUri(libPath, fileNameOrPartial);
+      libMatch = await FileSystemProviderInstance.search({
+        path: ddLibUri,
+        extensions: [],
+      });
+      if (libMatch) {
+        break;
+      }
+    }
+  }
+
+  // depending on whether we matched a member, check to apply validation on the name
+  if (needsMemberValidation) {
+    checkToValidateMember(fileNameOrPartial);
+  }
+  return libMatch;
 }
 
 type PreprocessorBuiltin = (

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2308,6 +2308,9 @@ async function resolveIncludeFileUri(
       }
     }
 
+    // what constitutes a valid member name, whether it's a member or file include
+    const memberNameRegex = /^[A-Z][A-Z0-9@#_$]*$/i;
+
     /**
      * Helper to check & validate member names when member name validations are enabled.
      * Pushes diagnostics to the context when validation fails.
@@ -2329,7 +2332,6 @@ async function resolveIncludeFileUri(
         );
       }
 
-      const memberNameRegex = /^[A-Z][A-Z0-9@#_$]*$/i;
       if (!memberNameRegex.test(memberName)) {
         // emit a diagnostic for invalid member names
         context.diagnostics.push(
@@ -2346,9 +2348,10 @@ async function resolveIncludeFileUri(
       if (isLibsDir(lib)) {
         const libFileUri = resolveLibFileUri(lib.dir, fileNameOrPartial);
 
-        if (isMemberWithoutDDName) {
-          // attempt to first resolve for any DDName that introduces this member
+        if (memberNameRegex.test(fileNameOrPartial)) {
+          // attempt to first resolve for any DDName that may introduce a member by this name
           // This is done to ensure resolution order of libs is maintained as members > files
+          // Same applies for both member & file includes, to ensure behavior is consistent.
           // Ex. If we have both `cpy/member.pli` and `cpy/A.B.C(member)`, with `cpy` in the libs list
           // We want to ensure that `A.B.C(member)` is resolved first before falling back to `member.pli`
           libMatch = await FileSystemProviderInstance.search({

--- a/packages/language/src/workspace/file-system-provider.ts
+++ b/packages/language/src/workspace/file-system-provider.ts
@@ -136,10 +136,20 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
   private readonly files: Map<string, string> = new Map<string, string>();
 
   /**
+   * Sorted list of files, ordered by depth 1st & alphabetically 2nd
+   * Used to ensure search returns the shallowest match regardless of insertion order
+   * Ex. /a/b/c/file.pli vs. /a/file.pli, where the latter should match first
+   * Lazily computed & set via `getSortedFiles`
+   */
+  private sortedFilesCache: string[] | undefined;
+
+  /**
    * Write a file to the virtualized file system
+   * Clears the sorted files cache
    */
   async writeFile(uri: URI, value: string): Promise<void> {
     this.files.set(uri.toString(true).toLowerCase(), value);
+    this.sortedFilesCache = undefined;
   }
 
   /**
@@ -167,22 +177,22 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
     if (!path.endsWith("/")) {
       path += "/";
     }
-    const entries: string[] = [];
+    const entries: Set<string> = new Set<string>();
     for (const filePath of this.files.keys()) {
       if (filePath.startsWith(path)) {
         const relativePath = filePath.substring(path.length);
         const parts = relativePath.split("/").filter((p) => p.length > 0);
-        if (parts.length > 0) {
-          entries.push(parts[0]);
+        if (parts.length > 0 && !entries.has(parts[0])) {
+          entries.add(parts[0]);
         }
       }
     }
-    if (entries.length === 0) {
+    if (entries.size === 0) {
       // when no files are found, we assume the directory does not exist
       // as we don't currently support creating empty dirs in the vfs
       throw new Error(`Directory not found: ${uri.toString(true)}`);
     }
-    return entries;
+    return Array.from(entries);
   }
 
   /**
@@ -194,9 +204,32 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
 
   /**
    * Deletes a file from the virtualized file system
+   * Drops the associated sorted files cache entry as well
    */
   async deleteFile(uri: URI): Promise<void> {
     this.files.delete(uri.toString(true).toLowerCase());
+    this.sortedFilesCache?.splice(
+      this.sortedFilesCache.indexOf(uri.toString(true).toLowerCase()),
+      1,
+    );
+  }
+
+  /**
+   * Helper to get/compute sorted virtual files by depth 1st & alphabetically 2nd.
+   * Generates sorted list on request, if not already available.
+   */
+  private getSortedFiles(): string[] {
+    if (!this.sortedFilesCache) {
+      this.sortedFilesCache = Array.from(this.files.keys()).sort((a, b) => {
+        const aSlashes = (a.match(/\//g) || []).length;
+        const bSlashes = (b.match(/\//g) || []).length;
+        if (aSlashes === bSlashes) {
+          return a.localeCompare(b);
+        }
+        return aSlashes - bSlashes;
+      });
+    }
+    return this.sortedFilesCache;
   }
 
   /**
@@ -229,7 +262,8 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
         const globalSearchPath = options.path.path
           .toLowerCase()
           .replace(/\\/g, "/");
-        for (const [filePath] of this.files) {
+        const sortedFiles = this.getSortedFiles();
+        for (const filePath of sortedFiles) {
           if (filePath.endsWith(globalSearchPath)) {
             return URI.parse(filePath);
           }
@@ -245,7 +279,8 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
     } else {
       // perform a search by a member w/ candidate dir path
       const memberPart = `(${options.member})`.toLowerCase();
-      for (const [filePath] of this.files) {
+      const sortedFiles = this.getSortedFiles();
+      for (const filePath of sortedFiles) {
         const fpl = filePath.toLowerCase();
         if (
           fpl.endsWith(memberPart) &&

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -431,7 +431,7 @@ export class PluginConfigurationProvider {
       const computedLibsMap: Map<string, LibsEntry> = new Map();
       const libsToProcess = [...processGroup.libs];
       while (libsToProcess.length > 0) {
-        const lib = libsToProcess.pop();
+        const lib = libsToProcess.shift();
         if (lib) {
           // read all files in this lib path
           // add any contained directories to the libs list, as well as the toProcess list
@@ -446,6 +446,10 @@ export class PluginConfigurationProvider {
 
           try {
             const entries = await FileSystemProviderInstance.readDir(libUri);
+            // add the lib itself first, since we know it exists now
+            computedLibsMap.set(`dir:${lib}`, {
+              dir: lib,
+            });
             if (entries.length) {
               for (const fileName of entries) {
                 // TODO @montymxb Nov. 7th, 2025: Handle stat checks in parallel to avoid blocking so long,
@@ -464,10 +468,6 @@ export class PluginConfigurationProvider {
                 }
               }
             }
-            // add the lib itself, now that we know it exists
-            computedLibsMap.set(`dir:${lib}`, {
-              dir: lib,
-            });
           } catch (e) {
             // could not read, try again to retrieve & read the parent directory
             // take its entries to see if our lib exists as a file or directory
@@ -510,7 +510,17 @@ export class PluginConfigurationProvider {
           }
         }
       }
-      const computedLibs = Array.from(computedLibsMap.values());
+      // get computed libs in sorted order, depth 1st, alpha 2nd
+      const computedLibs = Array.from(computedLibsMap.values()).sort((a, b) => {
+        const aKey = isLibsDir(a) ? a.dir : a.ddLib;
+        const bKey = isLibsDir(b) ? b.dir : b.ddLib;
+        const aDepth = (aKey.match(/\//g) || []).length;
+        const bDepth = (bKey.match(/\//g) || []).length;
+        if (aDepth - bDepth === 0) {
+          return aKey.localeCompare(bKey);
+        }
+        return aDepth - bDepth;
+      });
       processGroup.$computedLibs = computedLibs;
       // build a lookup set for dir entries only
       processGroup.$computedLibsSet = new Set(

--- a/packages/language/test/fourslash/preprocessor/include/bfs-include-resolution.ts
+++ b/packages/language/test/fourslash/preprocessor/include/bfs-include-resolution.ts
@@ -1,0 +1,75 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+// Tests that file & member includes resolve in a BFS search order
+// I.e. shallowest matching file/member is included first
+// And for matching depth, alphabetical order dictates which is included first
+
+/// <reference path="../../framework.ts" />
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////             "name": "default",
+////             "libs": [
+////                 "cpy",
+////                 "cpy2"
+////             ],
+////             "include-extensions": [
+////                 ".pli"
+////             ]
+////         }
+////     ]
+//// }
+
+// @filename: cpy/l1.pli
+//// DECLARE L1 FIXED;
+
+// @filename: cpy/TF(m1)
+//// DECLARE M1 FIXED;
+
+// @filename: cpy2/l3.pli
+//// DECLARE L3 FIXED;
+
+// @filename: cpy/a/l1.pli
+//// DECLARE L1_IN_A FIXED;
+
+// @filename: cpy/a/TF(m1)
+//// DECLARE M1_IN_A FIXED;
+
+// deeply nested file that should not match
+// @filename: cpy/a/b/l2.pli
+//// DECLARE L2_IN_A_B FIXED;
+
+// @filename: cpy/d/l2.pli
+//// DECLARE L2_IN_D FIXED;
+
+// shallower nested file that should match instead of the one above
+// also alphabetically before /cpy/d/l2.pli
+// @filename: cpy/c/l2.pli
+//// DECLARE L2_IN_C FIXED;
+
+// @filename: cpy/a/l3.pli
+//// DECLARE L3_IN_A FIXED;
+
+// @filename: main.pli
+//// %INCLUDE "l1.pli";
+//// %INCLUDE "l2.pli";
+//// %INCLUDE m1;
+//// %INCLUDE l3;
+
+preprocessor.expectTokens(`
+  DECLARE L1 FIXED;
+  DECLARE L2_IN_C FIXED;
+  DECLARE M1 FIXED;
+  DECLARE L3 FIXED;
+`);

--- a/packages/language/test/fourslash/preprocessor/include/include-resolution-order.ts
+++ b/packages/language/test/fourslash/preprocessor/include/include-resolution-order.ts
@@ -11,7 +11,7 @@
 
 // Tests that file & member includes resolve in a BFS search order
 // I.e. shallowest matching file/member is included first
-// And for matching depth, alphabetical order dictates which is included first
+// And for matching depth, alphabetical order breaks the tie
 
 /// <reference path="../../framework.ts" />
 

--- a/packages/language/test/fourslash/preprocessor/include/test-ddmember-include-recursive.ts
+++ b/packages/language/test/fourslash/preprocessor/include/test-ddmember-include-recursive.ts
@@ -9,14 +9,14 @@
  *
  */
 
-// Tests including a ddname(member) by its member
+// Tests including a ddname(member) by its member directly & recursively
 
 /// <reference path="../../framework.ts" />
 
 // @filename: cpy/MYLIB(m1)
 //// DECLARE LIB_VAR1 FIXED;
 
-// @filename: cpy/A.B.C(m2)
+// @filename: cpy/f2/A.B.C(m2)
 //// DECLARE LIB_VAR2 FIXED;
 
 // @filename: main.pli

--- a/packages/language/test/fourslash/preprocessor/include/test-ddname-over-file-preference.ts
+++ b/packages/language/test/fourslash/preprocessor/include/test-ddname-over-file-preference.ts
@@ -9,20 +9,19 @@
  *
  */
 
-// Tests including a ddname(member) directly as a string literal, w/ ddname or without.
-// TODO @montymxb this feature may be dropped later on, potential issue since
-// ddname(member) shouldn't be importable directly as a file, not the intended use case.
+// Tests that ddname(member) includes are preferred over file includes when both can match
 
 /// <reference path="../../framework.ts" />
 
 // @filename: cpy/MYLIB(member)
 //// DECLARE LIB_VAR FIXED;
 
+// @filename: cpy/member.pli
+//// DECLARE OTHER_VAR FIXED;
+
 // @filename: main.pli
-//// %INCLUDE "MYLIB(member)";
 //// %INCLUDE "member";
 
 preprocessor.expectTokens(`
-  DECLARE LIB_VAR FIXED;
   DECLARE LIB_VAR FIXED;
 `);


### PR DESCRIPTION
Fixes some recently reported issues with the way we resolve member & file includes:

- update include resolution to resolve in a bfs fashion w/ alphabetical sorting per level
    - ex. `%INCLUDE "a.pli";` should resolve `cpy/a.pli` over `cpy/nested/a.pli`
    - also `%INCLUDE "a.pli";` should resolve `x/a.pli` over `y/a.pli`
    - works for members & files
    - refactored search for the vfs to leverage a sorted files list, maintaining our suffix matching approaches
- resolve members before files for file-based includes (resolves point 10 of #511)
    - ex. `%INCLUDE "m1";` will now work similarly to `%INCLUDE m1;`, favoring matching members first
- improve an existing test case to ensure recursive ddname resolution works as expected

There's some tests I've tossed in for these as well. The vfs was particularly problematic given the order of insertion changes the testing results here, which was the justification for the sorted files list. The Array sort operation should be using something like Tim sort or Quick sort internally, but crawling the array for suffix matches is still unchanged. So it may be an improvement to use a suffix tree later on for these cases.