### PR TITLE
Implement deprecate validation

### DIFF
--- a/packages/language/src/preprocessor/compiler-options/options-pli.ts
+++ b/packages/language/src/preprocessor/compiler-options/options-pli.ts
@@ -990,14 +990,9 @@ export namespace CompilerOptions {
       format?: DefaultFormat;
     };
   }
-  export interface Deprecate {
-    // TODO ssmifi: check if these should really be accumulated or be overwritten per type.
-    items: DeprecateItem[];
-  }
-  export interface DeprecateItem {
-    type: DeprecateItemType;
-    value: string;
-  }
+  export type Deprecate = {
+    [K in keyof typeof DeprecateItemType]: Set<string>;
+  };
   export interface Display {
     std?: boolean;
     wto?: boolean;
@@ -1363,8 +1358,8 @@ export function getDefaultCompilerOptions(): CompilerOptions {
     currency: "$",
     dbcs: false,
     dbrmlib: false,
-    deprecate: { items: [] },
-    deprecateNext: { items: [] },
+    deprecate: undefined, // undef to quickly exit diagnostics by default
+    deprecateNext: undefined,
     ddsql: "",
     decimal: {
       checkfloat: false,

--- a/packages/language/src/preprocessor/compiler-options/translator-macro.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator-macro.ts
@@ -20,7 +20,9 @@ import {
   Translator,
 } from "./translator";
 
-const translator = new Translator<CompilerOptions>(getDefaultCompilerOptions());
+const translator = new Translator<CompilerOptions>(() =>
+  getDefaultCompilerOptions(),
+);
 
 translator.rule(["CASE"], (option, options) => {
   ensureArguments(option, 1, 1);

--- a/packages/language/src/preprocessor/compiler-options/translator-pli.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator-pli.ts
@@ -41,7 +41,9 @@ import {
   Translator,
 } from "./translator";
 
-const translator = new Translator<CompilerOptions>(getDefaultCompilerOptions());
+const translator = new Translator<CompilerOptions>(() =>
+  getDefaultCompilerOptions(),
+);
 
 const $1K = 1024;
 const $1M = 1024 * 1024;
@@ -874,41 +876,70 @@ translator.rule(["DEFAULT", "DFT"], (option, options, acceptor) => {
 
 /** {@link CompilerOptions.deprecate} */
 /** {@link CompilerOptions.deprecateNext} */
-translator.rule(["DEPRECATE", "DEPRECATENEXT"], (option, options, acceptor) => {
-  ensureArguments(option, 1);
-  let items: CompilerOptions.DeprecateItem[] = [];
-  if (option.name === "DEPRECATE") {
-    ensureToBeDefined(options.deprecate);
-    items = options.deprecate.items;
-  } else {
-    ensureToBeDefined(options.deprecateNext);
-    items = options.deprecateNext.items;
-  }
-  for (const opt of option.values) {
-    ensureType(opt, "option");
-    const type = ensureEnum(
-      opt,
-      CompilerOptionsCodes.Deprecate.InvalidParameter,
-      CompilerOptions.DeprecateItemType,
-    );
-    ensureArguments(opt, 0, 1);
-    const optionValue = opt.values[0];
-    ensureType(optionValue, "plain");
-    const value =
-      type === CompilerOptions.DeprecateItemType.STMT
-        ? ensureArgument(
-            optionValue,
-            CompilerOptionsCodes.Deprecate.InvalidStatementParameter,
-            Options.PLI_STATEMENT_NAMES,
-          )
-        : optionValue.value;
-    items.push({
-      type: type,
-      value: value,
-    });
-  }
-  reportDuplicateSubOptions(option, acceptor);
-});
+translator.rule(
+  ["DEPRECATE", "DEPRECATENEXT"],
+  (option, options, acceptor) => {
+    ensureArguments(option, 1);
+    let deprecateOptions =
+      option.name === "DEPRECATE" ? options.deprecate : options.deprecateNext;
+    if (!deprecateOptions) {
+      if (option.name === "DEPRECATE") {
+        options.deprecate = {
+          BUILTIN: new Set<string>(),
+          ENTRY: new Set<string>(),
+          INCLUDE: new Set<string>(),
+          STMT: new Set<string>(),
+          VARIABLE: new Set<string>(),
+        };
+        deprecateOptions = options.deprecate;
+      } else {
+        options.deprecateNext = {
+          BUILTIN: new Set<string>(),
+          ENTRY: new Set<string>(),
+          INCLUDE: new Set<string>(),
+          STMT: new Set<string>(),
+          VARIABLE: new Set<string>(),
+        };
+        deprecateOptions = options.deprecateNext;
+      }
+    }
+
+    for (const opt of option.values) {
+      ensureType(opt, "option");
+      const type = ensureEnum(
+        opt,
+        CompilerOptionsCodes.Deprecate.InvalidParameter,
+        CompilerOptions.DeprecateItemType,
+      );
+
+      const typeKey = CompilerOptions.DeprecateItemType[
+        type
+      ] as keyof CompilerOptions.Deprecate;
+      deprecateOptions[typeKey].clear();
+      for (const optionValue of opt.values) {
+        ensureType(optionValue, "plain");
+        if (optionValue.value.length === 0) {
+          // Just clear the list if the parameter is empty.
+          continue;
+        }
+        const value =
+          type === CompilerOptions.DeprecateItemType.STMT
+            ? ensureArgument(
+                optionValue,
+                CompilerOptionsCodes.Deprecate.InvalidStatementParameter,
+                Options.PLI_STATEMENT_NAMES,
+              )
+            : optionValue.value;
+
+        deprecateOptions[typeKey].add(value);
+      }
+    }
+    reportDuplicateSubOptions(option, acceptor);
+  },
+  undefined,
+  undefined,
+  { allowDuplicates: true },
+);
 
 /** {@link CompilerOptions.display} */
 translator.rule(["DISPLAY"], (option, options) => {

--- a/packages/language/src/preprocessor/compiler-options/translator-sql.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator-sql.ts
@@ -14,7 +14,9 @@ import { CompilerOptionsCodes } from "./codes";
 import { CompilerOptions, getDefaultCompilerOptions } from "./options-sql";
 import { ensureArguments, ensureType, Translator } from "./translator";
 
-const translator = new Translator<CompilerOptions>(getDefaultCompilerOptions());
+const translator = new Translator<CompilerOptions>(() =>
+  getDefaultCompilerOptions(),
+);
 
 translator.flag("ccsid0", ["CCSID0"], ["NOCCSID0"]);
 

--- a/packages/language/src/preprocessor/compiler-options/translator.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator.ts
@@ -31,6 +31,11 @@ interface TranslatorRule<T extends CompilerOptionsPP = CompilerOptionsPP> {
   negative?: string[];
   positiveTranslate?: Translate<T>;
   negativeTranslate?: Translate<T>;
+  options?: TranslatorRuleOptions;
+}
+
+interface TranslatorRuleOptions {
+  allowDuplicates?: boolean;
 }
 
 type TranslationDiagnosticAcceptor = (diagnostic: Diagnostic) => void;
@@ -51,12 +56,10 @@ enum RuleAlignment {
 
 export class Translator<T extends CompilerOptionsPP = CompilerOptionsPP> {
   options: T;
-  defaults: T;
   diagnostics: Diagnostic[] = [];
 
-  constructor(defaults: T) {
-    this.defaults = defaults;
-    this.options = defaults;
+  constructor(private defaultsFactory: () => T) {
+    this.options = defaultsFactory();
   }
 
   /**
@@ -72,12 +75,14 @@ export class Translator<T extends CompilerOptionsPP = CompilerOptionsPP> {
     positiveTranslate: Translate<T>,
     negative?: string[],
     negativeTranslate?: Translate<T>,
+    options?: TranslatorRuleOptions,
   ) {
     this.rules.push({
       positive,
       negative,
       positiveTranslate,
       negativeTranslate,
+      options,
     });
   }
 
@@ -106,7 +111,7 @@ export class Translator<T extends CompilerOptionsPP = CompilerOptionsPP> {
   clear() {
     this.appliedRules.clear();
     this.diagnostics = [];
-    this.options = { ...this.defaults };
+    this.options = this.defaultsFactory();
   }
 
   /**
@@ -157,7 +162,9 @@ export class Translator<T extends CompilerOptionsPP = CompilerOptionsPP> {
       if (!this.isRuleApplied(rule)) {
         this.appliedRules.set(rule, alignment);
       } else if (this.isRuleAlignedWith(rule, alignment)) {
-        this.reportDupeOptIssue(option, name);
+        if (!rule.options?.allowDuplicates) {
+          this.reportDupeOptIssue(option, name);
+        }
       } else {
         this.reportMutexOptIssue(option, name);
       }

--- a/packages/language/src/validation/compiler/IBM2444Iff-deprecate.ts
+++ b/packages/language/src/validation/compiler/IBM2444Iff-deprecate.ts
@@ -1,0 +1,218 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { diagnosticFromCode } from "../../language-server/types";
+import * as AST from "../../syntax-tree/ast";
+import { ValidationAcceptor } from "../validator";
+import { CompilationUnit } from "../../workspace/compilation-unit";
+import { isBuiltinDeclaration, isEntryDeclaration } from "../utils";
+import { ParametricPLICode, PLICodes } from "../pli-codes";
+import type { Token } from "../../parser/tokens";
+import { CompilerOptions } from "../../preprocessor/compiler-options/options-pli";
+
+const CATEGORY_KEYS: Record<
+  CompilerOptions.DeprecateItemType,
+  keyof CompilerOptions.Deprecate
+> = {
+  [CompilerOptions.DeprecateItemType.BUILTIN]: "BUILTIN",
+  [CompilerOptions.DeprecateItemType.ENTRY]: "ENTRY",
+  [CompilerOptions.DeprecateItemType.INCLUDE]: "INCLUDE",
+  [CompilerOptions.DeprecateItemType.STMT]: "STMT",
+  [CompilerOptions.DeprecateItemType.VARIABLE]: "VARIABLE",
+} as const;
+
+function checkDeprecation(
+  name: string,
+  category: CompilerOptions.DeprecateItemType,
+  token: Token,
+  compilationUnit: CompilationUnit,
+  acceptor: ValidationAcceptor,
+  errorCode: ParametricPLICode,
+  warningCode: ParametricPLICode,
+): void {
+  const categoryKey = CATEGORY_KEYS[category];
+
+  const deprecate =
+    compilationUnit.compilerOptions.deprecate?.[categoryKey]?.has(name);
+  if (deprecate) {
+    acceptor(diagnosticFromCode(errorCode, token, name));
+    return;
+  }
+
+  const deprecateNext =
+    compilationUnit.compilerOptions.deprecateNext?.[categoryKey]?.has(name);
+  if (deprecateNext) {
+    acceptor(diagnosticFromCode(warningCode, token, name));
+  }
+}
+
+export function DeprecateVariables(
+  node: AST.DeclaredVariable,
+  acceptor: ValidationAcceptor,
+  compilationUnit: CompilationUnit,
+): void {
+  if (
+    !compilationUnit.compilerOptions.deprecate &&
+    !compilationUnit.compilerOptions.deprecateNext
+  ) {
+    return;
+  }
+
+  if (!node.nameToken) {
+    return;
+  }
+
+  if (isBuiltinDeclaration(node)) {
+    checkDeprecation(
+      node.nameToken.originalImage,
+      CompilerOptions.DeprecateItemType.BUILTIN,
+      node.nameToken,
+      compilationUnit,
+      acceptor,
+      PLICodes.Error.IBM2444I,
+      PLICodes.Warning.IBM2643I,
+    );
+    return;
+  }
+
+  if (isEntryDeclaration(node)) {
+    checkDeprecation(
+      node.nameToken.originalImage,
+      CompilerOptions.DeprecateItemType.ENTRY,
+      node.nameToken,
+      compilationUnit,
+      acceptor,
+      PLICodes.Error.IBM2446I,
+      PLICodes.Warning.IBM2645I,
+    );
+    return;
+  }
+
+  checkDeprecation(
+    node.nameToken.originalImage,
+    CompilerOptions.DeprecateItemType.VARIABLE,
+    node.nameToken,
+    compilationUnit,
+    acceptor,
+    PLICodes.Error.IBM2447I,
+    PLICodes.Warning.IBM2646I,
+  );
+}
+
+export function DeprecateIncludes(
+  node: AST.IncludeDirective,
+  acceptor: ValidationAcceptor,
+  compilationUnit: CompilationUnit,
+): void {
+  if (
+    (compilationUnit.compilerOptions.deprecate?.INCLUDE.size || 0) == 0 &&
+    (compilationUnit.compilerOptions.deprecateNext?.INCLUDE.size || 0) == 0
+  ) {
+    return;
+  }
+
+  if (!node.token) {
+    return;
+  }
+
+  for (const item of node.items) {
+    let includeName =
+      item.kind === AST.SyntaxKind.IncludeItemFile
+        ? item.fileName
+        : (item as AST.IncludeItemMember).memberName;
+
+    if (!includeName) {
+      continue;
+    }
+
+    // TODO ssmifi: Since we do not allow . in plain text in the compiler option, we strip the extension here.
+    // The spec does only show plain text as valid input. This needs to be confirmed on the mainframe.
+    includeName = includeName.replace(/\.[^/.]+$/, "").toUpperCase();
+
+    checkDeprecation(
+      includeName,
+      CompilerOptions.DeprecateItemType.INCLUDE,
+      node.token,
+      compilationUnit,
+      acceptor,
+      PLICodes.Error.IBM3658I,
+      PLICodes.Warning.IBM3331I,
+    );
+  }
+}
+
+const STATEMENT_KEYWORD_MAP: Record<number, string> = {
+  [AST.SyntaxKind.AllocateStatement]: "ALLOCATE",
+  [AST.SyntaxKind.AssertStatement]: "ASSERT",
+  [AST.SyntaxKind.AttachStatement]: "ATTACH",
+  [AST.SyntaxKind.BeginStatement]: "BEGIN",
+  [AST.SyntaxKind.CallStatement]: "CALL",
+  [AST.SyntaxKind.CloseStatement]: "CLOSE",
+  [AST.SyntaxKind.DelayStatement]: "DELAY",
+  [AST.SyntaxKind.DeleteStatement]: "DELETE",
+  [AST.SyntaxKind.DetachStatement]: "DETACH",
+  [AST.SyntaxKind.DisplayStatement]: "DISPLAY",
+  [AST.SyntaxKind.ExitStatement]: "EXIT",
+  [AST.SyntaxKind.FetchStatement]: "FETCH",
+  [AST.SyntaxKind.FlushStatement]: "FLUSH",
+  [AST.SyntaxKind.FreeStatement]: "FREE",
+  [AST.SyntaxKind.GetFileStatement]: "GET",
+  [AST.SyntaxKind.GetStringStatement]: "GET",
+  [AST.SyntaxKind.GoToStatement]: "GOTO",
+  [AST.SyntaxKind.IterateStatement]: "ITERATE",
+  [AST.SyntaxKind.LeaveStatement]: "LEAVE",
+  [AST.SyntaxKind.LocateStatement]: "LOCATE",
+  [AST.SyntaxKind.OnStatement]: "ON",
+  [AST.SyntaxKind.OpenStatement]: "OPEN",
+  [AST.SyntaxKind.PutFileStatement]: "PUT",
+  [AST.SyntaxKind.PutStringStatement]: "PUT",
+  [AST.SyntaxKind.ReadStatement]: "READ",
+  [AST.SyntaxKind.ReleaseStatement]: "RELEASE",
+  [AST.SyntaxKind.ResignalStatement]: "RESIGNAL",
+  [AST.SyntaxKind.RevertStatement]: "REVERT",
+  [AST.SyntaxKind.RewriteStatement]: "REWRITE",
+  [AST.SyntaxKind.SignalStatement]: "SIGNAL",
+  [AST.SyntaxKind.StopStatement]: "STOP",
+  [AST.SyntaxKind.WaitStatement]: "WAIT",
+  [AST.SyntaxKind.WriteStatement]: "WRITE",
+} as const;
+
+export function DeprecateStatements(
+  node: AST.Statement,
+  acceptor: ValidationAcceptor,
+  compilationUnit: CompilationUnit,
+): void {
+  if (
+    (compilationUnit.compilerOptions.deprecate?.STMT.size || 0) == 0 &&
+    (compilationUnit.compilerOptions.deprecateNext?.STMT.size || 0) == 0
+  ) {
+    return;
+  }
+
+  if (!node.value || !node.startToken) {
+    return;
+  }
+
+  const statementKeyword = STATEMENT_KEYWORD_MAP[node.value.kind];
+  if (!statementKeyword) {
+    return;
+  }
+
+  checkDeprecation(
+    statementKeyword,
+    CompilerOptions.DeprecateItemType.STMT,
+    node.startToken,
+    compilationUnit,
+    acceptor,
+    PLICodes.Error.IBM2454I,
+    PLICodes.Warning.IBM2647I,
+  );
+}

--- a/packages/language/src/validation/pli-validator.ts
+++ b/packages/language/src/validation/pli-validator.ts
@@ -23,6 +23,10 @@ import { checkImplicitBuiltins } from "./language-server/implicit-builtins";
 import { IBM1376IE_attributes_in_declaration_lists } from "./compiler/IBM1376IE-attributes-in-declaration-lists";
 import { IBM3323I_IBM3324I_check_argument_count } from "./compiler/IBM3323I-IBM3324I-check-argument-count";
 import { IBM1352IE_declared_item_pli_scan_repetition } from "./compiler/IBM1352IE-declare-item-scan-repetition";
+import {
+  DeprecateStatements,
+  DeprecateVariables,
+} from "./compiler/IBM2444Iff-deprecate";
 
 /**
  * A function that accepts a diagnostic for PL/I validation
@@ -36,7 +40,7 @@ export function registerPliValidationChecks(): ValidationChecks {
     CallStatement: [IBM3323I_IBM3324I_check_argument_count],
     DeclaredItem: [IBM1352IE_declared_item_pli_scan_repetition, typeCheck],
     DeclareStatement: [IBM1376IE_attributes_in_declaration_lists, typeCheck],
-    DeclaredVariable: [typeCheck],
+    DeclaredVariable: [DeprecateVariables, typeCheck],
     DefineAliasStatement: [typeCheck],
     DefineOrdinalStatement: [typeCheck],
     DoStatement: [IBM2615I_do_loops_execute_once],
@@ -50,6 +54,7 @@ export function registerPliValidationChecks(): ValidationChecks {
     ],
     ReferenceItem: [checkImplicitBuiltins],
     SelectStatement: [IBM1059I_select_without_otherwise],
+    Statement: [DeprecateStatements],
     // TODO @wagner-laranjeiras -> When adding ReturnStatement to this list, make sure to include comment about IBM2412/10/09I.
   };
 }

--- a/packages/language/src/validation/pp-validator.ts
+++ b/packages/language/src/validation/pp-validator.ts
@@ -6,6 +6,7 @@ import { MACRO_Case } from "./macro/case";
 import { ValidationChecks } from "./validator";
 import { IBM1352IE_declared_item_pp_scan_repetition } from "./compiler/IBM1352IE-declare-item-scan-repetition";
 import { LSPIS001_standalone_skip_directive_not_supported } from "./language-server/LSPIS001-skip-statement-not-supported";
+import { DeprecateIncludes } from "./compiler/IBM2444Iff-deprecate";
 
 export function registerPreprocessorValidationChecks(): ValidationChecks {
   return {
@@ -15,6 +16,7 @@ export function registerPreprocessorValidationChecks(): ValidationChecks {
     ],
     DeclaredItem: [IBM1352IE_declared_item_pp_scan_repetition],
     DeclaredVariable: [MACRO_NamePrefix],
+    IncludeDirective: [DeprecateIncludes],
     Program: [MACRO_Case],
     ProcedureStatement: [MACRO_Deprecate, MACRO_NamePrefix],
     SkipDirective: [LSPIS001_standalone_skip_directive_not_supported],

--- a/packages/language/src/validation/utils.ts
+++ b/packages/language/src/validation/utils.ts
@@ -11,6 +11,9 @@
 
 import {
   CallStatement,
+  DeclarationAttribute,
+  DeclaredVariable,
+  DefaultAttribute,
   LabelPrefix,
   ProcedureStatement,
   SimpleOptions,
@@ -89,5 +92,27 @@ export function labelPrefixPointsToPackage(labelPrefix: LabelPrefix) {
   return (
     labelPrefix.container?.kind === SyntaxKind.Statement &&
     labelPrefix.container.value?.kind === SyntaxKind.Package
+  );
+}
+
+export function isBuiltinDeclaration(variable: DeclaredVariable): boolean {
+  const item = variable.container;
+  if (!item || item.kind !== SyntaxKind.DeclaredItem) {
+    return false;
+  }
+  return item.attributes.some(
+    (attr: DeclarationAttribute) =>
+      attr.kind === SyntaxKind.ComputationDataAttribute &&
+      attr.type === DefaultAttribute.BUILTIN,
+  );
+}
+
+export function isEntryDeclaration(variable: DeclaredVariable): boolean {
+  const item = variable.container;
+  if (!item || item.kind !== SyntaxKind.DeclaredItem) {
+    return false;
+  }
+  return item.attributes.some(
+    (attr: DeclarationAttribute) => attr.kind === SyntaxKind.EntryAttribute,
   );
 }

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/deprecate.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/deprecate.ts
@@ -39,32 +39,12 @@ verify.expectDiagnosticsAt(13, {
   message:
     code.CompilerOptions.Deprecate.InvalidStatementParameter.message("INVALID"),
 });
-verify.expectDiagnosticsAt([4, 8, 10, 12, 14, 16, 18, 20, 22], {
-  message: code.CompilerOptions.DupeOptionIssue.message("DEPRECATE"),
-});
 verify.expectCompilerOptions({
   deprecate: {
-    items: [
-      {
-        type: constants.CompilerOptions.DeprecateItemType.STMT,
-        value: "ALLOCATE",
-      },
-      {
-        type: constants.CompilerOptions.DeprecateItemType.BUILTIN,
-        value: "STRLEN",
-      },
-      {
-        type: constants.CompilerOptions.DeprecateItemType.ENTRY,
-        value: "MAIN",
-      },
-      {
-        type: constants.CompilerOptions.DeprecateItemType.INCLUDE,
-        value: "LIB",
-      },
-      {
-        type: constants.CompilerOptions.DeprecateItemType.VARIABLE,
-        value: "FOO",
-      },
-    ],
+    BUILTIN: new Set(["STRLEN"]),
+    ENTRY: new Set(["MAIN"]),
+    INCLUDE: new Set(["LIB"]),
+    STMT: new Set(["ALLOCATE"]),
+    VARIABLE: new Set(["FOO"]),
   },
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/deprecatenext.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/deprecatenext.ts
@@ -39,32 +39,12 @@ verify.expectDiagnosticsAt(13, {
   message:
     code.CompilerOptions.Deprecate.InvalidStatementParameter.message("INVALID"),
 });
-verify.expectDiagnosticsAt([4, 8, 10, 12, 14, 16, 18, 20, 22], {
-  message: code.CompilerOptions.DupeOptionIssue.message("DEPRECATENEXT"),
-});
 verify.expectCompilerOptions({
   deprecateNext: {
-    items: [
-      {
-        type: constants.CompilerOptions.DeprecateItemType.STMT,
-        value: "ALLOCATE",
-      },
-      {
-        type: constants.CompilerOptions.DeprecateItemType.BUILTIN,
-        value: "STRLEN",
-      },
-      {
-        type: constants.CompilerOptions.DeprecateItemType.ENTRY,
-        value: "MAIN",
-      },
-      {
-        type: constants.CompilerOptions.DeprecateItemType.INCLUDE,
-        value: "LIB",
-      },
-      {
-        type: constants.CompilerOptions.DeprecateItemType.VARIABLE,
-        value: "FOO",
-      },
-    ],
+    BUILTIN: new Set(["STRLEN"]),
+    ENTRY: new Set(["MAIN"]),
+    INCLUDE: new Set(["LIB"]),
+    STMT: new Set(["ALLOCATE"]),
+    VARIABLE: new Set(["FOO"]),
   },
 });

--- a/packages/language/test/fourslash/validate/IBM2444Iff-deprecate-variables/deprecate-builtin.ts
+++ b/packages/language/test/fourslash/validate/IBM2444Iff-deprecate-variables/deprecate-builtin.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(BUILTIN(STRLEN));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL <|1:STRLEN|> BUILTIN;
+////   DCL X FIXED BIN(31);
+////   X = STRLEN('TEST');
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2444I);

--- a/packages/language/test/fourslash/validate/IBM2444Iff-deprecate-variables/deprecate-entry.ts
+++ b/packages/language/test/fourslash/validate/IBM2444Iff-deprecate-variables/deprecate-entry.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(ENTRY(MYENTRY));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL <|1:MYENTRY|> ENTRY;
+////   CALL MYENTRY();
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2446I);

--- a/packages/language/test/fourslash/validate/IBM2444Iff-deprecate-variables/deprecate-variable-multiple.ts
+++ b/packages/language/test/fourslash/validate/IBM2444Iff-deprecate-variables/deprecate-variable-multiple.ts
@@ -1,0 +1,25 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(VARIABLE(VARB, VARC));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL <|1:VARB|> FIXED BIN(31);
+////   DCL <|2:VARC|> FIXED BIN(31);
+////   DCL VARD FIXED BIN(31);
+////   VARB = 2;
+////   VARC = 3;
+////   VARD = 4;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2447I);
+verify.expectDiagnosticsAt(2, code.Error.IBM2447I);

--- a/packages/language/test/fourslash/validate/IBM2444Iff-deprecate-variables/deprecate-variable.ts
+++ b/packages/language/test/fourslash/validate/IBM2444Iff-deprecate-variables/deprecate-variable.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(VARIABLE(VARB));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL <|1:VARB|> FIXED BIN(31);
+////   VARB = 2;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2447I);

--- a/packages/language/test/fourslash/validate/IBM2444Iff-deprecate-variables/deprecatenext-builtin.ts
+++ b/packages/language/test/fourslash/validate/IBM2444Iff-deprecate-variables/deprecatenext-builtin.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(BUILTIN(STRLEN));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL <|1:STRLEN|> BUILTIN;
+////   DCL X FIXED BIN(31);
+////   X = STRLEN('TEST');
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2643I);

--- a/packages/language/test/fourslash/validate/IBM2444Iff-deprecate-variables/deprecatenext-entry.ts
+++ b/packages/language/test/fourslash/validate/IBM2444Iff-deprecate-variables/deprecatenext-entry.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(ENTRY(MYENTRY));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL <|1:MYENTRY|> ENTRY;
+////   CALL MYENTRY();
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2645I);

--- a/packages/language/test/fourslash/validate/IBM2444Iff-deprecate-variables/deprecatenext-variable-multiple.ts
+++ b/packages/language/test/fourslash/validate/IBM2444Iff-deprecate-variables/deprecatenext-variable-multiple.ts
@@ -1,0 +1,25 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(VARIABLE(VARB, VARC));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL <|1:VARB|> FIXED BIN(31);
+////   DCL <|2:VARC|> FIXED BIN(31);
+////   DCL VARD FIXED BIN(31);
+////   VARB = 2;
+////   VARC = 3;
+////   VARD = 4;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2646I);
+verify.expectDiagnosticsAt(2, code.Warning.IBM2646I);

--- a/packages/language/test/fourslash/validate/IBM2444Iff-deprecate-variables/deprecatenext-variable.ts
+++ b/packages/language/test/fourslash/validate/IBM2444Iff-deprecate-variables/deprecatenext-variable.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(VARIABLE(VARB));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL <|1:VARB|> FIXED BIN(31);
+////   VARB = 2;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2646I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-allocate.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-allocate.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(STMT(ALLOCATE));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL VARB FIXED BIN(31);
+////   <|1:ALLOCATE|> VARB;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2454I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-assert.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-assert.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(STMT(ASSERT));
+//// TEST: PROC OPTIONS(MAIN);
+////   <|1:ASSERT|> TRUE(1);
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2454I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-attach.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-attach.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(STMT(ATTACH));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYTASK TASK;
+////   <|1:ATTACH|> MYTASK;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2454I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-begin.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-begin.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(STMT(BEGIN));
+//// TEST: PROC OPTIONS(MAIN);
+////   <|1:BEGIN|>;
+////     DCL X FIXED BIN(31);
+////   END;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2454I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-call.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-call.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(STMT(CALL));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYPROC ENTRY;
+////   <|1:CALL|> MYPROC();
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2454I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-close.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-close.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(STMT(CLOSE));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYFILE FILE;
+////   <|1:CLOSE|> FILE(MYFILE);
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2454I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-delay.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-delay.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(STMT(DELAY));
+//// TEST: PROC OPTIONS(MAIN);
+////   <|1:DELAY|> (1000);
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2454I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-delete.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-delete.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(STMT(DELETE));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYFILE FILE;
+////   <|1:DELETE|> FILE(MYFILE);
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2454I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-detach.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-detach.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(STMT(DETACH));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYTASK TASK;
+////   <|1:DETACH|> THREAD(MYTASK);
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2454I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-display.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-display.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(STMT(DISPLAY));
+//// TEST: PROC OPTIONS(MAIN);
+////   <|1:DISPLAY|> ('Hello World');
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2454I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-exit.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-exit.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(STMT(EXIT));
+//// TEST: PROC OPTIONS(MAIN);
+////   <|1:EXIT|>;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2454I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-fetch.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-fetch.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(STMT(FETCH));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYPROC ENTRY;
+////   <|1:FETCH|> MYPROC;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2454I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-flush.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-flush.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(STMT(FLUSH));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYFILE FILE;
+////   <|1:FLUSH|> FILE(MYFILE);
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2454I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-free.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-free.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(STMT(FREE));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL VARB FIXED BIN(31);
+////   <|1:FREE|> VARB;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2454I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-get.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-get.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(STMT(GET));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYFILE FILE;
+////   DCL X CHAR(10);
+////   <|1:GET|> FILE(MYFILE) LIST(X);
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2454I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-goto.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-goto.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(STMT(GOTO));
+//// TEST: PROC OPTIONS(MAIN);
+////   <|1:GOTO|> LBL;
+////   LBL: RETURN;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2454I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-iterate.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-iterate.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(STMT(ITERATE));
+//// TEST: PROC OPTIONS(MAIN);
+////   DO I = 1 TO 10;
+////     <|1:ITERATE|>;
+////   END;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2454I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-leave.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-leave.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(STMT(LEAVE));
+//// TEST: PROC OPTIONS(MAIN);
+////   DO I = 1 TO 10;
+////     <|1:LEAVE|>;
+////   END;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2454I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-locate.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-locate.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(STMT(LOCATE));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYFILE FILE;
+////   DCL X CHAR(10);
+////   <|1:LOCATE|> X FILE(MYFILE);
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2454I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-on.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-on.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(STMT(ON));
+//// TEST: PROC OPTIONS(MAIN);
+////   <|1:ON|> ERROR SYSTEM;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2454I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-open.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-open.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(STMT(OPEN));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYFILE FILE;
+////   <|1:OPEN|> FILE(MYFILE);
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2454I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-put.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-put.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(STMT(PUT));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYFILE FILE;
+////   DCL X CHAR(10);
+////   <|1:PUT|> FILE(MYFILE) LIST(X);
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2454I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-read.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-read.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(STMT(READ));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYFILE FILE;
+////   DCL X CHAR(10);
+////   <|1:READ|> FILE(MYFILE) INTO(X);
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2454I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-release.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-release.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(STMT(RELEASE));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYTASK TASK;
+////   <|1:RELEASE|> MYTASK;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2454I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-resignal.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-resignal.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(STMT(RESIGNAL));
+//// TEST: PROC OPTIONS(MAIN);
+////   ON ERROR BEGIN;
+////     <|1:RESIGNAL|>;
+////   END;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2454I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-revert.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-revert.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(STMT(REVERT));
+//// TEST: PROC OPTIONS(MAIN);
+////   <|1:REVERT|> ERROR;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2454I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-rewrite.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-rewrite.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(STMT(REWRITE));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYFILE FILE;
+////   DCL X CHAR(10);
+////   <|1:REWRITE|> FILE(MYFILE) FROM(X);
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2454I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-signal.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-signal.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(STMT(SIGNAL));
+//// TEST: PROC OPTIONS(MAIN);
+////   <|1:SIGNAL|> ERROR;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2454I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-stop.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-stop.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(STMT(STOP));
+//// TEST: PROC OPTIONS(MAIN);
+////   <|1:STOP|>;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2454I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-wait.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-wait.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(STMT(WAIT));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYTASK TASK;
+////   <|1:WAIT|> THREAD(MYTASK);
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2454I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-write.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecate-write.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(STMT(WRITE));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYFILE FILE;
+////   DCL X CHAR(10);
+////   <|1:WRITE|> FILE(MYFILE) FROM(X);
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM2454I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-allocate.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-allocate.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(ALLOCATE));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL VARB FIXED BIN(31);
+////   <|1:ALLOCATE|> VARB;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-assert.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-assert.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(ASSERT));
+//// TEST: PROC OPTIONS(MAIN);
+////   <|1:ASSERT|> TRUE(1);
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-attach.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-attach.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(ATTACH));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYTASK TASK;
+////   <|1:ATTACH|> MYTASK;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-begin.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-begin.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(BEGIN));
+//// TEST: PROC OPTIONS(MAIN);
+////   <|1:BEGIN|>;
+////     DCL X FIXED BIN(31);
+////   END;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-call.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-call.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(CALL));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYPROC ENTRY;
+////   <|1:CALL|> MYPROC();
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-close.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-close.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(CLOSE));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYFILE FILE;
+////   <|1:CLOSE|> FILE(MYFILE);
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-delay.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-delay.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(DELAY));
+//// TEST: PROC OPTIONS(MAIN);
+////   <|1:DELAY|> (1000);
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-delete.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-delete.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(DELETE));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYFILE FILE;
+////   <|1:DELETE|> FILE(MYFILE);
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-detach.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-detach.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(DETACH));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYTASK TASK;
+////   <|1:DETACH|> MYTASK;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-display.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-display.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(DISPLAY));
+//// TEST: PROC OPTIONS(MAIN);
+////   <|1:DISPLAY|> ('Hello World');
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-exit.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-exit.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(EXIT));
+//// TEST: PROC OPTIONS(MAIN);
+////   <|1:EXIT|>;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-fetch.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-fetch.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(FETCH));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYPROC ENTRY;
+////   <|1:FETCH|> MYPROC;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-flush.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-flush.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(FLUSH));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYFILE FILE;
+////   <|1:FLUSH|> FILE(MYFILE);
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-free.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-free.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(FREE));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL VARB FIXED BIN(31);
+////   <|1:FREE|> VARB;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-get.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-get.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(GET));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYFILE FILE;
+////   DCL X CHAR(10);
+////   <|1:GET|> FILE(MYFILE) LIST(X);
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-goto-not-in-pp.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-goto-not-in-pp.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(GOTO));
+////  %DCL X FIXED;
+////  %<|1:GOTO|> L1;
+////  %L1:;
+////  %X = 1;
+////  <|2:GOTO|> L2;
+////  L2:;
+
+verify.noDiagnostics(1, code.Warning.IBM2647I);
+verify.expectDiagnosticsAt(2, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-goto.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-goto.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(GOTO));
+//// TEST: PROC OPTIONS(MAIN);
+////   <|1:GOTO|> LBL;
+////   LBL: RETURN;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-iterate.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-iterate.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(ITERATE));
+//// TEST: PROC OPTIONS(MAIN);
+////   DO I = 1 TO 10;
+////     <|1:ITERATE|>;
+////   END;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-leave.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-leave.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(LEAVE));
+//// TEST: PROC OPTIONS(MAIN);
+////   DO I = 1 TO 10;
+////     <|1:LEAVE|>;
+////   END;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-locate.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-locate.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(LOCATE));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYFILE FILE;
+////   DCL X CHAR(10);
+////   <|1:LOCATE|> X FILE(MYFILE);
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-on.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-on.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(ON));
+//// TEST: PROC OPTIONS(MAIN);
+////   <|1:ON|> ERROR SYSTEM;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-open.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-open.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(OPEN));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYFILE FILE;
+////   <|1:OPEN|> FILE(MYFILE);
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-put.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-put.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(PUT));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYFILE FILE;
+////   DCL X CHAR(10);
+////   <|1:PUT|> FILE(MYFILE) LIST(X);
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-read.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-read.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(READ));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYFILE FILE;
+////   DCL X CHAR(10);
+////   <|1:READ|> FILE(MYFILE) INTO(X);
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-release.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-release.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(RELEASE));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYTASK TASK;
+////   <|1:RELEASE|> MYTASK;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-resignal.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-resignal.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(RESIGNAL));
+//// TEST: PROC OPTIONS(MAIN);
+////   ON ERROR BEGIN;
+////     <|1:RESIGNAL|> ERROR;
+////   END;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-revert.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-revert.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(REVERT));
+//// TEST: PROC OPTIONS(MAIN);
+////   <|1:REVERT|> ERROR;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-rewrite.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-rewrite.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(REWRITE));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYFILE FILE;
+////   DCL X CHAR(10);
+////   <|1:REWRITE|> FILE(MYFILE) FROM(X);
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-signal.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-signal.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(SIGNAL));
+//// TEST: PROC OPTIONS(MAIN);
+////   <|1:SIGNAL|> ERROR;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-stop.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-stop.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(STOP));
+//// TEST: PROC OPTIONS(MAIN);
+////   <|1:STOP|>;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-wait.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-wait.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(WAIT));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYTASK TASK;
+////   <|1:WAIT|> (MYTASK);
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-write.ts
+++ b/packages/language/test/fourslash/validate/IBM2454I-IBM2647I-deprecate-statements/deprecatenext-write.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(STMT(WRITE));
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL MYFILE FILE;
+////   DCL X CHAR(10);
+////   <|1:WRITE|> FILE(MYFILE) FROM(X);
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM2647I);

--- a/packages/language/test/fourslash/validate/IBM3331I-IBM3658I-deprecate-include/deprecate-include-multiple.ts
+++ b/packages/language/test/fourslash/validate/IBM3331I-IBM3658I-deprecate-include/deprecate-include-multiple.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(INCLUDE(B, LIB));
+//// TEST: PROC OPTIONS(MAIN);
+////   %<|1:INCLUDE|> "b.pli";
+////   %INCLUDE "c.pli";
+////   %<|2:INCLUDE|> lib;
+////   %INCLUDE LIB2;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM3658I);
+verify.expectDiagnosticsAt(2, code.Error.IBM3658I);

--- a/packages/language/test/fourslash/validate/IBM3331I-IBM3658I-deprecate-include/deprecate-include.ts
+++ b/packages/language/test/fourslash/validate/IBM3331I-IBM3658I-deprecate-include/deprecate-include.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATE(INCLUDE(b));
+//// TEST: PROC OPTIONS(MAIN);
+////   %<|1:INCLUDE|> "b.pli";
+////   %INCLUDE "c.pli";
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Error.IBM3658I);

--- a/packages/language/test/fourslash/validate/IBM3331I-IBM3658I-deprecate-include/deprecatenext-include-multiple.ts
+++ b/packages/language/test/fourslash/validate/IBM3331I-IBM3658I-deprecate-include/deprecatenext-include-multiple.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(INCLUDE(B, LIB));
+//// TEST: PROC OPTIONS(MAIN);
+////   %<|1:INCLUDE|> "b.pli";
+////   %INCLUDE "c.pli";
+////   %<|2:INCLUDE|> lib;
+////   %INCLUDE LIB2;
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM3331I);
+verify.expectDiagnosticsAt(2, code.Warning.IBM3331I);

--- a/packages/language/test/fourslash/validate/IBM3331I-IBM3658I-deprecate-include/deprecatenext-include.ts
+++ b/packages/language/test/fourslash/validate/IBM3331I-IBM3658I-deprecate-include/deprecatenext-include.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS DEPRECATENEXT(INCLUDE(B));
+//// TEST: PROC OPTIONS(MAIN);
+////   %<|1:INCLUDE|> "b.pli";
+////   %INCLUDE "c.pli";
+//// END TEST;
+
+verify.expectDiagnosticsAt(1, code.Warning.IBM3331I);


### PR DESCRIPTION
Closes https://github.com/zowe/zowe-pli-language-support/issues/398

This one looks bigger than it is because of all the statement tests. Functional changes are:
- Implement the deprecate validation for https://github.com/zowe/zowe-pli-language-support/issues/398
Therefore, 
  - ~Add token to statements~ (obsolete after rebase)
  - Use sets for deprecate/deprecatenext compiler options
  - Set deprecate/deprecatenext to undefined as default to avoid validations with empty lists
- Add a flag to compiler option rules that allows duplicates
- BUGFIX: Actually request a new default object when compiler options are reset. This fixes a bug where nested compiler options are not reset when changed