### PR TITLE
[Improvement] Handle ddname validation

### DIFF
--- a/packages/language/src/language-server/constants.ts
+++ b/packages/language/src/language-server/constants.ts
@@ -26,6 +26,7 @@ export namespace PluginConfiguration {
         name: "default",
         "compiler-options": [],
         libs: ["cpy", "inc"],
+        "member-name-validation": false,
         "include-extensions": [".pli", ".pl1", ".inc"],
         "implicit-builtins": ["SUBSTR"],
         "lsp-options": {

--- a/packages/language/src/language-server/text-documents.ts
+++ b/packages/language/src/language-server/text-documents.ts
@@ -223,7 +223,7 @@ export class NormalizedTextDocuments<T extends { uri: string }>
     let syncedDocument = this._syncedDocuments.get(UriUtils.normalize(uri));
     if (syncedDocument === undefined && this._loadFromURI) {
       try {
-        const uriName = UriUtils.normalize(uri);
+        let uriName = UriUtils.normalize(uri);
         const content = await FileSystemProviderInstance.readFile(
           URI.parse(uriName),
         );

--- a/packages/language/src/language-server/text-documents.ts
+++ b/packages/language/src/language-server/text-documents.ts
@@ -223,7 +223,7 @@ export class NormalizedTextDocuments<T extends { uri: string }>
     let syncedDocument = this._syncedDocuments.get(UriUtils.normalize(uri));
     if (syncedDocument === undefined && this._loadFromURI) {
       try {
-        let uriName = UriUtils.normalize(uri);
+        const uriName = UriUtils.normalize(uri);
         const content = await FileSystemProviderInstance.readFile(
           URI.parse(uriName),
         );

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2230,11 +2230,9 @@ function isMemberIncludeItem(obj: any): obj is MemberIncludeItem {
 
 /**
  * Encodes each segment of a URI path to ensure special characters are properly escaped.
- * Accepts either a string or URI object and returns the encoded URI as a string.
  */
-function encodeUri(input: string | URI): string {
-  const uri = typeof input === "string" ? URI.parse(input) : input;
-  const encodedPath = uri.path.split("/").map(encodeURIComponent).join("/");
+function encodeUri(input: URI): string {
+  const encodedPath = input.path.split("/").map(encodeURIComponent).join("/");
   return URI.parse(encodedPath).toString();
 }
 
@@ -2297,7 +2295,7 @@ async function runInclude(
   }
 
   try {
-    const document = await TextDocuments.get(encodeUri(uri.path));
+    const document = await TextDocuments.get(encodeUri(uri));
 
     if (!document) {
       throw new Error("Document not found after URI resolution.");

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2509,10 +2509,8 @@ async function resolveIncludeFileUri(
 
   let libMatch: URI | undefined;
   // whether a match was found for a member include
-  const TEST1 = isMemberWithoutDDName(item);
-  const TEST2 = isMemberWithDDName(item);
   let needsMemberValidation =
-    TEST1 || TEST2;
+    isMemberWithoutDDName(item) || isMemberWithDDName(item);
 
   for (const lib of computedLibs) {
     if (isLibsDir(lib)) {
@@ -2538,7 +2536,7 @@ async function resolveIncludeFileUri(
         path: libFileUri,
         extensions: pgroup.includeExtensions,
       });
-      if (libMatch && !isMemberWithDDName) {
+      if (libMatch && !isMemberWithDDName(item)) {
         // regular file match, no member to validate
         needsMemberValidation = false;
         break;

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2508,9 +2508,6 @@ async function resolveIncludeFileUri(
     isMemberWithoutDDName(item) || isMemberWithDDName(item);
 
   for (const lib of computedLibs) {
-    if (libMatch) {
-      break;
-    }
     if (isLibsDir(lib)) {
       const libFileUri = resolveLibFileUri(lib.dir, fileNameOrPartial);
 
@@ -2534,9 +2531,9 @@ async function resolveIncludeFileUri(
         path: libFileUri,
         extensions: pgroup.includeExtensions,
       });
-      if (libMatch && !isMemberWithDDName(item)) {
+      if (libMatch) {
         // regular file match, no member to validate
-        needsMemberValidation = false;
+        needsMemberValidation = isMemberWithDDName(item);
         break;
       }
     } else if (isMemberWithoutDDName(item)) {

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2228,13 +2228,14 @@ function isMemberIncludeItem(obj: any): obj is MemberIncludeItem {
   );
 }
 
-function handleUri(input: string | URI): string {
+/**
+ * Encodes each segment of a URI path to ensure special characters are properly escaped.
+ * Accepts either a string or URI object and returns the encoded URI as a string.
+ */
+function encodeUri(input: string | URI): string {
   const uri = typeof input === "string" ? URI.parse(input) : input;
-  const key = URI.parse(
-    uri.path.split("/").map(encodeURIComponent).join("/"),
-  ).toString();
-
-  return key;
+  const encodedPath = uri.path.split("/").map(encodeURIComponent).join("/");
+  return URI.parse(encodedPath).toString();
 }
 
 async function runInclude(
@@ -2296,7 +2297,7 @@ async function runInclude(
   }
 
   try {
-    const document = await TextDocuments.get(handleUri(uri));
+    const document = await TextDocuments.get(encodeUri(uri));
 
     if (!document) {
       throw new Error("Document not found after URI resolution.");
@@ -2416,16 +2417,8 @@ async function resolveIncludeFileUri(
     return undefined;
   }
 
-  // whether the include item is a standalone member, no ddname specified
-  // in such cases this member may be the suffix of an a ddname entry in the libs, (ex. `A.B.C(member)`)
-  // corresponding to mainframe behavior, if `cpy/A.B.C` or `cpy` is in libs, we should be able to resolve `member`
-  const isMemberWithoutDDName = isMemberIncludeItem(item) && !item.ddname;
-  // Check if it's member wish specified ddname
-  const isMemberWithDDName = !!(
-    isMemberIncludeItem(item) &&
-    item.ddname &&
-    item.memberName
-  );
+  const isMemberWithoutDDName2 = isMemberIncludeItem(item) && !item.ddname;
+  console.log(isMemberWithoutDDName2);
 
   /**
    * Computes the URI for a lib file based on whether the path is absolute or relative.
@@ -2484,9 +2477,42 @@ async function resolveIncludeFileUri(
     }
   }
 
+  /**
+   * Type guard to check if an include item is a standalone member without a DDName specified.
+   * In such cases, this member may be the suffix of a DDName entry in the libs (e.g., `A.B.C(member)`).
+   * Following mainframe behavior, if `cpy/A.B.C` or `cpy` is in libs, we should be able to resolve `member`.
+   *
+   * @param item - The include item to check
+   * @returns True if the item is a member include without a ddname
+   */
+  function isMemberWithoutDDName(
+    item: IncludeItem,
+  ): item is MemberIncludeItem & { ddname: undefined } {
+    return isMemberIncludeItem(item) && !item.ddname;
+  }
+
+  /**
+   * Type guard to check if an include item is a member with an explicitly specified DDName (ex. `ABC.DEF(MEMBER)`).
+   *
+   * @param item - The include item to check
+   * @returns True if the item is a member include with both ddname and memberName populated
+   */
+  function isMemberWithDDName(
+    item: IncludeItem,
+  ): item is MemberIncludeItem & { ddname: string; memberName: string } {
+    return (
+      isMemberIncludeItem(item) &&
+      Boolean(item.ddname) &&
+      Boolean(item.memberName)
+    );
+  }
+
   let libMatch: URI | undefined;
   // whether a match was found for a member include
-  let needsMemberValidation = isMemberWithoutDDName || isMemberWithDDName;
+  const TEST1 = isMemberWithoutDDName(item);
+  const TEST2 = isMemberWithDDName(item);
+  let needsMemberValidation =
+    TEST1 || TEST2;
 
   for (const lib of computedLibs) {
     if (isLibsDir(lib)) {
@@ -2517,7 +2543,7 @@ async function resolveIncludeFileUri(
         needsMemberValidation = false;
         break;
       }
-    } else if (isMemberWithoutDDName) {
+    } else if (isMemberWithoutDDName(item)) {
       // standalone member w/out an explicit ddname, search within ddlib for a match
       const ddLibUri = resolveLibFileUri(lib.ddLib);
       libMatch = await FileSystemProviderInstance.search({
@@ -2528,11 +2554,11 @@ async function resolveIncludeFileUri(
         break;
       }
     } else if (
-      isMemberWithDDName &&
-      lib.ddLib.toLowerCase().endsWith(item.ddname!.toLowerCase())
+      isMemberWithDDName(item) &&
+      lib.ddLib.toLowerCase().endsWith(item.ddname.toLowerCase())
     ) {
       // member w/ ddname, search for an exact match using ddlib
-      const end = lib.ddLib.length - item.ddname!.length;
+      const end = lib.ddLib.length - item.ddname.length;
       const libPath = lib.ddLib.substring(0, end);
       const ddLibUri = resolveLibFileUri(libPath, fileNameOrPartial);
       libMatch = await FileSystemProviderInstance.search({
@@ -2547,9 +2573,8 @@ async function resolveIncludeFileUri(
 
   // depending on whether we matched a member, check to apply validation on the name
   if (needsMemberValidation) {
-    const memberToValidate = isMemberWithDDName
-      ? // Extract the member name from the parenthesis
-        fileNameOrPartial.split("(")[1].split(")")[0]
+    const memberToValidate = isMemberWithDDName(item)
+      ? item.memberName
       : fileNameOrPartial;
 
     checkToValidateMember(memberToValidate);

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2228,14 +2228,6 @@ function isMemberIncludeItem(obj: any): obj is MemberIncludeItem {
   );
 }
 
-/**
- * Encodes each segment of a URI path to ensure special characters are properly escaped.
- */
-function encodeUri(input: URI): string {
-  const encodedPath = input.path.split("/").map(encodeURIComponent).join("/");
-  return URI.parse(encodedPath).toString();
-}
-
 async function runInclude(
   item: IncludeItem,
   context: InterpreterContext,
@@ -2295,7 +2287,7 @@ async function runInclude(
   }
 
   try {
-    const document = await TextDocuments.get(encodeUri(uri));
+    const document = await TextDocuments.get(uri);
 
     if (!document) {
       throw new Error("Document not found after URI resolution.");

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2488,7 +2488,7 @@ async function resolveIncludeFileUri(
     return (
       isMemberIncludeItem(item) &&
       item.ddname !== null &&
-      item.memberName !== null
+      item.memberName.length > 0
     );
   }
 

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2411,6 +2411,9 @@ async function resolveIncludeFileUri(
   // in such cases this member may be the suffix of an a ddname entry in the libs, (ex. `A.B.C(member)`)
   // corresponding to mainframe behavior, if `cpy/A.B.C` or `cpy` is in libs, we should be able to resolve `member`
   const isMemberWithoutDDName = isMemberIncludeItem(item) && !item.ddname;
+  // Check if it's member wish specified ddname
+  const isMemberWithDDName =
+    !!(isMemberIncludeItem(item) && item.ddname && item.memberName);
 
   /**
    * Computes the URI for a lib file based on whether the path is absolute or relative.
@@ -2471,7 +2474,7 @@ async function resolveIncludeFileUri(
 
   let libMatch: URI | undefined;
   // whether a match was found for a member include
-  let needsMemberValidation = isMemberWithoutDDName;
+  let needsMemberValidation = isMemberWithoutDDName || isMemberWithDDName;
 
   for (const lib of computedLibs) {
     if (isLibsDir(lib)) {
@@ -2497,7 +2500,7 @@ async function resolveIncludeFileUri(
         path: libFileUri,
         extensions: pgroup.includeExtensions,
       });
-      if (libMatch) {
+      if (libMatch && !isMemberWithDDName) {
         // regular file match, no member to validate
         needsMemberValidation = false;
         break;
@@ -2513,12 +2516,11 @@ async function resolveIncludeFileUri(
         break;
       }
     } else if (
-      isMemberIncludeItem(item) &&
-      item.ddname &&
-      lib.ddLib.toLowerCase().endsWith(item.ddname.toLowerCase())
+      isMemberWithDDName &&
+      lib.ddLib.toLowerCase().endsWith(item.ddname!.toLowerCase())
     ) {
       // member w/ ddname, search for an exact match using ddlib
-      const end = lib.ddLib.length - item.ddname.length;
+      const end = lib.ddLib.length - item.ddname!.length;
       const libPath = lib.ddLib.substring(0, end);
       const ddLibUri = resolveLibFileUri(libPath, fileNameOrPartial);
       libMatch = await FileSystemProviderInstance.search({
@@ -2533,7 +2535,12 @@ async function resolveIncludeFileUri(
 
   // depending on whether we matched a member, check to apply validation on the name
   if (needsMemberValidation) {
-    checkToValidateMember(fileNameOrPartial);
+    const memberToValidate = 
+    isMemberWithDDName
+      ? fileNameOrPartial.split("(")[1].split(")")[0]
+      : fileNameOrPartial;
+
+    checkToValidateMember(memberToValidate);
   }
   return libMatch;
 }

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2219,7 +2219,7 @@ function isFileIncludeItem(obj: any): obj is FileIncludeItem {
   );
 }
 
-export function isMemberIncludeItem(obj: any): obj is MemberIncludeItem {
+function isMemberIncludeItem(obj: any): obj is MemberIncludeItem {
   return (
     obj &&
     typeof obj === "object" &&
@@ -2287,7 +2287,16 @@ async function runInclude(
   }
 
   try {
-    const document = await TextDocuments.get(uri.path);
+    function toDocumentKey(input: string | URI): string {
+      const uri = typeof input === "string" ? URI.parse(input) : input;
+      const key = URI.parse(
+        uri.path.split("/").map(encodeURIComponent).join("/"),
+      ).toString();
+
+      return key;
+    }
+    const document = await TextDocuments.get(toDocumentKey(uri));
+
     if (!document) {
       throw new Error("Document not found after URI resolution.");
     }
@@ -2331,7 +2340,6 @@ async function runInclude(
   } catch (err) {
     failToResolve(err);
   }
-
   return uri.toString();
 }
 

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2297,7 +2297,7 @@ async function runInclude(
   }
 
   try {
-    const document = await TextDocuments.get(encodeUri(uri));
+    const document = await TextDocuments.get(encodeUri(uri.path));
 
     if (!document) {
       throw new Error("Document not found after URI resolution.");
@@ -2510,6 +2510,9 @@ async function resolveIncludeFileUri(
     isMemberWithoutDDName(item) || isMemberWithDDName(item);
 
   for (const lib of computedLibs) {
+    if (libMatch) {
+      break;
+    }
     if (isLibsDir(lib)) {
       const libFileUri = resolveLibFileUri(lib.dir, fileNameOrPartial);
 

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2219,7 +2219,7 @@ function isFileIncludeItem(obj: any): obj is FileIncludeItem {
   );
 }
 
-function isMemberIncludeItem(obj: any): obj is MemberIncludeItem {
+export function isMemberIncludeItem(obj: any): obj is MemberIncludeItem {
   return (
     obj &&
     typeof obj === "object" &&
@@ -2287,7 +2287,7 @@ async function runInclude(
   }
 
   try {
-    const document = await TextDocuments.get(uri);
+    const document = await TextDocuments.get(uri.path);
     if (!document) {
       throw new Error("Document not found after URI resolution.");
     }
@@ -2539,7 +2539,8 @@ async function resolveIncludeFileUri(
   // depending on whether we matched a member, check to apply validation on the name
   if (needsMemberValidation) {
     const memberToValidate = isMemberWithDDName
-      ? fileNameOrPartial.split("(")[1].split(")")[0]
+      ? // Extract the member name from the parenthesis
+        fileNameOrPartial.split("(")[1].split(")")[0]
       : fileNameOrPartial;
 
     checkToValidateMember(memberToValidate);

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2228,6 +2228,15 @@ function isMemberIncludeItem(obj: any): obj is MemberIncludeItem {
   );
 }
 
+function handleUri(input: string | URI): string {
+  const uri = typeof input === "string" ? URI.parse(input) : input;
+  const key = URI.parse(
+    uri.path.split("/").map(encodeURIComponent).join("/"),
+  ).toString();
+
+  return key;
+}
+
 async function runInclude(
   item: IncludeItem,
   context: InterpreterContext,
@@ -2287,15 +2296,7 @@ async function runInclude(
   }
 
   try {
-    function toDocumentKey(input: string | URI): string {
-      const uri = typeof input === "string" ? URI.parse(input) : input;
-      const key = URI.parse(
-        uri.path.split("/").map(encodeURIComponent).join("/"),
-      ).toString();
-
-      return key;
-    }
-    const document = await TextDocuments.get(toDocumentKey(uri));
+    const document = await TextDocuments.get(handleUri(uri));
 
     if (!document) {
       throw new Error("Document not found after URI resolution.");

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2417,9 +2417,6 @@ async function resolveIncludeFileUri(
     return undefined;
   }
 
-  const isMemberWithoutDDName2 = isMemberIncludeItem(item) && !item.ddname;
-  console.log(isMemberWithoutDDName2);
-
   /**
    * Computes the URI for a lib file based on whether the path is absolute or relative.
    * Relative paths are combined w/ the workspace path.

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2472,9 +2472,7 @@ async function resolveIncludeFileUri(
    * @param item - The include item to check
    * @returns True if the item is a member include without a ddname
    */
-  function isMemberWithoutDDName(
-    item: IncludeItem,
-  ): item is MemberIncludeItem {
+  function isMemberWithoutDDName(item: IncludeItem): item is MemberIncludeItem {
     return isMemberIncludeItem(item) && !item.ddname;
   }
 

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2474,7 +2474,7 @@ async function resolveIncludeFileUri(
    */
   function isMemberWithoutDDName(
     item: IncludeItem,
-  ): item is MemberIncludeItem & { ddname: undefined } {
+  ): item is MemberIncludeItem {
     return isMemberIncludeItem(item) && !item.ddname;
   }
 
@@ -2489,8 +2489,8 @@ async function resolveIncludeFileUri(
   ): item is MemberIncludeItem & { ddname: string; memberName: string } {
     return (
       isMemberIncludeItem(item) &&
-      Boolean(item.ddname) &&
-      Boolean(item.memberName)
+      item.ddname !== null &&
+      item.memberName !== null
     );
   }
 

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2412,8 +2412,11 @@ async function resolveIncludeFileUri(
   // corresponding to mainframe behavior, if `cpy/A.B.C` or `cpy` is in libs, we should be able to resolve `member`
   const isMemberWithoutDDName = isMemberIncludeItem(item) && !item.ddname;
   // Check if it's member wish specified ddname
-  const isMemberWithDDName =
-    !!(isMemberIncludeItem(item) && item.ddname && item.memberName);
+  const isMemberWithDDName = !!(
+    isMemberIncludeItem(item) &&
+    item.ddname &&
+    item.memberName
+  );
 
   /**
    * Computes the URI for a lib file based on whether the path is absolute or relative.
@@ -2535,8 +2538,7 @@ async function resolveIncludeFileUri(
 
   // depending on whether we matched a member, check to apply validation on the name
   if (needsMemberValidation) {
-    const memberToValidate = 
-    isMemberWithDDName
+    const memberToValidate = isMemberWithDDName
       ? fileNameOrPartial.split("(")[1].split(")")[0]
       : fileNameOrPartial;
 

--- a/packages/language/src/workspace/file-system-provider.ts
+++ b/packages/language/src/workspace/file-system-provider.ts
@@ -305,16 +305,12 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
       // perform a search by a member w/ candidate dir path
       const memberPart = `(${options.member})`.toLowerCase();
       const sortedFiles = this.getSortedFiles().map(stripSchemaFromURIString);
+      const normalizedDirPath = stripSchemaFromURIString(
+        options.dirPath.toString(true),
+      ).toLowerCase();
       for (const filePath of sortedFiles) {
         const fpl = filePath.toLowerCase();
-        if (
-          fpl.endsWith(memberPart) &&
-          fpl.startsWith(
-            stripSchemaFromURIString(
-              options.dirPath.toString(true),
-            ).toLowerCase(),
-          )
-        ) {
+        if (fpl.endsWith(memberPart) && fpl.startsWith(normalizedDirPath)) {
           return URI.parse(filePath);
         }
       }

--- a/packages/language/src/workspace/file-system-provider.ts
+++ b/packages/language/src/workspace/file-system-provider.ts
@@ -306,7 +306,6 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
       const memberPart = `(${options.member})`.toLowerCase();
       const sortedFiles = this.getSortedFiles();
       for (const filePath of sortedFiles) {
-        // const fpl = stripSchemaFromURIString(filePath).toLowerCase();
         const fpl = filePath.toLowerCase();
         if (
           fpl.endsWith(memberPart) &&

--- a/packages/language/src/workspace/file-system-provider.ts
+++ b/packages/language/src/workspace/file-system-provider.ts
@@ -53,16 +53,8 @@ export function isPathSearch(obj: any): obj is PathSearch {
 
 /**
  * Converts a filesystem path into a valid `file://` URI.
- *
- * This function safely encodes the path so it can be parsed as a URI
- * without changing its structure. Each path segment is encoded
- * individually using `encodeURIComponent`, while path separators (`/`)
- * are preserved.
- *
- * This avoids common URI parsing issues, such as:
- * - Unencoded `#` characters being interpreted as fragment delimiters
- * - Over-encoding `/` and `:` (which would break the URI structure)
- * - Using `encodeURIComponent` on the entire path, which is incorrect
+ * Strips any existing `file:` prefix before conversion.
+ * The resulting URI properly encodes special characters while preserving path structure.
  */
 function filePathToFileURI(path: string): URI {
   const stringPath = path.toLowerCase().includes("file:")

--- a/packages/language/src/workspace/file-system-provider.ts
+++ b/packages/language/src/workspace/file-system-provider.ts
@@ -52,6 +52,25 @@ export function isPathSearch(obj: any): obj is PathSearch {
 }
 
 /**
+ * Converts a filesystem path into a valid `file://` URI.
+ *
+ * This function safely encodes the path so it can be parsed as a URI
+ * without changing its structure. Each path segment is encoded
+ * individually using `encodeURIComponent`, while path separators (`/`)
+ * are preserved.
+ *
+ * This avoids common URI parsing issues, such as:
+ * - Unencoded `#` characters being interpreted as fragment delimiters
+ * - Over-encoding `/` and `:` (which would break the URI structure)
+ * - Using `encodeURIComponent` on the entire path, which is incorrect
+ */
+function filePathToFileURI(path: string): URI {
+  return URI.parse(
+    "file://" + path.split("/").map(encodeURIComponent).join("/"),
+  );
+}
+
+/**
  * File or directory stats
  */
 export interface Stats {
@@ -240,9 +259,10 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
    */
   async search(options: SearchOptions): Promise<URI | undefined> {
     if (isPathSearch(options)) {
+      // const hasParenthesis = options.path.toString(true).includes("(") && options.path.toString(true).includes(")");
+      // const searchString = hasParenthesis ? "file://"+options.path.path : options.path.toString(true)
       // perform a search with a uri
-      const searchPath = options.path
-        .toString(true)
+      let searchPath = decodeURIComponent(options.path.toString(true))
         .toLowerCase()
         .replace(/\\/g, "/");
       const extensions = options.extensions ?? [];
@@ -286,7 +306,7 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
           fpl.endsWith(memberPart) &&
           fpl.startsWith(options.dirPath.toString(true).toLowerCase())
         ) {
-          return URI.parse(filePath);
+          return filePathToFileURI(filePath);
         }
       }
     }

--- a/packages/language/src/workspace/file-system-provider.ts
+++ b/packages/language/src/workspace/file-system-provider.ts
@@ -52,15 +52,14 @@ export function isPathSearch(obj: any): obj is PathSearch {
 }
 
 /**
- * Converts a filesystem path into a valid `file://` URI.
  * Strips any existing `file:` prefix before conversion.
  * The resulting URI properly encodes special characters while preserving path structure.
  */
-function filePathToFileURI(path: string): URI {
+function stripSchemaFromURIString(path: string): string {
   const stringPath = path.toLowerCase().includes("file:")
     ? path.replace("file:", "")
     : path;
-  return URI.file(stringPath);
+  return stringPath;
 }
 
 /**
@@ -256,7 +255,8 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
         return aSlashes - bSlashes;
       });
     }
-    return this.sortedFilesCache;
+
+    return this.sortedFilesCache.map(stripSchemaFromURIString);
   }
 
   /**
@@ -306,12 +306,17 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
       const memberPart = `(${options.member})`.toLowerCase();
       const sortedFiles = this.getSortedFiles();
       for (const filePath of sortedFiles) {
+        // const fpl = stripSchemaFromURIString(filePath).toLowerCase();
         const fpl = filePath.toLowerCase();
         if (
           fpl.endsWith(memberPart) &&
-          fpl.startsWith(options.dirPath.toString(true).toLowerCase())
+          fpl.startsWith(
+            stripSchemaFromURIString(
+              options.dirPath.toString(true),
+            ).toLowerCase(),
+          )
         ) {
-          return filePathToFileURI(filePath);
+          return URI.parse(filePath);
         }
       }
     }

--- a/packages/language/src/workspace/file-system-provider.ts
+++ b/packages/language/src/workspace/file-system-provider.ts
@@ -172,11 +172,22 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
   }
 
   /**
+   * Converts a URI object to a normalized file:// URL string.
+   * Ensures proper file:// protocol prefix and includes fragment if present.
+   * Returns lowercase normalized path for case-insensitive comparison.
+   */
+  buildUri(uri: URI): string {
+    const prefix = uri.path.startsWith("/") ? "file://" : "file:///";
+    const fragment = uri.fragment ? `#${uri.fragment}` : "";
+    return `${prefix}${uri.path}${fragment}`.toLowerCase();
+  }
+
+  /**
    * Attempts to read a file synchronously from the virtualized file system.
    * If the file does not exist, undefined is returned.
    */
   async readFile(uri: URI): Promise<string | undefined> {
-    return this.files.get(uri.toString(true).toLowerCase());
+    return this.files.get(this.buildUri(uri));
   }
 
   /**

--- a/packages/language/src/workspace/file-system-provider.ts
+++ b/packages/language/src/workspace/file-system-provider.ts
@@ -256,7 +256,7 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
       });
     }
 
-    return this.sortedFilesCache.map(stripSchemaFromURIString);
+    return this.sortedFilesCache;
   }
 
   /**
@@ -304,7 +304,7 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
     } else {
       // perform a search by a member w/ candidate dir path
       const memberPart = `(${options.member})`.toLowerCase();
-      const sortedFiles = this.getSortedFiles();
+      const sortedFiles = this.getSortedFiles().map(stripSchemaFromURIString);
       for (const filePath of sortedFiles) {
         const fpl = filePath.toLowerCase();
         if (

--- a/packages/language/src/workspace/file-system-provider.ts
+++ b/packages/language/src/workspace/file-system-provider.ts
@@ -176,8 +176,12 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
    * Ensures proper file:// protocol prefix and includes fragment if present.
    * Returns lowercase normalized path for case-insensitive comparison.
    */
-  buildUri(uri: URI): string {
+  reconstructFileUri(uri: URI): string {
     const prefix = uri.path.startsWith("/") ? "file://" : "file:///";
+    // In some cases, filenames containing `#` (e.g. `A1@#_$`) are split by URI parsing:
+    // everything after `#` is interpreted as a URI fragment. As a result, the path
+    // becomes `A1@` and `_$` is treated as the fragment, causing part of the filename
+    // to be lost if not handled explicitly.
     const fragment = uri.fragment ? `#${uri.fragment}` : "";
     return `${prefix}${uri.path}${fragment}`.toLowerCase();
   }
@@ -187,7 +191,7 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
    * If the file does not exist, undefined is returned.
    */
   async readFile(uri: URI): Promise<string | undefined> {
-    return this.files.get(this.buildUri(uri));
+    return this.files.get(this.reconstructFileUri(uri));
   }
 
   /**
@@ -270,9 +274,6 @@ export class VirtualFileSystemProvider implements FileSystemProvider {
    */
   async search(options: SearchOptions): Promise<URI | undefined> {
     if (isPathSearch(options)) {
-      // const hasParenthesis = options.path.toString(true).includes("(") && options.path.toString(true).includes(")");
-      // const searchString = hasParenthesis ? "file://"+options.path.path : options.path.toString(true)
-      // perform a search with a uri
       let searchPath = decodeURIComponent(options.path.toString(true))
         .toLowerCase()
         .replace(/\\/g, "/");

--- a/packages/language/src/workspace/file-system-provider.ts
+++ b/packages/language/src/workspace/file-system-provider.ts
@@ -65,9 +65,10 @@ export function isPathSearch(obj: any): obj is PathSearch {
  * - Using `encodeURIComponent` on the entire path, which is incorrect
  */
 function filePathToFileURI(path: string): URI {
-  return URI.parse(
-    "file://" + path.split("/").map(encodeURIComponent).join("/"),
-  );
+  const stringPath = path.toLowerCase().includes("file:")
+    ? path.replace("file:", "")
+    : path;
+  return URI.file(stringPath);
 }
 
 /**

--- a/packages/language/test/fourslash/preprocessor/include/with-member-validation.ts
+++ b/packages/language/test/fourslash/preprocessor/include/with-member-validation.ts
@@ -64,48 +64,48 @@
 //// DECLARE V9 FIXED;
 
 // @filename: main.pli
-//// %INCLUDE <|1:m12345678|>;
-//// %INCLUDE <|2:m1234567|>;
-//// %INCLUDE <|3:A1@#_$|>;
+//// %INCLUDE <|m12345678|>;
+//// %INCLUDE <|m1234567|>;
+//// %INCLUDE <|A1@#_$|>;
 //// // bad include
-//// %INCLUDE <|4:_A1@#|>;
+//// %INCLUDE <|_A1@#|>;
 //// // legitimate file include
-//// %INCLUDE <|5:__legitimatefile|>;
-//// %INCLUDE ABC.DEF(<|6:GHI|>);
-//// %INCLUDE ABC.DEF(<|7:GH@#_$I|>);
-//// %INCLUDE ABC.DEF(<|8:GHIJKLMNO|>);
-//// %INCLUDE ABC.DEF(<|9:#GH@#_$I|>);
-//// %INCLUDE ABC.DEF(<|10:_GH@#_$IJKLM|>);
+//// %INCLUDE <|__legitimatefile|>;
+//// %INCLUDE ABC.DEF(<|GHI|>);
+//// %INCLUDE ABC.DEF(<|GH@#_$I|>);
+//// %INCLUDE ABC.DEF(<|GHIJKLMNO|>);
+//// %INCLUDE ABC.DEF(<|#GH@#_$I|>);
+//// %INCLUDE ABC.DEF(<|_GH@#_$IJKLM|>);
 
 // verify 1 diagnostic on the first include only
-verify.expectExclusiveDiagnosticsAt(1, [
+verify.expectExclusiveDiagnosticsAt("m12345678", [
   code.LSP.MemberValidation.ExceedsMaxLength,
 ]);
 // no diagnostics on the second include
-verify.expectExclusiveDiagnosticsAt(2, []);
+verify.expectExclusiveDiagnosticsAt("m1234567", []);
 // no diagnostics on the 3rd include
-verify.expectExclusiveDiagnosticsAt(3, []);
+verify.expectExclusiveDiagnosticsAt("A1@#_$", []);
 
 // verify 2 diagnostics on the 4th include
 // one for invalid starting char, and another for unresolved include
-verify.expectExclusiveDiagnosticsAt(4, [
+verify.expectExclusiveDiagnosticsAt("_A1@#", [
   code.LSP.MemberValidation.InvalidName,
   code.Severe.IBM1848I,
 ]);
 
 // verify no diagnostics on the legitimate file include
-verify.expectExclusiveDiagnosticsAt(5, []);
+verify.expectExclusiveDiagnosticsAt("__legitimatefile", []);
 
 // verify no diagnostic on the member with valid ddnames.
-verify.expectExclusiveDiagnosticsAt(6, []);
-verify.expectExclusiveDiagnosticsAt(7, []);
+verify.expectExclusiveDiagnosticsAt("GHI", []);
+verify.expectExclusiveDiagnosticsAt("GH@#_$I", []);
 
 // verify diagnostics for members with ddnames: exceeding lenght (8), invalid name (9), both (10)
-verify.expectExclusiveDiagnosticsAt(8, [
+verify.expectExclusiveDiagnosticsAt("GHIJKLMNO", [
   code.LSP.MemberValidation.ExceedsMaxLength,
 ]);
-verify.expectExclusiveDiagnosticsAt(9, [code.LSP.MemberValidation.InvalidName]);
-verify.expectExclusiveDiagnosticsAt(10, [
+verify.expectExclusiveDiagnosticsAt("#GH@#_$I", [code.LSP.MemberValidation.InvalidName]);
+verify.expectExclusiveDiagnosticsAt("_GH@#_$IJKLM", [
   code.LSP.MemberValidation.ExceedsMaxLength,
   code.LSP.MemberValidation.InvalidName,
 ]);

--- a/packages/language/test/fourslash/preprocessor/include/with-member-validation.ts
+++ b/packages/language/test/fourslash/preprocessor/include/with-member-validation.ts
@@ -43,6 +43,26 @@
 // @filename: cpy/__legitimatefile.pli
 //// DECLARE V4 FIXED;
 
+// @filename: cpy/ABC.DEF(GHI)
+//// // expecting to be valid
+//// DECLARE V5 FIXED;
+
+// @filename: cpy/ABC.DEF(GH@#_$I)
+//// // expecting to be valid
+//// DECLARE V6 FIXED;
+
+// @filename: cpy/ABC.DEF(GHIJKLMNO)
+//// // expecting to be invalid
+//// DECLARE V7 FIXED;
+
+// @filename: cpy/ABC.DEF(#GH@#_$I)
+//// // expecting to be invalid
+//// DECLARE V8 FIXED;
+
+// @filename: cpy/ABC.DEF(_GH@#_$IJKLM)
+//// // expecting to be invalid
+//// DECLARE V9 FIXED;
+
 // @filename: main.pli
 //// %INCLUDE <|1:m12345678|>;
 //// %INCLUDE <|2:m1234567|>;
@@ -51,6 +71,11 @@
 //// %INCLUDE <|4:_A1@#|>;
 //// // legitimate file include
 //// %INCLUDE <|5:__legitimatefile|>;
+//// %INCLUDE ABC.DEF(<|6:GHI|>);
+//// %INCLUDE ABC.DEF(<|7:GH@#_$I|>);
+//// %INCLUDE ABC.DEF(<|8:GHIJKLMNO|>);
+//// %INCLUDE ABC.DEF(<|9:#GH@#_$I|>);
+//// %INCLUDE ABC.DEF(<|10:_GH@#_$IJKLM|>);
 
 // verify 1 diagnostic on the first include only
 verify.expectExclusiveDiagnosticsAt(1, [
@@ -68,8 +93,22 @@ verify.expectExclusiveDiagnosticsAt(4, [
   code.Severe.IBM1848I,
 ]);
 
-// lastly verify no diagnostics on the legitimate file include
+// verify no diagnostics on the legitimate file include
 verify.expectExclusiveDiagnosticsAt(5, []);
+
+// verify no diagnostic on the member with valid ddnames.
+verify.expectExclusiveDiagnosticsAt(6, []);
+verify.expectExclusiveDiagnosticsAt(7, []);
+
+// verify diagnostics for members with ddnames: exceeding lenght (8), invalid name (9), both (10)
+verify.expectExclusiveDiagnosticsAt(8, [
+  code.LSP.MemberValidation.ExceedsMaxLength,
+]);
+verify.expectExclusiveDiagnosticsAt(9, [code.LSP.MemberValidation.InvalidName]);
+verify.expectExclusiveDiagnosticsAt(10, [
+  code.LSP.MemberValidation.ExceedsMaxLength,
+  code.LSP.MemberValidation.InvalidName,
+]);
 
 // still expecting the same tokens as before
 preprocessor.expectTokens(`
@@ -77,4 +116,9 @@ preprocessor.expectTokens(`
   DECLARE V2 FIXED;
   DECLARE V3 FIXED;
   DECLARE V4 FIXED;
+  DECLARE V5 FIXED;
+  DECLARE V6 FIXED;
+  DECLARE V7 FIXED;
+  DECLARE V8 FIXED;
+  DECLARE V9 FIXED;
 `);

--- a/packages/language/test/fourslash/preprocessor/include/with-member-validation.ts
+++ b/packages/language/test/fourslash/preprocessor/include/with-member-validation.ts
@@ -104,7 +104,9 @@ verify.expectExclusiveDiagnosticsAt("GH@#_$I", []);
 verify.expectExclusiveDiagnosticsAt("GHIJKLMNO", [
   code.LSP.MemberValidation.ExceedsMaxLength,
 ]);
-verify.expectExclusiveDiagnosticsAt("#GH@#_$I", [code.LSP.MemberValidation.InvalidName]);
+verify.expectExclusiveDiagnosticsAt("#GH@#_$I", [
+  code.LSP.MemberValidation.InvalidName,
+]);
 verify.expectExclusiveDiagnosticsAt("_GH@#_$IJKLM", [
   code.LSP.MemberValidation.ExceedsMaxLength,
   code.LSP.MemberValidation.InvalidName,


### PR DESCRIPTION
Issue #399 

This PR is a follow-up to #478. 
It
- creates explicitly a "member-name-validation" field on the config and set it to false as default
- adds diagnostics for members using the ABC.DEF(filename) syntax
- extends testing
- improves handling of URI differences between VFS and extension files, including proper encoding and decoding.