### PR TITLE
Improve caching of program configs

### DIFF
--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -86,6 +86,10 @@ export interface CompilationUnit {
   readonly services: CompilationServices;
   readonly programConfig: ProgramConfig | undefined;
   readonly processGroup: ProcessGroup | undefined;
+  /**
+   * Resets all caches associated with this compilation unit.
+   */
+  reset(): void;
 }
 
 export interface CompilationServices {
@@ -138,6 +142,10 @@ export async function createCompilationUnit(
     }),
     inferer: new DefaultTypeInferer(),
   };
+  // Cache for programConfig and processGroup to avoid repeated lookups
+  // They cannot change during the lifetime of a compilation unit anyway
+  let cachedProgramConfig: ProgramConfig | undefined | null = null;
+  let cachedProcessGroup: ProcessGroup | undefined | null = null;
   const unit: CompilationUnit = {
     uri,
     services,
@@ -171,15 +179,36 @@ export async function createCompilationUnit(
     rootScope: await getBuiltinScope(uri),
     rootPreprocessorScope: await getRootPreprocessorScope(uri),
     get programConfig() {
-      return PluginConfigurationProviderInstance.getProgramConfig(uri);
+      if (cachedProgramConfig !== null) {
+        return cachedProgramConfig;
+      }
+      cachedProgramConfig =
+        PluginConfigurationProviderInstance.getProgramConfig(uri);
+      return cachedProgramConfig;
     },
     get processGroup() {
-      if (this.programConfig) {
-        return PluginConfigurationProviderInstance.getProcessGroupConfig(
-          this.programConfig.pgroup,
-        );
+      if (cachedProcessGroup !== null) {
+        return cachedProcessGroup;
       }
-      return undefined;
+      if (this.programConfig) {
+        cachedProcessGroup =
+          PluginConfigurationProviderInstance.getProcessGroupConfig(
+            this.programConfig.pgroup,
+          );
+      } else {
+        cachedProcessGroup = undefined;
+      }
+      return cachedProcessGroup;
+    },
+    reset() {
+      services.files.clear();
+      services.typeCache.clear();
+      unit.statementOrderCache.clear();
+      unit.referencesCache.clear();
+      unit.scopeCaches.clear();
+      unit.diagnostics.clear();
+      cachedProcessGroup = null;
+      cachedProgramConfig = null;
     },
   };
 

--- a/packages/language/src/workspace/lifecycle.ts
+++ b/packages/language/src/workspace/lifecycle.ts
@@ -32,14 +32,10 @@ export async function lifecycle(
   document: TextDocument,
   cancellation: CancellationToken,
 ): Promise<void> {
-  compilationUnit.services.files.clear();
-  compilationUnit.services.typeCache.clear();
-  compilationUnit.statementOrderCache.clear();
-  compilationUnit.referencesCache.clear();
-  compilationUnit.scopeCaches.clear();
-  compilationUnit.diagnostics.clear();
+  compilationUnit.reset();
   await interruptAndCheck(cancellation);
   await tokenize(compilationUnit, document);
+  await interruptAndCheck(cancellation);
   parse(compilationUnit);
   await interruptAndCheck(cancellation);
   generateSymbolTable(compilationUnit);


### PR DESCRIPTION
This change caches the program config and process group config in the compiler unit to ensure that we don't have to look it up all the time. Especially during validation, which has to access those configs quite often. This should speed up performance for all use cases, but especially when dealing with large files.