### PR TITLE
Improve symbol table generation performance

### DIFF
--- a/packages/language/src/language-server/completion/follow-elements.ts
+++ b/packages/language/src/language-server/completion/follow-elements.ts
@@ -24,13 +24,13 @@ import { SimpleCompletionItem } from "../types";
 import { CompilationUnit } from "../../workspace/compilation-unit";
 
 const DataSpecificationCompletionKeywordsArray =
-  CompletionKeywords.DeclarationKeyword.values();
+  CompletionKeywords.DeclarationKeyword.valuesArray();
 const StatementStartCompletionKeywordsArray =
-  CompletionKeywords.StatementStart.values();
+  CompletionKeywords.StatementStart.valuesArray();
 const StatementStartPreprocessorCompletionKeywordsArray =
-  CompletionKeywords.StatementStartPreprocessor.values();
+  CompletionKeywords.StatementStartPreprocessor.valuesArray();
 const StatementStartPreprocessorWithPercentCompletionKeywordsArray =
-  CompletionKeywords.StatementStartPreprocessorWithPercent.values();
+  CompletionKeywords.StatementStartPreprocessorWithPercent.valuesArray();
 const AllStatementStartKeywordsArray = [
   ...StatementStartCompletionKeywordsArray,
   ...StatementStartPreprocessorWithPercentCompletionKeywordsArray,
@@ -349,7 +349,7 @@ export function provideEntryPointFollowElements(
         {
           kind: FollowKind.CstNode,
           items:
-            CompletionKeywords.StatementStartPreprocessorInProcedure.values(),
+            CompletionKeywords.StatementStartPreprocessorInProcedure.valuesArray(),
         },
         {
           kind: FollowKind.LocalReference,
@@ -359,7 +359,7 @@ export function provideEntryPointFollowElements(
       return [
         {
           kind: FollowKind.CstNode,
-          items: CompletionKeywords.StatementStartPreprocessor.values(),
+          items: CompletionKeywords.StatementStartPreprocessor.valuesArray(),
         },
         {
           kind: FollowKind.LocalReference,

--- a/packages/language/src/linking/qualified-syntax-node.ts
+++ b/packages/language/src/linking/qualified-syntax-node.ts
@@ -35,6 +35,8 @@ export class QualifiedSyntaxNode {
    */
   public isRedeclared: boolean | undefined = undefined;
 
+  private _id: string | null = null;
+
   private constructor(
     public readonly token: Token,
     public readonly node: SyntaxNode,
@@ -92,6 +94,10 @@ export class QualifiedSyntaxNode {
   }
 
   getId(): string {
+    // Computing the ID is somewhat expensive, cache the result
+    if (this._id !== null) {
+      return this._id;
+    }
     const parts: string[] = [];
     // Ensure that implicit and explicit declarations get different IDs
     // Some declarations (mainly parameters) are first implicitly declared
@@ -106,7 +112,8 @@ export class QualifiedSyntaxNode {
       parts.push(current.token.id?.toString() || "NaN");
       current = current.parent;
     }
-    return parts.join("_");
+    this._id = parts.join("_");
+    return this._id;
   }
 
   /**

--- a/packages/language/src/linking/scope.ts
+++ b/packages/language/src/linking/scope.ts
@@ -130,7 +130,16 @@ export class ScopeCache {
   }
 
   get(node: SyntaxNode): Scope | undefined {
-    return this.scopes.get(node);
+    const existing = this.scopes.get(node);
+    if (existing) {
+      return existing;
+    }
+    // Get container node scope
+    const parentNode = node.container;
+    if (parentNode) {
+      return this.get(parentNode);
+    }
+    return undefined;
   }
 
   clear(): void {
@@ -138,7 +147,7 @@ export class ScopeCache {
     this.uniqueScopes.clear();
   }
 
-  values(): Scope[] {
-    return Array.from(this.uniqueScopes);
+  values(): IterableIterator<Scope> {
+    return this.uniqueScopes.values();
   }
 }

--- a/packages/language/src/linking/symbol-table.ts
+++ b/packages/language/src/linking/symbol-table.ts
@@ -39,10 +39,6 @@ import { LinkerErrorReporter } from "./error";
 import { DiagnosticCategory } from "../validation/diagnostics-store";
 import { getFirstStructureVariable } from "../syntax-tree/ast-utils";
 
-function nonNull<T>(value: T | null | undefined): value is T {
-  return value !== null && value !== undefined;
-}
-
 /**
  * Terminology:
  * - Redeclaration: A symbol that is declared with the same name in the same scope.
@@ -290,7 +286,13 @@ function getQualifiedSymbols(
   }
 }
 
-const RedeclarationPriority = [SyntaxKind.LabelPrefix];
+function redeclarationPriority(kind: SyntaxKind): number {
+  if (kind === SyntaxKind.LabelPrefix) {
+    return 1;
+  } else {
+    return 0;
+  }
+}
 
 /**
  * Assigns the `isRedeclared` property to all symbols that are redeclared.
@@ -299,19 +301,17 @@ const RedeclarationPriority = [SyntaxKind.LabelPrefix];
  */
 function assignRedeclaredSymbols(scopeCache: ScopeCache) {
   for (const scope of scopeCache.values()) {
-    const symbolsGroups = Array.from(
-      scope.symbolTable.symbols.entriesGroupedByKey(),
-      ([, symbols]) =>
-        symbols
-          .filter((symbol) => !symbol.isImplicit) // We don't want to check implicit declarations for redeclarations.
-          .filter((symbol) => symbol.level === 1) // Get the symbols that are at the first level of scope.
-          .filter((symbol) => symbol.node.kind !== SyntaxKind.WildcardItem), // Wildcard items are not checked for redeclarations.
-    );
+    for (const [, symbols] of scope.symbolTable.symbols.entriesGroupedByKey()) {
+      const filteredSymbols = symbols.filter(
+        (symbol) =>
+          !symbol.isImplicit && // We don't want to check implicit declarations for redeclarations.
+          symbol.level === 1 && // Get the symbols that are at the first level of scope.
+          symbol.node.kind !== SyntaxKind.WildcardItem, // Wildcard items are not checked for redeclarations.
+      );
 
-    for (const symbols of symbolsGroups) {
       // A group of symbols is colliding if it contains more than one symbol.
-      const isColliding = symbols.length > 1;
-      for (const symbol of symbols) {
+      const isColliding = filteredSymbols.length > 1;
+      for (const symbol of filteredSymbols) {
         symbol.isRedeclared = isColliding;
       }
 
@@ -320,13 +320,17 @@ function assignRedeclaredSymbols(scopeCache: ScopeCache) {
       // and variable declaration, the label prefix should always
       // take precedence (i.e, be marked as not redeclared).
       if (isColliding) {
-        const [first] = symbols.toSorted(
-          (a, b) =>
-            RedeclarationPriority.indexOf(b.node.kind) -
-            RedeclarationPriority.indexOf(a.node.kind),
-        );
-
-        first.isRedeclared = false;
+        let item = filteredSymbols[0];
+        let itemPrio = redeclarationPriority(item.node.kind);
+        for (let i = 1; i < filteredSymbols.length; i++) {
+          const symbol = filteredSymbols[i];
+          const prio = redeclarationPriority(symbol.node.kind);
+          if (prio > itemPrio) {
+            item = symbol;
+            itemPrio = prio;
+          }
+        }
+        item.isRedeclared = false;
       }
     }
   }
@@ -377,28 +381,40 @@ export function iterateSymbols(unit: CompilationUnit): void {
   );
 
   const preprocessorScope = Scope.createChild(unit.rootPreprocessorScope);
+  scopeCaches.preprocessor.add(unit.preprocessorAst, preprocessorScope);
 
-  iterateSymbolTable(unit.preprocessorAst, preprocessorScope, {
-    unit,
-    reporter,
-    scopeCache: scopeCaches.preprocessor,
-    referencesCache,
-    statementOrderCache,
-  });
+  iterateSymbolTable(
+    unit.preprocessorAst,
+    preprocessorScope,
+    {
+      unit,
+      reporter,
+      scopeCache: scopeCaches.preprocessor,
+      referencesCache,
+      statementOrderCache,
+    },
+    false,
+  );
   // TODO: Active this when we have some tests
   // assignRedeclaredSymbols(scopeCaches.preprocessor);
 
   // Generate a new scope
   // Otherwise we will add symbols to the root scope (which contains builtins)
   const regularScope = Scope.createChild(unit.rootScope);
+  scopeCaches.regular.add(unit.ast, regularScope);
 
-  iterateSymbolTable(unit.ast, regularScope, {
-    unit,
-    reporter,
-    scopeCache: scopeCaches.regular,
-    referencesCache,
-    statementOrderCache,
-  });
+  iterateSymbolTable(
+    unit.ast,
+    regularScope,
+    {
+      unit,
+      reporter,
+      scopeCache: scopeCaches.regular,
+      referencesCache,
+      statementOrderCache,
+    },
+    false,
+  );
   assignRedeclaredSymbols(scopeCaches.regular);
 }
 
@@ -425,9 +441,16 @@ function handleProcedureStatement(
     end: null,
   };
 
-  forEachNode(newNode, (child) => iterateSymbolTable(child, scope, context));
+  context.scopeCache.add(node, scope);
+
+  forEachNode(newNode, (child) =>
+    iterateSymbolTable(child, scope, context, false),
+  );
   if (node.end) {
-    iterateSymbolTable(node.end, parentScope, context);
+    // Iterate the end node with a separate scope
+    iterateSymbolTable(node.end, parentScope, context, false);
+    // Also add the parent scope to the end node
+    context.scopeCache.add(node.end, parentScope);
   }
 }
 
@@ -443,28 +466,34 @@ function iterateSymbolTable(
   node: SyntaxNode,
   parentScope: Scope,
   context: IterateSymbolTableContext,
+  prioRef: boolean,
 ): void {
+  if (
+    !prioRef &&
+    (node.kind === SyntaxKind.LikeAttribute ||
+      node.kind === SyntaxKind.TypeAttribute)
+  ) {
+    prioRef = true;
+  }
   const ref = getReference(node);
-  if (ref) {
+
+  if (ref !== undefined) {
     // Reset the reference node to undefined to allow re-resolution.
     // This is necessary because cached AST nodes may have references
     // that were resolved in a previous lifecycle run.
     ref.node = undefined;
 
-    if (getPriorityReferenceElement(ref) !== null) {
+    if (prioRef) {
       context.referencesCache.priorityAdd(ref);
     } else {
       context.referencesCache.add(ref);
     }
   }
 
-  // We connect the current node to its scope for usage in the linking phase.
-  context.scopeCache.add(node, parentScope);
-
   const continueRunning = handleNode(node, parentScope, context);
   if (continueRunning) {
     forEachNode(node, (child) =>
-      iterateSymbolTable(child, parentScope, context),
+      iterateSymbolTable(child, parentScope, context, prioRef),
     );
   }
 }
@@ -536,14 +565,14 @@ function handleNode(
       break;
     // E.g. `A, B = 1;`
     case SyntaxKind.AssignmentStatement:
-      const refs = node.refs
-        .map((ref) => ref.element?.element?.ref)
-        .filter(nonNull);
-      for (const ref of refs) {
-        parentScope.symbolTable.addImplicitDeclarationByReference(
-          ref,
-          context.reporter,
-        );
+      for (const nodeRef of node.refs) {
+        const ref = nodeRef.element?.element?.ref;
+        if (ref) {
+          parentScope.symbolTable.addImplicitDeclarationByReference(
+            ref,
+            context.reporter,
+          );
+        }
       }
       break;
     // Any statement is added to the statement order cache

--- a/packages/language/src/utils/collections.ts
+++ b/packages/language/src/utils/collections.ts
@@ -125,10 +125,12 @@ export class MultiMap<K, V> {
   /**
    * Returns a stream of key, value pairs for every entry in the map.
    */
-  entries(): [K, V][] {
-    return Array.from(this.map.entries(), ([key, array]) =>
-      array.map((value) => [key, value] as [K, V]),
-    ).flat();
+  *entries(): IterableIterator<[K, V]> {
+    for (const [key, values] of this.map.entries()) {
+      for (const value of values) {
+        yield [key, value];
+      }
+    }
   }
 
   /**
@@ -145,8 +147,20 @@ export class MultiMap<K, V> {
   /**
    * Returns a stream of values in the map.
    */
-  values(): V[] {
-    return Array.from(this.map.values()).flatMap((a) => a);
+  *values(): IterableIterator<V> {
+    for (const values of this.map.values()) {
+      for (const value of values) {
+        yield value;
+      }
+    }
+  }
+
+  valuesArray(): V[] {
+    const result: V[] = [];
+    for (const values of this.map.values()) {
+      result.push(...values);
+    }
+    return result;
   }
 
   /**

--- a/packages/language/src/validation/validator.ts
+++ b/packages/language/src/validation/validator.ts
@@ -137,29 +137,24 @@ function linkingRedeclarationErrorsToDiagnostics(
   regularScopeCache: ScopeCache,
   reporter: LinkerErrorReporter,
 ) {
-  const symbols = new Set(
-    regularScopeCache
-      .values()
-      .flatMap((scope) => scope.symbolTable.symbols.values())
-      .filter((symbol) => symbol.isRedeclared),
-  );
+  for (const scope of regularScopeCache.values()) {
+    for (const symbol of scope.symbolTable.symbols.values()) {
+      const nameToken = symbol.token;
+      if (!symbol.isRedeclared || !nameToken) {
+        continue;
+      }
 
-  for (const symbol of symbols) {
-    const nameToken = symbol.token;
-    if (!nameToken) {
-      continue;
-    }
-
-    /**
-     * Throw different errors depending on if the declaration is a label for a procedure or a declaration statement.
-     *
-     * TODO @didrikmunther: A LabelPrefix without a procedure option should throw a IBM1911I error instead.
-     * Currently, we don't have a way to know if a label is a statement label or a procedure label.
-     */
-    if (symbol.node.kind === SyntaxKind.LabelPrefix) {
-      reporter.reportAlreadyDeclared(nameToken, symbol.name);
-    } else {
-      reporter.reportRepeatedDeclaration(nameToken, symbol.name);
+      /**
+       * Throw different errors depending on if the declaration is a label for a procedure or a declaration statement.
+       *
+       * TODO @didrikmunther: A LabelPrefix without a procedure option should throw a IBM1911I error instead.
+       * Currently, we don't have a way to know if a label is a statement label or a procedure label.
+       */
+      if (symbol.node.kind === SyntaxKind.LabelPrefix) {
+        reporter.reportAlreadyDeclared(nameToken, symbol.name);
+      } else {
+        reporter.reportRepeatedDeclaration(nameToken, symbol.name);
+      }
     }
   }
 }

--- a/packages/language/test/fourslash/completion/declaration-type.ts
+++ b/packages/language/test/fourslash/completion/declaration-type.ts
@@ -16,7 +16,7 @@
 
 completion.expectAt(1, {
   includes: [
-    ...constants.CompletionKeywords.DeclarationKeyword.values().map(
+    ...constants.CompletionKeywords.DeclarationKeyword.valuesArray().map(
       (keyword) => keyword.label,
     ),
   ],

--- a/packages/language/test/fourslash/completion/pp/procedure-start.ts
+++ b/packages/language/test/fourslash/completion/pp/procedure-start.ts
@@ -25,7 +25,7 @@ completion.expectAt("inside", {
     "CALL",
     "RETURN",
     // Include all other statement-starting preprocessor keywords
-    ...constants.CompletionKeywords.StatementStartPreprocessorInProcedure.values().map(
+    ...constants.CompletionKeywords.StatementStartPreprocessorInProcedure.valuesArray().map(
       (keyword) => keyword.label,
     ),
   ],

--- a/packages/language/test/fourslash/completion/preprocessor-keywords.ts
+++ b/packages/language/test/fourslash/completion/preprocessor-keywords.ts
@@ -15,7 +15,7 @@
 
 completion.expectAt(1, {
   includes:
-    constants.CompletionKeywords.StatementStartPreprocessor.values().map(
+    constants.CompletionKeywords.StatementStartPreprocessor.valuesArray().map(
       (keyword) => keyword.label,
     ),
 });

--- a/packages/language/test/fourslash/completion/start-of-statement.ts
+++ b/packages/language/test/fourslash/completion/start-of-statement.ts
@@ -20,10 +20,10 @@ completion.expectAt(1, {
     "B",
     "C",
     "D",
-    ...constants.CompletionKeywords.StatementStart.values().map(
+    ...constants.CompletionKeywords.StatementStart.valuesArray().map(
       (keyword) => keyword.label,
     ),
-    ...constants.CompletionKeywords.StatementStartPreprocessorWithPercent.values().map(
+    ...constants.CompletionKeywords.StatementStartPreprocessorWithPercent.valuesArray().map(
       (keyword) => keyword.label,
     ),
   ],


### PR DESCRIPTION
Improves the performance of the symbol table generation by ~40% by improving on four main points:

1. Only set the scope on the procedure/package level and walk up the parent chain if necessary. Theoretically, this is computationally the same, but reduces the size of the scope maps massively, and therefore reduces memory pressure.
2. Cache the IDs of qualified syntax nodes, which was expensive to compute.
3. Move the decision whether something is a priority reference into the recursion algorithm. This ensures that we don't have to walk the expression tree multiple times.
4. Massively reduces the garbage we produce during the symbol table generation by replacing the multi-map function results with iterators instead of arrays. This massively cuts down on the produced garbage. Previously, the symbol table generation spent ~30% just in the garbage collector, which this PR reduces to <10%.