### PR TITLE
Fix re-resolution of cached references

### DIFF
--- a/packages/language/src/linking/symbol-table.ts
+++ b/packages/language/src/linking/symbol-table.ts
@@ -446,6 +446,11 @@ function iterateSymbolTable(
 ): void {
   const ref = getReference(node);
   if (ref) {
+    // Reset the reference node to undefined to allow re-resolution.
+    // This is necessary because cached AST nodes may have references
+    // that were resolved in a previous lifecycle run.
+    ref.node = undefined;
+
     if (getPriorityReferenceElement(ref) !== null) {
       context.referencesCache.priorityAdd(ref);
     } else {


### PR DESCRIPTION
Fix for https://github.com/zowe/zowe-pli-language-support/issues/544 3

If the lifecycle is triggered by a change that uses the instruction cache, e.g. due to changes to plugin config, the symbol table does not resolve the references again and no linker diagnostics are generated. 
The fix invalidates the references that the symbol table wants to build before resolution.