### PR TITLE
Generate variables for EXEC CICS statements

### DIFF
--- a/packages/language/src/parser/cics-parser.ts
+++ b/packages/language/src/parser/cics-parser.ts
@@ -53,3 +53,14 @@ export function cicsResponseStatement(
   );
   return statement;
 }
+
+export function isCicsExecStatement(state: ParserState): boolean {
+  const isExec = state.canConsume(t.EXEC, t.ExecFragment);
+  if (isExec) {
+    const execToken = state.peek(2);
+    if (execToken && /^CICS/i.test(execToken.image)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/packages/language/src/parser/parser-entry.ts
+++ b/packages/language/src/parser/parser-entry.ts
@@ -20,7 +20,11 @@ import {
   statement,
 } from "./preprocessor-parser";
 import { isSqlAttributeStatement, sqlAttributeStatement } from "./sql-parser";
-import { cicsResponseStatement, isCicsResponseStatement } from "./cics-parser";
+import {
+  cicsResponseStatement,
+  isCicsExecStatement,
+  isCicsResponseStatement,
+} from "./cics-parser";
 
 export type PreprocessorParserResult = {
   statements: ast.Statement[];
@@ -71,6 +75,16 @@ export function preprocessorParse(
           stmt = cicsRespStatement;
         }
         break;
+      case t.EXEC.tokenTypeIdx:
+        if (isCicsExecStatement(state)) {
+          // Do not really parse the CICS EXEC statement yet
+          // Just create a placeholder AST node for now
+          isTokenStatement = true;
+          const cicsExecStatement = ast.createCicsExecStatement();
+          const stmtWrapper = ast.createStatement();
+          stmtWrapper.value = cicsExecStatement;
+          statements.push(stmtWrapper);
+        }
     }
     if (isTokenStatement) {
       // Otherwise construct a token statement

--- a/packages/language/src/parser/tokens.ts
+++ b/packages/language/src/parser/tokens.ts
@@ -1882,7 +1882,7 @@ export const DISABLED = registerKeyword({
  * Characters which start a preprocessor directive.
  * Used as start/stop points for the token statement
  */
-export const PPSignifier = [Percent, INCLUDE_ALT, SQL, DFHRESP];
+export const PPSignifier = [Percent, INCLUDE_ALT, SQL, DFHRESP, EXEC];
 
 export const terminals = [
   WS,

--- a/packages/language/src/preprocessor/instruction-generator.ts
+++ b/packages/language/src/preprocessor/instruction-generator.ts
@@ -12,6 +12,7 @@
 import * as inst from "./instructions";
 import * as ast from "../syntax-tree/ast";
 import { assertType, getAttributes } from "./util";
+import { createCicsResponseInstruction } from "./instructions";
 
 interface GenerateInstructionContext {
   labels: Map<string, inst.InstructionNode>;
@@ -187,6 +188,9 @@ function generateInstructionForStatement(
     case ast.SyntaxKind.CicsResponseStatement:
       instruction = generateCicsResponseInstruction(value);
       break;
+    case ast.SyntaxKind.CicsExecStatement:
+      instruction = inst.createCicsExecInstruction();
+      break;
     default:
       return undefined;
   }
@@ -310,10 +314,7 @@ function generateCicsResponseInstruction(
   if (node.code === null) {
     return undefined;
   }
-  return {
-    kind: inst.InstructionKind.CicsResponseCode,
-    code: node.code,
-  };
+  return createCicsResponseInstruction(node.code);
 }
 
 function generateSqlAttributeInstruction(

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -277,7 +277,7 @@ interface InterpreterContext {
   options: InterpreterOptions;
   returnValue: Value;
   counterValue: number;
-  sqlAttributeCache: SqlAttributeCache;
+  generationCache: GenerationCache;
   /**
    * MACNAME returns the name of the preprocessor procedure within which it is invoked.
    * It is invalid to invoke MACNAME outside of a preprocessor procedure.
@@ -286,14 +286,15 @@ interface InterpreterContext {
   instructionCounterLimit: number;
 }
 
-interface SqlAttributeCache {
+interface GenerationCache {
   lastProcedureTokenIndex: number;
-  entries: Map<number, SqlAttributeEntry>;
+  entries: Map<number, GenerationCacheEntry>;
 }
 
-interface SqlAttributeEntry {
-  hasFile: boolean;
-  lobSizes: Set<number>;
+interface GenerationCacheEntry {
+  hasSqlLobFile: boolean;
+  hasCicsExec: boolean;
+  sqlLobSizes: Set<number>;
 }
 
 interface DoType3Context {
@@ -350,7 +351,7 @@ export async function runInstructions(
     counter: new Map(),
     returnValue: defaultEmptyValue,
     counterValue: 1,
-    sqlAttributeCache: {
+    generationCache: {
       lastProcedureTokenIndex: 0,
       entries: new Map(),
     },
@@ -526,6 +527,9 @@ function runInstructionSync(
     case inst.InstructionKind.CicsResponseCode:
       runCicsResponseInstruction(instruction, context);
       break;
+    case inst.InstructionKind.CicsExecStatement:
+      runCicsExecInstruction(instruction, context);
+      break;
   }
   return undefined;
 }
@@ -536,6 +540,22 @@ function runCicsResponseInstruction(
 ): void {
   const codeValue = instruction.code.toString();
   context.tokens.push(...lex(codeValue));
+}
+
+function getGenerationCacheEntry(
+  context: InterpreterContext,
+  offset: number,
+): GenerationCacheEntry {
+  let entry = context.generationCache.entries.get(offset);
+  if (!entry) {
+    entry = {
+      hasSqlLobFile: false,
+      hasCicsExec: false,
+      sqlLobSizes: new Set(),
+    };
+    context.generationCache.entries.set(offset, entry);
+  }
+  return entry;
 }
 
 const LOCATOR_TYPE = "FIXED BIN(31)";
@@ -574,23 +594,17 @@ function runSqlAttributeInstruction(
     if (procSemicolonIndex === undefined) {
       return;
     }
-    let entry = context.sqlAttributeCache.entries.get(procSemicolonIndex);
-    if (!entry) {
-      entry = {
-        hasFile: false,
-        lobSizes: new Set(),
-      };
-      context.sqlAttributeCache.entries.set(procSemicolonIndex, entry);
-    }
+    const entry = getGenerationCacheEntry(context, procSemicolonIndex);
     if (body.kind === ast.SyntaxKind.SqlAttributeLobFile) {
-      if (!entry.hasFile) {
+      if (!entry.hasSqlLobFile) {
+        entry.hasSqlLobFile = true;
         insertSqlAttributeLobFileTokens(context, procSemicolonIndex);
       }
       context.tokens.push(...lex(LOB_FILE_TYPE));
     } else if (body.kind === ast.SyntaxKind.SqlAttributeLob) {
       const computedLength = computeLobLength(body);
-      if (!entry.lobSizes.has(computedLength)) {
-        entry.lobSizes.add(computedLength);
+      if (!entry.sqlLobSizes.has(computedLength)) {
+        entry.sqlLobSizes.add(computedLength);
         insertSqlAttributeLobTokens(
           context,
           procSemicolonIndex,
@@ -626,6 +640,8 @@ function insertSqlAttributeLobFileTokens(
   context: InterpreterContext,
   offset: number,
 ): void {
+  // These declarations aren't documented anywhere
+  // They are extracted from the PL/I code after running through the SQL preprocessor
   context.tokens.splice(
     offset,
     0,
@@ -642,6 +658,81 @@ function insertSqlAttributeLobFileTokens(
     DCL SQL_FILE_OVERWRITE FIXED BIN(31) VALUE(16);
     DCL SQL_FILE_APPEND    FIXED BIN(31) VALUE(32);
   `),
+  );
+}
+
+function runCicsExecInstruction(
+  instruction: inst.CicsExecInstruction,
+  context: InterpreterContext,
+): void {
+  const procSemicolonIndex = findProcSemicolon(context);
+  if (procSemicolonIndex === undefined) {
+    return;
+  }
+  const entry = getGenerationCacheEntry(context, procSemicolonIndex);
+  if (!entry.hasCicsExec) {
+    entry.hasCicsExec = true;
+    insertCicsExecTokens(context, procSemicolonIndex);
+  }
+}
+
+function insertCicsExecTokens(
+  context: InterpreterContext,
+  offset: number,
+): void {
+  // These declarations aren't documented anywhere
+  // They are extracted from the PL/I code after running through the CICS preprocessor
+  context.tokens.splice(
+    offset,
+    0,
+    ...lex(`
+      DCL 
+        1 DFHCNSTS STATIC,
+          2 DFHLDVER CHAR(22) INIT('LD TABLE DFHEITAB 730.'),
+          2 DFHEIB0 FIXED BIN(15) INIT(0),
+          2 DFHEID0 FIXED DEC(7) INIT(0),
+          2 DFHEICB CHAR(8) INIT('        ');
+      DCL DFHEPI ENTRY, DFHEIPTR PTR;
+      DCL 
+        1 DFHEIBLK BASED (DFHEIPTR),
+          2 EIBTIME  FIXED DEC(7),
+          2 EIBDATE  FIXED DEC(7),
+          2 EIBTRNID CHAR(4),
+          2 EIBTASKN FIXED DEC(7),
+          2 EIBTRMID CHAR(4),
+          2 EIBFIL01 FIXED BIN(15),
+          2 EIBCPOSN FIXED BIN(15),
+          2 EIBCALEN FIXED BIN(15),
+          2 EIBAID   CHAR(1),
+          2 EIBFN    CHAR(2),
+          2 EIBRCODE CHAR(6),
+          2 EIBDS    CHAR(8),
+          2 EIBREQID CHAR(8),
+          2 EIBRSRCE CHAR(8),
+          2 EIBSYNC  CHAR(1),
+          2 EIBFREE  CHAR(1),
+          2 EIBRECV  CHAR(1),
+          2 EIBFIL02 CHAR(1),
+          2 EIBATT   CHAR(1),
+          2 EIBEOC   CHAR(1),
+          2 EIBFMH   CHAR(1),
+          2 EIBCOMPL CHAR(1),
+          2 EIBSIG   CHAR(1),
+          2 EIBCONF  CHAR(1),
+          2 EIBERR   CHAR(1),
+          2 EIBERRCD CHAR(4),
+          2 EIBSYNRB CHAR(1),
+          2 EIBNODAT CHAR(1),
+          2 EIBRESP  FIXED BIN(31),
+          2 EIBRESP2 FIXED BIN(31),
+          2 EIBRLDBK CHAR(1);
+      DCL 
+        1 DFHCNTBS  STATIC,
+          2  DFHLDTBS CHAR(22) INIT('LD TABLE DFHEITBS 730.');
+      DCL DFHDUMMY STATIC FIXED BIN(15) INIT(0);
+      DCL DFHEI0 ENTRY VARIABLE INIT(DFHEI01) AUTO OPTIONS(INTER ASSEMBLER);
+      DCL DFHEI01 ENTRY OPTIONS(INTER ASSEMBLER);
+    `),
   );
 }
 
@@ -666,12 +757,12 @@ function insertSqlAttributeLobTokens(
  * Searches for the nearest procedure semicolon token before the current position
  */
 function findProcSemicolon(context: InterpreterContext): number | undefined {
-  const min = context.sqlAttributeCache.lastProcedureTokenIndex;
+  const min = context.generationCache.lastProcedureTokenIndex;
   const max = context.tokens.length - 1;
   for (let i = max; i >= min; i--) {
     const token = context.tokens[i];
     if (token.tokenTypeIdx === PreprocessorTokens.Procedure.tokenTypeIdx) {
-      context.sqlAttributeCache.lastProcedureTokenIndex = i;
+      context.generationCache.lastProcedureTokenIndex = i;
       for (let j = i + 1; j <= max; j++) {
         const nextToken = context.tokens[j].tokenTypeIdx;
         if (nextToken === PreprocessorTokens.Semicolon.tokenTypeIdx) {

--- a/packages/language/src/preprocessor/instructions.ts
+++ b/packages/language/src/preprocessor/instructions.ts
@@ -87,6 +87,7 @@ export enum InstructionKind {
   Note,
   SqlAttribute,
   CicsResponseCode,
+  CicsExecStatement,
 
   // Expression types
   BinaryExpression,
@@ -113,11 +114,31 @@ export type Instruction =
   | NoteInstruction
   | CallInstruction
   | SqlAttributeInstruction
-  | CicsResponseInstruction;
+  | CicsResponseInstruction
+  | CicsExecInstruction;
 
 export interface CicsResponseInstruction {
   kind: InstructionKind.CicsResponseCode;
   code: ast.CicsResponseCode;
+}
+
+export function createCicsResponseInstruction(
+  code: ast.CicsResponseCode,
+): CicsResponseInstruction {
+  return {
+    kind: InstructionKind.CicsResponseCode,
+    code,
+  };
+}
+
+export interface CicsExecInstruction {
+  kind: InstructionKind.CicsExecStatement;
+}
+
+export function createCicsExecInstruction(): CicsExecInstruction {
+  return {
+    kind: InstructionKind.CicsExecStatement,
+  };
 }
 
 export interface SqlAttributeInstruction {

--- a/packages/language/src/syntax-tree/ast-iterator.ts
+++ b/packages/language/src/syntax-tree/ast-iterator.ts
@@ -980,6 +980,7 @@ export function forEachNode(
     case SyntaxKind.SqlAttributeTableLocator:
     case SyntaxKind.SqlAttributeResultSetLocator:
     case SyntaxKind.CicsResponseStatement:
+    case SyntaxKind.CicsExecStatement:
       break;
     default:
       assertUnreachable(node);

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -225,6 +225,7 @@ export enum SyntaxKind {
   WriteStatementOption,
   XFormatItem,
   CicsResponseStatement,
+  CicsExecStatement,
 }
 
 export enum KeywordConditions {
@@ -659,9 +660,20 @@ export type SyntaxNode =
   // Preprocessor nodes
   | ActivateStatement
   | ActivateItem
+  | AnswerStatement
   | DeactivateStatement
   | TokenStatement
-  | AnswerStatement
+  | CicsExecStatement
+  | CicsResponseStatement
+  | SqlAttributeStatement
+  | SqlAttributeBinary
+  | SqlAttributeLob
+  | SqlAttributeLobLocator
+  | SqlAttributeLobFile
+  | SqlAttributeRowId
+  | SqlAttributeTableLocator
+  | SqlAttributeResultSetLocator
+
   // Normal nodes
   | AFormatItem
   | AllocateDimension
@@ -842,15 +854,6 @@ export type SyntaxNode =
   | Statement
   | StopStatement
   | StringLiteral
-  | SqlAttributeStatement
-  | CicsResponseStatement
-  | SqlAttributeBinary
-  | SqlAttributeLob
-  | SqlAttributeLobLocator
-  | SqlAttributeLobFile
-  | SqlAttributeRowId
-  | SqlAttributeTableLocator
-  | SqlAttributeResultSetLocator
   | TypeAttribute
   | UnaryExpression
   | ValueAttribute
@@ -1044,7 +1047,8 @@ export type Unit =
   | NoPrintDirective
   | SkipDirective
   | SqlAttributeStatement
-  | CicsResponseStatement;
+  | CicsResponseStatement
+  | CicsExecStatement;
 
 // Preprocessor AST
 
@@ -2921,5 +2925,18 @@ export function createCicsResponseStatement(): CicsResponseStatement {
     token: null,
     code: null,
     codeToken: null,
+  };
+}
+
+// This is a placeholder for future CICS EXEC statements
+// It is currently used to generate the correct AST structure
+export interface CicsExecStatement extends AstNode {
+  kind: SyntaxKind.CicsExecStatement;
+}
+
+export function createCicsExecStatement(): CicsExecStatement {
+  return {
+    kind: SyntaxKind.CicsExecStatement,
+    container: null,
   };
 }

--- a/packages/language/test/fourslash/preprocessor/cics/eibresp-with-dfhresp.ts
+++ b/packages/language/test/fourslash/preprocessor/cics/eibresp-with-dfhresp.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// TEST: PROC;
+////   EXEC CICS SOMETHING;
+////   IF <|EIBRESP|> = DFHRESP(NORMAL) THEN
+////     PUT('NORMALPROC');
+////   ENDIF;
+//// END;
+
+verify.noDiagnostics("EIBRESP");

--- a/packages/language/test/fourslash/preprocessor/cics/exec-generates-declarations.ts
+++ b/packages/language/test/fourslash/preprocessor/cics/exec-generates-declarations.ts
@@ -1,0 +1,74 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// TEST: PROC;
+////   DCL VAR1 FIXED BIN(31);
+////   EXEC CICS SOMETHING1;
+////   EXEC CICS SOMETHING2;
+//// END;
+
+// The EXEC CICS statement should generate a few declarations after the PROC semicolon ONCE
+preprocessor.expectTokens(`
+TEST: PROC;
+    DCL 
+      1 DFHCNSTS STATIC,
+        2 DFHLDVER CHAR(22) INIT('LD TABLE DFHEITAB 730.'),
+        2 DFHEIB0 FIXED BIN(15) INIT(0),
+        2 DFHEID0 FIXED DEC(7) INIT(0),
+        2 DFHEICB CHAR(8) INIT('        ');
+    DCL DFHEPI ENTRY, DFHEIPTR PTR;
+    DCL 
+      1 DFHEIBLK BASED (DFHEIPTR),
+        2 EIBTIME  FIXED DEC(7),
+        2 EIBDATE  FIXED DEC(7),
+        2 EIBTRNID CHAR(4),
+        2 EIBTASKN FIXED DEC(7),
+        2 EIBTRMID CHAR(4),
+        2 EIBFIL01 FIXED BIN(15),
+        2 EIBCPOSN FIXED BIN(15),
+        2 EIBCALEN FIXED BIN(15),
+        2 EIBAID   CHAR(1),
+        2 EIBFN    CHAR(2),
+        2 EIBRCODE CHAR(6),
+        2 EIBDS    CHAR(8),
+        2 EIBREQID CHAR(8),
+        2 EIBRSRCE CHAR(8),
+        2 EIBSYNC  CHAR(1),
+        2 EIBFREE  CHAR(1),
+        2 EIBRECV  CHAR(1),
+        2 EIBFIL02 CHAR(1),
+        2 EIBATT   CHAR(1),
+        2 EIBEOC   CHAR(1),
+        2 EIBFMH   CHAR(1),
+        2 EIBCOMPL CHAR(1),
+        2 EIBSIG   CHAR(1),
+        2 EIBCONF  CHAR(1),
+        2 EIBERR   CHAR(1),
+        2 EIBERRCD CHAR(4),
+        2 EIBSYNRB CHAR(1),
+        2 EIBNODAT CHAR(1),
+        2 EIBRESP  FIXED BIN(31),
+        2 EIBRESP2 FIXED BIN(31),
+        2 EIBRLDBK CHAR(1);
+    DCL 
+      1 DFHCNTBS  STATIC,
+        2  DFHLDTBS CHAR(22) INIT('LD TABLE DFHEITBS 730.');
+    DCL DFHDUMMY STATIC FIXED BIN(15) INIT(0);
+    DCL DFHEI0 ENTRY VARIABLE INIT(DFHEI01) AUTO OPTIONS(INTER ASSEMBLER);
+    DCL DFHEI01 ENTRY OPTIONS(INTER ASSEMBLER);
+
+    DCL VAR1 FIXED BIN(31);
+    EXEC CICS SOMETHING1;
+    EXEC CICS SOMETHING2;
+END;
+`);


### PR DESCRIPTION
As part of an effort to improve the PL/I tolerance, we need to ensure that the expected declaration statements are generated when running into an `EXEC CICS...` statement. The CICS preprocessor will then generate a bunch of declarations after the last `PROC` statement encountered. Similar to how the `SQL TYPE` attribute does it.

These variables are required for any PL/I code that has any interaction with CICS. Related to point 1 of https://github.com/zowe/zowe-pli-language-support/issues/511. This code simply mirrors the behavior of the CICS preprocessor when encountering a `EXEC CICS...` statement.