### PR TITLE
Fix misplaced diagnostics in compiler options with plugin configs

### DIFF
--- a/packages/language/src/preprocessor/compiler-options-processor.ts
+++ b/packages/language/src/preprocessor/compiler-options-processor.ts
@@ -67,7 +67,9 @@ export class CompilerOptionsProcessor {
       mergedAbstractOptions = {
         options: [...programConfig.abstractOptions.options],
         tokens: [],
-        issues: [],
+        issues: programConfig.issues
+          ? programConfig.issues.map((diag) => ({ ...diag }))
+          : [],
       };
     }
 
@@ -81,7 +83,7 @@ export class CompilerOptionsProcessor {
       if (mergedAbstractOptions) {
         mergedAbstractOptions.options.push(...srcAbstractOptions.options);
         mergedAbstractOptions.tokens.push(...srcAbstractOptions.tokens);
-        mergedAbstractOptions.issues = srcAbstractOptions.issues;
+        mergedAbstractOptions.issues.push(...srcAbstractOptions.issues);
       } else {
         mergedAbstractOptions = srcAbstractOptions;
       }
@@ -99,7 +101,7 @@ export class CompilerOptionsProcessor {
       //  this should be removed once we break up the translation process to avoid this issue
 
       //  shave off the issues that are already present in the process group config
-      const issueCount = programConfig?.issueCount;
+      const issueCount = programConfig?.issues?.length;
       if (issueCount) {
         if (ranges.length === 0) {
           // no *PROCESS to attach to, slice them off instead
@@ -107,6 +109,9 @@ export class CompilerOptionsProcessor {
             compilerOptionResult.issues.slice(issueCount);
         } else {
           const range = ranges[0];
+          const sourceCompilerOptionsUri = compilerOptionResult.issues.find(
+            (issue) => issue.uri !== undefined,
+          )?.uri;
           // update just these first 'issueCount' issues to report on *PROCESS
           for (let i = 0; i < issueCount; i++) {
             if (i < compilerOptionResult.issues.length) {
@@ -117,6 +122,7 @@ export class CompilerOptionsProcessor {
                   range.start + CompilerOptionsProcessor.PROCESS_TOKEN_LENGTH,
               };
               issue.message = `PLI Plugin Config: ${issue.message}`;
+              issue.uri = sourceCompilerOptionsUri;
             } else {
               // leave the rest alone
               break;

--- a/packages/language/src/preprocessor/compiler-options/parser.ts
+++ b/packages/language/src/preprocessor/compiler-options/parser.ts
@@ -315,7 +315,7 @@ export function parseAbstractCompilerOptions(
       uri: uri?.toString(),
       message: parserError.message,
       range: tokenToRange(errorToken),
-      severity: 1,
+      severity: Severity.E,
     });
   }
   return {

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -11,6 +11,7 @@
 
 import { minimatch } from "minimatch";
 import { Diagnostic } from "vscode-languageserver-types";
+import { Diagnostic as CompilationUnitDiagnostic } from "../language-server/types";
 import { CompilerOptionResult } from "../preprocessor/compiler-options/options";
 import {
   AbstractCompilerOptions,
@@ -53,7 +54,7 @@ export interface ProgramConfig {
    * Number of issues found in the pli-options for this program config (which generate compiler options)
    * Used to avoid duplicate issue reporting later on when running translation in a program context
    */
-  issueCount?: number;
+  issues?: CompilationUnitDiagnostic[];
 }
 
 interface SerializedProgramConfig {
@@ -564,7 +565,7 @@ export class PluginConfigurationProvider {
         );
       }
       programConfig.abstractOptions = abstractOptions;
-      programConfig.issueCount = translatedOptions.issues.length;
+      programConfig.issues = translatedOptions.issues;
     }
   }
 

--- a/packages/language/test/fourslash/preprocessor/compiler-options/diagnostic-placement.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/diagnostic-placement.ts
@@ -1,0 +1,60 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////         "name": "default",
+////         "compiler-options": [
+////             "AGGREGATE",
+////             "MARGINS(2,7)"
+////         ],
+////         "pli-options": {
+////            "SYSPARM": "'from process group'",
+////            "SYSTEM": "MVS",
+////            "MARGINS": "2,72"
+////         },
+////         "libs": [
+////             "cpy"
+////         ],
+////         "include-extensions": [
+////             ".pli",
+////             ".cpy",
+////             ".inc"
+////         ]
+////         }
+////     ]
+//// }
+
+// @filename: main.pli
+// @wrap: process
+////*<|1:PROCESS|> NOPP;
+////*PROCESS <|2:pp|>(cics(''));
+////*PROCESS pp(<|3:include|>   /*Error4: no validation */
+//// MPPROG: PROCEDURE OPTIONS (MAIN);
+////    DCL TRUE BIT(1) INIT(1);
+//// END MPPROG;
+
+verify.expectDiagnosticsAt(1, {
+  message:
+    "PLI Plugin Config: " +
+    code.CompilerOptions.DupeOptionIssue.message("MARGINS"),
+});
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.MutexOptionIssue.message("PP"),
+});
+verify.expectDiagnosticsAt(3, {
+  severity: constants.Severity.E,
+  message: "Expecting token of type --> parenClose <-- but found --> '' <--",
+});


### PR DESCRIPTION
Fixes https://github.com/zowe/zowe-pli-language-support/issues/524 1

This error only occurs if there are diagnostics originating in the plugin configs. In this case, the `issueCount` in the programConfig might override the properties in the diagnostics of the source file. Hence, the source file diagnostics are misplaced and the config diagnostics are lost. 

The fix
1. copies the diagnostics from the config because we are changing their properties,
2. shows the config diagnostics at the first `*PROCESS` again,
3. and sets the correct severity for parser errors in the compiler options.

Also added a test to check correct placement of the diagnostics in this constellation.

On a side note: Is it (still) necessary to maintain both `compiler-options` and `pli-options` in the plugin config? For me, this was just another layer of confusion. If not, we should maybe settle on the more convenient syntax and drop the other one.