### PR TITLE
Fix preprocessor builtins path

### DIFF
--- a/packages/language/src/workspace/builtins.ts
+++ b/packages/language/src/workspace/builtins.ts
@@ -897,7 +897,7 @@ export const BuiltinsTextDocument = TextDocument.create(
 );
 
 export const BuiltinsMacroFile = "builtins-macro.pli";
-export const BuiltinsMacroUri = `${BuiltinsUriSchema}:/${BuiltinsMacroFile}.pli`;
+export const BuiltinsMacroUri = `${BuiltinsUriSchema}:/${BuiltinsMacroFile}`;
 export const BuiltinsMacro = ` /* Preprocessor built-ins */
  COLLATE: PROC RETURNS(); END;
  COMMENT: PROC RETURNS(); END;


### PR DESCRIPTION
Fixes a minor bug that prevented opening the macro builtins file.