### PR TITLE
Improve parser error recovery

### DIFF
--- a/packages/language/src/parser/parser-state.ts
+++ b/packages/language/src/parser/parser-state.ts
@@ -30,31 +30,33 @@ import {
 import { tokenIdxToClass } from "./token-type-factory";
 import * as environment from "../workspace/environment";
 
-export function preprocessorParserState(tokens: t.Token[]): ParserState {
-  return new ParserState(tokens, ParserStateMode.Preprocessor);
+export enum RecoveryResult {
+  /**
+   * Recover at the current token
+   */
+  Recover,
+  /**
+   * Recover after the current token
+   */
+  RecoverNext,
+  /**
+   * Continue the recovery process (the parser state will go on to the next token)
+   */
+  Continue,
 }
 
-export function finalParserState(tokens: t.Token[]): ParserState {
-  return new ParserState(tokens, ParserStateMode.Final);
-}
-
-export enum ParserStateMode {
-  Preprocessor,
-  Final,
-}
+export type RecoveryFunction = () => RecoveryResult;
 
 export class ParserState {
   readonly tokens: t.Token[];
-  readonly mode: ParserStateMode;
   readonly diagnostics: Diagnostic[];
   public index: number;
   public inError = false;
 
   private inProcedure = false;
 
-  constructor(tokens: t.Token[], mode: ParserStateMode) {
+  constructor(tokens: t.Token[]) {
     this.tokens = tokens;
-    this.mode = mode;
     this.diagnostics = [];
     this.index = 0;
   }
@@ -182,14 +184,22 @@ export class ParserState {
     this.inError = true;
   }
 
-  recover(): void {
+  recover(fn: RecoveryFunction): void {
     if (!this.inError) {
       // Prevent error recovery if not in error state.
       return;
     }
-    if (this.mode === ParserStateMode.Preprocessor) {
-      this.performPreprocessorRecovery();
-    } else if (this.mode === ParserStateMode.Final) {
+    let state = RecoveryResult.Continue;
+    while (
+      this.index < this.tokens.length &&
+      state === RecoveryResult.Continue
+    ) {
+      // Advance to the next token
+      this.index++;
+      state = fn();
+    }
+    if (state === RecoveryResult.RecoverNext) {
+      this.index++;
     }
     this.inError = false;
   }
@@ -200,28 +210,6 @@ export class ParserState {
    */
   skipRecovery(): void {
     this.inError = false;
-  }
-
-  private performPreprocessorRecovery(): void {
-    // If the preprocessor parser encounters an error, it should attempt to:
-    // 1. Find a semicolon at the current line, and skip that token
-    // 2. Find a percent sign at the current line, and stop
-    // 3. If neither is found, skip to the next line
-    const currentLine = (this.token || this.last)?.startLine ?? 0;
-    while (this.index < this.tokens.length) {
-      const token = this.tokens[this.index];
-      if (token.startLine !== currentLine) {
-        // Moved to next line, stop here
-        break;
-      } else if (tokenMatcher(token, t.Semicolon)) {
-        this.index++;
-        break;
-      } else if (tokenMatcher(token, t.Percent)) {
-        break;
-      } else {
-        this.index++;
-      }
-    }
   }
 
   tryConsume(

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -19,7 +19,7 @@ import {
 } from "./parser-types";
 import * as ast from "../syntax-tree/ast";
 import { tokenMatcher } from "chevrotain";
-import { finalParserState, ParserState } from "./parser-state";
+import { ParserState, RecoveryResult } from "./parser-state";
 import * as tokens from "./tokens";
 import { CstNodeKind } from "../syntax-tree/cst";
 import {
@@ -27,13 +27,13 @@ import {
   IntermediateBinaryExpression,
 } from "./abstract-parser";
 import { Severe } from "../validation/pli-codes";
-import { Severity } from "../language-server/types";
+import { Diagnostic, Severity } from "../language-server/types";
 
 export function parsePli(input: tokens.Token[]): {
   tree: ast.Program;
-  diagnostics: any;
+  diagnostics: Diagnostic[];
 } {
-  const state = finalParserState(input);
+  const state = new ParserState(input);
   const program = pliProgram.rule(state);
   const tree = program ?? ast.createProgram();
   return { tree, diagnostics: state.diagnostics };
@@ -670,40 +670,25 @@ const statement = rule(
       element.value = unit.rule(state);
     }
 
-    recover(
-      state,
-      () =>
+    state.recover(() => {
+      const token = state.token;
+      if (!token) {
+        return RecoveryResult.Continue;
+      }
+      if (tokenMatcher(state.token, tokens.Semicolon)) {
+        return RecoveryResult.RecoverNext;
+      } else if (
         state.canConsumeFirst(statement.first()) ||
-        performAssignmentLookahead(state),
-    );
+        performAssignmentLookahead(state)
+      ) {
+        return RecoveryResult.Recover;
+      }
+      return RecoveryResult.Continue;
+    });
 
     return element;
   },
 );
-
-//this logic is also used in the tests, so the break condition is generic
-export function recover(
-  state: ParserState,
-  breakCondition: () => boolean,
-): void {
-  if (!state.inError) {
-    // Prevent error recovery if not in error state.
-    return;
-  }
-  while (state.index < state.tokens.length) {
-    const token = state.tokens[state.index];
-    if (tokenMatcher(token, tokens.Semicolon)) {
-      state.index++;
-      break;
-    }
-    if (breakCondition()) {
-      break;
-    } else {
-      state.index++;
-    }
-  }
-  state.inError = false;
-}
 
 const unit = orRule<ast.Unit>(
   () => allocateStatement,
@@ -6046,9 +6031,7 @@ const expression = rule(
       rhs && element.items.push(rhs);
     }
 
-    return element && element.items.length > 0
-      ? constructBinaryExpression(element)
-      : null;
+    return constructBinaryExpression(element);
   },
 );
 

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -670,25 +670,27 @@ const statement = rule(
       element.value = unit.rule(state);
     }
 
-    state.recover(() => {
-      const token = state.token;
-      if (!token) {
-        return RecoveryResult.Continue;
-      }
-      if (tokenMatcher(state.token, tokens.Semicolon)) {
-        return RecoveryResult.RecoverNext;
-      } else if (
-        state.canConsumeFirst(statement.first()) ||
-        performAssignmentLookahead(state)
-      ) {
-        return RecoveryResult.Recover;
-      }
-      return RecoveryResult.Continue;
-    });
+    state.recover(() => performRecovery(state));
 
     return element;
   },
 );
+
+function performRecovery(state: ParserState): RecoveryResult {
+  const token = state.token;
+  if (!token) {
+    return RecoveryResult.Continue;
+  }
+  if (tokenMatcher(state.token, tokens.Semicolon)) {
+    return RecoveryResult.RecoverNext;
+  } else if (
+    state.canConsumeFirst(statement.first()) ||
+    performAssignmentLookahead(state)
+  ) {
+    return RecoveryResult.Recover;
+  }
+  return RecoveryResult.Continue;
+}
 
 const unit = orRule<ast.Unit>(
   () => allocateStatement,

--- a/packages/language/src/parser/preprocessor-parser.ts
+++ b/packages/language/src/parser/preprocessor-parser.ts
@@ -9,7 +9,11 @@
  *
  */
 
-import { generateTokenErrorName, ParserState } from "./parser-state";
+import {
+  generateTokenErrorName,
+  ParserState,
+  RecoveryResult,
+} from "./parser-state";
 import * as ast from "../syntax-tree/ast";
 import {
   constructBinaryExpression,
@@ -282,7 +286,8 @@ export function commonStatement(
     }
   }
   // Recover at the end of a statement, noop if not in error case
-  state.recover();
+  const lastToken = state.token || state.last;
+  state.recover(() => performRecovery(state, lastToken));
   if (endStmt) {
     if (!options.endPercent && startPercent) {
       // We have a starting percent, but don't require it for the %END statement
@@ -310,6 +315,29 @@ export function commonStatement(
 
   statement.value = unit;
   return statement;
+}
+
+function performRecovery(
+  state: ParserState,
+  lastToken?: t.Token,
+): RecoveryResult {
+  // If the preprocessor parser encounters an error, it should attempt to:
+  // 1. Find a semicolon at the current line, and skip that token
+  // 2. Find a percent sign at the current line, and stop
+  // 3. If neither is found, skip to the next line
+  const currentLine = lastToken?.startLine ?? 0;
+  const currentToken = state.token;
+  if (!currentToken) {
+    return RecoveryResult.Continue;
+  }
+  if (currentToken.startLine !== currentLine) {
+    return RecoveryResult.Recover;
+  } else if (tokenMatcher(currentToken, t.Percent)) {
+    return RecoveryResult.Recover;
+  } else if (tokenMatcher(currentToken, t.Semicolon)) {
+    return RecoveryResult.RecoverNext;
+  }
+  return RecoveryResult.Continue;
 }
 
 function callStatement(state: ParserState): ast.CallStatement {

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -13,7 +13,7 @@ import { tokenMatcher } from "chevrotain";
 import { TextDocuments } from "../language-server/text-documents";
 import { Diagnostic, diagnosticFromCode } from "../language-server/types";
 import { preprocessorParse } from "../parser/parser-entry";
-import { preprocessorParserState } from "../parser/parser-state";
+import { ParserState } from "../parser/parser-state";
 import { tokenize } from "../parser/tokenizer";
 import { Token } from "../parser/tokens";
 import * as ast from "../syntax-tree/ast";
@@ -2189,7 +2189,7 @@ async function runInclude(
         uri,
       );
       const tokenizeResult = tokenize(processedContent, uri);
-      const subState = preprocessorParserState(tokenizeResult.tokens);
+      const subState = new ParserState(tokenizeResult.tokens);
       const subProgram = preprocessorParse(subState);
       subProgram.diagnostics.push(...tokenizeResult.diagnostics);
       const result = generateInstructions(subProgram.statements);

--- a/packages/language/src/preprocessor/pli-lexer.ts
+++ b/packages/language/src/preprocessor/pli-lexer.ts
@@ -26,7 +26,7 @@ import { EvaluationResults, runInstructions } from "./instruction-interpreter";
 import { createIncludeInstruction, InstructionNode } from "./instructions";
 import { CstNodeKind } from "../syntax-tree/cst";
 import { initLexer, tokenize } from "../parser/tokenizer";
-import { preprocessorParserState } from "../parser/parser-state";
+import { ParserState } from "../parser/parser-state";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { getDefaultCompilerOptions } from "./compiler-options/options";
 import { CompilerOptions } from "./compiler-options/options-pli";
@@ -73,7 +73,7 @@ export class PliLexer {
         uri,
       );
       const tokenizeResult = tokenize(textWithoutMargins, uri);
-      const state = preprocessorParserState(tokenizeResult.tokens);
+      const state = new ParserState(tokenizeResult.tokens);
       // Do a full parsing of the input text to extract all *local* statements
       const {
         statements,

--- a/packages/language/src/typesystem/primitive-type-builder.ts
+++ b/packages/language/src/typesystem/primitive-type-builder.ts
@@ -726,6 +726,7 @@ export class DefaultPrimitiveTypeBuilder implements PrimitiveTypeBuilder {
       case ast.DefaultAttribute.EVENT: //no documentation found
       case ast.DefaultAttribute.EXCLUSIVE: //no documentation found
       case ast.DefaultAttribute.IRREDUCIBLE: //no documentation found, but @see https://www.ibm.com/support/pages/apar/PI26521
+      case ast.DefaultAttribute.REDUCIBLE: //no documentation found
       case ast.DefaultAttribute.MEMBER: //no documentation found
       case ast.DefaultAttribute.NATIVE: //no documentation found
       case ast.DefaultAttribute.NOINIT: //no documentation found
@@ -740,41 +741,6 @@ export class DefaultPrimitiveTypeBuilder implements PrimitiveTypeBuilder {
       case ast.DefaultAttribute.RESERVED: //@see https://www.ibm.com/docs/en/epfz/6.1.0?topic=declarations-reserved-attribute
       case ast.DefaultAttribute.STRUCTURE: //@see https://www.ibm.com/docs/en/epfz/6.1.0?topic=definitions-defining-typed-structures-unions
       case ast.DefaultAttribute.VARIABLE: //@see https://www.ibm.com/docs/en/epfz/6.1.0?topic=attributes-variable-attribute
-      case ast.DefaultAttribute.BACKWARDS:
-      case ast.DefaultAttribute.BYADDR:
-      case ast.DefaultAttribute.BYVALUE:
-      case ast.DefaultAttribute.CONDITION:
-      case ast.DefaultAttribute.CONSTANT:
-      case ast.DefaultAttribute.DIMACROSS:
-      case ast.DefaultAttribute.EVENT:
-      case ast.DefaultAttribute.EXCLUSIVE:
-      case ast.DefaultAttribute.INONLY:
-      case ast.DefaultAttribute.INOUT:
-      case ast.DefaultAttribute.IRREDUCIBLE:
-      case ast.DefaultAttribute.REDUCIBLE:
-      case ast.DefaultAttribute.KEYED:
-      case ast.DefaultAttribute.LABEL:
-      case ast.DefaultAttribute.LIST:
-      case ast.DefaultAttribute.MEMBER:
-      case ast.DefaultAttribute.NATIVE:
-      case ast.DefaultAttribute.NOINIT:
-      case ast.DefaultAttribute.NONNATIVE:
-      case ast.DefaultAttribute.NOSCAN:
-      case ast.DefaultAttribute.NULLINIT:
-      case ast.DefaultAttribute.OPTIONAL:
-      case ast.DefaultAttribute.OPTIONS:
-      case ast.DefaultAttribute.OUTONLY:
-      case ast.DefaultAttribute.PARAMETER:
-      case ast.DefaultAttribute.POSITION:
-      case ast.DefaultAttribute.PRINT:
-      case ast.DefaultAttribute.RANGE:
-      case ast.DefaultAttribute.RESCAN:
-      case ast.DefaultAttribute.RESERVED:
-      case ast.DefaultAttribute.SCAN:
-      case ast.DefaultAttribute.STRUCTURE:
-      case ast.DefaultAttribute.TRANSIENT:
-      case ast.DefaultAttribute.UNION:
-      case ast.DefaultAttribute.VARIABLE:
       case ast.DefaultAttribute.CHARGRAPHIC:
       case ast.DefaultAttribute.JSONIGNORE:
       case ast.DefaultAttribute.JSONNAME:

--- a/packages/language/test/fourslash/parser/recover-after-multi-token-lookahead.ts
+++ b/packages/language/test/fourslash/parser/recover-after-multi-token-lookahead.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+//// DEFINE <|TEST|>;
+
+// Verify that the parser displays an error message at the position of the token TEST
+// Indirectly ensures that the parser recovers without an infinite loop.
+verify.expectDiagnosticsAt("TEST", {
+  severity: constants.Severity.S,
+});

--- a/packages/language/test/parser/pli-preprocessor-parser-state.test.ts
+++ b/packages/language/test/parser/pli-preprocessor-parser-state.test.ts
@@ -11,13 +11,13 @@
 
 import { describe, expect, test } from "vitest";
 import { PreprocessorTokens } from "../../src/preprocessor/pli-preprocessor-tokens";
-import { preprocessorParserState } from "../../src/parser/parser-state";
+import { ParserState } from "../../src/parser/parser-state";
 import { URI } from "../../src/utils/uri";
 import { tokenize } from "../../src/parser/tokenizer";
 
 function parserStateFromText(text: string, uri: URI) {
   const result = tokenize(text, uri);
-  const state = preprocessorParserState(result.tokens);
+  const state = new ParserState(result.tokens);
   return state;
 }
 

--- a/packages/language/test/rules.test.ts
+++ b/packages/language/test/rules.test.ts
@@ -13,13 +13,12 @@ import { TokenType } from "chevrotain";
 import { describe, expect, test } from "vitest";
 import { orRule, rule, sequence } from "../src/parser/parser-types";
 import { SyntaxNode } from "../src/syntax-tree/ast";
-import { ParserState, ParserStateMode } from "../src/parser/parser-state";
+import { ParserState, RecoveryResult } from "../src/parser/parser-state";
 import {
   createTokenInstance as originalCreateTokenInstance,
   Token,
 } from "../src/parser/tokens";
 import { createToken } from "../src/parser/token-type-factory";
-import { recover } from "../src/parser/parser";
 
 namespace Tokens {
   export const ID = createToken({
@@ -123,7 +122,11 @@ namespace Rules {
       while (!state.eof) {
         const stmt = statement.rule(state);
         stmt && program.push(stmt);
-        recover(state, () => state.canConsumeFirst(statement.first()));
+        state.recover(() => {
+          return state.canConsumeFirst(statement.first())
+            ? RecoveryResult.Recover
+            : RecoveryResult.Continue;
+        });
       }
       return program;
     },
@@ -132,16 +135,13 @@ namespace Rules {
 
 describe("Rule tests", () => {
   test("Simple rule set", () => {
-    const state = new ParserState(
-      [
-        TokenInstances.Person,
-        TokenInstances.IdBob,
-        TokenInstances.Hello,
-        TokenInstances.IdAlice,
-        TokenInstances.Exclamation,
-      ],
-      ParserStateMode.Final,
-    );
+    const state = new ParserState([
+      TokenInstances.Person,
+      TokenInstances.IdBob,
+      TokenInstances.Hello,
+      TokenInstances.IdAlice,
+      TokenInstances.Exclamation,
+    ]);
 
     const result = Rules.program.rule(state)!;
 
@@ -153,10 +153,10 @@ describe("Rule tests", () => {
   });
 
   test("Keyword IDs", () => {
-    const state = new ParserState(
-      [TokenInstances.Person, TokenInstances.IdPerson],
-      ParserStateMode.Final,
-    );
+    const state = new ParserState([
+      TokenInstances.Person,
+      TokenInstances.IdPerson,
+    ]);
 
     const result = Rules.program.rule(state)!;
 
@@ -166,10 +166,7 @@ describe("Rule tests", () => {
   });
 
   test("Error", () => {
-    const state = new ParserState(
-      [TokenInstances.IdBob],
-      ParserStateMode.Final,
-    );
+    const state = new ParserState([TokenInstances.IdBob]);
 
     Rules.program.rule(state)!;
 


### PR DESCRIPTION
I've noticed that we don't recover correctly if the parser fails during the lookahead of a new statement. I.e. with the input:

```
DEFINE TEST;
```

The parser expects either `ORDINAL`, `STRUCTURE` or `ALIAS`. If none of them appear, the parser does not advance, and instantly recovers, which leads to an infinite loop in the parser.

This change adjusts the recovery process to always skip at least one token, which ensures that we don't get caught in a loop. It also moves the recovery logic outside of the parser state.