### PR TITLE
Fix procedure includes

### DIFF
--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2319,7 +2319,7 @@ async function runInclude(
       uri,
     });
     context.diagnostics.push(...cachedResult.diagnostics);
-    for (const [key, value] of Object.entries(cachedResult.result.procedures)) {
+    for (const [key, value] of cachedResult.result.procedures.entries()) {
       context.procedures.set(key, value);
     }
     const newContext: InterpreterContext = {

--- a/packages/language/test/fourslash/preprocessor/include/call-proc-from-other-file.ts
+++ b/packages/language/test/fourslash/preprocessor/include/call-proc-from-other-file.ts
@@ -1,0 +1,24 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: cpy/lib.pli
+//// %TEST_PROC: PROC (INPUT) STATEMENT;
+////   ANS(INPUT || " OUTPUT");
+//// %END;
+//// %ACT TEST_PROC;
+
+// @filename: main.pli
+//// %INCLUDE LIB;
+//// TEST_PROC(TEST);
+
+preprocessor.expectTokens("TEST OUTPUT");


### PR DESCRIPTION
Fixes a minor oversight in the instruction interpreter, which prevented procedures from included files to be available in their including files.