### PR TITLE
Fix disappearing rulers

### DIFF
--- a/packages/vscode-extension/src/extension/decorators.ts
+++ b/packages/vscode-extension/src/extension/decorators.ts
@@ -98,8 +98,9 @@ export namespace SkippedCodeDecorator {
 export namespace MarginIndicatorDecorator {
   const marginIndicatorRangesByUri = new Map<
     string,
-    { m: number; n: number }
+    { m: number; n: number; active: boolean }
   >();
+  let revalidate = false;
 
   export function register(client: LanguageClient, settings: Settings): void {
     client.onNotification(
@@ -108,13 +109,24 @@ export namespace MarginIndicatorDecorator {
         marginIndicatorRangesByUri.set(params.uri, {
           m: params.m,
           n: params.n,
+          active: true,
         });
         updateRulers(settings);
       },
     );
 
     vscode.workspace.onDidCloseTextDocument((doc) => {
-      marginIndicatorRangesByUri.delete(doc.uri.toString());
+      const margins = marginIndicatorRangesByUri.get(doc.uri.toString());
+      if (!margins) return;
+      margins.active = false;
+      revalidate = true; // Force subsequent update
+      updateRulers(settings);
+    });
+
+    vscode.workspace.onDidOpenTextDocument((doc) => {
+      const margins = marginIndicatorRangesByUri.get(doc.uri.toString());
+      if (!margins) return;
+      margins.active = true;
       updateRulers(settings);
     });
   }
@@ -137,7 +149,10 @@ export namespace MarginIndicatorDecorator {
     // The left ruler should be left of the column number (-1), whereas
     // the right ruler should be right of the column number.
     if (settings.marginIndicatorRulers === "automatic") {
-      for (const margins of marginIndicatorRangesByUri.values()) {
+      const activeMargins = Array.from(
+        marginIndicatorRangesByUri.values(),
+      ).filter((m) => m.active);
+      for (const margins of activeMargins) {
         if (!rulers.includes(margins.m - 1)) {
           rulers.push(margins.m - 1);
         }
@@ -149,12 +164,13 @@ export namespace MarginIndicatorDecorator {
       rulers = [1, 72];
     }
 
-    if (rulers.length === existingRulers.length) {
+    if (rulers.length === existingRulers.length && !revalidate) {
       // If the rulers are the same, no need to update
       if (rulers.every((r, i) => r === existingRulers[i])) {
         return;
       }
     }
+    revalidate = false;
     config.update("rulers", rulers, vscode.ConfigurationTarget.Global, true);
   }
 }


### PR DESCRIPTION
Fixes https://github.com/zowe/zowe-pli-language-support/issues/511 12

Fixes two issues with the rulers:
1. Under the assumption that the LS will resend the margin information, it got removed when a document is closed. However, if the document is still in the compilation unit, it will not be resend anymore until changed. The new implementation rather deactivates the rulers for this document but keeps them in storage. 
2. There is a race condition when writing and reading configurations simultaneously. When browsing through files, documents are closed and opened quickly enough. The opened document still sees the stale config and may not set new ruler information. Rather than relying on a complex sync, we just force a reset after a document was disabled. The rulers are calculated on every update, which arrive in order, so this simpler solution does the job.

The change also makes sure that an update is only triggered when a document was opened/closed that actually had margin information.