### PR TITLE
Consolidate lifecycle diagnostics

### DIFF
--- a/packages/language/src/preprocessor/pli-lexer.ts
+++ b/packages/language/src/preprocessor/pli-lexer.ts
@@ -19,7 +19,6 @@ import {
 } from "./compiler-options-processor";
 import { CompilationUnit } from "../workspace/compilation-unit";
 import { Reference, Statement } from "../syntax-tree/ast";
-import { Diagnostic } from "../language-server/types";
 import { Token } from "../parser/tokens";
 import { generateInstructions } from "./instruction-generator";
 import { EvaluationResults, runInstructions } from "./instruction-interpreter";
@@ -30,10 +29,10 @@ import { ParserState } from "../parser/parser-state";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { getDefaultCompilerOptions } from "./compiler-options/options";
 import { CompilerOptions } from "./compiler-options/options-pli";
+import { DiagnosticCategory } from "../validation/diagnostics-store";
 
 export interface LexerResult {
   all: Token[];
-  diagnostics: Diagnostic[];
   compilerOptions: CompilerOptionsProcessorResult;
   statements: Statement[];
   evaluationResults: EvaluationResults;
@@ -66,7 +65,6 @@ export class PliLexer {
     unit.compilerOptions = opts;
     initLexer(opts);
     unit.instructionCache.update(opts);
-    const allDiagnostics: Diagnostic[] = [];
     const instruction = unit.instructionCache.get(uri, inputText, () => {
       const textWithoutMargins = this.marginsProcessor.processMargins(
         compilerOptionsResult,
@@ -89,8 +87,11 @@ export class PliLexer {
         result,
       };
     });
-    allDiagnostics.push(...instruction.diagnostics);
-    allDiagnostics.push(...this.marginsProcessor.issues);
+    unit.diagnostics.addAll(DiagnosticCategory.Lexer, instruction.diagnostics);
+    unit.diagnostics.addAll(
+      DiagnosticCategory.Lexer,
+      this.marginsProcessor.issues,
+    );
 
     const incAfter = compilerOptionsResult.result?.options.incAfter;
     if (incAfter?.process) {
@@ -114,11 +115,18 @@ export class PliLexer {
     if (compilerOptionsResult.result) {
       instruction.tokens.unshift(...compilerOptionsResult.result.tokens);
     }
-    allDiagnostics.push(...output.errors);
+    const uriString = uri.toString();
+    unit.diagnostics.addAll(DiagnosticCategory.Lexer, output.errors);
+    unit.diagnostics.addAll(
+      DiagnosticCategory.CompilerOptions,
+      (compilerOptionsResult.result?.issues ?? []).filter(
+        (e) => e.uri === uriString,
+      ),
+    );
+
     return {
       all: output.all,
       compilerOptions: compilerOptionsResult,
-      diagnostics: allDiagnostics,
       statements: [...instruction.statements, ...output.statements],
       evaluationResults: output.evaluationResults,
       tokenReferences: output.references,

--- a/packages/language/src/workspace/lifecycle.ts
+++ b/packages/language/src/workspace/lifecycle.ts
@@ -63,15 +63,6 @@ export async function tokenize(
   compilationUnit.preprocessorAst.statements = result.statements;
   compilationUnit.preprocessorEvaluationResults = result.evaluationResults;
   compilationUnit.referencesCache.addAll(result.tokenReferences);
-  const uri = compilationUnit.uri.toString();
-  compilationUnit.diagnostics.addAll(
-    DiagnosticCategory.Lexer,
-    result.diagnostics,
-  );
-  compilationUnit.diagnostics.addAll(
-    DiagnosticCategory.CompilerOptions,
-    (result.compilerOptions.result?.issues ?? []).filter((e) => e.uri === uri),
-  );
   return result;
 }
 

--- a/packages/language/test/parser/pli-lexer.test.ts
+++ b/packages/language/test/parser/pli-lexer.test.ts
@@ -34,12 +34,9 @@ describe("PL/1 Lexer", () => {
     tokenizeWithErrors = async (text: string) => {
       const uri = URI.file("/test/test.pli");
       const document = TextDocument.create(uri.toString(), "pli", 0, text);
-      const { diagnostics } = await lexer.tokenize(
-        await createCompilationUnit(uri),
-        document,
-        uri,
-      );
-      return diagnostics.map((e) => e.message);
+      const unit = await createCompilationUnit(uri);
+      await lexer.tokenize(unit, document, uri);
+      return unit.diagnostics.getAll().map((e) => e.message);
     };
   });
 


### PR DESCRIPTION
Analysis and suggestions for https://github.com/zowe/zowe-pli-language-support/issues/468

There are currently seven diagnostic categories. Some of these add entries directly to the diagnostic store, while others use an acceptor pattern. This is reasonable, as different tasks can benefit from different strategies, and we want to keep both the lexer and parser as straightforward as possible. I also recommend keeping the parser’s state decoupled for now.

Hence, I only suggest moving responsibility for the lexer diagnostics into the pli-lexer to streamline the lifecycle. What do you think?

<img width="666" height="272" alt="image" src="https://github.com/user-attachments/assets/b010cf09-ac2a-4bf2-9a24-fa36baef1ae3" />

