### PR TITLE
Fix macro variable completion

### DIFF
--- a/packages/language/src/workspace/lifecycle.ts
+++ b/packages/language/src/workspace/lifecycle.ts
@@ -61,6 +61,9 @@ export async function tokenize(
   );
   compilationUnit.tokens = result.all;
   compilationUnit.preprocessorAst.statements = result.statements;
+  result.statements.forEach((stmt) => {
+    stmt.container = compilationUnit.preprocessorAst;
+  });
   compilationUnit.preprocessorEvaluationResults = result.evaluationResults;
   compilationUnit.referencesCache.addAll(result.tokenReferences);
   const uri = compilationUnit.uri.toString();

--- a/packages/language/test/fourslash/completion/pp/assignment.ts
+++ b/packages/language/test/fourslash/completion/pp/assignment.ts
@@ -1,0 +1,28 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// DCL X FIXED BIN(31) INIT(1);
+//// %DCL A FIXED INIT(10);
+//// %A = <|1>20;
+//// X = <|2>42;
+
+// Completion at 1 should suggest pp variables only
+completion.expectAt(1, {
+  includes: ["A"],
+  excludes: ["X"],
+});
+// Completion at 2 should suggest non-pp variables only
+completion.expectAt(2, {
+  includes: ["X"],
+  excludes: ["A"],
+});


### PR DESCRIPTION
Fixes an issue that proposed non-pp variables in macro context. This was because the root of the pp-statements was never set correctly. This change fixes the issue and adds a test.