### PR TITLE
[Improvement] Fix include resolutions on files outside the workspace

### DIFF
--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2365,6 +2365,14 @@ async function resolveIncludeFileUri(
     );
 
   if (!pgroup) {
+    ///////////// UGLY CODE JUST FOR TEST
+    const test = PluginConfigurationProviderInstance.getProgramConfig(context.entryUri);
+    if (test) console.log(test);
+
+
+
+
+    ///////////////////////
     // no process group to resolve libs from
     return undefined;
   }

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2365,14 +2365,6 @@ async function resolveIncludeFileUri(
     );
 
   if (!pgroup) {
-    ///////////// UGLY CODE JUST FOR TEST
-    const test = PluginConfigurationProviderInstance.getProgramConfig(context.entryUri);
-    if (test) console.log(test);
-
-
-
-
-    ///////////////////////
     // no process group to resolve libs from
     return undefined;
   }

--- a/packages/language/src/utils/uri.ts
+++ b/packages/language/src/utils/uri.ts
@@ -44,6 +44,13 @@ export namespace UriUtils {
     path: string;
     drive: string | null;
   } {
+    if (!UriUtils.isWindows) {
+      return {
+        path: path,
+        drive: null,
+      };
+    }
+
     // Check for leading slash before drive: /C:/ or /c:/
     if (/^\/[a-zA-Z]:\//.test(path)) {
       const drive = path.substring(1, 3); // Extract "C:" and lowercase

--- a/packages/language/src/utils/uri.ts
+++ b/packages/language/src/utils/uri.ts
@@ -40,7 +40,7 @@ export namespace UriUtils {
    *
    * @returns Object with normalized path and extracted drive letter
    */
-  function processDriveLetter(path: string): {
+  export function processDriveLetter(path: string): {
     path: string;
     drive: string | null;
   } {

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -696,10 +696,16 @@ export class PluginConfigurationProvider {
     //   config key:   file:///workspace/Users/alice/projects/app/bin/app-ext.pli
     // Without this fallback, the config would not be found.
     for (const [pattern, config] of this.programConfigs.entries()) {
-      const progConfigPath = uri.toLowerCase().includes("file:///")
+      let encodedProgConfigPath = uri.toLowerCase().includes("file:///")
         ? uri.replace("file:///", "")
         : uri;
-      if (pattern.endsWith(progConfigPath)) return config;
+      encodedProgConfigPath = encodedProgConfigPath.replace(
+        /^([a-zA-Z]):/,
+        (_, drive) => encodeURIComponent(drive + ":"),
+      );
+      encodedProgConfigPath = encodedProgConfigPath.toLowerCase();
+      const newPattern = pattern.replace(/%5C/gi, "/").toLowerCase();
+      if (newPattern.endsWith(encodedProgConfigPath)) return config;
     }
     // no match
     return undefined;

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -595,9 +595,9 @@ export class PluginConfigurationProvider {
 
   /**
    * Sets the program configs of this plugin configuration provider, overwriting any existing configs.
-   * The config key is set as the full path relative to the workspace.
+   * Program paths are normalized and resolved relative to the workspace (unless absolute).
    * Post-processes the program configs after setting them, to ensure abstract options are built.
-   * @param workspacePath The full workspace path (used as a prefix for program config keys)
+   * @param workspacePath The full workspace path (used as base for resolving relative program paths)
    * @param programConfigs Program configs loaded from .pliplugin/pgm_conf.json (when present)
    */
   public setProgramConfigs(
@@ -606,11 +606,36 @@ export class PluginConfigurationProvider {
   ): void {
     this.programConfigs.clear();
     const workspaceUri = URI.parse(workspacePath);
+
     for (const config of programConfigs) {
-      const newPath = UriUtils.joinPath(workspaceUri, config.program);
-      this.programConfigs.set(newPath.toString(), config);
+      const resolvedUri = this.resolveProgramPath(config.program, workspaceUri);
+      this.programConfigs.set(resolvedUri.toString(), config);
     }
     this.postProcessProgramConfigs();
+  }
+
+  /**
+   * Resolves a program path to an absolute URI.
+   * Normalizes backslashes to forward slashes, then returns the path as-is if absolute,
+   * or joins it with the workspace URI if relative.
+   */
+  private resolveProgramPath(programPath: string, workspaceUri: URI): URI {
+    const normalizedProgramPath = programPath.replace(/\\/g, "/");
+    if (this.isAbsolutePath(normalizedProgramPath)) {
+      return URI.parse(normalizedProgramPath);
+    }
+    return UriUtils.joinPath(workspaceUri, normalizedProgramPath);
+  }
+
+  /**
+   * Determines if a path is absolute (either Windows-style with drive letter or Unix-style).
+   * Paths starting with "*" are treated as relative even if they appear absolute.
+   */
+  private isAbsolutePath(path: string): boolean {
+    const hasWindowsDrive = Boolean(UriUtils.processDriveLetter(path).drive);
+    const hasUnixRoot = !UriUtils.isPathRelative(path) && !path.startsWith("*");
+
+    return hasWindowsDrive || hasUnixRoot;
   }
 
   /**
@@ -657,8 +682,6 @@ export class PluginConfigurationProvider {
    * Lookup order:
    * 1. Exact match against registered config keys.
    * 2. Glob pattern match (using minimatch) against decoded URIs.
-   * 3. Fallback suffix match to handle configs stored with a workspace-prefixed
-   *    absolute path that would otherwise never resolve.
    *
    * @see https://github.com/isaacs/minimatch
    * @param program Name of the program to get a config for
@@ -687,47 +710,8 @@ export class PluginConfigurationProvider {
         );
       }
     }
-    // Program configs added via absolute path are stored with their absolute path prefixed by
-    // the workspace path,producing URIs that will never exactly match a real program URI.
-    // As a last resort, we strip the `file:///` prefix from the program URI and check
-    // whether any config key ends with that path segment.
-    // Example:
-    //   program URI:  file:///Users/mockUser/projects/app/bin/app-ext.pli
-    //   config pattern:   file:///workspace/Users/mockUser/projects/app/bin/app-ext.pli
-    // Without this fallback, the config would not be found.
-    for (const [pattern, config] of this.programConfigs.entries()) {
-      const { normalizedUri, normalizedPattern } = this.normalizeSearchPatterns(
-        uri,
-        pattern,
-      );
-      if (normalizedPattern.endsWith(normalizedUri)) return config;
-    }
     // no match
     return undefined;
-  }
-
-  /**
-   * Normalizes a search URI and pattern for consistent cross-platform file path matching.
-   *
-   * @param searchUri - The file URI to normalize
-   * @param pattern - The search pattern to normalize
-   * @returns Object containing normalized URI and pattern
-   */
-  private normalizeSearchPatterns(searchUri: string, pattern: string) {
-    const normalizedPattern = pattern.replace(/%5C/gi, "/").toLowerCase();
-
-    const uriWithoutProtocol = searchUri.toLowerCase().includes("file:///")
-      ? searchUri.replace("file:///", "")
-      : searchUri;
-
-    // Encode and lowercase Windows drive letters (C: → c%3a)
-    const normalizedUri = uriWithoutProtocol
-      .replace(/^([a-zA-Z]):/, (_, driveLetter) =>
-        encodeURIComponent(driveLetter + ":"),
-      )
-      .toLowerCase();
-
-    return { normalizedUri, normalizedPattern };
   }
 
   /**

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -765,9 +765,9 @@ export class PluginConfigurationProvider {
     for (const config of this.processGroupConfigs.values()) {
       for (const lib of config.$computedLibsSet) {
         const normalizedLib = lib.replace(/\\/g, "/");
-        const isPathAbsolute = UriUtils.isWindows
-          ? !!UriUtils.processDriveLetter(normalizedLib).drive
-          : !UriUtils.isPathRelative(normalizedLib);
+        const isPathAbsolute =
+          UriUtils.processDriveLetter(normalizedLib).drive ||
+          !UriUtils.isPathRelative(normalizedLib);
 
         const matches = isPathAbsolute
           ? normalizedLib.endsWith(dirname)

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -653,32 +653,23 @@ export class PluginConfigurationProvider {
   }
 
   /**
-   * Returns the program config for the given program.
-   * If no exact match is found, will attempt to match against
-   * any glob patterns registered as a config keys using minimatch.
-   * See: https://github.com/isaacs/minimatch for ref
+   * Returns the program config for the given program URI.
+   * Lookup order:
+   * 1. Exact match against registered config keys.
+   * 2. Glob pattern match (using minimatch) against decoded URIs.
+   * 3. Fallback suffix match to handle configs stored with a workspace-prefixed
+   *    absolute path that would otherwise never resolve.
+   *
+   * @see https://github.com/isaacs/minimatch
    * @param program Name of the program to get a config for
    * @returns Associated program config, or undefined if not found
    */
   public getProgramConfig(program: URI): ProgramConfig | undefined {
     // Note that we need to decode the URI
     const uri = program.toString(true);
-    // try direct match first
-    // TO INVESTIGATE:
-    // Current uri value = 'file:///Users/pli/pgm-test/app-ext.pli'
-    // Current this.programConfigs values:
-    // "file:///Users/wagnerlaranjeiras/Desktop/Typefox/broadcom/broadcom-pli/code_samples/plugin-example/%2A.pli"
-    // "file:///Users/wagnerlaranjeiras/Desktop/Typefox/broadcom/broadcom-pli/code_samples/plugin-example/Users/pli/pgm-test/app-ext.pli"
-
     const direct = this.programConfigs.get(uri);
     if (direct) {
       return direct;
-    }
-    for (const [pattern, config] of this.programConfigs.entries()) {
-      const newUri = uri.toLowerCase().includes("file:///")
-        ? uri.replace("file:///", "")
-        : uri;
-      if (pattern.endsWith(newUri)) return config;
     }
     // fallback to glob matching
     for (const [pattern, config] of this.programConfigs.entries()) {
@@ -695,6 +686,20 @@ export class PluginConfigurationProvider {
           `Invalid glob pattern "${pattern}" for program "${program}": ${e}`,
         );
       }
+    }
+    // Program configs added via absolute path are stored with their absolute path prefixed by
+    // the workspace path,producing URIs that will never exactly match a real program URI.
+    // As a last resort, we strip the `file:///` prefix from the program URI and check
+    // whether any config key ends with that path segment.
+    // Example:
+    //   program URI:  file:///Users/mockUser/projects/app/bin/app-ext.pli
+    //   config key:   file:///workspace/Users/alice/projects/app/bin/app-ext.pli
+    // Without this fallback, the config would not be found.
+    for (const [pattern, config] of this.programConfigs.entries()) {
+      const progConfigPath = uri.toLowerCase().includes("file:///")
+        ? uri.replace("file:///", "")
+        : uri;
+      if (pattern.endsWith(progConfigPath)) return config;
     }
     // no match
     return undefined;

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -721,8 +721,18 @@ export class PluginConfigurationProvider {
   public getProcessGroupConfigFromLib(libUri: URI): ProcessGroup | undefined {
     const dirname = UriUtils.basename(UriUtils.dirname(libUri));
     for (const config of this.processGroupConfigs.values()) {
-      if (config.$computedLibsSet.has(dirname)) {
-        return config;
+      for (const lib of config.$computedLibsSet) {
+        const isPathAbsolute = UriUtils.isWindows
+          ? !!(UriUtils.processDriveLetter(lib).drive)
+          : !UriUtils.isPathRelative(lib);
+
+        const matches = isPathAbsolute
+          ? lib.endsWith(dirname)
+          : lib === dirname;
+
+        if (matches) {
+          return config;
+        }
       }
     }
     return undefined;

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -666,7 +666,7 @@ export class PluginConfigurationProvider {
     // try direct match first
     // TO INVESTIGATE:
     // Current uri value = 'file:///Users/pli/pgm-test/app-ext.pli'
-    // Current this.programConfigs values: 
+    // Current this.programConfigs values:
     // "file:///Users/wagnerlaranjeiras/Desktop/Typefox/broadcom/broadcom-pli/code_samples/plugin-example/%2A.pli"
     // "file:///Users/wagnerlaranjeiras/Desktop/Typefox/broadcom/broadcom-pli/code_samples/plugin-example/Users/pli/pgm-test/app-ext.pli"
 
@@ -675,7 +675,9 @@ export class PluginConfigurationProvider {
       return direct;
     }
     for (const [pattern, config] of this.programConfigs.entries()) {
-      const newUri = uri.toLowerCase().includes("file:///") ?  uri.replace("file:///", "") : uri;
+      const newUri = uri.toLowerCase().includes("file:///")
+        ? uri.replace("file:///", "")
+        : uri;
       if (pattern.endsWith(newUri)) return config;
     }
     // fallback to glob matching

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -519,7 +519,9 @@ export class PluginConfigurationProvider {
       processGroup.$computedLibs = computedLibs;
       // build a lookup set for dir entries only
       processGroup.$computedLibsSet = new Set(
-        computedLibs.filter((e) => isLibsDir(e)).map((e) => e.dir),
+        computedLibs
+          .filter((e) => isLibsDir(e))
+          .map((e) => e.dir.replace(/\\/g, "/")),
       );
     }
     return diagnostics;
@@ -746,20 +748,15 @@ export class PluginConfigurationProvider {
    */
   public getProcessGroupConfigFromLib(libUri: URI): ProcessGroup | undefined {
     const dirname = UriUtils.basename(UriUtils.dirname(libUri));
+    const absolutePathLib = UriUtils.dirname(libUri)
+      .toString()
+      .replace(/^file:\/\//, "");
     for (const config of this.processGroupConfigs.values()) {
-      for (const lib of config.$computedLibsSet) {
-        const normalizedLib = lib.replace(/\\/g, "/");
-        const isPathAbsolute =
-          UriUtils.processDriveLetter(normalizedLib).drive ||
-          !UriUtils.isPathRelative(normalizedLib);
-
-        const matches = isPathAbsolute
-          ? normalizedLib.endsWith(dirname)
-          : normalizedLib === dirname;
-
-        if (matches) {
-          return config;
-        }
+      if (
+        config.$computedLibsSet.has(dirname) ||
+        config.$computedLibsSet.has(absolutePathLib)
+      ) {
+        return config;
       }
     }
     return undefined;

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -693,7 +693,7 @@ export class PluginConfigurationProvider {
     // whether any config key ends with that path segment.
     // Example:
     //   program URI:  file:///Users/mockUser/projects/app/bin/app-ext.pli
-    //   config key:   file:///workspace/Users/alice/projects/app/bin/app-ext.pli
+    //   config pattern:   file:///workspace/Users/mockUser/projects/app/bin/app-ext.pli
     // Without this fallback, the config would not be found.
     for (const [pattern, config] of this.programConfigs.entries()) {
       const { normalizedUri, normalizedPattern } = this.normalizeSearchPatterns(
@@ -764,13 +764,14 @@ export class PluginConfigurationProvider {
     const dirname = UriUtils.basename(UriUtils.dirname(libUri));
     for (const config of this.processGroupConfigs.values()) {
       for (const lib of config.$computedLibsSet) {
+        const normalizedLib = lib.replace(/\\/g, "/");
         const isPathAbsolute = UriUtils.isWindows
-          ? !!UriUtils.processDriveLetter(lib).drive
-          : !UriUtils.isPathRelative(lib);
+          ? !!UriUtils.processDriveLetter(normalizedLib).drive
+          : !UriUtils.isPathRelative(normalizedLib);
 
         const matches = isPathAbsolute
-          ? lib.endsWith(dirname)
-          : lib === dirname;
+          ? normalizedLib.endsWith(dirname)
+          : normalizedLib === dirname;
 
         if (matches) {
           return config;

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -696,19 +696,38 @@ export class PluginConfigurationProvider {
     //   config key:   file:///workspace/Users/alice/projects/app/bin/app-ext.pli
     // Without this fallback, the config would not be found.
     for (const [pattern, config] of this.programConfigs.entries()) {
-      let encodedProgConfigPath = uri.toLowerCase().includes("file:///")
-        ? uri.replace("file:///", "")
-        : uri;
-      encodedProgConfigPath = encodedProgConfigPath.replace(
-        /^([a-zA-Z]):/,
-        (_, drive) => encodeURIComponent(drive + ":"),
+      const { normalizedUri, normalizedPattern } = this.normalizeSearchPatterns(
+        uri,
+        pattern,
       );
-      encodedProgConfigPath = encodedProgConfigPath.toLowerCase();
-      const newPattern = pattern.replace(/%5C/gi, "/").toLowerCase();
-      if (newPattern.endsWith(encodedProgConfigPath)) return config;
+      if (normalizedPattern.endsWith(normalizedUri)) return config;
     }
     // no match
     return undefined;
+  }
+
+  /**
+   * Normalizes a search URI and pattern for consistent cross-platform file path matching.
+   *
+   * @param searchUri - The file URI to normalize
+   * @param pattern - The search pattern to normalize
+   * @returns Object containing normalized URI and pattern
+   */
+  private normalizeSearchPatterns(searchUri: string, pattern: string) {
+    const normalizedPattern = pattern.replace(/%5C/gi, "/").toLowerCase();
+
+    const uriWithoutProtocol = searchUri.toLowerCase().includes("file:///")
+      ? searchUri.replace("file:///", "")
+      : searchUri;
+
+    // Encode and lowercase Windows drive letters (C: → c%3a)
+    const normalizedUri = uriWithoutProtocol
+      .replace(/^([a-zA-Z]):/, (_, driveLetter) =>
+        encodeURIComponent(driveLetter + ":"),
+      )
+      .toLowerCase();
+
+    return { normalizedUri, normalizedPattern };
   }
 
   /**

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -723,7 +723,7 @@ export class PluginConfigurationProvider {
     for (const config of this.processGroupConfigs.values()) {
       for (const lib of config.$computedLibsSet) {
         const isPathAbsolute = UriUtils.isWindows
-          ? !!(UriUtils.processDriveLetter(lib).drive)
+          ? !!UriUtils.processDriveLetter(lib).drive
           : !UriUtils.isPathRelative(lib);
 
         const matches = isPathAbsolute

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -664,9 +664,19 @@ export class PluginConfigurationProvider {
     // Note that we need to decode the URI
     const uri = program.toString(true);
     // try direct match first
+    // TO INVESTIGATE:
+    // Current uri value = 'file:///Users/pli/pgm-test/app-ext.pli'
+    // Current this.programConfigs values: 
+    // "file:///Users/wagnerlaranjeiras/Desktop/Typefox/broadcom/broadcom-pli/code_samples/plugin-example/%2A.pli"
+    // "file:///Users/wagnerlaranjeiras/Desktop/Typefox/broadcom/broadcom-pli/code_samples/plugin-example/Users/pli/pgm-test/app-ext.pli"
+
     const direct = this.programConfigs.get(uri);
     if (direct) {
       return direct;
+    }
+    for (const [pattern, config] of this.programConfigs.entries()) {
+      const newUri = uri.toLowerCase().includes("file:///") ?  uri.replace("file:///", "") : uri;
+      if (pattern.endsWith(newUri)) return config;
     }
     // fallback to glob matching
     for (const [pattern, config] of this.programConfigs.entries()) {

--- a/packages/language/test/lsp/get-proc-group-config-from-lib.test.ts
+++ b/packages/language/test/lsp/get-proc-group-config-from-lib.test.ts
@@ -1,0 +1,59 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { describe, expect, test } from "vitest"
+import { deserializeProcessGroup, PluginConfigurationProvider, PluginConfigurationProviderInstance, setPluginConfigurationProvider } from "../../src/workspace/plugin-configuration-provider"
+import { URI } from "../../src/utils/uri";
+
+async function setupConfig(testLibs: string[]) {
+    const pluginConfig = new PluginConfigurationProvider();
+    setPluginConfigurationProvider(pluginConfig);
+    const processGroup = deserializeProcessGroup({
+        name: "default",
+        "include-extensions": [".pli"],
+        libs: testLibs
+    });
+    await pluginConfig.setProcessGroupConfigs([processGroup]);
+}
+
+describe("Process group library path matching", () => {
+    test("matches library under workspace-relative lib directory", async () => {
+        await setupConfig(["cpy"]);
+        const testUri = URI.parse("/workspace/cpy/a.pli");
+        const config = PluginConfigurationProviderInstance.getProcessGroupConfigFromLib(testUri);
+
+        expect(config).toBeDefined();
+    });
+
+    test("matches absolute Windows-style library path", async () => {
+        await setupConfig(["cpy", "C:/Users/pgm"]);
+        const testUri = URI.parse("C:/Users/pgm/ext-pgm.pli");
+        const config = PluginConfigurationProviderInstance.getProcessGroupConfigFromLib(testUri);
+
+        expect(config).toBeDefined();
+    });
+
+    test("matches backslash Windows library path against normalized URI", async () => {
+        await setupConfig(["cpy", "C:\\Users\\pgm"]);
+        const testUri = URI.parse("C:/Users/pgm/ext-pgm.pli");
+        const config = PluginConfigurationProviderInstance.getProcessGroupConfigFromLib(testUri);
+
+        expect(config).toBeDefined();
+    });
+
+    test("matches configured library regardless of platform path differences", async () => {
+        await setupConfig(["cpy", "/Users/mockUser/pgm"]);
+        const testUri = URI.parse("C:/Users/pgm/ext-pgm.pli");
+        const config = PluginConfigurationProviderInstance.getProcessGroupConfigFromLib(testUri);
+
+        expect(config).toBeDefined();
+    });
+});

--- a/packages/language/test/lsp/get-proc-group-config-from-lib.test.ts
+++ b/packages/language/test/lsp/get-proc-group-config-from-lib.test.ts
@@ -9,51 +9,60 @@
  *
  */
 
-import { describe, expect, test } from "vitest"
-import { deserializeProcessGroup, PluginConfigurationProvider, PluginConfigurationProviderInstance, setPluginConfigurationProvider } from "../../src/workspace/plugin-configuration-provider"
+import { describe, expect, test } from "vitest";
+import {
+  deserializeProcessGroup,
+  PluginConfigurationProvider,
+  PluginConfigurationProviderInstance,
+  setPluginConfigurationProvider,
+} from "../../src/workspace/plugin-configuration-provider";
 import { URI } from "../../src/utils/uri";
 
 async function setupConfig(testLibs: string[]) {
-    const pluginConfig = new PluginConfigurationProvider();
-    setPluginConfigurationProvider(pluginConfig);
-    const processGroup = deserializeProcessGroup({
-        name: "default",
-        "include-extensions": [".pli"],
-        libs: testLibs
-    });
-    await pluginConfig.setProcessGroupConfigs([processGroup]);
+  const pluginConfig = new PluginConfigurationProvider();
+  setPluginConfigurationProvider(pluginConfig);
+  const processGroup = deserializeProcessGroup({
+    name: "default",
+    "include-extensions": [".pli"],
+    libs: testLibs,
+  });
+  await pluginConfig.setProcessGroupConfigs([processGroup]);
 }
 
 describe("Process group library path matching", () => {
-    test("matches library under workspace-relative lib directory", async () => {
-        await setupConfig(["cpy"]);
-        const testUri = URI.parse("/workspace/cpy/a.pli");
-        const config = PluginConfigurationProviderInstance.getProcessGroupConfigFromLib(testUri);
+  test("matches library under workspace-relative lib directory", async () => {
+    await setupConfig(["cpy"]);
+    const testUri = URI.parse("/workspace/cpy/a.pli");
+    const config =
+      PluginConfigurationProviderInstance.getProcessGroupConfigFromLib(testUri);
 
-        expect(config).toBeDefined();
-    });
+    expect(config).toBeDefined();
+  });
 
-    test("matches absolute Windows-style library path", async () => {
-        await setupConfig(["cpy", "C:/Users/pgm"]);
-        const testUri = URI.parse("C:/Users/pgm/ext-pgm.pli");
-        const config = PluginConfigurationProviderInstance.getProcessGroupConfigFromLib(testUri);
+  test("matches absolute Windows-style library path", async () => {
+    await setupConfig(["cpy", "C:/Users/pgm"]);
+    const testUri = URI.parse("C:/Users/pgm/ext-pgm.pli");
+    const config =
+      PluginConfigurationProviderInstance.getProcessGroupConfigFromLib(testUri);
 
-        expect(config).toBeDefined();
-    });
+    expect(config).toBeDefined();
+  });
 
-    test("matches backslash Windows library path against normalized URI", async () => {
-        await setupConfig(["cpy", "C:\\Users\\pgm"]);
-        const testUri = URI.parse("C:/Users/pgm/ext-pgm.pli");
-        const config = PluginConfigurationProviderInstance.getProcessGroupConfigFromLib(testUri);
+  test("matches backslash Windows library path against normalized URI", async () => {
+    await setupConfig(["cpy", "C:\\Users\\pgm"]);
+    const testUri = URI.parse("C:/Users/pgm/ext-pgm.pli");
+    const config =
+      PluginConfigurationProviderInstance.getProcessGroupConfigFromLib(testUri);
 
-        expect(config).toBeDefined();
-    });
+    expect(config).toBeDefined();
+  });
 
-    test("matches configured library regardless of platform path differences", async () => {
-        await setupConfig(["cpy", "/Users/mockUser/pgm"]);
-        const testUri = URI.parse("C:/Users/pgm/ext-pgm.pli");
-        const config = PluginConfigurationProviderInstance.getProcessGroupConfigFromLib(testUri);
+  test("matches configured library regardless of platform path differences", async () => {
+    await setupConfig(["cpy", "/Users/mockUser/pgm"]);
+    const testUri = URI.parse("C:/Users/pgm/ext-pgm.pli");
+    const config =
+      PluginConfigurationProviderInstance.getProcessGroupConfigFromLib(testUri);
 
-        expect(config).toBeDefined();
-    });
+    expect(config).toBeDefined();
+  });
 });

--- a/packages/language/test/lsp/get-proc-group-config-from-lib.test.ts
+++ b/packages/language/test/lsp/get-proc-group-config-from-lib.test.ts
@@ -40,8 +40,8 @@ describe("Process group library path matching", () => {
   });
 
   test("matches absolute Windows-style library path", async () => {
-    await setupConfig(["cpy", "C:/Users/pgm"]);
-    const testUri = URI.parse("C:/Users/pgm/ext-pgm.pli");
+    await setupConfig(["cpy", "C:/Users/mockUser/pgm"]);
+    const testUri = URI.parse("C:/Users/mockUser/pgm/ext-pgm.pli");
     const config =
       PluginConfigurationProviderInstance.getProcessGroupConfigFromLib(testUri);
 
@@ -49,8 +49,8 @@ describe("Process group library path matching", () => {
   });
 
   test("matches backslash Windows library path against normalized URI", async () => {
-    await setupConfig(["cpy", "C:\\Users\\pgm"]);
-    const testUri = URI.parse("C:/Users/pgm/ext-pgm.pli");
+    await setupConfig(["cpy", "C:\\Users\\mockUser\\pgm"]);
+    const testUri = URI.parse("C:/Users/mockUser/pgm/ext-pgm.pli");
     const config =
       PluginConfigurationProviderInstance.getProcessGroupConfigFromLib(testUri);
 
@@ -59,7 +59,7 @@ describe("Process group library path matching", () => {
 
   test("matches configured library regardless of platform path differences", async () => {
     await setupConfig(["cpy", "/Users/mockUser/pgm"]);
-    const testUri = URI.parse("C:/Users/pgm/ext-pgm.pli");
+    const testUri = URI.parse("C:/Users/mockUser/pgm/ext-pgm.pli");
     const config =
       PluginConfigurationProviderInstance.getProcessGroupConfigFromLib(testUri);
 

--- a/packages/language/test/lsp/get-proc-group-config-from-lib.test.ts
+++ b/packages/language/test/lsp/get-proc-group-config-from-lib.test.ts
@@ -57,9 +57,9 @@ describe("Process group library path matching", () => {
     expect(config).toBeDefined();
   });
 
-  test("matches configured library regardless of platform path differences", async () => {
+  test("matches absolute path lib for Unix environments", async () => {
     await setupConfig(["cpy", "/Users/mockUser/pgm"]);
-    const testUri = URI.parse("C:/Users/mockUser/pgm/ext-pgm.pli");
+    const testUri = URI.parse("/Users/mockUser/pgm/ext-pgm.pli");
     const config =
       PluginConfigurationProviderInstance.getProcessGroupConfigFromLib(testUri);
 

--- a/packages/language/test/lsp/get-prog-config.test.ts
+++ b/packages/language/test/lsp/get-prog-config.test.ts
@@ -67,9 +67,9 @@ describe("Check if `getProgramConfig` inside `PluginConfigurationProvider` retri
     test("matches absolute UNIX style path", async () => {
       await setupConfig([
         { program: "*.pli", pgroup: "default" },
-        { program: "Users/pgm/ext-pgm.pli", pgroup: "default" },
+        { program: "/Users/pgm/ext-pgm.pli", pgroup: "default" },
       ]);
-      const testUri = URI.parse("Users/pgm/ext-pgm.pli");
+      const testUri = URI.parse("/Users/pgm/ext-pgm.pli");
       const config =
         PluginConfigurationProviderInstance.getProgramConfig(testUri);
 

--- a/packages/language/test/lsp/get-prog-config.test.ts
+++ b/packages/language/test/lsp/get-prog-config.test.ts
@@ -26,7 +26,7 @@ async function setupConfig(
 }
 
 describe("Check if `getProgramConfig` inside `PluginConfigurationProvider` retrieve proper values.", () => {
-  (test("atches workspace-relative program - most common use case", async () => {
+  (test("Matches workspace-relative program - most common use case", async () => {
     await setupConfig([{ program: "*.pli", pgroup: "default" }]);
     const testUri = URI.parse("workspace/a.pli");
     const config =

--- a/packages/language/test/lsp/get-prog-config.test.ts
+++ b/packages/language/test/lsp/get-prog-config.test.ts
@@ -26,7 +26,7 @@ async function setupConfig(
 }
 
 describe("Check if `getProgramConfig` inside `PluginConfigurationProvider` retrieve proper values.", () => {
-  (test("Matches workspace-relative program - most common use case", async () => {
+  test("Matches workspace-relative program - most common use case", async () => {
     await setupConfig([{ program: "*.pli", pgroup: "default" }]);
     const testUri = URI.parse("workspace/a.pli");
     const config =
@@ -74,5 +74,5 @@ describe("Check if `getProgramConfig` inside `PluginConfigurationProvider` retri
         PluginConfigurationProviderInstance.getProgramConfig(testUri);
 
       expect(config).toBeDefined();
-    }));
+    });
 });

--- a/packages/language/test/lsp/get-prog-config.test.ts
+++ b/packages/language/test/lsp/get-prog-config.test.ts
@@ -1,0 +1,60 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { describe, expect, test } from "vitest"
+import { PluginConfigurationProvider, PluginConfigurationProviderInstance, setPluginConfigurationProvider } from "../../src/workspace/plugin-configuration-provider"
+import { URI } from "../../src/utils/uri";
+
+async function setupConfig(programConfig: { program: string, pgroup: string }[]) {
+    const pluginConfig = new PluginConfigurationProvider();
+    setPluginConfigurationProvider(pluginConfig);
+    pluginConfig.setProgramConfigs("/workspace",
+        programConfig,
+    );
+}
+
+describe("Check if `getProgramConfig` inside `PluginConfigurationProvider` retrieve proper values.", () => {
+    test("atches workspace-relative program - most common use case", async () => {
+        await setupConfig([{ program: "*.pli", pgroup: "default" }]);
+        const testUri = URI.parse("workspace/a.pli");
+        const config = PluginConfigurationProviderInstance.getProgramConfig(testUri);
+
+        expect(config).toBeDefined();
+    }),
+        test("does NOT match absolute path outside workspace that isn't explicitely included as program", async () => {
+        await setupConfig([{ program: "*.pli", pgroup: "default" }]);
+        const testUri = URI.parse("C:/Users/pgm/ext-pgm.pli");
+        const config = PluginConfigurationProviderInstance.getProgramConfig(testUri);
+
+        expect(config).toBeUndefined();
+    }),
+        test("return match for absolute Windows-style path properly registered", async () => {
+        await setupConfig([{ program: "*.pli", pgroup: "default" }, { program: "C:/Users/pgm/ext-pgm.pli", pgroup: "default" }]);
+        const testUri = URI.parse("C:/Users/pgm/ext-pgm.pli");
+        const config = PluginConfigurationProviderInstance.getProgramConfig(testUri);
+
+        expect(config).toBeDefined();
+    }),
+        test("return match for properly registered absolute Windows-style with backslashes against normalized URI path.", async () => {
+        await setupConfig([{ program: "*.pli", pgroup: "default" }, { program: "C:\\Users\\pgm\\ext-pgm.pli", pgroup: "default" }]);
+        const testUri = URI.parse("C:/Users/pgm/ext-pgm.pli");
+        const config = PluginConfigurationProviderInstance.getProgramConfig(testUri);
+
+        expect(config).toBeDefined();
+    }),
+    test("matches absolute UNIX style path", async () => {
+        await setupConfig([{ program: "*.pli", pgroup: "default" }, { program: "Users/pgm/ext-pgm.pli", pgroup: "default" }]);
+        const testUri = URI.parse("Users/pgm/ext-pgm.pli");
+        const config = PluginConfigurationProviderInstance.getProgramConfig(testUri);
+
+        expect(config).toBeDefined();
+    })
+})

--- a/packages/language/test/lsp/get-prog-config.test.ts
+++ b/packages/language/test/lsp/get-prog-config.test.ts
@@ -26,7 +26,7 @@ async function setupConfig(
 }
 
 describe("Check if `getProgramConfig` inside `PluginConfigurationProvider` retrieve proper values.", () => {
-  test("Matches workspace-relative program - most common use case", async () => {
+  (test("Matches workspace-relative program - most common use case", async () => {
     await setupConfig([{ program: "*.pli", pgroup: "default" }]);
     const testUri = URI.parse("workspace/a.pli");
     const config =
@@ -74,5 +74,5 @@ describe("Check if `getProgramConfig` inside `PluginConfigurationProvider` retri
         PluginConfigurationProviderInstance.getProgramConfig(testUri);
 
       expect(config).toBeDefined();
-    });
+    }));
 });

--- a/packages/language/test/lsp/get-prog-config.test.ts
+++ b/packages/language/test/lsp/get-prog-config.test.ts
@@ -9,52 +9,70 @@
  *
  */
 
-import { describe, expect, test } from "vitest"
-import { PluginConfigurationProvider, PluginConfigurationProviderInstance, setPluginConfigurationProvider } from "../../src/workspace/plugin-configuration-provider"
+import { describe, expect, test } from "vitest";
+import {
+  PluginConfigurationProvider,
+  PluginConfigurationProviderInstance,
+  setPluginConfigurationProvider,
+} from "../../src/workspace/plugin-configuration-provider";
 import { URI } from "../../src/utils/uri";
 
-async function setupConfig(programConfig: { program: string, pgroup: string }[]) {
-    const pluginConfig = new PluginConfigurationProvider();
-    setPluginConfigurationProvider(pluginConfig);
-    pluginConfig.setProgramConfigs("/workspace",
-        programConfig,
-    );
+async function setupConfig(
+  programConfig: { program: string; pgroup: string }[],
+) {
+  const pluginConfig = new PluginConfigurationProvider();
+  setPluginConfigurationProvider(pluginConfig);
+  pluginConfig.setProgramConfigs("/workspace", programConfig);
 }
 
 describe("Check if `getProgramConfig` inside `PluginConfigurationProvider` retrieve proper values.", () => {
-    test("atches workspace-relative program - most common use case", async () => {
-        await setupConfig([{ program: "*.pli", pgroup: "default" }]);
-        const testUri = URI.parse("workspace/a.pli");
-        const config = PluginConfigurationProviderInstance.getProgramConfig(testUri);
+  (test("atches workspace-relative program - most common use case", async () => {
+    await setupConfig([{ program: "*.pli", pgroup: "default" }]);
+    const testUri = URI.parse("workspace/a.pli");
+    const config =
+      PluginConfigurationProviderInstance.getProgramConfig(testUri);
 
-        expect(config).toBeDefined();
+    expect(config).toBeDefined();
+  }),
+    test("does NOT match absolute path outside workspace that isn't explicitely included as program", async () => {
+      await setupConfig([{ program: "*.pli", pgroup: "default" }]);
+      const testUri = URI.parse("C:/Users/pgm/ext-pgm.pli");
+      const config =
+        PluginConfigurationProviderInstance.getProgramConfig(testUri);
+
+      expect(config).toBeUndefined();
     }),
-        test("does NOT match absolute path outside workspace that isn't explicitely included as program", async () => {
-        await setupConfig([{ program: "*.pli", pgroup: "default" }]);
-        const testUri = URI.parse("C:/Users/pgm/ext-pgm.pli");
-        const config = PluginConfigurationProviderInstance.getProgramConfig(testUri);
+    test("return match for absolute Windows-style path properly registered", async () => {
+      await setupConfig([
+        { program: "*.pli", pgroup: "default" },
+        { program: "C:/Users/pgm/ext-pgm.pli", pgroup: "default" },
+      ]);
+      const testUri = URI.parse("C:/Users/pgm/ext-pgm.pli");
+      const config =
+        PluginConfigurationProviderInstance.getProgramConfig(testUri);
 
-        expect(config).toBeUndefined();
+      expect(config).toBeDefined();
     }),
-        test("return match for absolute Windows-style path properly registered", async () => {
-        await setupConfig([{ program: "*.pli", pgroup: "default" }, { program: "C:/Users/pgm/ext-pgm.pli", pgroup: "default" }]);
-        const testUri = URI.parse("C:/Users/pgm/ext-pgm.pli");
-        const config = PluginConfigurationProviderInstance.getProgramConfig(testUri);
+    test("return match for properly registered absolute Windows-style with backslashes against normalized URI path.", async () => {
+      await setupConfig([
+        { program: "*.pli", pgroup: "default" },
+        { program: "C:\\Users\\pgm\\ext-pgm.pli", pgroup: "default" },
+      ]);
+      const testUri = URI.parse("C:/Users/pgm/ext-pgm.pli");
+      const config =
+        PluginConfigurationProviderInstance.getProgramConfig(testUri);
 
-        expect(config).toBeDefined();
-    }),
-        test("return match for properly registered absolute Windows-style with backslashes against normalized URI path.", async () => {
-        await setupConfig([{ program: "*.pli", pgroup: "default" }, { program: "C:\\Users\\pgm\\ext-pgm.pli", pgroup: "default" }]);
-        const testUri = URI.parse("C:/Users/pgm/ext-pgm.pli");
-        const config = PluginConfigurationProviderInstance.getProgramConfig(testUri);
-
-        expect(config).toBeDefined();
+      expect(config).toBeDefined();
     }),
     test("matches absolute UNIX style path", async () => {
-        await setupConfig([{ program: "*.pli", pgroup: "default" }, { program: "Users/pgm/ext-pgm.pli", pgroup: "default" }]);
-        const testUri = URI.parse("Users/pgm/ext-pgm.pli");
-        const config = PluginConfigurationProviderInstance.getProgramConfig(testUri);
+      await setupConfig([
+        { program: "*.pli", pgroup: "default" },
+        { program: "Users/pgm/ext-pgm.pli", pgroup: "default" },
+      ]);
+      const testUri = URI.parse("Users/pgm/ext-pgm.pli");
+      const config =
+        PluginConfigurationProviderInstance.getProgramConfig(testUri);
 
-        expect(config).toBeDefined();
-    })
-})
+      expect(config).toBeDefined();
+    }));
+});


### PR DESCRIPTION
`getProcessGroupConfigFromLib` does not correctly handle libraries provided as absolute paths, causing valid files to be missed.

ex.: For example, the URI path `"C:/pli/app-ext"` does not match the `"app-ext"` lib.

`getProgramConfig` suffers from a similar issue, where, in it's case, the program configuration can't be computed.

ex.: the program URI `"file:///Users/mockUser/projects/app/bin/app-ext.pli"` would never match, because it's stored in the configuration such as: `"file:///workspace/Users/mockUser/projects/app/bin/app-ext.pli"`

This PR adds explicit absolute-path detection and updates the lookup logic to correctly resolve such libraries and programs.
