### PR TITLE
Fix parsing of PUT data specifications

### DIFF
--- a/packages/language/src/language-server/completion/follow-elements.ts
+++ b/packages/language/src/language-server/completion/follow-elements.ts
@@ -178,6 +178,7 @@ const expressionFollowKinds = new Set([
   CstNodeKind.InitAcrossExpression_Comma,
   CstNodeKind.EnvironmentOptionItem_Comma,
   CstNodeKind.DataSpecificationDataList_Comma,
+  CstNodeKind.ParenthesizedExpression_Comma,
 
   // After specific keywords
   CstNodeKind.ActivateStatement_ACTIVATE,

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -3890,10 +3890,8 @@ const dataSpecificationDataListItem = rule(
   (state: ParserState): ast.DataSpecificationDataListItem => {
     const element = ast.createDataSpecificationDataListItem();
 
-    // TODO: research, in some example, this can be found:
-    // ((I, ENTRY(I) DO I = 0 TO ENTRY_TABLE_COUNT))
-    // However, this does not conform to the language reference
-    element.value = expression.rule(state);
+    // Allows multiple sub-expressions separated by comma
+    element.value = expression.rule(state, undefined, true);
 
     return element;
   },
@@ -6171,7 +6169,15 @@ const referenceItem = rule(
 
 const expression = rule(
   () => primaryExpression.first(),
-  (state: ParserState, refType?: ast.ReferenceType): ast.Expression | null => {
+  (
+    state: ParserState,
+    // Some syntax nodes allow references to also target types (instead of just variables)
+    // This parameter indicates whether we are in such a context
+    refType?: ast.ReferenceType,
+    // Indicates whether we are parsing a data specification expression of a PUT/GET statement
+    // This enables some special syntax rules for parenthesized expressions
+    dataSpecification?: boolean,
+  ): ast.Expression | null => {
     const element: IntermediateBinaryExpression = {
       infix: true,
       items: [],
@@ -6180,7 +6186,7 @@ const expression = rule(
     };
 
     // Parse first primary expression
-    const lhs = primaryExpression.rule(state, refType);
+    const lhs = primaryExpression.rule(state, refType, dataSpecification);
     lhs && element.items.push(lhs);
 
     // Parse zero or more operator-expression pairs
@@ -6198,7 +6204,7 @@ const expression = rule(
         );
         element.operatorTokens.push(operatorToken);
       }
-      const rhs = primaryExpression.rule(state, refType);
+      const rhs = primaryExpression.rule(state, refType, dataSpecification);
       rhs && element.items.push(rhs);
     }
 
@@ -6208,7 +6214,10 @@ const expression = rule(
 
 const primaryExpression = orRule<
   ast.Expression,
-  [ast.ReferenceType | undefined]
+  [
+    refType: ast.ReferenceType | undefined,
+    dataSpecification: boolean | undefined,
+  ]
 >(
   () => literal,
   () => parenthesizedExpression,
@@ -6221,6 +6230,7 @@ const parenthesizedExpression = rule(
   (
     state: ParserState,
     refType?: ast.ReferenceType,
+    dataSpecification?: boolean,
   ): ast.Parenthesis | ast.Literal => {
     const element = ast.createParenthesis();
 
@@ -6229,7 +6239,26 @@ const parenthesizedExpression = rule(
       CstNodeKind.ParenthesizedExpression_OpenParen,
       tokens.OpenParen,
     );
-    element.value = expression.rule(state, refType);
+    const expr = expression.rule(state, refType, dataSpecification);
+    if (expr) {
+      element.expressions.push(expr);
+    }
+
+    // Additional expressions separated by commas
+    // These are exclusively used for PUT statements, but the syntax for that is completely undocumented
+    while (
+      dataSpecification &&
+      state.tryConsume(
+        element,
+        CstNodeKind.ParenthesizedExpression_Comma,
+        tokens.Comma,
+      )
+    ) {
+      const nextExpr = expression.rule(state, refType, dataSpecification);
+      if (nextExpr) {
+        element.expressions.push(nextExpr);
+      }
+    }
 
     // Optional DO clause
     if (

--- a/packages/language/src/syntax-tree/ast-iterator.ts
+++ b/packages/language/src/syntax-tree/ast-iterator.ts
@@ -737,8 +737,8 @@ export function forEachNode(
     case SyntaxKind.PageFormatItem:
       break;
     case SyntaxKind.Parenthesis:
-      if (node.value) {
-        action(node.value);
+      for (const value of node.expressions) {
+        action(value);
       }
       if (node.do) {
         action(node.do);

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -3342,7 +3342,7 @@ export function createPageFormatItem(): PageFormatItem {
 
 export interface Parenthesis extends AstNode {
   kind: SyntaxKind.Parenthesis;
-  value: Expression | null;
+  expressions: Expression[];
   do: DoType3 | null;
 }
 
@@ -3350,7 +3350,7 @@ export function createParenthesis(): Parenthesis {
   return {
     kind: SyntaxKind.Parenthesis,
     container: null,
-    value: null,
+    expressions: [],
     do: null,
   };
 }

--- a/packages/language/src/syntax-tree/cst.ts
+++ b/packages/language/src/syntax-tree/cst.ts
@@ -676,6 +676,7 @@ export enum CstNodeKind {
   ReferenceItem_Ref,
   BinaryExpression_Operator,
   ParenthesizedExpression_OpenParen,
+  ParenthesizedExpression_Comma,
   ParenthesizedExpression_DO,
   ParenthesizedExpression_CloseParen,
   MemberCall_Dot,

--- a/packages/language/src/typesystem/infer.ts
+++ b/packages/language/src/typesystem/infer.ts
@@ -200,10 +200,11 @@ export class DefaultTypeInferer implements TypeInferer {
         //TODO implement
         return TypeDescriptions.Unknown();
       case ast.SyntaxKind.Parenthesis: {
-        if (!expression.value) {
+        if (expression.expressions.length === 0) {
           return TypeDescriptions.Unknown();
         }
-        return this.inferType(expression.value, compilationUnit);
+        // Infer type of the first expression inside the parenthesis
+        return this.inferType(expression.expressions[0], compilationUnit);
       }
       case ast.SyntaxKind.Literal: {
         if (!expression.value) {

--- a/packages/language/test/fourslash/parser/put-edit-multi-value-expr.ts
+++ b/packages/language/test/fourslash/parser/put-edit-multi-value-expr.ts
@@ -1,0 +1,22 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// DCL ENTRY_TABLE_COUNT FIXED BIN(31) INIT(10);
+//// DCL I FIXED BIN(31);
+//// DCL ENTRY(ENTRY_TABLE_COUNT) FIXED BIN(31);
+//// PUT SKIP(2) EDIT
+////   ((I, ENTRY(I) DO I = 0 TO ENTRY_TABLE_COUNT))
+////   (SKIP, F(4), X(1), A(33), A(8), (5) F(6), X(1), A, X(1), A);
+
+verify.noParserDiagnostics();


### PR DESCRIPTION
Related to https://github.com/zowe/zowe-pli-language-support/issues/520. It is still not clear what exactly something like `((I, ENTRY(I) DO I = 0 TO ENTRY_TABLE_COUNT))` means as a semantic construct, but this change adjusts the parser to support the syntax.

I'll keep the issue open so that we can clarify the semantics of this syntax in a separate change.