### PR TITLE
Update case upper validation logic

### DIFF
--- a/packages/language/src/preprocessor/compiler-options-processor.ts
+++ b/packages/language/src/preprocessor/compiler-options-processor.ts
@@ -11,24 +11,23 @@
 
 import { Range } from "../language-server/types";
 import { CompilerOptionResult } from "./compiler-options/options";
-import {
-  parseAbstractCompilerOptions,
-  AbstractCompilerOptions,
-} from "./compiler-options/parser";
-import { translateCompilerOptions } from "./compiler-options/translate";
+import { parseAbstractCompilerOptions } from "./compiler-options/parser";
+import { CompilerOptionTranslator } from "./compiler-options/translate";
 import { createTokenInstance, PROCESS, Token } from "../parser/tokens";
 import { CstNodeKind } from "../syntax-tree/cst";
 import { URI } from "../utils/uri";
 import { PluginConfigurationProviderInstance } from "../workspace/plugin-configuration-provider";
+import { CompilerOptionSource } from "./compiler-options/translator";
 
 export interface CompilerOptionsProcessorResult {
   result: CompilerOptionResult | undefined;
   text: string;
 }
-
 export class CompilerOptionsProcessor {
   // constant for the *PROCESS token length
   private static readonly PROCESS_TOKEN_LENGTH = 8;
+
+  protected translator = new CompilerOptionTranslator();
 
   /**
    * Extracts compiler options from the given text
@@ -40,111 +39,86 @@ export class CompilerOptionsProcessor {
     text: string,
     uri: URI,
   ): CompilerOptionsProcessorResult {
+    // Extract options and build modified text in a single pass
     const ranges = this.getCompilerOptionsRange(text, uri);
-    let sourceCompilerOptions: string[] = [];
-    let newText = text;
+    const sourceCompilerOptions: string[] = [];
+    const textSegments: string[] = [];
+    let lastPosition = 0;
+
     for (const range of ranges) {
-      // newText should recognize the line break for the margins in the first line after the process directive,
-      // because removing the linebreaks could position the first line of the program outside the margins.
+      // Extract the compiler option text (after *PROCESS token)
       const offset =
         range.start + CompilerOptionsProcessor.PROCESS_TOKEN_LENGTH;
       sourceCompilerOptions.push(text.substring(offset, range.end));
-      newText =
-        newText.substring(0, range.start) +
-        " ".repeat(range.end - range.start - 1) +
-        "\n" +
-        newText.substring(range.end);
+
+      // Build the modified text: keep text before range, replace range with spaces + newline
+      textSegments.push(text.substring(lastPosition, range.start));
+      textSegments.push(" ".repeat(range.end - range.start - 1));
+      textSegments.push("\n");
+
+      lastPosition = range.end;
     }
 
-    // Retrieve compiler options from the plugin configuration provider
+    // Append remaining text after last range
+    textSegments.push(text.substring(lastPosition));
+    const newText = textSegments.join("");
+
+    // Start the compiler options translation here
+    this.translator.clear();
+
+    // Retrieve compiler options from the plugin configuration provider.
+    // We run the translation of the plugin configuration first, so that
+    // duplicate or mutual exclusive options are recognized when translating
+    // the current source file.
     const programConfig =
       PluginConfigurationProviderInstance.getProgramConfig(uri);
 
-    // apply abstract options from the program config
-    // factors in compiler-options as well as pli-options from program & group configs (key-value macro pairs)
-    let mergedAbstractOptions: AbstractCompilerOptions | undefined = undefined;
     if (programConfig?.abstractOptions) {
-      mergedAbstractOptions = {
-        options: [...programConfig.abstractOptions.options],
-        tokens: [],
-        issues: programConfig.issues
-          ? programConfig.issues.map((diag) => ({ ...diag }))
-          : [],
-      };
+      if (ranges.length === 0) {
+        // If there is no anchor in the current file, diagnostics are not added at all.
+        // Just run the compiler options translation.
+        this.translator.setDiagnosticAnchor();
+      } else {
+        // If there is at least one process directive, use the first one as anchor
+        // for the plugin configuration diagnostics.
+        const range = ranges[0];
+        this.translator.setDiagnosticAnchor(
+          {
+            start: range.start + 1,
+            end: range.start + CompilerOptionsProcessor.PROCESS_TOKEN_LENGTH,
+          },
+          uri.toString(),
+          (text) => `PLI Plugin Config: ${text}`,
+        );
+      }
+
+      // Add the compiler option parser issues and start the translation.
+      this.translator.addIssues(programConfig.issues || []);
+      this.translator.translateCompilerOptions(programConfig.abstractOptions, {
+        source: CompilerOptionSource.PLUGIN_CONFIG,
+      });
     }
 
-    for (const [index, srcCompilerOpts] of sourceCompilerOptions.entries()) {
-      const srcAbstractOptions = parseAbstractCompilerOptions(
-        srcCompilerOpts,
+    // Now translate all options from the source file.
+    this.translator.clearDiagnosticAnchor();
+    for (const [index, option] of sourceCompilerOptions.entries()) {
+      const sourceOptions = parseAbstractCompilerOptions(
+        option,
         uri,
         ranges[index].start + CompilerOptionsProcessor.PROCESS_TOKEN_LENGTH,
       );
 
-      if (mergedAbstractOptions) {
-        mergedAbstractOptions.options.push(...srcAbstractOptions.options);
-        mergedAbstractOptions.tokens.push(...srcAbstractOptions.tokens);
-        mergedAbstractOptions.issues.push(...srcAbstractOptions.issues);
-      } else {
-        mergedAbstractOptions = srcAbstractOptions;
-      }
+      // Add parser errors and translate.
+      this.translator.addIssues(sourceOptions.issues);
+      this.translator.translateCompilerOptions(sourceOptions, {
+        source: CompilerOptionSource.SOURCE_FILE,
+      });
     }
 
-    if (mergedAbstractOptions) {
-      const compilerOptionResult = translateCompilerOptions(
-        mergedAbstractOptions,
-      );
-
-      // TODO @montymxb Jun. 18th, 2025: Block below is a temporary fix to avoid reporting the same issues repeatedly
-      //  i.e. parsing & translation from config reveals duplicate or bad options,
-      //  and translation again (in a program context) reinvokes duplicate + validation checks.
-      //  We want a subset of the dupe checks, but we don't want the validation issues again (however these come together atm)
-      //  this should be removed once we break up the translation process to avoid this issue
-
-      //  shave off the issues that are already present in the process group config
-      const issueCount = programConfig?.issues?.length;
-      if (issueCount) {
-        if (ranges.length === 0) {
-          // no *PROCESS to attach to, slice them off instead
-          compilerOptionResult.issues =
-            compilerOptionResult.issues.slice(issueCount);
-        } else {
-          const range = ranges[0];
-          const sourceCompilerOptionsUri = compilerOptionResult.issues.find(
-            (issue) => issue.uri !== undefined,
-          )?.uri;
-          // update just these first 'issueCount' issues to report on *PROCESS
-          for (let i = 0; i < issueCount; i++) {
-            if (i < compilerOptionResult.issues.length) {
-              const issue = compilerOptionResult.issues[i];
-              issue.range = {
-                start: range.start + 1,
-                end:
-                  range.start + CompilerOptionsProcessor.PROCESS_TOKEN_LENGTH,
-              };
-              issue.message = `PLI Plugin Config: ${issue.message}`;
-              issue.uri = sourceCompilerOptionsUri;
-            } else {
-              // leave the rest alone
-              break;
-            }
-          }
-        }
-      }
-
-      for (const range of ranges) {
-        compilerOptionResult.tokens.unshift(range.token);
-      }
-
-      return {
-        result: compilerOptionResult,
-        text: newText,
-      };
-    } else {
-      return {
-        result: undefined,
-        text: newText,
-      };
-    }
+    return {
+      result: this.translator.getResults(),
+      text: newText,
+    };
   }
 
   private getCompilerOptionsRange(

--- a/packages/language/src/preprocessor/compiler-options/options-macro.ts
+++ b/packages/language/src/preprocessor/compiler-options/options-macro.ts
@@ -10,7 +10,10 @@
  */
 
 export interface CompilerOptions {
-  case?: CompilerOptions.Case;
+  case?: {
+    case: CompilerOptions.Case;
+    explicitlySet: boolean;
+  };
   dbcs?: CompilerOptions.Dbcs;
   deprecate?: Set<string>;
   deprecateNext?: Set<string>;
@@ -56,7 +59,10 @@ export namespace CompilerOptions {
 export function getDefaultCompilerOptions(): CompilerOptions {
   // Contrary to the spec, our current implementation and tests use UPPER as default for case and rescan.
   return {
-    case: CompilerOptions.Case.UPPER,
+    case: {
+      case: CompilerOptions.Case.UPPER,
+      explicitlySet: false,
+    },
     dbcs: CompilerOptions.Dbcs.INEXACT,
     deprecate: new Set(),
     deprecateNext: new Set(),

--- a/packages/language/src/preprocessor/compiler-options/options-pli.ts
+++ b/packages/language/src/preprocessor/compiler-options/options-pli.ts
@@ -1147,6 +1147,11 @@ export namespace CompilerOptions {
   export interface PPValue {
     value?: string;
     token?: Token;
+    // PP values are accumulated, e.g., by multiple directives or configurations.
+    // However, they should be processed only once. This has to be done during the processing phase
+    // and cannot be postponed to a later stage, because the options might depend on the concrete configuration.
+    // Therefore, we keep track whether they have already been processed.
+    processed?: boolean;
   }
   export type Proceed = {
     // *PROCESS NOPROCEED; actually results in NOPROCEED( I ); which stops

--- a/packages/language/src/preprocessor/compiler-options/parser.ts
+++ b/packages/language/src/preprocessor/compiler-options/parser.ts
@@ -35,7 +35,7 @@ import { createToken } from "../../parser/token-type-factory";
 
 const commaToken = createToken({ name: "comma", pattern: "," });
 const semicolonToken = createToken({ name: "semicolon", pattern: ";" });
-const stringToken = createToken({
+export const stringToken = createToken({
   name: "string",
   pattern: /("(""|\\.|[^"\\])*"|'(''|\\.|[^'\\])*')/,
 });

--- a/packages/language/src/preprocessor/compiler-options/translate.ts
+++ b/packages/language/src/preprocessor/compiler-options/translate.ts
@@ -24,97 +24,194 @@ import {
 } from "./options-pli";
 import { CompilerOptions as CompilerOptionsMacro } from "./options-macro";
 import { CompilerOptions as CompilerOptionsSQL } from "./options-sql";
-import { Translator } from "./translator";
+import {
+  CompilerOptionSource,
+  RuleConfiguration,
+  Translator,
+} from "./translator";
+import { Diagnostic, Range } from "../../language-server/types";
 
-const translator = getTranslatorPLI();
-const translatorMacro = getTranslatorMacro();
-const translatorSQL = getTranslatorSQL();
+export interface DiagnosticAnchor {
+  range: Range;
+  uri: string;
+  message: (text: string) => string;
+}
+export class CompilerOptionTranslator {
+  protected translator = getTranslatorPLI();
+  protected translatorMacro = getTranslatorMacro();
+  protected translatorSQL = getTranslatorSQL();
 
-export function translateCompilerOptions(
-  input: AbstractCompilerOptions,
-): CompilerOptionResult {
-  // TODO ssmifi: Defaults are set here. They do not need to be set individually.
-  translator.clear();
-  translator.diagnostics = [...input.issues];
-  const options = optionsToUpperCase(input.options);
-  if (options.some((option) => option.name === "PP")) {
-    // If there are PP compiler options, ignore the defaults, because the settings in PP start empty and are accumulated.
-    translator.options.pp = { items: [] };
-  }
-  for (const option of options) {
-    translator.translate(option);
-  }
-
-  // Handle nested compiler options that are not yet parsed.
-  translatorMacro.clear();
-  parseNestedOptions(
-    translatorMacro,
-    CompilerOptions.PPItemName.MACRO,
-    translator.options.ppMacro,
-  );
-  translatorSQL.clear();
-  parseNestedOptions(
-    translatorSQL,
-    CompilerOptions.PPItemName.SQL,
-    translator.options.ppSql,
-  );
-
-  return {
+  protected result: CompilerOptionResult = {
     options: {
-      ...(translator.options as CompilerOptionsPLI),
-      macroOptions: translatorMacro.options as CompilerOptionsMacro,
-      sqlOptions: translatorSQL.options as CompilerOptionsSQL,
+      ...({} as CompilerOptionsPLI),
+      macroOptions: {} as CompilerOptionsMacro,
+      sqlOptions: {} as CompilerOptionsSQL,
     },
-    tokens: input.tokens,
-    issues: [
-      ...translator.diagnostics,
-      ...translatorMacro.diagnostics,
-      ...translatorSQL.diagnostics,
-    ],
+    tokens: [],
+    issues: [],
   };
-}
 
-function parseNestedOptions<T extends CompilerOptionsPP>(
-  ppTranslator: Translator<T>,
-  ppItemName: CompilerOptions.PPItemName,
-  ppDirectValue: CompilerOptions.PPValue | false | undefined,
-): void {
-  const items: CompilerOptions.PPValue[] = [
-    ...(ppDirectValue ? [ppDirectValue] : []),
-    ...(translator.options.pp?.items
-      .filter(
-        (item) => item.name === ppItemName && typeof item.value === "string",
-      )
-      .map((item) => ({ value: item.value, token: item.token })) ?? []),
-  ];
+  protected diagnosticAnchor: DiagnosticAnchor | null | undefined = undefined;
 
-  for (const item of items) {
-    const nestedOptions = parseAbstractCompilerOptions(
-      item.value as string,
-      item.token?.uri,
-      (item.token?.startOffset ?? 0) + 1,
-    );
-    nestedOptions.options.forEach((option) => ppTranslator.translate(option));
-    ppTranslator.diagnostics.push(...nestedOptions.issues);
-  }
-}
-
-// TODO ssmifi: remove the upper cases from the individual rules.
-function optionsToUpperCase(options: CompilerOption[]): CompilerOption[] {
-  const upperCasedOptions: CompilerOption[] = [...options];
-  const optionToUpperCase = (option: CompilerOption) => {
-    option.name = option.name.toUpperCase();
-    for (const value of option.values) {
-      switch (value.kind) {
-        case SyntaxKind.CompilerOptionText:
-          value.value = value.value.toUpperCase();
-          break;
-        case SyntaxKind.CompilerOption:
-          optionToUpperCase(value);
-      }
+  translateCompilerOptions(
+    input: AbstractCompilerOptions,
+    configuration?: RuleConfiguration,
+  ): void {
+    const options = this.optionsToUpperCase(input.options);
+    if (options.some((option) => option.name === "PP")) {
+      // If there are PP compiler options, ignore the defaults, because the settings in PP start empty and are accumulated.
+      this.translator.options.pp = { items: [] };
     }
-  };
+    for (const option of options) {
+      this.translator.translate(option, configuration);
+    }
 
-  upperCasedOptions.forEach(optionToUpperCase);
-  return upperCasedOptions;
+    // Handle nested compiler options that are not yet parsed.
+    this.parseNestedOptions(
+      this.translatorMacro,
+      CompilerOptions.PPItemName.MACRO,
+      this.translator.options.ppMacro,
+      configuration,
+    );
+    this.parseNestedOptions(
+      this.translatorSQL,
+      CompilerOptions.PPItemName.SQL,
+      this.translator.options.ppSql,
+      configuration,
+    );
+
+    this.result.options = {
+      ...(this.translator.options as CompilerOptionsPLI),
+      macroOptions: this.translatorMacro.options as CompilerOptionsMacro,
+      sqlOptions: this.translatorSQL.options as CompilerOptionsSQL,
+    };
+    if (configuration?.source === CompilerOptionSource.SOURCE_FILE) {
+      this.result.tokens.push(...input.tokens);
+    }
+    this.result.issues.push(
+      ...this.applyDiagnosticAnchor([
+        ...this.translator.diagnostics,
+        ...this.translatorMacro.diagnostics,
+        ...this.translatorSQL.diagnostics,
+      ]),
+    );
+    this.translator.clearIssues();
+    this.translatorMacro.clearIssues();
+    this.translatorSQL.clearIssues();
+  }
+
+  clear(): void {
+    this.translator.clear();
+    this.translatorMacro.clear();
+    this.translatorSQL.clear();
+    this.result = {
+      options: {
+        ...({} as CompilerOptionsPLI),
+        macroOptions: {} as CompilerOptionsMacro,
+        sqlOptions: {} as CompilerOptionsSQL,
+      },
+      tokens: [],
+      issues: [],
+    };
+  }
+
+  getResults(): CompilerOptionResult {
+    return this.result;
+  }
+
+  protected parseNestedOptions<T extends CompilerOptionsPP>(
+    ppTranslator: Translator<T>,
+    ppItemName: CompilerOptions.PPItemName,
+    ppDirectValue: CompilerOptions.PPValue | false | undefined,
+    configuration?: RuleConfiguration,
+  ): void {
+    const items: CompilerOptions.PPValue[] = [
+      ...(ppDirectValue ? [ppDirectValue] : []),
+    ];
+
+    // Process items from pp.items array and mark them as processed
+    const ppItems =
+      this.translator.options.pp?.items.filter(
+        (item) =>
+          item.name === ppItemName &&
+          typeof item.value === "string" &&
+          !item.processed,
+      ) ?? [];
+
+    items.push(...ppItems);
+
+    for (const item of items) {
+      const nestedOptions = parseAbstractCompilerOptions(
+        item.value as string,
+        item.token?.uri,
+        (item.token?.startOffset ?? 0) + 1,
+      );
+      item.processed = true;
+      nestedOptions.options.forEach((option) =>
+        ppTranslator.translate(option, configuration),
+      );
+      ppTranslator.diagnostics.push(...nestedOptions.issues);
+    }
+  }
+
+  // TODO ssmifi: remove the upper cases from the individual rules.
+  protected optionsToUpperCase(options: CompilerOption[]): CompilerOption[] {
+    const upperCasedOptions: CompilerOption[] = [...options];
+    const optionToUpperCase = (option: CompilerOption) => {
+      option.name = option.name.toUpperCase();
+      for (const value of option.values) {
+        switch (value.kind) {
+          case SyntaxKind.CompilerOptionText:
+            value.value = value.value.toUpperCase();
+            break;
+          case SyntaxKind.CompilerOption:
+            optionToUpperCase(value);
+        }
+      }
+    };
+
+    upperCasedOptions.forEach(optionToUpperCase);
+    return upperCasedOptions;
+  }
+
+  setDiagnosticAnchor(): void;
+  setDiagnosticAnchor(
+    range: Range,
+    uri: string,
+    message: (text: string) => string,
+  ): void;
+  setDiagnosticAnchor(
+    range?: Range,
+    uri?: string,
+    message?: (text: string) => string,
+  ): void {
+    if (!range || !uri || !message) {
+      this.diagnosticAnchor = null;
+    } else {
+      this.diagnosticAnchor = { range, uri, message };
+    }
+  }
+
+  clearDiagnosticAnchor(): void {
+    this.diagnosticAnchor = undefined;
+  }
+
+  protected applyDiagnosticAnchor(diagnostics: Diagnostic[]): Diagnostic[] {
+    if (this.diagnosticAnchor === undefined) {
+      return diagnostics;
+    } else if (this.diagnosticAnchor === null) {
+      return [];
+    } else {
+      return diagnostics.map((diag) => ({
+        ...diag,
+        range: this.diagnosticAnchor!.range,
+        uri: this.diagnosticAnchor!.uri,
+        message: this.diagnosticAnchor!.message(diag.message),
+      }));
+    }
+  }
+
+  addIssues(issues: Diagnostic[]): void {
+    this.result.issues.push(...issues);
+  }
 }

--- a/packages/language/src/preprocessor/compiler-options/translator-macro.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator-macro.ts
@@ -13,8 +13,10 @@ import { diagnosticFromCode } from "../../language-server/types";
 import { CompilerOptionsCodes } from "./codes";
 import { CompilerOptions, getDefaultCompilerOptions } from "./options-macro";
 import {
+  CompilerOptionSource,
   ensureArguments,
   ensureEnum,
+  ensureToBeDefined,
   ensureType,
   originalImage,
   Translator,
@@ -24,15 +26,22 @@ const translator = new Translator<CompilerOptions>(() =>
   getDefaultCompilerOptions(),
 );
 
-translator.rule(["CASE"], (option, options) => {
+translator.rule(["CASE"], (option, options, _, configuration) => {
   ensureArguments(option, 1, 1);
+  ensureToBeDefined(options.case);
   const value = option.values[0];
   ensureType(value, "plain");
-  options.case = ensureEnum(
-    value,
-    CompilerOptionsCodes.PPMacro.Case.InvalidParameter,
-    CompilerOptions.Case,
-  );
+  options.case = {
+    case: ensureEnum(
+      value,
+      CompilerOptionsCodes.PPMacro.Case.InvalidParameter,
+      CompilerOptions.Case,
+    ),
+    explicitlySet:
+      configuration?.source !== undefined
+        ? configuration.source === CompilerOptionSource.SOURCE_FILE
+        : false,
+  };
 });
 
 translator.rule(["DBCS"], (option, options, acceptor) => {

--- a/packages/language/src/preprocessor/compiler-options/translator.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator.ts
@@ -31,10 +31,19 @@ interface TranslatorRule<T extends CompilerOptionsPP = CompilerOptionsPP> {
   negative?: string[];
   positiveTranslate?: Translate<T>;
   negativeTranslate?: Translate<T>;
-  options?: TranslatorRuleOptions;
+  settings?: RuleSettings;
 }
 
-interface TranslatorRuleOptions {
+export enum CompilerOptionSource {
+  SOURCE_FILE,
+  PLUGIN_CONFIG,
+}
+
+export interface RuleConfiguration {
+  source?: CompilerOptionSource;
+}
+
+export interface RuleSettings {
   allowDuplicates?: boolean;
 }
 
@@ -44,6 +53,7 @@ type Translate<T extends CompilerOptionsPP> = (
   option: CompilerOption,
   options: T,
   acceptor: TranslationDiagnosticAcceptor,
+  configuration?: RuleConfiguration,
 ) => void;
 
 /**
@@ -75,14 +85,14 @@ export class Translator<T extends CompilerOptionsPP = CompilerOptionsPP> {
     positiveTranslate: Translate<T>,
     negative?: string[],
     negativeTranslate?: Translate<T>,
-    options?: TranslatorRuleOptions,
+    settings?: RuleSettings,
   ) {
     this.rules.push({
       positive,
       negative,
       positiveTranslate,
       negativeTranslate,
-      options,
+      settings,
     });
   }
 
@@ -114,6 +124,10 @@ export class Translator<T extends CompilerOptionsPP = CompilerOptionsPP> {
     this.options = this.defaultsFactory();
   }
 
+  clearIssues() {
+    this.diagnostics = [];
+  }
+
   /**
    * Indicates whether a translator rule has been applied to a given option on this run
    */
@@ -131,7 +145,7 @@ export class Translator<T extends CompilerOptionsPP = CompilerOptionsPP> {
     return this.appliedRules.get(rule) === alignment;
   }
 
-  translate(option: CompilerOption) {
+  translate(option: CompilerOption, configuration?: RuleConfiguration): void {
     const name = option.name.toUpperCase();
 
     const reportError = (error: unknown) => {
@@ -162,7 +176,7 @@ export class Translator<T extends CompilerOptionsPP = CompilerOptionsPP> {
       if (!this.isRuleApplied(rule)) {
         this.appliedRules.set(rule, alignment);
       } else if (this.isRuleAlignedWith(rule, alignment)) {
-        if (!rule.options?.allowDuplicates) {
+        if (!rule.settings?.allowDuplicates) {
           this.reportDupeOptIssue(option, name);
         }
       } else {
@@ -176,7 +190,7 @@ export class Translator<T extends CompilerOptionsPP = CompilerOptionsPP> {
         ) => {
           localDiagnostics.push(diagnostic);
         };
-        translate?.(option, this.options, diagnosticsAcceptor);
+        translate?.(option, this.options, diagnosticsAcceptor, configuration);
         this.diagnostics.push(...localDiagnostics); // Only add diagnostics if no exception was thrown.
       } catch (err) {
         reportError(err);

--- a/packages/language/src/validation/macro/case.ts
+++ b/packages/language/src/validation/macro/case.ts
@@ -14,14 +14,9 @@ import * as AST from "../../syntax-tree/ast";
 import { ValidationAcceptor } from "../validator";
 import { CompilationUnit } from "../../workspace/compilation-unit";
 import { CompilerOptions as MacroCompilerOptions } from "../../preprocessor/compiler-options/options-macro";
-import { Token } from "../../parser/tokens";
-import {
-  TraversalState,
-  traverseAllNodes,
-} from "../../syntax-tree/ast-iterator";
-import { PreprocessorTokens } from "../../preprocessor/pli-preprocessor-tokens";
-import { MultiMap } from "../../utils/collections";
 import { LspCodes } from "../lsp-codes";
+import { PreprocessorTokens } from "../../preprocessor/pli-preprocessor-tokens";
+import { stringToken } from "../../preprocessor/compiler-options/parser";
 
 export function MACRO_Case(
   node: AST.Program,
@@ -29,62 +24,49 @@ export function MACRO_Case(
   compilationUnit: CompilationUnit,
 ) {
   if (!compilationUnit.processGroup?.lspOptions.caseUpperValidation) return;
-  if (node !== compilationUnit.preprocessorAst) return;
   if (
-    compilationUnit.compilerOptions.macroOptions.case !==
-    MacroCompilerOptions.Case.UPPER
-  )
+    compilationUnit.compilerOptions.macroOptions.case === undefined ||
+    !compilationUnit.compilerOptions.macroOptions.case.explicitlySet ||
+    compilationUnit.compilerOptions.macroOptions.case?.case !==
+      MacroCompilerOptions.Case.UPPER
+  ) {
     return;
+  }
 
   const MAX_DIAGNOSTICS = 100;
   let diagnosticCount = 0;
 
-  const tokenMap = new MultiMap<AST.SyntaxNode, Token>();
   for (const token of compilationUnit.services.files.getAllTokens()) {
-    if (token.element) {
-      tokenMap.add(token.element, token);
-    }
-  }
+    // Tokens of the compiler options parser use the original token from chevrotain and do not set the originalImage field.
+    // However, their image field contains the original text.
+    const isCompilerOptionToken = token.originalImage === undefined;
+    const image = token.originalImage ?? token.image;
 
-  const processedTokens = new Set<Token>();
-
-  traverseAllNodes(compilationUnit.preprocessorAst, (child) => {
-    if (diagnosticCount >= MAX_DIAGNOSTICS) {
-      return TraversalState.Stop;
-    }
-
-    const nodeTokens = tokenMap.get(child);
-    for (const token of nodeTokens) {
-      if (processedTokens.has(token)) continue;
-      processedTokens.add(token);
-
-      // Skip string tokens
-      if (
-        token.tokenType?.tokenTypeIdx === PreprocessorTokens.String.tokenTypeIdx
-      ) {
+    // Skip string tokens
+    if (isCompilerOptionToken) {
+      if (token.tokenType.tokenTypeIdx === stringToken.tokenTypeIdx) {
         continue;
       }
-
-      if (/[a-z]/.test(token.originalImage)) {
-        if (diagnosticCount >= MAX_DIAGNOSTICS) {
-          return TraversalState.Stop;
-        }
-
-        const diagnostic = diagnosticFromCode(
-          LspCodes.UpperCase,
-          token,
-          token.image,
-        );
-        // Diagnostic data needed for the quickfix
-        diagnostic.data = {
-          uri: diagnostic.uri,
-          text: token.originalImage,
-        };
-        acceptor(diagnostic);
-        diagnosticCount++;
+    } else {
+      if (token.tokenTypeIdx === PreprocessorTokens.String.tokenTypeIdx) {
+        continue;
       }
     }
 
-    return TraversalState.Continue;
-  });
+    if (/[a-z]/.test(image)) {
+      const diagnostic = diagnosticFromCode(LspCodes.UpperCase, token, image);
+
+      // Diagnostic data needed for the quickfix
+      diagnostic.data = {
+        uri: diagnostic.uri,
+        text: token.originalImage,
+      };
+      acceptor(diagnostic);
+
+      diagnosticCount++;
+      if (diagnosticCount >= MAX_DIAGNOSTICS) {
+        break;
+      }
+    }
+  }
 }

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -12,12 +12,10 @@
 import { minimatch } from "minimatch";
 import { Diagnostic as LspDiagnostic } from "vscode-languageserver-types";
 import { Diagnostic } from "../language-server/types";
-import { CompilerOptionResult } from "../preprocessor/compiler-options/options";
 import {
   AbstractCompilerOptions,
   parseAbstractCompilerOptions,
 } from "../preprocessor/compiler-options/parser";
-import { translateCompilerOptions } from "../preprocessor/compiler-options/translate";
 import { isBoolean, isNumber, isStringArray } from "../utils/types";
 import { URI, UriUtils } from "../utils/uri";
 import { FileSystemProviderInstance } from "./file-system-provider";
@@ -151,7 +149,7 @@ export function deserializeProcessGroup(
         : MAX_INSTRUCTION_COUNTER,
       caseUpperValidation: isBoolean(lspOptions["case-upper-validation"])
         ? lspOptions["case-upper-validation"]
-        : false,
+        : true,
     },
     memberNameValidation: isBoolean(memberNameValidation)
       ? memberNameValidation
@@ -543,36 +541,17 @@ export class PluginConfigurationProvider {
         ...(processGroupConfig?.compilerOptions || []),
       ].join(" ");
       // combine them and pass them all together to parse and translate
-      const [abstractOptions, translatedOptions, collectedIssues] =
-        this.parseAndTranslateOptions(rawCompilerOptions);
-      for (const issue of collectedIssues) {
+      const abstractOptions = parseAbstractCompilerOptions(
+        `${rawCompilerOptions} ${rawCompilerOptions}`,
+      );
+      for (const issue of abstractOptions.issues) {
         console.error(
           `Error in compiler options for program config "${programConfig.program}": ${issue}`,
         );
       }
       programConfig.abstractOptions = abstractOptions;
-      programConfig.issues = translatedOptions.issues;
+      programConfig.issues = abstractOptions.issues;
     }
-  }
-
-  /**
-   * Helper to translate some string of compiler options into a tuple of abstract & translated options
-   * @param options Options string to parse and translate
-   * @returns Tuple of AbstractCompilerOptions and CompilerOptionResult
-   */
-  private parseAndTranslateOptions(
-    options: string,
-  ): [AbstractCompilerOptions, CompilerOptionResult, string[]] {
-    const abstractOptions = parseAbstractCompilerOptions(options);
-    const translatedOptions = translateCompilerOptions(abstractOptions);
-    const collectedIssues: string[] = [];
-    for (const issue of [
-      ...translatedOptions.issues,
-      ...abstractOptions.issues,
-    ]) {
-      collectedIssues.push(issue.message);
-    }
-    return [abstractOptions, translatedOptions, collectedIssues];
   }
 
   /**

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-macro/case.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-macro/case.ts
@@ -21,6 +21,9 @@ verify.expectDiagnosticsAt(1, {
 
 verify.expectCompilerOptions({
   macroOptions: {
-    case: constants.CompilerOptions.Macro.Case.UPPER,
+    case: {
+      case: constants.CompilerOptions.Macro.Case.UPPER,
+      explicitlySet: true,
+    },
   },
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-macro/ppmacro.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-macro/ppmacro.ts
@@ -18,19 +18,23 @@
 ////*PROCESS <|8:PPMACRO|>(<|9:''|>);
 ////*PROCESS <|10:PPMACRO|>(<|11:'   '|>);
 ////*PROCESS <|12:PPMACRO|>('CASE(UPPER)');
+////*PROCESS <|14:PPMACRO|>(<|15:'abc'|>);
 
 verify.expectDiagnosticsAt(2, {
   message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
 });
-verify.expectDiagnosticsAt([4, 6, 8, 10, 12], {
+verify.expectDiagnosticsAt([4, 6, 8, 10, 12, 14], {
   message: code.CompilerOptions.DupeOptionIssue.message("PPMACRO"),
 });
 verify.expectDiagnosticsAt([5, 7], {
   message: code.CompilerOptions.ExpectedString.message(),
 });
-verify.noDiagnostics([9, 11]);
+verify.noDiagnostics([9, 11, 15]);
 verify.expectCompilerOptions({
   macroOptions: {
-    case: constants.CompilerOptions.Macro.Case.UPPER,
+    case: {
+      case: constants.CompilerOptions.Macro.Case.UPPER,
+      explicitlySet: true,
+    },
   },
 });

--- a/packages/language/test/fourslash/validate/builtins-implicit-declaration.ts
+++ b/packages/language/test/fourslash/validate/builtins-implicit-declaration.ts
@@ -25,7 +25,7 @@
 //// END RGT005;
 
 verify.expectExclusiveErrorCodesAt(1, code.Error.IBM1373I);
-verify.expectExclusiveErrorCodesAt(2, code.Error.IBM1373I);
-verify.expectDiagnosticsAt(2, {
+verify.expectDiagnosticsAt(1, {
   severity: constants.Severity.W,
 });
+verify.noDiagnostics(2, code.Error.IBM1373I);

--- a/packages/language/test/fourslash/validate/macro/case-opt-in-explicit.ts
+++ b/packages/language/test/fourslash/validate/macro/case-opt-in-explicit.ts
@@ -11,18 +11,6 @@
 
 /// <reference path="../../framework.ts" />
 
-// @filename: .pliplugin/proc_grps.json
-//// {
-////     "pgroups": [
-////         {
-////         "name": "default",
-////         "lsp-options": {
-////             "case-upper-validation": true
-////         }
-////         }
-////     ]
-//// }
-
 ////%PROCESS PP(MACRO('CASE(UPPER)'));
 //// %DCL <|1:x|> <|2:char|>;
 //// %DCL Y CHAR;

--- a/packages/language/test/fourslash/validate/macro/case-opt-out-no-explicit-config.ts
+++ b/packages/language/test/fourslash/validate/macro/case-opt-out-no-explicit-config.ts
@@ -16,6 +16,9 @@
 ////     "pgroups": [
 ////         {
 ////         "name": "default",
+////         "compiler-options": [
+////             "PP(MACRO('CASE(UPPER)'))"
+////         ],
 ////         "lsp-options": {
 ////             "case-upper-validation": true
 ////         }
@@ -23,7 +26,6 @@
 ////     ]
 //// }
 
-////%PROCESS PP(MACRO('CASE(UPPER)'));
 //// %DCL <|1:x|> <|2:char|>;
 //// %DCL Y CHAR;
 //// %X = <|3:"PUT SKIP LIST('Hello, World!');"|>;
@@ -37,6 +39,6 @@
 ////   Y
 //// END RGT005;
 
-verify.expectDiagnosticsAt(1, code.LspCodes.UpperCase);
-verify.expectDiagnosticsAt(2, code.LspCodes.UpperCase);
-verify.expectDiagnosticsAt(3, code.LspCodes.UpperCase);
+verify.noDiagnostics(1, code.LspCodes.UpperCase);
+verify.noDiagnostics(2, code.LspCodes.UpperCase);
+verify.noDiagnostics(3, code.LspCodes.UpperCase);

--- a/packages/language/test/fourslash/validate/macro/case-opt-out-no-explicit.ts
+++ b/packages/language/test/fourslash/validate/macro/case-opt-out-no-explicit.ts
@@ -23,7 +23,6 @@
 ////     ]
 //// }
 
-////%PROCESS PP(MACRO('CASE(UPPER)'));
 //// %DCL <|1:x|> <|2:char|>;
 //// %DCL Y CHAR;
 //// %X = <|3:"PUT SKIP LIST('Hello, World!');"|>;
@@ -37,6 +36,6 @@
 ////   Y
 //// END RGT005;
 
-verify.expectDiagnosticsAt(1, code.LspCodes.UpperCase);
-verify.expectDiagnosticsAt(2, code.LspCodes.UpperCase);
-verify.expectDiagnosticsAt(3, code.LspCodes.UpperCase);
+verify.noDiagnostics(1, code.LspCodes.UpperCase);
+verify.noDiagnostics(2, code.LspCodes.UpperCase);
+verify.noDiagnostics(3, code.LspCodes.UpperCase);

--- a/packages/language/test/fourslash/validate/macro/case-opt-out.ts
+++ b/packages/language/test/fourslash/validate/macro/case-opt-out.ts
@@ -11,6 +11,18 @@
 
 /// <reference path="../../framework.ts" />
 
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////         "name": "default",
+////         "lsp-options": {
+////             "case-upper-validation": false
+////         }
+////         }
+////     ]
+//// }
+
 ////%PROCESS PP(MACRO('CASE(UPPER)'));
 //// %DCL <|1:x|> <|2:char|>;
 //// %DCL Y CHAR;

--- a/packages/language/test/fourslash/validate/typesystem/like/like-structure-inner-node-type.ts
+++ b/packages/language/test/fourslash/validate/typesystem/like/like-structure-inner-node-type.ts
@@ -14,8 +14,8 @@
 // @wrap: main
 //// declare 1 person,
 ////           2 address,
-////.            3 street char(100),
-////.            3 city char(50);
+////             3 street char(100),
+////             3 city char(50);
 //// declare <|same|> like person.address;
 //// declare <|same2|> like address;
 

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -298,29 +298,17 @@ export class TestBuilder {
       PluginConfigurationProviderInstance.setProgramConfigs("", [
         {
           program: "*.pli",
-          pgroup: "default",
+          pgroup:
+            PluginConfiguration.DEFAULT_PROGRAM_FILE_CONTENT.pgms[0].pgroup,
         },
       ]);
     }
 
     // add process group config if not present on disc
     if (!hasProcessGroupConfig) {
-      await PluginConfigurationProviderInstance.setProcessGroupConfigs([
-        {
-          name: "default",
-          libs: ["cpy"],
-          $computedLibs: [],
-          $computedLibsSet: new Set<string>(),
-          includeExtensions: [".pli"],
-          compilerOptions: [],
-          implicitBuiltins: new Set(),
-          lspOptions: {
-            checkMargins: false,
-            instructionCounterLimit: 5000,
-            caseUpperValidation: false,
-          },
-        },
-      ]);
+      await PluginConfigurationProviderInstance.parseProcessGroupConfigs(
+        JSON.stringify(PluginConfiguration.DEFAULT_PROCESS_GROUP_FILE_CONTENT),
+      );
     }
   }
 


### PR DESCRIPTION
Solution for https://github.com/zowe/zowe-pli-language-support/issues/544 4 CASE(UPPER)

- As discussed, the `MACRO('CASE(UPPER)')` validation is now triggered when the corresponding directive is present in the source file. For this, the compiler option translator had to be extended to recognize the origin of the options. Before the change, it was more or less agnostic about whether it originated from the plugin configuration or the source files.
- The whole validation can still be turned off by setting `case-upper-validation` to false in the `pli-options`.
- I took the opportunity to clean up `extractCompilerOptions` a bit.
  - The top level translator itself if now wrapped in a class so that different sender can just incrementally translate rules. Note that the single translator rules for pli, macro, and sql are still residing in single objects each. 
  - The diagnostics are handled by the translator itself and it provides functions to anchor them to the source file instead of the post-processing.
  - The input text processing only uses a single substring for the text after the directives, which should improve performance when there are multiple directives.
  - Removed the translation in the `plugin-configuration-provider` as it was not really used anyways. It is enough when the configuration rules are parsed here and translated later. 
- The `test-builder` uses the config's defaults by default now. If a test needs a particular set of options, it should set them in the test files.

_edit_: As requested: The macro case upper option considers all input text, hence also affecting non-preprocessor code. 