### PR TITLE
Remove pli-options from plugin config

### DIFF
--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -18,13 +18,7 @@ import {
   parseAbstractCompilerOptions,
 } from "../preprocessor/compiler-options/parser";
 import { translateCompilerOptions } from "../preprocessor/compiler-options/translate";
-import {
-  isBoolean,
-  isNumber,
-  isRecordOf,
-  isString,
-  isStringArray,
-} from "../utils/types";
+import { isBoolean, isNumber, isStringArray } from "../utils/types";
 import { URI, UriUtils } from "../utils/uri";
 import { FileSystemProviderInstance } from "./file-system-provider";
 import { MAX_INSTRUCTION_COUNTER } from "../preprocessor/instruction-interpreter";
@@ -41,7 +35,7 @@ export type PliOptions = Record<string, string>;
 export interface ProgramConfig {
   program: string;
   pgroup: string;
-  pliOptions: PliOptions;
+  compilerOptions?: string[];
 
   /**
    * Prebuilt abstract options for this program config.
@@ -60,15 +54,15 @@ export interface ProgramConfig {
 interface SerializedProgramConfig {
   program: string;
   pgroup: string;
-  "pli-options"?: PliOptions;
+  "compiler-options"?: string[];
 }
 
 function deserializeProgramConfig(obj: SerializedProgramConfig): ProgramConfig {
-  const pliOptions = obj["pli-options"] || {};
+  const compilerOptions = obj["compiler-options"] || [];
   return {
     program: obj.program,
     pgroup: obj.pgroup,
-    pliOptions: isRecordOf(pliOptions, isString) ? pliOptions : {},
+    compilerOptions: isStringArray(compilerOptions) ? compilerOptions : [],
   };
 }
 
@@ -79,7 +73,6 @@ function deserializeProgramConfig(obj: SerializedProgramConfig): ProgramConfig {
 export interface ProcessGroup {
   name: string;
   compilerOptions: string[];
-  pliOptions: PliOptions;
 
   /**
    * Actual libs as they're loaded from the config on disk.
@@ -132,7 +125,6 @@ export function deserializeProcessGroup(
   obj: SerializedProcessGroup,
 ): ProcessGroup {
   const compilerOptions = obj["compiler-options"] || [];
-  const pliOptions = obj["pli-options"] || {};
   const includeExtensions = obj["include-extensions"] || [];
   const implicitBuiltins = obj["implicit-builtins"] || [];
   const libs = obj.libs || [];
@@ -143,7 +135,6 @@ export function deserializeProcessGroup(
   return {
     name: obj.name,
     compilerOptions: isStringArray(compilerOptions) ? compilerOptions : [],
-    pliOptions: isRecordOf(pliOptions, isString) ? pliOptions : {},
     libs: isStringArray(libs) ? libs : [],
     $computedLibs: [],
     $computedLibsSet: new Set<string>(),
@@ -178,7 +169,6 @@ export function serializeProcessGroup(
   return {
     name: group.name,
     "compiler-options": group.compilerOptions,
-    "pli-options": group.pliOptions,
     libs: group.libs,
     "include-extensions": group.includeExtensions,
     "implicit-builtins": Array.from(group.implicitBuiltins).map((b) =>
@@ -194,7 +184,6 @@ export function serializeProcessGroup(
 interface SerializedProcessGroup {
   name: string;
   "compiler-options"?: string[];
-  "pli-options"?: PliOptions;
   libs?: string[];
   "include-extensions"?: string[];
   "implicit-builtins"?: string[];
@@ -549,16 +538,13 @@ export class PluginConfigurationProvider {
       );
 
       // collect raw compiler options from the group
-      const rawCompilerOptions = (
-        processGroupConfig?.compilerOptions || []
-      ).join(" ");
-      // collect raw pli-options from the group & program config
-      const rawPliOptions =
-        this.pliOptionsStringForProgramConfig(programConfig);
-
+      const rawCompilerOptions = [
+        ...(programConfig.compilerOptions || []),
+        ...(processGroupConfig?.compilerOptions || []),
+      ].join(" ");
       // combine them and pass them all together to parse and translate
       const [abstractOptions, translatedOptions, collectedIssues] =
-        this.parseAndTranslateOptions(`${rawCompilerOptions} ${rawPliOptions}`);
+        this.parseAndTranslateOptions(rawCompilerOptions);
       for (const issue of collectedIssues) {
         console.error(
           `Error in compiler options for program config "${programConfig.program}": ${issue}`,
@@ -740,32 +726,6 @@ export class PluginConfigurationProvider {
       }
     }
     return undefined;
-  }
-
-  /**
-   * Extracts & converts the merged pli-options for a given program config & associated process group to a compiler option string
-   * Program config pli-options override process group pli-options.
-   * @param programConfig Program config entry to retrieve options for, factoring in process group options too
-   * @returns Merged pli-options as a string, or "" if none
-   */
-  private pliOptionsStringForProgramConfig(
-    programConfig: ProgramConfig,
-  ): string {
-    const group = this.getProcessGroupConfig(programConfig.pgroup);
-    const groupOpts = group?.pliOptions ?? {};
-    const progOpts = programConfig.pliOptions;
-    // merge w/ program config entries taking precedence
-    const merged = { ...groupOpts, ...progOpts };
-    if (Object.keys(merged).length === 0) {
-      return "";
-    } else {
-      // form literal PP option strings
-      // e.g. { SYSPARM: "'a'"} => "SYSPARM('a')" // note the quotes
-      // e.g. { SYSTEM: "MVS", "SYSTEM(MVS)"
-      return Object.entries(merged)
-        .map(([key, value]) => `${key}(${value})`)
-        .join(" ");
-    }
   }
 }
 

--- a/packages/language/test/fourslash/preprocessor/compiler-options/diagnostic-placement.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/diagnostic-placement.ts
@@ -11,6 +11,19 @@
 
 /// <reference path="../../framework.ts" />
 
+// @filename: .pliplugin/pgm_conf.json
+//// {
+////  "pgms": [
+////      {
+////      "program": "*.pli",
+////      "pgroup": "default",
+////      "compiler-options": [
+////          "MARGINS(2,72)"
+////      ]
+////      }
+////  ]
+//// }
+
 // @filename: .pliplugin/proc_grps.json
 //// {
 ////     "pgroups": [
@@ -20,11 +33,6 @@
 ////             "AGGREGATE",
 ////             "MARGINS(2,7)"
 ////         ],
-////         "pli-options": {
-////            "SYSPARM": "'from process group'",
-////            "SYSTEM": "MVS",
-////            "MARGINS": "2,72"
-////         },
 ////         "libs": [
 ////             "cpy"
 ////         ],

--- a/packages/language/test/lsp/apply-quick-fixes.test.ts
+++ b/packages/language/test/lsp/apply-quick-fixes.test.ts
@@ -48,7 +48,7 @@ beforeEach(async () => {
 
   await pluginConfig.setProcessGroupConfigs([processGroup]);
   pluginConfig.setProgramConfigs("/workspace", [
-    { program: "main.pli", pgroup: "default", pliOptions: {} },
+    { program: "main.pli", pgroup: "default" },
   ]);
 });
 

--- a/packages/language/test/lsp/definition-source.test.ts
+++ b/packages/language/test/lsp/definition-source.test.ts
@@ -46,7 +46,7 @@ async function setupIncludes(path: string, libEntry: string): Promise<void> {
 
   await pluginConfig.setProcessGroupConfigs([processGroup]);
   pluginConfig.setProgramConfigs("/workspace", [
-    { program: "*.pli", pgroup: "default", pliOptions: {} },
+    { program: "*.pli", pgroup: "default" },
   ]);
 }
 

--- a/packages/language/test/parser/pli-lexer.test.ts
+++ b/packages/language/test/parser/pli-lexer.test.ts
@@ -118,7 +118,6 @@ describe("PL/1 Lexer", () => {
       const programConfig: ProgramConfig = {
         program: "test.pli",
         pgroup: "testGroup",
-        pliOptions: {},
       };
       const processGroupConfig: ProcessGroup = {
         name: "testGroup",
@@ -133,7 +132,6 @@ describe("PL/1 Lexer", () => {
           instructionCounterLimit: 5000,
           caseUpperValidation: false,
         },
-        pliOptions: {},
       };
 
       await PluginConfigurationProviderInstance.init("/test");
@@ -169,7 +167,6 @@ describe("PL/1 Lexer", () => {
       const programConfig: ProgramConfig = {
         program: "test.pli",
         pgroup: "missingGroup",
-        pliOptions: {},
       };
 
       await PluginConfigurationProviderInstance.init("/test");
@@ -194,7 +191,6 @@ describe("PL/1 Lexer", () => {
       const programConfig: ProgramConfig = {
         program: "test.pli",
         pgroup: "testGroup",
-        pliOptions: {},
       };
       const processGroupConfig: ProcessGroup = {
         name: "testGroup",
@@ -209,7 +205,6 @@ describe("PL/1 Lexer", () => {
           instructionCounterLimit: 5000,
           caseUpperValidation: false,
         },
-        pliOptions: {},
       };
 
       await PluginConfigurationProviderInstance.init("/test");

--- a/packages/language/test/preprocessor/pli-preprocessor.test.ts
+++ b/packages/language/test/preprocessor/pli-preprocessor.test.ts
@@ -34,7 +34,6 @@ async function init(libPath: string): Promise<Diagnostic[]> {
   const programConfig: ProgramConfig = {
     program: "test.pli",
     pgroup: "testGroup",
-    pliOptions: {},
   };
   const processGroupConfig: ProcessGroup = {
     name: "testGroup",
@@ -49,7 +48,6 @@ async function init(libPath: string): Promise<Diagnostic[]> {
       instructionCounterLimit: 5000,
       caseUpperValidation: false,
     },
-    pliOptions: {},
   };
 
   await PluginConfigurationProviderInstance.init("/test");

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -299,7 +299,6 @@ export class TestBuilder {
         {
           program: "*.pli",
           pgroup: "default",
-          pliOptions: {},
         },
       ]);
     }
@@ -320,7 +319,6 @@ export class TestBuilder {
             instructionCounterLimit: 5000,
             caseUpperValidation: false,
           },
-          pliOptions: {},
         },
       ]);
     }

--- a/packages/language/test/validating.test.ts
+++ b/packages/language/test/validating.test.ts
@@ -378,7 +378,7 @@ describe("Validating", () => {
       });
       await pluginConfig.setProcessGroupConfigs([processGroup]);
       pluginConfig.setProgramConfigs("/", [
-        { program: "**/*.pli", pgroup: "default", pliOptions: {} },
+        { program: "**/*.pli", pgroup: "default" },
       ]);
 
       const doc = await parseWithValidations(` %INCLUDE 'nonexistent.pli';

--- a/packages/language/test/workspace/compilation-unit.test.ts
+++ b/packages/language/test/workspace/compilation-unit.test.ts
@@ -64,7 +64,6 @@ describe("Compilation Unit Tests", () => {
       {
         program: "test/entry.pli",
         pgroup: "",
-        pliOptions: {},
       },
     ]);
     expect(
@@ -95,7 +94,6 @@ describe("Compilation Unit Tests", () => {
       {
         program: "test/*.pli",
         pgroup: "",
-        pliOptions: {},
       },
     ]);
 
@@ -134,7 +132,6 @@ describe("Compilation Unit Tests", () => {
       {
         program: "src/*.pli",
         pgroup: "default",
-        pliOptions: {},
       },
     ]);
     // Simulate the process group config (normally this would be loaded from a config file)
@@ -151,7 +148,6 @@ describe("Compilation Unit Tests", () => {
           instructionCounterLimit: 5000,
           caseUpperValidation: false,
         },
-        pliOptions: {},
         implicitBuiltins: new Set(),
       },
     ]);

--- a/packages/language/test/workspace/plugin-configuration.test.ts
+++ b/packages/language/test/workspace/plugin-configuration.test.ts
@@ -49,7 +49,6 @@ describe("Plugin Configuration Tests", () => {
         instructionCounterLimit: 5000,
         caseUpperValidation: false,
       },
-      pliOptions: {},
       implicitBuiltins: new Set(),
     };
   }
@@ -169,7 +168,6 @@ describe("Plugin Configuration Tests", () => {
           instructionCounterLimit: 5000,
           caseUpperValidation: false,
         },
-        pliOptions: {},
         implicitBuiltins: new Set(),
       },
     ]);

--- a/packages/vscode-extension/schemas/pgm_conf.schema.json
+++ b/packages/vscode-extension/schemas/pgm_conf.schema.json
@@ -17,9 +17,12 @@
             "type": "string",
             "description": "Program group label (e.g., 'default')."
           },
-          "pli-options": {
-            "type": "object",
-            "description": "Macro definitions which will be passed to the PL/I compiler."
+          "compiler-options": {
+            "type": "array",
+            "description": "Compiler options for these programs.",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": ["program", "pgroup"],

--- a/packages/vscode-extension/schemas/proc_grps.schema.json
+++ b/packages/vscode-extension/schemas/proc_grps.schema.json
@@ -27,10 +27,6 @@
               "type": "string"
             }
           },
-          "pli-options": {
-            "type": "object",
-            "description": "Macro definitions which will be passed to the PL/I compiler."
-          },
           "include-extensions": {
             "type": "array",
             "description": "List of file extensions to treat as include files.",


### PR DESCRIPTION
As confirmed earlier (see https://github.com/zowe/zowe-pli-language-support/issues/535), this one removes the old `pli-options` from the plugin config.