### PR TITLE
Improve code completion (statements/expressions)

### DIFF
--- a/packages/language/src/language-server/completion/completion-generator.ts
+++ b/packages/language/src/language-server/completion/completion-generator.ts
@@ -10,11 +10,15 @@
  */
 
 import { CompletionItemKind } from "vscode-languageserver-types";
-import { Statement, SyntaxKind, SyntaxNode } from "../../syntax-tree/ast";
+import {
+  isPreprocessorNode,
+  Statement,
+  SyntaxKind,
+  SyntaxNode,
+} from "../../syntax-tree/ast";
 import { CompilationUnit } from "../../workspace/compilation-unit";
 import { FollowElement, FollowKind } from "./follow-elements";
 import { getQualifiedName } from "../../linking/resolver";
-import { getCompletionKeywords } from "./keywords";
 import { SimpleCompletionItem } from "../types";
 
 export function generateCompletionItems(
@@ -25,15 +29,14 @@ export function generateCompletionItems(
   const items: SimpleCompletionItem[] = [];
 
   if (followElement.kind === FollowKind.CstNode) {
-    const keywords = followElement.types.flatMap(getCompletionKeywords);
-    items.push(...keywords);
+    items.push(...followElement.items);
   }
   if (followElement.kind === FollowKind.QualifiedReference) {
     context = followElement.previous;
   } else if (!context) {
     return items;
   }
-  const scopeCache = isPreprocessorNode(context, unit)
+  const scopeCache = isPreprocessorNode(unit, context)
     ? unit.scopeCaches.preprocessor
     : unit.scopeCaches.regular;
   const scope = scopeCache.get(context);
@@ -83,12 +86,4 @@ function getCompletionKind(node: SyntaxNode): CompletionItemKind {
     }
   }
   return CompletionItemKind.Variable;
-}
-
-function isPreprocessorNode(node: SyntaxNode, unit: CompilationUnit): boolean {
-  let parent = node;
-  while (parent.container) {
-    parent = parent.container;
-  }
-  return unit.preprocessorAst === parent;
 }

--- a/packages/language/src/language-server/completion/completion-request.ts
+++ b/packages/language/src/language-server/completion/completion-request.ts
@@ -42,9 +42,9 @@ export function completionRequest(
   let context: SyntaxNode | undefined;
   if (token) {
     context = getTokenContext(tokens, tokenIndex);
-    followElements.push(...getFollowElements(context, token));
+    followElements.push(...getFollowElements(unit, context, token));
   } else {
-    followElements.push(...provideEntryPointFollowElements());
+    followElements.push(...provideEntryPointFollowElements(unit));
   }
   const items = followElements.flatMap((element) =>
     generateCompletionItems(unit, context, element),

--- a/packages/language/src/language-server/completion/follow-elements.ts
+++ b/packages/language/src/language-server/completion/follow-elements.ts
@@ -10,20 +10,30 @@
  */
 
 import { Token } from "../../parser/tokens";
-import { MemberCall, SyntaxKind, SyntaxNode } from "../../syntax-tree/ast";
+import {
+  getContainer,
+  isPreprocessorNode,
+  MemberCall,
+  SyntaxKind,
+  SyntaxNode,
+} from "../../syntax-tree/ast";
 import { CstNodeKind } from "../../syntax-tree/cst";
-import { CompletionKeywords } from "./keywords";
+import { CompletionKeywords, kw } from "./keywords";
 import * as tokens from "../../parser/tokens";
+import { SimpleCompletionItem } from "../types";
+import { CompilationUnit } from "../../workspace/compilation-unit";
 
 const DataSpecificationCompletionKeywordsArray =
-  CompletionKeywords.DeclarationKeyword.keysArray();
+  CompletionKeywords.DeclarationKeyword.values();
 const StatementStartCompletionKeywordsArray =
-  CompletionKeywords.StatementStart.keysArray();
+  CompletionKeywords.StatementStart.values();
 const StatementStartPreprocessorCompletionKeywordsArray =
-  CompletionKeywords.StatementStartPreprocessor.keysArray();
+  CompletionKeywords.StatementStartPreprocessor.values();
+const StatementStartPreprocessorWithPercentCompletionKeywordsArray =
+  CompletionKeywords.StatementStartPreprocessorWithPercent.values();
 const AllStatementStartKeywordsArray = [
   ...StatementStartCompletionKeywordsArray,
-  ...StatementStartPreprocessorCompletionKeywordsArray,
+  ...StatementStartPreprocessorWithPercentCompletionKeywordsArray,
 ];
 
 export enum FollowKind {
@@ -34,7 +44,7 @@ export enum FollowKind {
 
 export interface FollowCstNode {
   kind: FollowKind.CstNode;
-  types: CstNodeKind[];
+  items: SimpleCompletionItem[];
 }
 
 export interface FollowLocalReference {
@@ -98,7 +108,95 @@ function getFollowElementsForUnknownToken(token: Token): FollowElement[] {
   return [];
 }
 
+const expressionFollowKinds = new Set([
+  // Within expressions
+  CstNodeKind.BinaryExpression_Operator,
+  CstNodeKind.UnaryExpression_Operator,
+  CstNodeKind.AssignmentStatement_Operator,
+
+  // After '(' in various places
+  CstNodeKind.Dimensions_OpenParen,
+  CstNodeKind.PutStatement_OpenParen,
+  CstNodeKind.InitialAttribute_OpenParenDirect,
+  CstNodeKind.ReturnStatement_OpenParen,
+  CstNodeKind.DoWhile_OpenParenWhile,
+  CstNodeKind.DoWhile_OpenParenUntil,
+  CstNodeKind.DoUntil_OpenParenUntil,
+  CstNodeKind.DoUntil_OpenParenWhile,
+  CstNodeKind.EntryStatement_OpenParenEnv,
+  CstNodeKind.AssertStatement_OpenParen0,
+  CstNodeKind.AssertStatement_OpenParen1,
+  CstNodeKind.AttachStatement_OpenParenTStack,
+  CstNodeKind.OrdinalValue_OpenParen,
+  CstNodeKind.DelayStatement_OpenParen,
+  CstNodeKind.DeleteStatement_OpenParenKey,
+  CstNodeKind.DisplayStatement_OpenParenExpression,
+  CstNodeKind.FetchEntry_OpenParenTitle,
+  CstNodeKind.FormatListItemLevel_OpenParen,
+  CstNodeKind.AFormatItem_OpenParen,
+  CstNodeKind.BFormatItem_OpenParen,
+  CstNodeKind.FFormatItem_OpenParen,
+  CstNodeKind.EFormatItem_OpenParen,
+  CstNodeKind.ColumnFormatItem_OpenParen,
+  CstNodeKind.GFormatItem_OpenParen,
+  CstNodeKind.LineFormatItem_OpenParen,
+  CstNodeKind.SkipFormatItem_OpenParen,
+  CstNodeKind.XFormatItem_OpenParen,
+  CstNodeKind.GetStatement_OpenParen,
+  CstNodeKind.GetFile_OpenParen,
+  CstNodeKind.GetSkip_OpenParen,
+  CstNodeKind.LocateStatementOption_OpenParen,
+  CstNodeKind.OpenOption_OpenParen,
+  CstNodeKind.PutItem_OpenParen,
+  CstNodeKind.ReadStatementFile_OpenParen,
+  CstNodeKind.RewriteStatementFile_OpenParen,
+  CstNodeKind.SelectStatement_OpenParen,
+  CstNodeKind.WhenStatement_OpenParen,
+  CstNodeKind.WriteStatementFile_OpenParen,
+  CstNodeKind.InitialAttribute_OpenParenInitAcross,
+  CstNodeKind.InitAcrossExpression_OpenParen,
+  CstNodeKind.DefinedAttribute_OpenParenPos,
+  CstNodeKind.ValueAttribute_OpenParen,
+  CstNodeKind.ValueListAttribute_OpenParen,
+  CstNodeKind.ValueRangeAttribute_OpenParen,
+  CstNodeKind.EnvironmentAttributeItem_OpenParen,
+  CstNodeKind.EntryAttribute_OpenParenEnv,
+  CstNodeKind.ParenthesizedExpression_OpenParen,
+  CstNodeKind.ProcedureCallArgs_OpenParen,
+  CstNodeKind.DataSpecificationOptions_OpenParenList,
+
+  // After ',' in various places
+  CstNodeKind.AssertStatement_Comma0,
+  CstNodeKind.DefaultStatement_Comma,
+  CstNodeKind.FFormatItem_CommaFractional,
+  CstNodeKind.FFormatItem_CommaScalingFactor,
+  CstNodeKind.EFormatItem_Comma0,
+  CstNodeKind.EFormatItem_Comma1,
+  CstNodeKind.WhenStatement_Comma,
+  CstNodeKind.InitialAttribute_CommaInitAcross,
+  CstNodeKind.InitAcrossExpression_Comma,
+  CstNodeKind.EnvironmentAttributeItem_Comma,
+  CstNodeKind.DataSpecificationDataList_Comma,
+
+  // After specific keywords
+  CstNodeKind.ActivateStatement_ACTIVATE,
+  CstNodeKind.DeactivateStatement_DEACTIVATE,
+  CstNodeKind.InscanDirective_INSCAN,
+  CstNodeKind.AssertStatement_TEXT,
+  CstNodeKind.AssignmentStatement_DIMACROSS,
+  CstNodeKind.DefaultStatement_DEFAULT,
+  CstNodeKind.DoSpecification_TO0,
+  CstNodeKind.DoSpecification_BY0,
+  CstNodeKind.DoSpecification_BY1,
+  CstNodeKind.DoSpecification_TO1,
+  CstNodeKind.DoSpecification_UPTHRU,
+  CstNodeKind.DoSpecification_DOWNTHRU,
+  CstNodeKind.DoSpecification_REPEAT,
+  CstNodeKind.IfStatement_IF,
+]);
+
 export function getFollowElements(
+  unit: CompilationUnit,
   context: SyntaxNode | undefined,
   token: Token,
 ): FollowElement[] {
@@ -118,7 +216,7 @@ export function getFollowElements(
       return [
         {
           kind: FollowKind.CstNode,
-          types: DataSpecificationCompletionKeywordsArray,
+          items: DataSpecificationCompletionKeywordsArray,
         },
       ];
     case CstNodeKind.DeactivateStatement_Semicolon:
@@ -175,26 +273,9 @@ export function getFollowElements(
     case CstNodeKind.WaitStatement_Semicolon:
     case CstNodeKind.WriteStatement_Semicolon:
     case CstNodeKind.DeclareStatement_Semicolon:
-      return [
-        {
-          kind: FollowKind.CstNode,
-          types: AllStatementStartKeywordsArray,
-        },
-        {
-          kind: FollowKind.LocalReference,
-        },
-      ];
-    // Happens on '(' in `PUT()`
-    case CstNodeKind.Dimensions_OpenParen:
-    // Happens on '(' in `PUT(f)`
-    case CstNodeKind.DataSpecificationOptions_OpenParenList:
-    // Happens on ',' in `PUT(A, )`
-    case CstNodeKind.DataSpecificationDataList_Comma:
-      return [
-        {
-          kind: FollowKind.LocalReference,
-        },
-      ];
+    // We are at the start of a new statement
+    case CstNodeKind.LabelPrefix_Colon:
+      return provideEntryPointFollowElements(unit, context);
     case CstNodeKind.AssignmentStatement_Operator:
     case CstNodeKind.BinaryExpression_Operator:
     case CstNodeKind.UnaryExpression_Operator:
@@ -211,7 +292,7 @@ export function getFollowElements(
         },
         {
           kind: FollowKind.CstNode,
-          types: StatementStartPreprocessorCompletionKeywordsArray,
+          items: StatementStartPreprocessorCompletionKeywordsArray,
         },
       ];
     case CstNodeKind.MemberCall_Dot:
@@ -227,19 +308,70 @@ export function getFollowElements(
         }
       }
       break;
+    case CstNodeKind.PutStatement_PUT:
+      return [
+        {
+          kind: FollowKind.CstNode,
+          items: [kw("STRING")],
+        },
+      ];
+  }
+
+  if (expressionFollowKinds.has(token.kind)) {
+    return [
+      {
+        kind: FollowKind.LocalReference,
+      },
+    ];
   }
 
   return [];
 }
 
-export function provideEntryPointFollowElements(): FollowElement[] {
-  /**
-   * TODO @didrikmunther: What follow elements are available for an empty program?
-   */
-  return [
-    {
-      kind: FollowKind.CstNode,
-      types: AllStatementStartKeywordsArray,
-    },
-  ];
+export function provideEntryPointFollowElements(
+  unit: CompilationUnit,
+  context?: SyntaxNode,
+): FollowElement[] {
+  const allKeywords: FollowElement = {
+    kind: FollowKind.CstNode,
+    items: AllStatementStartKeywordsArray,
+  };
+  if (!context) {
+    return [allKeywords];
+  }
+  if (isPreprocessorNode(unit, context)) {
+    const isProc = context.kind === SyntaxKind.ProcedureStatement;
+    const procItem = isProc
+      ? context
+      : getContainer(context, SyntaxKind.ProcedureStatement);
+    if (procItem) {
+      return [
+        {
+          kind: FollowKind.CstNode,
+          items:
+            CompletionKeywords.StatementStartPreprocessorInProcedure.values(),
+        },
+        {
+          kind: FollowKind.LocalReference,
+        },
+      ];
+    } else {
+      return [
+        {
+          kind: FollowKind.CstNode,
+          items: CompletionKeywords.StatementStartPreprocessor.values(),
+        },
+        {
+          kind: FollowKind.LocalReference,
+        },
+      ];
+    }
+  } else {
+    return [
+      allKeywords,
+      {
+        kind: FollowKind.LocalReference,
+      },
+    ];
+  }
 }

--- a/packages/language/src/language-server/completion/keywords.ts
+++ b/packages/language/src/language-server/completion/keywords.ts
@@ -14,35 +14,166 @@ import { CstNodeKind } from "../../syntax-tree/cst";
 import { MultiMap } from "../../utils/collections";
 import { SimpleCompletionItem } from "../types";
 
-const createSimpleCompletionItemCreator =
-  (properties: Omit<SimpleCompletionItem, "label" | "text">) =>
-  (label: string, text?: string): SimpleCompletionItem => ({
-    ...properties,
-    label,
-    text: text ?? label,
-  });
+interface Decorator {
+  (item: SimpleCompletionItem): SimpleCompletionItem;
+}
+
+interface Combinator extends Decorator {
+  decorate(
+    fn: (item: SimpleCompletionItem) => SimpleCompletionItem,
+  ): Combinator;
+  build(): Builder;
+}
+
+interface Builder {
+  (
+    label: string,
+    text?: string,
+    moreProps?: Partial<SimpleCompletionItem>,
+  ): SimpleCompletionItem;
+}
+
+function combine(...decorators: Decorator[]): Combinator {
+  const decorator: Decorator = (item) => {
+    for (const dec of decorators) {
+      item = dec(item);
+    }
+    return item;
+  };
+  const combinator = decorator as Combinator;
+  combinator.decorate = function (
+    fn: (item: SimpleCompletionItem) => SimpleCompletionItem,
+  ): Combinator {
+    return combine(...decorators, fn);
+  };
+  combinator.build = function (): Builder {
+    return (
+      label: string,
+      text?: string,
+      moreProps?: Partial<SimpleCompletionItem>,
+    ) => {
+      let item: SimpleCompletionItem = {
+        ...moreProps,
+        label,
+        text: text ?? label,
+        kind: CompletionItemKind.Keyword,
+      };
+      for (const decorator of decorators) {
+        item = decorator(item);
+      }
+      return item;
+    };
+  };
+  return combinator;
+}
+
+const macro: Decorator = (item) => {
+  item.detail = "MACRO";
+  return item;
+};
+
+const prependPercent: Decorator = (item) => {
+  item.text = `%${item.text}`;
+  item.label = `%${item.label}`;
+  return item;
+};
+
+const snippet: Decorator = (item) => {
+  item.insertTextFormat = InsertTextFormat.Snippet;
+  return item;
+};
+
+const keyword: Decorator = (item) => {
+  item.kind = CompletionItemKind.Keyword;
+  return item;
+};
+
+/**
+ * Preprocessor keyword without percent sign
+ */
+export const ppkw = combine(macro, keyword).build();
+
+/**
+ * Preprocessor keyword with percent sign
+ */
+export const ppkwp = combine(macro, prependPercent, keyword).build();
+
+/**
+ * Preprocessor keyword, optionally with percent sign
+ */
+export const ppkwc = (
+  withPercent: boolean,
+  label: string,
+  text?: string,
+  moreProps?: Partial<SimpleCompletionItem>,
+) => {
+  if (withPercent) {
+    return ppkwp(label, text, moreProps);
+  } else {
+    return ppkw(label, text, moreProps);
+  }
+};
 
 /**
  * Plaintext keyword
  */
-const kw = createSimpleCompletionItemCreator({
-  kind: CompletionItemKind.Keyword,
-});
+export const kw = combine(keyword).build();
 
 /**
  * Snippet keyword
  */
-const kws = createSimpleCompletionItemCreator({
-  kind: CompletionItemKind.Keyword,
-  insertTextFormat: InsertTextFormat.Snippet,
-});
+const kws = combine(keyword, snippet).build();
+
+type CompletionKeywordMap = MultiMap<CstNodeKind, string>;
+
+const allPPStartKeywords = new MultiMap<CstNodeKind, string>([
+  [CstNodeKind.DeactivateStatement_DEACTIVATE, "DEACTIVATE"],
+  [CstNodeKind.ActivateStatement_ACTIVATE, "ACTIVATE"],
+  [CstNodeKind.IncludeDirective_INCLUDE, "INCLUDE"],
+  [CstNodeKind.InscanDirective_INSCAN, "INSCAN"],
+  [CstNodeKind.DeclareStatement_DECLARE, "DECLARE"],
+  [CstNodeKind.PageDirective_PAGE, "PAGE"],
+  [CstNodeKind.PopDirective_POP, "POP"],
+  [CstNodeKind.PushDirective_PUSH, "PUSH"],
+  [CstNodeKind.PrintDirective_PRINT, "PRINT"],
+  [CstNodeKind.NoPrintDirective_NOPRINT, "NOPRINT"],
+  [CstNodeKind.DoStatement_DO, "DO"],
+  [CstNodeKind.GoToStatement_GOTO, "GO TO"],
+  [CstNodeKind.LeaveStatement_LEAVE, "LEAVE"],
+  [CstNodeKind.IfStatement_IF, "IF"],
+  [CstNodeKind.IterateStatement_ITERATE, "ITERATE"],
+  [CstNodeKind.NoteDirective_PercentNOTE, "NOTE"],
+  [CstNodeKind.ProcedureStatement_PROCEDURE, "PROCEDURE"],
+  [CstNodeKind.ReplaceStatement_REPLACE, "REPLACE"],
+  [CstNodeKind.SelectStatement_SELECT, "SELECT"],
+]);
+
+function createMap(
+  map: CompletionKeywordMap,
+  builder: Builder,
+): MultiMap<CstNodeKind, SimpleCompletionItem> {
+  const result = new MultiMap<CstNodeKind, SimpleCompletionItem>();
+  for (const [kind, label] of map.entries()) {
+    result.add(kind, builder(label));
+  }
+  return result;
+}
 
 export const CompletionKeywords = {
-  StatementStartPreprocessor: new MultiMap([
-    [CstNodeKind.DeactivateStatement_DEACTIVATE, kw("%DEACTIVATE")],
-    [CstNodeKind.DeactivateStatement_DEACTIVATE, kw("%DEACT")],
-    [CstNodeKind.ActivateStatement_ACTIVATE, kw("%ACTIVATE")],
-    [CstNodeKind.ActivateStatement_ACTIVATE, kw("%ACT")],
+  StatementStartPreprocessor: createMap(allPPStartKeywords, ppkw),
+  StatementStartPreprocessorWithPercent: createMap(allPPStartKeywords, ppkwp),
+  StatementStartPreprocessorInProcedure: new MultiMap([
+    [CstNodeKind.DeclareStatement_DECLARE, kw("DECLARE")],
+    [CstNodeKind.AnswerStatement_ANSWER, kw("ANSWER")],
+    [CstNodeKind.CallStatement_CALL, kw("CALL")],
+    [CstNodeKind.DoStatement_DO, kw("DO")],
+    [CstNodeKind.GoToStatement_GOTO, kw("GO TO")],
+    [CstNodeKind.IfStatement_IF, kw("IF")],
+    [CstNodeKind.IterateStatement_ITERATE, kw("ITERATE")],
+    [CstNodeKind.LeaveStatement_LEAVE, kw("LEAVE")],
+    [CstNodeKind.NoteDirective_PercentNOTE, kw("NOTE")],
+    [CstNodeKind.ReturnStatement_RETURN, kw("RETURN")],
+    [CstNodeKind.SelectStatement_SELECT, kw("SELECT")],
   ]),
   StatementStart: new MultiMap([
     [CstNodeKind.ProcedureStatement_PROCEDURE, kw("PROCEDURE")],
@@ -69,8 +200,6 @@ export const CompletionKeywords = {
     [CstNodeKind.GetStatement_GET, kw("GET")],
     [CstNodeKind.GoToStatement_GOTO, kw("GO TO")],
     [CstNodeKind.GoToStatement_GOTO, kw("GOTO")],
-    [CstNodeKind.GoToStatement_GO, kw("GO")],
-    [CstNodeKind.GoToStatement_TO, kw("TO")], // This only appears after the `GO` keyword (can be done later)
     [CstNodeKind.IfStatement_IF, kw("IF")],
     [CstNodeKind.IterateStatement_ITERATE, kw("ITERATE")],
     [CstNodeKind.LeaveStatement_LEAVE, kw("LEAVE")],

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -13,6 +13,7 @@ import { Range } from "../language-server/types";
 import { Token } from "../parser/tokens";
 import { assertUnreachable } from "../utils/common";
 import { isObject } from "../utils/types";
+import type { CompilationUnit } from "../workspace/compilation-unit";
 
 export enum SyntaxKind {
   // Preprocessor AST
@@ -676,6 +677,17 @@ export function createReference<T extends SyntaxNode>(
     node: undefined,
     type,
   };
+}
+
+export function isPreprocessorNode(
+  unit: CompilationUnit,
+  node: SyntaxNode,
+): boolean {
+  let parent = node;
+  while (parent.container) {
+    parent = parent.container;
+  }
+  return unit.preprocessorAst === parent;
 }
 
 export type Wildcard<T> = T | "*";

--- a/packages/language/test/fourslash/completion/declaration-dimensions.ts
+++ b/packages/language/test/fourslash/completion/declaration-dimensions.ts
@@ -11,20 +11,9 @@
 
 /// <reference path="../framework.ts" />
 
-//// DCL 1 A, 2 B, 3 C, 4 D char(10);
-//// <|1>
+//// DCL A FIXED BIN INIT(10);
+//// DCL B(<|1>);
 
 completion.expectAt(1, {
-  includes: [
-    "A",
-    "B",
-    "C",
-    "D",
-    ...constants.CompletionKeywords.StatementStart.values().map(
-      (keyword) => keyword.label,
-    ),
-    ...constants.CompletionKeywords.StatementStartPreprocessorWithPercent.values().map(
-      (keyword) => keyword.label,
-    ),
-  ],
+  includes: ["A"],
 });

--- a/packages/language/test/fourslash/completion/fuzzy.ts
+++ b/packages/language/test/fourslash/completion/fuzzy.ts
@@ -11,7 +11,13 @@
 
 /// <reference path="../framework.ts" />
 
-//// DCL 1 ROOT, 2 firstCompletionValue;
+//// DCL 1 ROOT,
+////   2 firstCompletionValue,
+////   2 secondCompletionValue;
 //// PUT(ROOT.fcv<|1>);
 
-completion.expectAt(1, { includes: ["firstCompletionValue"] });
+completion.expectAt(1, {
+  includes: ["firstCompletionValue"],
+  // Fuzzy matching should remove this entry
+  excludes: ["secondCompletionValue"],
+});

--- a/packages/language/test/fourslash/completion/pp/procedure-start.ts
+++ b/packages/language/test/fourslash/completion/pp/procedure-start.ts
@@ -1,0 +1,34 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// %TEST: <|outside>PROC;
+////   <|inside>
+//// %END;
+
+// Expect PROCEDURE keyword at the start of a procedure definition
+completion.expectAt("outside", {
+  includes: ["PROCEDURE"],
+});
+completion.expectAt("inside", {
+  includes: [
+    // Ensure that the labels don't use percent signs
+    "CALL",
+    "RETURN",
+    // Include all other statement-starting preprocessor keywords
+    ...constants.CompletionKeywords.StatementStartPreprocessorInProcedure.values().map(
+      (keyword) => keyword.label,
+    ),
+  ],
+  // Procedures cannot be nested in the preprocessor
+  excludes: ["PROCEDURE"],
+});

--- a/packages/language/test/fourslash/completion/put-string.ts
+++ b/packages/language/test/fourslash/completion/put-string.ts
@@ -11,20 +11,8 @@
 
 /// <reference path="../framework.ts" />
 
-//// DCL 1 A, 2 B, 3 C, 4 D char(10);
-//// <|1>
+//// DCL 1 A, 2 B;
+//// PUT <|str>STRING (<|expr>);
 
-completion.expectAt(1, {
-  includes: [
-    "A",
-    "B",
-    "C",
-    "D",
-    ...constants.CompletionKeywords.StatementStart.values().map(
-      (keyword) => keyword.label,
-    ),
-    ...constants.CompletionKeywords.StatementStartPreprocessorWithPercent.values().map(
-      (keyword) => keyword.label,
-    ),
-  ],
-});
+completion.expectAt("str", { includes: ["STRING"], excludes: ["A", "B"] });
+completion.expectAt("expr", { includes: ["A", "B"] });


### PR DESCRIPTION
Based on top of https://github.com/zowe/zowe-pli-language-support/pull/541.

Improves the completion further for start of statements (especially for the preprocessor use case) and when we expect an expression next.

We now maintain a list of cst nodes that are supposed to precede an expression (or a general reference).