### PR TITLE
Fix locator call in assignment lookahead

### DIFF
--- a/packages/language/src/parser/parser-lookahead.ts
+++ b/packages/language/src/parser/parser-lookahead.ts
@@ -13,13 +13,28 @@ import { tokenMatcher } from "chevrotain";
 import { ParserState } from "./parser-state";
 import * as tokens from "./tokens";
 
+const assignmentIndicators = tokens.combine(
+  tokens.AssignmentOperator,
+  tokens.Dot,
+  tokens.MinusGreaterThan,
+  tokens.Comma,
+);
+
 function indicatesAssignment(token: tokens.Token): boolean {
-  return (
-    tokenMatcher(token, tokens.AssignmentOperator) ||
-    tokenMatcher(token, tokens.Dot) ||
-    tokenMatcher(token, tokens.Comma)
-  );
+  return assignmentIndicators[token.tokenTypeIdx] === true;
 }
+
+const expressionTokens = tokens.combine(
+  tokens.ID,
+  tokens.BinaryOperator,
+  tokens.UnaryOperator,
+  tokens.AssignmentOperator,
+  tokens.STRING_TERM,
+  tokens.NUMBER,
+  tokens.Comma,
+  tokens.Dot,
+  tokens.MinusGreaterThan,
+);
 
 export function performAssignmentLookahead(state: ParserState): boolean {
   if (performIfLookahead(state)) {
@@ -28,16 +43,7 @@ export function performAssignmentLookahead(state: ParserState): boolean {
     // e.g. IF (2 + 3) = 5 THEN; ...
     return false;
   }
-  const expressionTokenTypes = [
-    tokens.ID,
-    tokens.BinaryOperator,
-    tokens.UnaryOperator,
-    tokens.AssignmentOperator,
-    tokens.STRING_TERM,
-    tokens.NUMBER,
-    tokens.Comma,
-    tokens.Dot,
-  ];
+
   let i = 1;
   let token = state.peek(i++);
   // First token of an assigment needs to be an ID
@@ -73,11 +79,7 @@ export function performAssignmentLookahead(state: ParserState): boolean {
       // Semicolon indicates the end of the statement
       return false;
     } else {
-      if (
-        !expressionTokenTypes.some((tokenType) =>
-          tokenMatcher(token, tokenType),
-        )
-      ) {
+      if (!expressionTokens[token.tokenTypeIdx]) {
         // Non-expression token found, stop lookahead
         return false;
       }

--- a/packages/language/src/parser/tokens.ts
+++ b/packages/language/src/parser/tokens.ts
@@ -300,6 +300,25 @@ export const EnvironmentOptionValueName =
   registerCombination<ast.EnvironmentOptionValueName>(
     "EnvironmentOptionValueName",
   );
+
+/**
+ * Combines the given token types into a lookup table for fast lookaheads.
+ */
+export function combine(...tokenTypes: TokenType[]): boolean[] {
+  const result: boolean[] = [];
+  for (const token of tokenTypes) {
+    const id = token.tokenTypeIdx ?? -1;
+    if (id >= 0) {
+      result[id] = true;
+    }
+    if (token.categoryMatches) {
+      for (const category of token.categoryMatches) {
+        result[category] = true;
+      }
+    }
+  }
+  return result;
+}
 // Custom functions
 
 export function escapeRegExp(value: string): string {

--- a/packages/language/test/fourslash/parser/assignment-locator.ts
+++ b/packages/language/test/fourslash/parser/assignment-locator.ts
@@ -1,0 +1,18 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// DCL (NEXT, PUT, CURR) POINTER;
+//// PUT->NEXT = CURR;
+
+verify.noParserDiagnostics();


### PR DESCRIPTION
I noticed during testing of some other parser issues that statements such as `A->B = C` don't parse correctly due to missing handling of the `->` operator (locator call) in the lookahead.

This change adds operator to the lookahead logic and improves handling of the lookahead in general by combining multiple tokens into a single *lookahead table*.