### PR TITLE
Use one mutex per compilation unit

### DIFF
--- a/packages/language/src/language-server/commands.ts
+++ b/packages/language/src/language-server/commands.ts
@@ -11,65 +11,60 @@
 
 import { URI } from "vscode-uri";
 import { FileSystemProviderInstance } from "../workspace/file-system-provider";
-import { Mutex } from "../workspace/mutex";
 import { PluginConfigurationProviderInstance } from "../workspace/plugin-configuration-provider";
 import { ExecuteCommandParams } from "vscode-languageserver";
 import { UriUtils } from "../utils/uri";
 import { PluginConfiguration } from "./constants";
 
 export async function commandResolveInclude(params: ExecuteCommandParams) {
-  return Mutex.run(async () => {
-    const [uri, content] = params.arguments as string[];
-    try {
-      await FileSystemProviderInstance.writeFile(URI.parse(uri), content);
-    } catch (err) {
-      console.error("Failed to write proc_grps.json:", err);
-    }
-  });
+  const [uri, content] = params.arguments as string[];
+  try {
+    await FileSystemProviderInstance.writeFile(URI.parse(uri), content);
+  } catch (err) {
+    console.error("Failed to write proc_grps.json:", err);
+  }
 }
 
 export async function commandCreateConfig(params: ExecuteCommandParams) {
-  return Mutex.run(async () => {
-    const workspaceFolderUri = URI.parse(
-      PluginConfigurationProviderInstance.getWorkspacePath(),
+  const workspaceFolderUri = URI.parse(
+    PluginConfigurationProviderInstance.getWorkspacePath(),
+  );
+  if (!workspaceFolderUri || !params.arguments) {
+    return;
+  }
+  try {
+    const entryUri = params.arguments[0];
+    await FileSystemProviderInstance.writeFile(
+      UriUtils.joinPath(
+        workspaceFolderUri,
+        PluginConfiguration.PROGRAM_FILE_PATH,
+      ),
+      JSON.stringify(
+        {
+          ...PluginConfiguration.DEFAULT_PROGRAM_FILE_CONTENT,
+          pgms: [
+            {
+              ...PluginConfiguration.DEFAULT_PROGRAM_FILE_CONTENT.pgms[0],
+              program: entryUri,
+            },
+          ],
+        },
+        null,
+        2,
+      ),
     );
-    if (!workspaceFolderUri || !params.arguments) {
-      return;
-    }
-    try {
-      const entryUri = params.arguments[0];
-      await FileSystemProviderInstance.writeFile(
-        UriUtils.joinPath(
-          workspaceFolderUri,
-          PluginConfiguration.PROGRAM_FILE_PATH,
-        ),
-        JSON.stringify(
-          {
-            ...PluginConfiguration.DEFAULT_PROGRAM_FILE_CONTENT,
-            pgms: [
-              {
-                ...PluginConfiguration.DEFAULT_PROGRAM_FILE_CONTENT.pgms[0],
-                program: entryUri,
-              },
-            ],
-          },
-          null,
-          2,
-        ),
-      );
-      await FileSystemProviderInstance.writeFile(
-        UriUtils.joinPath(
-          workspaceFolderUri,
-          PluginConfiguration.PROCESS_GROUP_FILE_PATH,
-        ),
-        JSON.stringify(
-          PluginConfiguration.DEFAULT_PROCESS_GROUP_FILE_CONTENT,
-          null,
-          2,
-        ),
-      );
-    } catch (err) {
-      console.error("Failed to create configuration: ", err);
-    }
-  });
+    await FileSystemProviderInstance.writeFile(
+      UriUtils.joinPath(
+        workspaceFolderUri,
+        PluginConfiguration.PROCESS_GROUP_FILE_PATH,
+      ),
+      JSON.stringify(
+        PluginConfiguration.DEFAULT_PROCESS_GROUP_FILE_CONTENT,
+        null,
+        2,
+      ),
+    );
+  } catch (err) {
+    console.error("Failed to create configuration: ", err);
+  }
 }

--- a/packages/language/src/language-server/connection-handler.ts
+++ b/packages/language/src/language-server/connection-handler.ts
@@ -9,14 +9,17 @@
  *
  */
 
-import { CompilationUnitHandler } from "../workspace/compilation-unit";
+import {
+  CompilationUnit,
+  CompilationUnitHandler,
+} from "../workspace/compilation-unit";
 import {
   CancellationToken,
   Connection,
   DocumentHighlight,
   TextDocumentSyncKind,
 } from "vscode-languageserver";
-import { URI, UriUtils } from "../utils/uri";
+import { URI } from "../utils/uri";
 import { definitionRequest } from "./definition-request";
 import { referencesRequest } from "./references-request";
 import { semanticTokenLegend, semanticTokens } from "./semantic-tokens";
@@ -57,6 +60,21 @@ export function startLanguageServer(connection: Connection): void {
   const compilationUnitHandler = new CompilationUnitHandler();
   compilationUnitHandler.listen(connection);
   let folders: WorkspaceFolder[] = [];
+
+  function withReadMutex<T>(
+    uri: string,
+    cb: (uri: URI, unit?: CompilationUnit) => Promise<T>,
+  ) {
+    const parsedUri = URI.parse(uri);
+    const compilationUnit =
+      compilationUnitHandler.getCompilationUnit(parsedUri);
+    if (!compilationUnit) {
+      return cb(parsedUri, undefined);
+    }
+    return compilationUnit.mutex.read(async () => {
+      return cb(parsedUri, compilationUnit);
+    });
+  }
 
   connection.onInitialize(async (params) => {
     // init the plugin config provider in reverse folder order, last plugin config encountered will take precedence
@@ -124,66 +142,53 @@ export function startLanguageServer(connection: Connection): void {
     compilationUnitHandler.finalize();
   });
   connection.onHover(async (params) => {
-    const uri = params.textDocument.uri;
     const position = params.position;
-    const parsedUri = URI.parse(uri);
-    const compilationUnit =
-      compilationUnitHandler.getCompilationUnit(parsedUri);
-    if (!compilationUnit) {
-      return null;
-    }
-    return compilationUnit.mutex.read(async () => {
-      const textDocument = compilationUnit.services.files.getDocument(uri);
+    return withReadMutex(
+      params.textDocument.uri,
+      async (uri, compilationUnit) => {
+        const textDocument = compilationUnit?.services.files.getDocument(uri);
 
-      if (!textDocument) {
-        return null;
-      }
+        if (!textDocument || !compilationUnit) {
+          return null;
+        }
 
-      const offset = textDocument.offsetAt(position);
-      const response = hoverRequest(compilationUnit, parsedUri, offset);
-      if (!response) {
-        return null;
-      }
+        const offset = textDocument.offsetAt(position);
+        const response = hoverRequest(compilationUnit, uri, offset);
+        if (!response) {
+          return null;
+        }
 
-      return hoverResponseToLSP(textDocument, response);
-    });
+        return hoverResponseToLSP(textDocument, response);
+      },
+    );
   });
   connection.onCompletion(async (params) => {
-    const uri = params.textDocument.uri;
     const position = params.position;
-    const parsedUri = URI.parse(uri);
-    const compilationUnit =
-      compilationUnitHandler.getCompilationUnit(parsedUri);
-    if (!compilationUnit) {
-      return [];
-    }
-    return compilationUnit.mutex.read(async () => {
-      const textDocument = compilationUnit.services.files.getDocument(uri);
-      if (textDocument) {
+    return withReadMutex(
+      params.textDocument.uri,
+      async (uri, compilationUnit) => {
+        const textDocument = compilationUnit?.services.files.getDocument(uri);
+        if (!textDocument || !compilationUnit) {
+          return [];
+        }
         const offset = textDocument.offsetAt(position);
-        const result = completionRequest(
-          compilationUnit,
-          parsedUri,
-          offset,
-        ).map((completionItem) =>
-          completionItemToLSP(textDocument, completionItem),
+        const result = completionRequest(compilationUnit, uri, offset).map(
+          (completionItem) => completionItemToLSP(textDocument, completionItem),
         );
 
         return result;
-      }
-      return [];
-    });
+      },
+    );
   });
   connection.onDefinition(async (params) => {
     const position = params.position;
-    const uri = URI.parse(params.textDocument.uri);
-    const compilationUnit = compilationUnitHandler.getCompilationUnit(uri);
-    if (!compilationUnit) {
-      return [];
-    }
-    return compilationUnit.mutex.read(async () => {
-      const textDocument = compilationUnit.services.files.getDocument(uri);
-      if (textDocument) {
+    return withReadMutex(
+      params.textDocument.uri,
+      async (uri, compilationUnit) => {
+        const textDocument = compilationUnit?.services.files.getDocument(uri);
+        if (!compilationUnit || !textDocument) {
+          return [];
+        }
         const offset = textDocument.offsetAt(position);
         const definition = definitionRequest(compilationUnit, uri, offset);
         const lspDefinitions: LocationLink[] = [];
@@ -203,28 +208,20 @@ export function startLanguageServer(connection: Connection): void {
           }
         }
         return lspDefinitions;
-      }
-      return [];
-    });
+      },
+    );
   });
   connection.onReferences(async (params) => {
-    const uri = params.textDocument.uri;
     const position = params.position;
-    const parsedUri = URI.parse(uri);
-    const compilationUnit =
-      compilationUnitHandler.getCompilationUnit(parsedUri);
-    if (!compilationUnit) {
-      return [];
-    }
-    return compilationUnit.mutex.read(async () => {
-      const textDocument = compilationUnit.services.files.getDocument(uri);
-      if (textDocument) {
+    return withReadMutex(
+      params.textDocument.uri,
+      async (uri, compilationUnit) => {
+        const textDocument = compilationUnit?.services.files.getDocument(uri);
+        if (!textDocument || !compilationUnit) {
+          return [];
+        }
         const offset = textDocument.offsetAt(position);
-        const definition = referencesRequest(
-          compilationUnit,
-          parsedUri,
-          offset,
-        );
+        const definition = referencesRequest(compilationUnit, uri, offset);
         const lspDefinitions: Location[] = [];
         for (const def of definition) {
           const doc = compilationUnit.services.files.getDocument(def.uri);
@@ -237,70 +234,58 @@ export function startLanguageServer(connection: Connection): void {
           }
         }
         return lspDefinitions;
-      }
-      return [];
-    });
+      },
+    );
   });
   connection.languages.semanticTokens.on(async (params) => {
-    const uri = params.textDocument.uri;
-    const compilationUnit = compilationUnitHandler.getCompilationUnit(
-      URI.parse(uri),
-    );
-    if (!compilationUnit) {
-      return {
-        data: [],
-      };
-    }
-    return compilationUnit.mutex.read(async () => {
-      const textDocument = compilationUnit.services.files.getDocument(uri);
-      if (textDocument) {
+    return withReadMutex(
+      params.textDocument.uri,
+      async (uri, compilationUnit) => {
+        const textDocument = compilationUnit?.services.files.getDocument(uri);
+        if (!compilationUnit || !textDocument) {
+          return {
+            data: [],
+          };
+        }
         return {
           data: semanticTokens(textDocument, compilationUnit),
         };
-      }
-      return {
-        data: [],
-      };
-    });
+      },
+    );
   });
   connection.onDocumentHighlight(async (params) => {
-    const uri = UriUtils.normalize(params.textDocument.uri);
     const position = params.position;
-    const parsedUri = URI.parse(uri);
-    const unit = compilationUnitHandler.getCompilationUnit(parsedUri);
-    if (!unit) {
-      return [];
-    }
-    return unit.mutex.read(async () => {
-      const textDocument = unit.services.files.getDocument(uri);
-      if (textDocument) {
+    return withReadMutex(
+      params.textDocument.uri,
+      async (uri, compilationUnit) => {
+        const textDocument = compilationUnit?.services.files.getDocument(uri);
+        if (!textDocument || !compilationUnit) {
+          return [];
+        }
         const offset = textDocument.offsetAt(position);
-        const definitions = getReferenceLocations(unit, parsedUri, offset);
+        const definitions = getReferenceLocations(compilationUnit, uri, offset);
         return definitions
-          .filter((e) => e.uri === uri)
+          .filter((e) => e.uri === uri.toString())
           .map((def) =>
             DocumentHighlight.create(rangeToLSP(textDocument, def.range)),
           );
-      }
-      return [];
-    });
+      },
+    );
   });
   connection.onRenameRequest(async (params) => {
-    const uri = params.textDocument.uri;
     const position = params.position;
-    const parsedUri = URI.parse(uri);
-    const unit = compilationUnitHandler.getCompilationUnit(parsedUri);
-    if (!unit) {
-      return null;
-    }
-    return unit.mutex.read(async () => {
-      const textDocument = unit.services.files.getDocument(uri);
-      if (textDocument) {
+    return withReadMutex(
+      params.textDocument.uri,
+      async (uri, compilationUnit) => {
+        const textDocument = compilationUnit?.services.files.getDocument(uri);
+        if (!textDocument || !compilationUnit) {
+          return null;
+        }
         const offset = textDocument.offsetAt(position);
-        const renameLocations = renameRequest(unit, parsedUri, offset);
+        const renameLocations = renameRequest(compilationUnit, uri, offset);
         const changes: Record<string, TextEdit[]> = {};
         for (const [key, locations] of Object.entries(renameLocations)) {
-          const textDocument = unit.services.files.getDocument(key);
+          const textDocument = compilationUnit.services.files.getDocument(key);
           if (textDocument) {
             changes[key] = locations.map(
               (location) =>
@@ -311,32 +296,24 @@ export function startLanguageServer(connection: Connection): void {
             );
           }
         }
-
-        return {
-          changes,
-        };
-      }
-
-      return null;
-    });
+        return { changes };
+      },
+    );
   });
   connection.onDocumentSymbol(async (params) => {
-    const uri = params.textDocument.uri;
-    const parsedUri = URI.parse(uri);
-    const unit = compilationUnitHandler.getCompilationUnit(parsedUri);
-    if (!unit) {
-      return [];
-    }
-    return unit.mutex.read(async () => {
-      const textDocument = unit.services.files.getDocument(uri);
-      if (textDocument) {
-        const requestResult = documentSymbolRequest(parsedUri, unit);
+    return withReadMutex(
+      params.textDocument.uri,
+      async (uri, compilationUnit) => {
+        const textDocument = compilationUnit?.services.files.getDocument(uri);
+        if (!textDocument || !compilationUnit) {
+          return [];
+        }
+        const requestResult = documentSymbolRequest(uri, compilationUnit);
         return requestResult.map((symbol) =>
           documentSymbolToLSP(textDocument, symbol),
         );
-      }
-      return [];
-    });
+      },
+    );
   });
   connection.onWorkspaceSymbol(async (params) => {
     return workspaceSymbolRequest(

--- a/packages/language/src/language-server/connection-handler.ts
+++ b/packages/language/src/language-server/connection-handler.ts
@@ -41,7 +41,6 @@ import { workspaceSymbolRequest } from "./workspace-symbol-request";
 import { PluginConfigurationProviderInstance } from "../workspace/plugin-configuration-provider";
 import { completionRequest } from "./completion/completion-request";
 import { hoverRequest } from "./hover-request";
-import { Mutex } from "../workspace/mutex";
 import { applyQuickFixes } from "./code-actions/apply-quick-fixes";
 import { applySourceActions } from "./code-actions/apply-source-actions";
 import { commandCreateConfig, commandResolveInclude } from "./commands";
@@ -125,15 +124,18 @@ export function startLanguageServer(connection: Connection): void {
     compilationUnitHandler.finalize();
   });
   connection.onHover(async (params) => {
-    return Mutex.read(async () => {
-      const uri = params.textDocument.uri;
-      const position = params.position;
-      const parsedUri = URI.parse(uri);
-      const compilationUnit =
-        compilationUnitHandler.getCompilationUnit(parsedUri);
-      const textDocument = compilationUnit?.services.files.getDocument(uri);
+    const uri = params.textDocument.uri;
+    const position = params.position;
+    const parsedUri = URI.parse(uri);
+    const compilationUnit =
+      compilationUnitHandler.getCompilationUnit(parsedUri);
+    if (!compilationUnit) {
+      return null;
+    }
+    return compilationUnit.mutex.read(async () => {
+      const textDocument = compilationUnit.services.files.getDocument(uri);
 
-      if (!textDocument || !compilationUnit) {
+      if (!textDocument) {
         return null;
       }
 
@@ -147,14 +149,17 @@ export function startLanguageServer(connection: Connection): void {
     });
   });
   connection.onCompletion(async (params) => {
-    return Mutex.read(async () => {
-      const uri = params.textDocument.uri;
-      const position = params.position;
-      const parsedUri = URI.parse(uri);
-      const compilationUnit =
-        compilationUnitHandler.getCompilationUnit(parsedUri);
-      const textDocument = compilationUnit?.services.files.getDocument(uri);
-      if (textDocument && compilationUnit) {
+    const uri = params.textDocument.uri;
+    const position = params.position;
+    const parsedUri = URI.parse(uri);
+    const compilationUnit =
+      compilationUnitHandler.getCompilationUnit(parsedUri);
+    if (!compilationUnit) {
+      return [];
+    }
+    return compilationUnit.mutex.read(async () => {
+      const textDocument = compilationUnit.services.files.getDocument(uri);
+      if (textDocument) {
         const offset = textDocument.offsetAt(position);
         const result = completionRequest(
           compilationUnit,
@@ -170,17 +175,20 @@ export function startLanguageServer(connection: Connection): void {
     });
   });
   connection.onDefinition(async (params) => {
-    return Mutex.read(async () => {
-      const position = params.position;
-      const uri = URI.parse(params.textDocument.uri);
-      const compilationUnit = compilationUnitHandler.getCompilationUnit(uri);
-      const textDocument = compilationUnit?.services.files.getDocument(uri);
-      if (textDocument && compilationUnit) {
+    const position = params.position;
+    const uri = URI.parse(params.textDocument.uri);
+    const compilationUnit = compilationUnitHandler.getCompilationUnit(uri);
+    if (!compilationUnit) {
+      return [];
+    }
+    return compilationUnit.mutex.read(async () => {
+      const textDocument = compilationUnit.services.files.getDocument(uri);
+      if (textDocument) {
         const offset = textDocument.offsetAt(position);
         const definition = definitionRequest(compilationUnit, uri, offset);
         const lspDefinitions: LocationLink[] = [];
         for (const def of definition) {
-          const doc = compilationUnit?.services.files.getDocument(def.uri);
+          const doc = compilationUnit.services.files.getDocument(def.uri);
           if (doc) {
             const range = rangeToLSP(doc, def.range);
             const sourceRange = def.source
@@ -200,14 +208,17 @@ export function startLanguageServer(connection: Connection): void {
     });
   });
   connection.onReferences(async (params) => {
-    return Mutex.read(async () => {
-      const uri = params.textDocument.uri;
-      const position = params.position;
-      const parsedUri = URI.parse(uri);
-      const compilationUnit =
-        compilationUnitHandler.getCompilationUnit(parsedUri);
-      const textDocument = compilationUnit?.services.files.getDocument(uri);
-      if (textDocument && compilationUnit) {
+    const uri = params.textDocument.uri;
+    const position = params.position;
+    const parsedUri = URI.parse(uri);
+    const compilationUnit =
+      compilationUnitHandler.getCompilationUnit(parsedUri);
+    if (!compilationUnit) {
+      return [];
+    }
+    return compilationUnit.mutex.read(async () => {
+      const textDocument = compilationUnit.services.files.getDocument(uri);
+      if (textDocument) {
         const offset = textDocument.offsetAt(position);
         const definition = referencesRequest(
           compilationUnit,
@@ -216,7 +227,7 @@ export function startLanguageServer(connection: Connection): void {
         );
         const lspDefinitions: Location[] = [];
         for (const def of definition) {
-          const doc = compilationUnit?.services.files.getDocument(def.uri);
+          const doc = compilationUnit.services.files.getDocument(def.uri);
           if (doc) {
             const range = rangeToLSP(doc, def.range);
             lspDefinitions.push({
@@ -231,13 +242,18 @@ export function startLanguageServer(connection: Connection): void {
     });
   });
   connection.languages.semanticTokens.on(async (params) => {
-    return Mutex.read(async () => {
-      const uri = params.textDocument.uri;
-      const compilationUnit = compilationUnitHandler.getCompilationUnit(
-        URI.parse(uri),
-      );
-      const textDocument = compilationUnit?.services.files.getDocument(uri);
-      if (textDocument && compilationUnit) {
+    const uri = params.textDocument.uri;
+    const compilationUnit = compilationUnitHandler.getCompilationUnit(
+      URI.parse(uri),
+    );
+    if (!compilationUnit) {
+      return {
+        data: [],
+      };
+    }
+    return compilationUnit.mutex.read(async () => {
+      const textDocument = compilationUnit.services.files.getDocument(uri);
+      if (textDocument) {
         return {
           data: semanticTokens(textDocument, compilationUnit),
         };
@@ -248,13 +264,16 @@ export function startLanguageServer(connection: Connection): void {
     });
   });
   connection.onDocumentHighlight(async (params) => {
-    return Mutex.read(async () => {
-      const uri = UriUtils.normalize(params.textDocument.uri);
-      const position = params.position;
-      const parsedUri = URI.parse(uri);
-      const unit = compilationUnitHandler.getCompilationUnit(parsedUri);
-      const textDocument = unit?.services.files.getDocument(uri);
-      if (textDocument && unit) {
+    const uri = UriUtils.normalize(params.textDocument.uri);
+    const position = params.position;
+    const parsedUri = URI.parse(uri);
+    const unit = compilationUnitHandler.getCompilationUnit(parsedUri);
+    if (!unit) {
+      return [];
+    }
+    return unit.mutex.read(async () => {
+      const textDocument = unit.services.files.getDocument(uri);
+      if (textDocument) {
         const offset = textDocument.offsetAt(position);
         const definitions = getReferenceLocations(unit, parsedUri, offset);
         return definitions
@@ -267,13 +286,16 @@ export function startLanguageServer(connection: Connection): void {
     });
   });
   connection.onRenameRequest(async (params) => {
-    return Mutex.read(async () => {
-      const uri = params.textDocument.uri;
-      const position = params.position;
-      const parsedUri = URI.parse(uri);
-      const unit = compilationUnitHandler.getCompilationUnit(parsedUri);
-      const textDocument = unit?.services.files.getDocument(uri);
-      if (textDocument && unit) {
+    const uri = params.textDocument.uri;
+    const position = params.position;
+    const parsedUri = URI.parse(uri);
+    const unit = compilationUnitHandler.getCompilationUnit(parsedUri);
+    if (!unit) {
+      return null;
+    }
+    return unit.mutex.read(async () => {
+      const textDocument = unit.services.files.getDocument(uri);
+      if (textDocument) {
         const offset = textDocument.offsetAt(position);
         const renameLocations = renameRequest(unit, parsedUri, offset);
         const changes: Record<string, TextEdit[]> = {};
@@ -299,12 +321,15 @@ export function startLanguageServer(connection: Connection): void {
     });
   });
   connection.onDocumentSymbol(async (params) => {
-    return Mutex.read(async () => {
-      const uri = params.textDocument.uri;
-      const parsedUri = URI.parse(uri);
-      const unit = compilationUnitHandler.getCompilationUnit(parsedUri);
-      const textDocument = unit?.services.files.getDocument(uri);
-      if (textDocument && unit) {
+    const uri = params.textDocument.uri;
+    const parsedUri = URI.parse(uri);
+    const unit = compilationUnitHandler.getCompilationUnit(parsedUri);
+    if (!unit) {
+      return [];
+    }
+    return unit.mutex.read(async () => {
+      const textDocument = unit.services.files.getDocument(uri);
+      if (textDocument) {
         const requestResult = documentSymbolRequest(parsedUri, unit);
         return requestResult.map((symbol) =>
           documentSymbolToLSP(textDocument, symbol),
@@ -314,57 +339,48 @@ export function startLanguageServer(connection: Connection): void {
     });
   });
   connection.onWorkspaceSymbol(async (params) => {
-    return Mutex.read(async () => {
-      return workspaceSymbolRequest(
-        params.query,
-        compilationUnitHandler.getAllCompilationUnits(),
-      );
-    });
+    return workspaceSymbolRequest(
+      params.query,
+      compilationUnitHandler.getAllCompilationUnits(),
+    );
   });
   connection.onNotification(
     WorkspaceDidChangePlipluginConfigNotification,
-    () => {
-      Mutex.run(async () => {
-        // handle changes to the .pliplugin config folder's contents
-        const diagnostics =
-          await PluginConfigurationProviderInstance.reloadConfigurations();
-        const ws = PluginConfigurationProviderInstance.getWorkspacePath();
-        const wsPrefix = ws.endsWith("/") ? ws : ws + "/";
-        connection.sendDiagnostics({
-          uri: wsPrefix + PluginConfiguration.PROCESS_GROUP_FILE_PATH,
-          diagnostics,
-        });
-
-        // reindex reachable compilation units
-        await compilationUnitHandler.reindex(
-          connection,
-          CancellationToken.None,
-        );
+    async () => {
+      // handle changes to the .pliplugin config folder's contents
+      const diagnostics =
+        await PluginConfigurationProviderInstance.reloadConfigurations();
+      const ws = PluginConfigurationProviderInstance.getWorkspacePath();
+      const wsPrefix = ws.endsWith("/") ? ws : ws + "/";
+      connection.sendDiagnostics({
+        uri: wsPrefix + PluginConfiguration.PROCESS_GROUP_FILE_PATH,
+        diagnostics,
       });
+
+      // reindex reachable compilation units
+      await compilationUnitHandler.reindex(connection, CancellationToken.None);
     },
   );
 
   connection.onCodeAction(async (params) => {
-    return Mutex.read(async () => {
-      const requestedKinds = params.context.only;
-      const isSourceActionRequest =
-        requestedKinds?.includes(CodeActionKind.SourceFixAll) ||
-        requestedKinds?.includes(CodeActionKind.Source);
+    const requestedKinds = params.context.only;
+    const isSourceActionRequest =
+      requestedKinds?.includes(CodeActionKind.SourceFixAll) ||
+      requestedKinds?.includes(CodeActionKind.Source);
 
-      if (isSourceActionRequest) {
-        const sourceActions = await applySourceActions(
-          params.textDocument.uri,
-          compilationUnitHandler,
-        );
-        return sourceActions || [];
-      } else {
-        const diagnostics = params.context.diagnostics as Diagnostic[];
-        if (!diagnostics || !diagnostics.length) return [];
+    if (isSourceActionRequest) {
+      const sourceActions = await applySourceActions(
+        params.textDocument.uri,
+        compilationUnitHandler,
+      );
+      return sourceActions || [];
+    } else {
+      const diagnostics = params.context.diagnostics as Diagnostic[];
+      if (!diagnostics || !diagnostics.length) return [];
 
-        const actions = await applyQuickFixes(diagnostics);
-        return actions || [];
-      }
-    });
+      const actions = await applyQuickFixes(diagnostics);
+      return actions || [];
+    }
   });
 
   connection.onExecuteCommand(async (params) => {

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -41,7 +41,7 @@ import {
   ProgramConfig,
 } from "./plugin-configuration-provider.js";
 import { EvaluationResults } from "../preprocessor/instruction-interpreter.js";
-import { Mutex } from "./mutex.js";
+import { createMutex, Mutex } from "./mutex.js";
 import { Deferred, isOperationCancelled } from "../utils/promises.js";
 import { InstructionCache } from "../preprocessor/instruction-cache.js";
 import { TextDocument } from "vscode-languageserver-textdocument";
@@ -86,6 +86,7 @@ export interface CompilationUnit {
   readonly services: CompilationServices;
   readonly programConfig: ProgramConfig | undefined;
   readonly processGroup: ProcessGroup | undefined;
+  readonly mutex: Mutex;
   /**
    * Resets all caches associated with this compilation unit.
    */
@@ -200,6 +201,7 @@ export async function createCompilationUnit(
       }
       return cachedProcessGroup;
     },
+    mutex: createMutex(),
     reset() {
       services.files.clear();
       services.typeCache.clear();
@@ -278,18 +280,12 @@ export class CompilationUnitHandler {
   }
 
   listen(connection: Connection): void {
-    // Before we start listening, we need to set up the mutex
-    // to prevent compilation unit updates before we're ready.
-    Mutex.run(async () => {
-      await this.ready.promise;
-    });
     this.connection = connection;
     const textDocuments = EditorDocuments;
     textDocuments.listen(connection);
     textDocuments.onDidChangeContent((event) => {
-      Mutex.cancel();
       const uri = URI.parse(event.document.uri);
-      Mutex.run((token) => this.updateUri(uri, token));
+      this.updateUri(uri);
     });
     textDocuments.onDidClose((event) => {
       connection.sendDiagnostics({
@@ -299,23 +295,23 @@ export class CompilationUnitHandler {
     });
   }
 
-  async updateUri(
-    uri: URI,
-    cancellationToken: CancellationToken,
-  ): Promise<void> {
+  async updateUri(uri: URI): Promise<void> {
+    await this.ready.promise;
     const unit = await this.getOrCreateCompilationUnit(uri);
     if (!unit) {
       // standalone library files do not synthesize new compilation units
       return;
     }
-    const document = await EditorDocuments.get(unit.uri);
-    if (!document) {
-      return;
-    }
-    await this.process(unit, document, this.connection, cancellationToken);
-    // TODO: Wagner Laranjeiras -> includeCache based on changes of a specific file.
-    unit.services.includeCache.clear();
-    unit.requestCaches.revalidateAll({ connection: this.connection, unit });
+    unit.mutex.run(async (cancellationToken) => {
+      const document = await EditorDocuments.get(unit.uri);
+      if (!document) {
+        return;
+      }
+      await this.process(unit, document, this.connection, cancellationToken);
+      // TODO: Wagner Laranjeiras -> includeCache based on changes of a specific file.
+      unit.services.includeCache.clear();
+      unit.requestCaches.revalidateAll({ connection: this.connection, unit });
+    });
   }
 
   /**
@@ -368,10 +364,12 @@ export class CompilationUnitHandler {
       if (cancellationToken.isCancellationRequested) {
         return;
       }
-      const textDocument = await TextDocuments.get(unit.uri.toString());
-      if (textDocument) {
-        this.process(unit, textDocument, connection, cancellationToken);
-      }
+      unit.mutex.run(async (cancellationToken) => {
+        const textDocument = await TextDocuments.get(unit.uri.toString());
+        if (textDocument) {
+          this.process(unit, textDocument, connection, cancellationToken);
+        }
+      });
     }
   }
 }

--- a/packages/language/src/workspace/mutex.ts
+++ b/packages/language/src/workspace/mutex.ts
@@ -19,7 +19,13 @@ export type MutexFunc<T = void> = (
   cancellation: CancellationToken,
 ) => Promise<T>;
 
-class MutexImpl {
+export interface Mutex {
+  cancel(): void;
+  run<T = void>(func: MutexFunc<T>, cancel?: boolean): Promise<T>;
+  read<T = void>(func: MutexFunc<T>): Promise<T>;
+}
+
+class MutexImpl implements Mutex {
   private current: Promise<unknown> = Promise.resolve();
   private source = new CancellationTokenSource();
 
@@ -60,15 +66,8 @@ class MutexImpl {
   read<T = void>(func: MutexFunc<T>): Promise<T> {
     return this.run(func, false);
   }
-
-  /**
-   * Returns a promise that indicates when the mutex is done and ready for the next operation.
-   *
-   * Note that this will prevent cancellation of the current operation!
-   */
-  ready(): Promise<void> {
-    return this.read(() => Promise.resolve());
-  }
 }
 
-export const Mutex = new MutexImpl();
+export function createMutex(): Mutex {
+  return new MutexImpl();
+}


### PR DESCRIPTION
Fixes an issue that pops up quite consistently when opening a workspace that has multiple files open on startup. Only one of the files will receive their semantic highlighting. Currently, this can also be observed on the playground for the same reason:

Since we only have one global mutex, opening multiple files at the same time will abort all build processes except for the last one that was triggered. Since each compilation unit can be built independently from one another, the obvious solution is to have one mutex per compilation unit.

This PR adapts the codebase to do exactly that.

Testing this isn't exactly straightforward - one easy test case is that the playground should be immediately highlighted. Do a bit of manual smoke testing to confirm that this change didn't break other behavior.