### PR TITLE
Fix IF <> assignment ambiguity

### DIFF
--- a/packages/language/src/parser/parser-lookahead.ts
+++ b/packages/language/src/parser/parser-lookahead.ts
@@ -1,0 +1,141 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { tokenMatcher } from "chevrotain";
+import { ParserState } from "./parser-state";
+import * as tokens from "./tokens";
+
+function indicatesAssignment(token: tokens.Token): boolean {
+  return (
+    tokenMatcher(token, tokens.AssignmentOperator) ||
+    tokenMatcher(token, tokens.Dot) ||
+    tokenMatcher(token, tokens.Comma)
+  );
+}
+
+export function performAssignmentLookahead(state: ParserState): boolean {
+  if (performIfLookahead(state)) {
+    // IF ... THEN detected, not an assignment
+    // We need this check first since IF can be followed by an expression that makes it look like an assignment
+    // e.g. IF (2 + 3) = 5 THEN; ...
+    return false;
+  }
+  const expressionTokenTypes = [
+    tokens.ID,
+    tokens.BinaryOperator,
+    tokens.UnaryOperator,
+    tokens.AssignmentOperator,
+    tokens.STRING_TERM,
+    tokens.NUMBER,
+    tokens.Comma,
+    tokens.Dot,
+  ];
+  let i = 1;
+  let token = state.peek(i++);
+  // First token of an assigment needs to be an ID
+  if (!token || !tokenMatcher(token, tokens.ID)) {
+    return false;
+  }
+  token = state.peek(i++);
+  if (token && indicatesAssignment(token)) {
+    // We have found a match immediately with the assignment operator (or a dot for member assignment, or a comma for multiple assignment)
+    return true;
+  } else if (!token || !tokenMatcher(token, tokens.OpenParen)) {
+    // Otherwise expect an open parenthesis next
+    return false;
+  }
+
+  // The compiler will not use more than 160 tokens to perform the lookahead
+  const max = 160;
+  let parenthesis = 1;
+  while (i < max) {
+    const token = state.peek(i++);
+    if (!token) {
+      return false;
+    }
+    if (parenthesis === 0) {
+      // If we close the outermost parenthesis, expect an assignment indicator next
+      return indicatesAssignment(token);
+    }
+    if (tokenMatcher(token, tokens.OpenParen)) {
+      parenthesis++;
+    } else if (tokenMatcher(token, tokens.CloseParen)) {
+      parenthesis--;
+    } else if (tokenMatcher(token, tokens.Semicolon)) {
+      // Semicolon indicates the end of the statement
+      return false;
+    } else {
+      if (
+        !expressionTokenTypes.some((tokenType) =>
+          tokenMatcher(token, tokenType),
+        )
+      ) {
+        // Non-expression token found, stop lookahead
+        return false;
+      }
+      // Continue with the next token, the current token is a valid expression token
+    }
+  }
+  // If we reach this point, the lookahead was not successful
+  return false;
+}
+
+function performIfLookahead(state: ParserState): boolean {
+  let i = 1;
+  let token = state.peek(i++);
+  // First token needs to be IF
+  if (!token || !tokenMatcher(token, tokens.IF)) {
+    return false;
+  }
+  // Then we need to search for THEN before reaching the end of the statement
+  let parenthesis = 0;
+  const max = 160;
+  while (i < max) {
+    token = state.peek(i++);
+    if (!token) {
+      return false;
+    }
+    // THEN found outside of parentheses after IF and another token
+    if (i > 2 && parenthesis === 0 && tokenMatcher(token, tokens.THEN)) {
+      return true;
+    } else if (tokenMatcher(token, tokens.OpenParen)) {
+      parenthesis++;
+    } else if (tokenMatcher(token, tokens.CloseParen)) {
+      parenthesis--;
+    } else if (tokenMatcher(token, tokens.Semicolon)) {
+      // Semicolon indicates the end of the statement
+      return false;
+    }
+  }
+  // If we reach this point, the lookahead was not successful
+  return false;
+}
+
+export function performEndStatementLookahead(state: ParserState): boolean {
+  const lookahead = (la: number) => state.peek(la);
+  let index: number = 1;
+  let token: tokens.Token | undefined = undefined;
+  while ((token = lookahead(index)) && !tokenMatcher(token, tokens.END)) {
+    const idToken = lookahead(index);
+    const colonToken = lookahead(index + 1);
+    if (!idToken || !colonToken) {
+      return false;
+    }
+    if (
+      !tokenMatcher(idToken, tokens.ID) ||
+      !tokenMatcher(colonToken, tokens.Colon)
+    ) {
+      return false;
+    }
+    index += 2;
+  }
+  return token !== undefined && tokenMatcher(token, tokens.END);
+}

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -28,6 +28,10 @@ import {
 } from "./abstract-parser";
 import { Severe } from "../validation/pli-codes";
 import { Diagnostic, Severity } from "../language-server/types";
+import {
+  performAssignmentLookahead,
+  performEndStatementLookahead,
+} from "./parser-lookahead";
 
 export function parsePli(input: tokens.Token[]): {
   tree: ast.Program;
@@ -6498,130 +6502,3 @@ const numberLiteral = rule(
     return element;
   },
 );
-
-function indicatesAssignment(token: tokens.Token): boolean {
-  return (
-    tokenMatcher(token, tokens.AssignmentOperator) ||
-    tokenMatcher(token, tokens.Dot) ||
-    tokenMatcher(token, tokens.Comma)
-  );
-}
-
-export function performAssignmentLookahead(state: ParserState): boolean {
-  if (performIfLookahead(state)) {
-    // IF ... THEN detected, not an assignment
-    // We need this check first since IF can be followed by an expression that makes it look like an assignment
-    // e.g. IF (2 + 3) = 5 THEN; ...
-    return false;
-  }
-  const expressionTokenTypes = [
-    tokens.ID,
-    tokens.BinaryOperator,
-    tokens.UnaryOperator,
-    tokens.AssignmentOperator,
-    tokens.STRING_TERM,
-    tokens.NUMBER,
-    tokens.Comma,
-    tokens.Dot,
-  ];
-  let i = 1;
-  let token = state.peek(i++);
-  // First token of an assigment needs to be an ID
-  if (!token || !tokenMatcher(token, tokens.ID)) {
-    return false;
-  }
-  token = state.peek(i++);
-  if (token && indicatesAssignment(token)) {
-    // We have found a match immediately with the assignment operator (or a dot for member assignment, or a comma for multiple assignment)
-    return true;
-  } else if (!token || !tokenMatcher(token, tokens.OpenParen)) {
-    // Otherwise expect an open parenthesis next
-    return false;
-  }
-
-  // The compiler will not use more than 160 tokens to perform the lookahead
-  const max = 160;
-  let parenthesis = 1;
-  while (i < max) {
-    const token = state.peek(i++);
-    if (!token) {
-      return false;
-    }
-    if (parenthesis === 0) {
-      // If we close the outermost parenthesis, expect an assignment indicator next
-      return indicatesAssignment(token);
-    }
-    if (tokenMatcher(token, tokens.OpenParen)) {
-      parenthesis++;
-    } else if (tokenMatcher(token, tokens.CloseParen)) {
-      parenthesis--;
-    } else if (tokenMatcher(token, tokens.Semicolon)) {
-      // Semicolon indicates the end of the statement
-      return false;
-    } else {
-      if (
-        !expressionTokenTypes.some((tokenType) =>
-          tokenMatcher(token, tokenType),
-        )
-      ) {
-        // Non-expression token found, stop lookahead
-        return false;
-      }
-      // Continue with the next token, the current token is a valid expression token
-    }
-  }
-  // If we reach this point, the lookahead was not successful
-  return false;
-}
-
-function performIfLookahead(state: ParserState): boolean {
-  let i = 1;
-  let token = state.peek(i++);
-  // First token needs to be IF
-  if (!token || !tokenMatcher(token, tokens.IF)) {
-    return false;
-  }
-  // Then we need to search for THEN before reaching the end of the statement
-  let parenthesis = 0;
-  const max = 160;
-  while (i < max) {
-    token = state.peek(i++);
-    if (!token) {
-      return false;
-    }
-    // THEN found outside of parentheses after IF and another token
-    if (i > 2 && parenthesis === 0 && tokenMatcher(token, tokens.THEN)) {
-      return true;
-    } else if (tokenMatcher(token, tokens.OpenParen)) {
-      parenthesis++;
-    } else if (tokenMatcher(token, tokens.CloseParen)) {
-      parenthesis--;
-    } else if (tokenMatcher(token, tokens.Semicolon)) {
-      // Semicolon indicates the end of the statement
-      return false;
-    }
-  }
-  // If we reach this point, the lookahead was not successful
-  return false;
-}
-
-function performEndStatementLookahead(state: ParserState): boolean {
-  const lookahead = (la: number) => state.peek(la);
-  let index: number = 1;
-  let token: tokens.Token | undefined = undefined;
-  while ((token = lookahead(index)) && !tokenMatcher(token, tokens.END)) {
-    const idToken = lookahead(index);
-    const colonToken = lookahead(index + 1);
-    if (!idToken || !colonToken) {
-      return false;
-    }
-    if (
-      !tokenMatcher(idToken, tokens.ID) ||
-      !tokenMatcher(colonToken, tokens.Colon)
-    ) {
-      return false;
-    }
-    index += 2;
-  }
-  return token !== undefined && tokenMatcher(token, tokens.END);
-}

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -6499,7 +6499,21 @@ const numberLiteral = rule(
   },
 );
 
+function indicatesAssignment(token: tokens.Token): boolean {
+  return (
+    tokenMatcher(token, tokens.AssignmentOperator) ||
+    tokenMatcher(token, tokens.Dot) ||
+    tokenMatcher(token, tokens.Comma)
+  );
+}
+
 export function performAssignmentLookahead(state: ParserState): boolean {
+  if (performIfLookahead(state)) {
+    // IF ... THEN detected, not an assignment
+    // We need this check first since IF can be followed by an expression that makes it look like an assignment
+    // e.g. IF (2 + 3) = 5 THEN; ...
+    return false;
+  }
   const expressionTokenTypes = [
     tokens.ID,
     tokens.BinaryOperator,
@@ -6510,36 +6524,32 @@ export function performAssignmentLookahead(state: ParserState): boolean {
     tokens.Comma,
     tokens.Dot,
   ];
-
-  let previousToken: tokens.Token | undefined = undefined;
-  const lookahead: (la: number) => tokens.Token | undefined = (la) => {
-    previousToken = state.peek(la - 1);
-    return state.peek(la);
-  };
   let i = 1;
-  let token = lookahead(i++);
+  let token = state.peek(i++);
   // First token of an assigment needs to be an ID
   if (!token || !tokenMatcher(token, tokens.ID)) {
     return false;
-  } else if (token.tokenTypeIdx === tokens.ID.tokenTypeIdx) {
-    return true;
   }
-  token = lookahead(i);
-  // We have found a match immediately with the assignment operator
-  if (token && tokenMatcher(token, tokens.AssignmentOperator)) {
+  token = state.peek(i++);
+  if (token && indicatesAssignment(token)) {
+    // We have found a match immediately with the assignment operator (or a dot for member assignment, or a comma for multiple assignment)
     return true;
+  } else if (!token || !tokenMatcher(token, tokens.OpenParen)) {
+    // Otherwise expect an open parenthesis next
+    return false;
   }
 
   // The compiler will not use more than 160 tokens to perform the lookahead
   const max = 160;
-  let parenthesis = 0;
+  let parenthesis = 1;
   while (i < max) {
-    const token = lookahead(i++);
+    const token = state.peek(i++);
     if (!token) {
       return false;
     }
-    if (parenthesis === 0 && tokenMatcher(token, tokens.AssignmentOperator)) {
-      return true;
+    if (parenthesis === 0) {
+      // If we close the outermost parenthesis, expect an assignment indicator next
+      return indicatesAssignment(token);
     }
     if (tokenMatcher(token, tokens.OpenParen)) {
       parenthesis++;
@@ -6554,14 +6564,41 @@ export function performAssignmentLookahead(state: ParserState): boolean {
           tokenMatcher(token, tokenType),
         )
       ) {
+        // Non-expression token found, stop lookahead
         return false;
       }
-      if (tokenMatcher(token, tokens.ID)) {
-        if (previousToken && tokenMatcher(previousToken, tokens.ID)) {
-          return false;
-        }
-      }
       // Continue with the next token, the current token is a valid expression token
+    }
+  }
+  // If we reach this point, the lookahead was not successful
+  return false;
+}
+
+function performIfLookahead(state: ParserState): boolean {
+  let i = 1;
+  let token = state.peek(i++);
+  // First token needs to be IF
+  if (!token || !tokenMatcher(token, tokens.IF)) {
+    return false;
+  }
+  // Then we need to search for THEN before reaching the end of the statement
+  let parenthesis = 0;
+  const max = 160;
+  while (i < max) {
+    token = state.peek(i++);
+    if (!token) {
+      return false;
+    }
+    // THEN found outside of parentheses after IF and another token
+    if (i > 2 && parenthesis === 0 && tokenMatcher(token, tokens.THEN)) {
+      return true;
+    } else if (tokenMatcher(token, tokens.OpenParen)) {
+      parenthesis++;
+    } else if (tokenMatcher(token, tokens.CloseParen)) {
+      parenthesis--;
+    } else if (tokenMatcher(token, tokens.Semicolon)) {
+      // Semicolon indicates the end of the statement
+      return false;
     }
   }
   // If we reach this point, the lookahead was not successful

--- a/packages/language/src/parser/preprocessor-parser.ts
+++ b/packages/language/src/parser/preprocessor-parser.ts
@@ -30,7 +30,7 @@ import {
   tokenToRange,
 } from "../language-server/types";
 import { PLICodes } from "../validation/pli-codes";
-import { performAssignmentLookahead } from "./parser";
+import { performAssignmentLookahead } from "./parser-lookahead";
 
 const tokenEndSet = new Set(t.PPSignifier.map((tok) => tok.tokenTypeIdx!));
 

--- a/packages/language/src/parser/preprocessor-parser.ts
+++ b/packages/language/src/parser/preprocessor-parser.ts
@@ -30,6 +30,7 @@ import {
   tokenToRange,
 } from "../language-server/types";
 import { PLICodes } from "../validation/pli-codes";
+import { performAssignmentLookahead } from "./parser";
 
 const tokenEndSet = new Set(t.PPSignifier.map((tok) => tok.tokenTypeIdx!));
 
@@ -157,7 +158,7 @@ export function commonStatement(
   }
   let unit: ast.Unit | null = null;
   let endStmt: ast.EndStatement | null = null;
-  if (performAssignmentLookahead((la) => state.peek(la))) {
+  if (performAssignmentLookahead(state)) {
     unit = assignmentStatement(state);
   } else if (state.isInProcedure()) {
     switch (state.token?.tokenTypeIdx) {
@@ -1759,66 +1760,4 @@ function isXInstruction(token: t.Token | null | undefined): boolean {
   }
   const char0 = token.image.charCodeAt(0);
   return char0 === XCharCodeLower || char0 === XCharCode;
-}
-
-const expressionTokenTypes = [
-  t.ID,
-  t.BinaryOperator,
-  t.UnaryOperator,
-  t.AssignmentOperator,
-  t.STRING_TERM,
-  t.NUMBER,
-  t.Comma,
-];
-
-export function performAssignmentLookahead(
-  lookahead: (la: number) => t.Token | undefined,
-): boolean {
-  let i = 1;
-  let token = lookahead(i++);
-  // First token of an assigment needs to be an ID
-  if (!token || !tokenMatcher(token, t.ID)) {
-    return false;
-  }
-  token = lookahead(i++);
-  // We have found a match immediately with the assignment operator
-  if (token && tokenMatcher(token, t.AssignmentOperator)) {
-    return true;
-  }
-  // Otherwise expect an opening parenthesis
-  if (!token || !tokenMatcher(token, t.OpenParen)) {
-    return false;
-  }
-  // The compiler will not use more than 160 tokens to perform the lookahead
-  const max = 160;
-  let parenthesis = 1;
-  while (i < max) {
-    const token = lookahead(i++);
-    if (!token) {
-      return false;
-    }
-    if (parenthesis === 0) {
-      // If we are outside of the parentheses, we always try to match the assignment operator
-      return tokenMatcher(token, t.AssignmentOperator);
-    }
-    if (tokenMatcher(token, t.OpenParen)) {
-      parenthesis++;
-    } else if (tokenMatcher(token, t.CloseParen)) {
-      parenthesis--;
-    } else if (tokenMatcher(token, t.Semicolon)) {
-      // Semicolon indicates the end of the statement
-      return false;
-    } else {
-      if (
-        !expressionTokenTypes.some((tokenType) =>
-          tokenMatcher(token, tokenType),
-        )
-      ) {
-        return false;
-      }
-      // Continue with the next token, the current token is a valid expression token
-    }
-  }
-  // If we reach this point, the lookahead was not successful
-  return false;
 }

--- a/packages/language/test/fourslash/parser/assignment-multi-variable-array.ts
+++ b/packages/language/test/fourslash/parser/assignment-multi-variable-array.ts
@@ -1,0 +1,18 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// DCL (A(10), B) FIXED BIN(31);
+//// A(5), B = 123;
+
+verify.noParserDiagnostics();

--- a/packages/language/test/fourslash/parser/assignment-multi-variable.ts
+++ b/packages/language/test/fourslash/parser/assignment-multi-variable.ts
@@ -1,0 +1,18 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// DCL (A, B) FIXED BIN(31);
+//// A, B = 123;
+
+verify.noParserDiagnostics();

--- a/packages/language/test/fourslash/parser/assignment-with-array-membercall.ts
+++ b/packages/language/test/fourslash/parser/assignment-with-array-membercall.ts
@@ -1,0 +1,18 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// DCL 1 A(10), 2 B FIXED BIN(31);
+//// A(10).B = 123;
+
+verify.noParserDiagnostics();

--- a/packages/language/test/fourslash/parser/assignment-with-array-named-if.ts
+++ b/packages/language/test/fourslash/parser/assignment-with-array-named-if.ts
@@ -1,0 +1,18 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// DCL 1 IF(10) FIXED BIN(31);
+//// IF(10) = 123;
+
+verify.noParserDiagnostics();

--- a/packages/language/test/fourslash/parser/assignment-with-membercall-array.ts
+++ b/packages/language/test/fourslash/parser/assignment-with-membercall-array.ts
@@ -1,0 +1,18 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// DCL 1 A, 2 B(10) FIXED BIN(31);
+//// A.B(10) = 123;
+
+verify.noParserDiagnostics();

--- a/packages/language/test/fourslash/parser/assignment-with-membercall.ts
+++ b/packages/language/test/fourslash/parser/assignment-with-membercall.ts
@@ -1,0 +1,18 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// DCL 1 A, 2 B FIXED BIN(31);
+//// A.B = 123;
+
+verify.noParserDiagnostics();

--- a/packages/language/test/fourslash/parser/if-double-then.ts
+++ b/packages/language/test/fourslash/parser/if-double-then.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// DCL <|1:THEN|> FIXED BIN(31);
+//// IF <|1>THEN THEN; DO; END;
+
+verify.noParserDiagnostics();
+linker.expectLinks();

--- a/packages/language/test/fourslash/parser/if-with-equals.ts
+++ b/packages/language/test/fourslash/parser/if-with-equals.ts
@@ -1,0 +1,17 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// IF 1 = 2 THEN; DO; END;
+
+verify.noParserDiagnostics();

--- a/packages/language/test/fourslash/parser/if-with-parenthesis-equals.ts
+++ b/packages/language/test/fourslash/parser/if-with-parenthesis-equals.ts
@@ -1,0 +1,17 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// IF (1 + 2) = 3 THEN; DO; END;
+
+verify.noParserDiagnostics();

--- a/packages/language/test/fourslash/parser/if-with-parenthesis-operator-equals.ts
+++ b/packages/language/test/fourslash/parser/if-with-parenthesis-operator-equals.ts
@@ -1,0 +1,17 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// IF (1 + 2) * 2 = 6 THEN; DO; END;
+
+verify.noParserDiagnostics();


### PR DESCRIPTION
Based on https://github.com/zowe/zowe-pli-language-support/pull/546 (I needed the `verify.noParserDiagnostics()` test function).

Related to an error in https://github.com/zowe/zowe-pli-language-support/issues/545.

Whenever we encountered an IF that looked like it could be an assignment, but that was actually an `IF` (including the `THEN`), we still thought that it'd be an assignment. For example: `IF (2 * 3) = 6 THEN;...`. Without the `THEN`, this is actually an assignment:

```
// IF statement
IF (2 * 3) = 6 THEN; ...
// Assignment
IF (2 * 3) = 6;
```

Previously, our code assumed that both of these would be assignments. This change fixes the ambiguity in the lookahead and adds a bunch of new tests for the different cases.