### PR TITLE
Fix OR operator lexing

### DIFF
--- a/packages/language/src/parser/tokenizer.ts
+++ b/packages/language/src/parser/tokenizer.ts
@@ -297,7 +297,6 @@ function tokenizeOrSymbol(context: TokenizerContext): tokens.Token | undefined {
     context.advance(2, false);
     return context.createTokenInstance(tokens.PipeEquals);
   }
-  context.index++;
   context.advance(1, false);
   return context.createTokenInstance(tokens.Pipe);
 }

--- a/packages/language/test/compiler/lexing.test.ts
+++ b/packages/language/test/compiler/lexing.test.ts
@@ -43,7 +43,7 @@ describe("Lexer uses compiler options", () => {
   test("Should lex correct OR without compiler option", async () => {
     const doc = await parseStmts(`
   DECLARE VAR FIXED;
-  VAR = 1 | 2;
+  VAR = 1|2;
   VAR |= 2;
   VAR = 1 || 0;
   VAR ||= 0;


### PR DESCRIPTION
Removes the erroneous `context.index++` and lets the `advance` handle everything.