### PR TITLE
[Bugfix] Fix search for DD members without DD names

### DIFF
--- a/packages/vscode-extension/src/language/main.ts
+++ b/packages/vscode-extension/src/language/main.ts
@@ -73,9 +73,12 @@ class NodeFileSystemProvider implements FileSystemProvider {
         nocase: true,
       });
     } else {
+      // Windows paths may contain double slashes, which can prevent blob search from finding matches.
+      // This mainly affects INCLUDEs for members without DD names (ddname(member)).
+      const forwardSlashPath = options.dirPath.fsPath.replace(/\\/g, "/");
       // member lookup w/ dir path
       files = await glob.glob(
-        `${options.dirPath.fsPath}**/*\\(${options.member}\\)`,
+        `${forwardSlashPath}**/*\\(${options.member}\\)`,
         {
           nodir: true,
           absolute: true,

--- a/packages/vscode-extension/src/language/main.ts
+++ b/packages/vscode-extension/src/language/main.ts
@@ -73,18 +73,15 @@ class NodeFileSystemProvider implements FileSystemProvider {
         nocase: true,
       });
     } else {
-      // Windows paths may contain double slashes, which can prevent blob search from finding matches.
+      // Windows paths may contain backslashes that need to be normalized before using them as glob patterns.
       // This mainly affects INCLUDEs for members without DD names (ddname(member)).
-      const forwardSlashPath = options.dirPath.fsPath.replace(/\\/g, "/");
+      const normalizedPath = options.dirPath.fsPath.replace(/\\/g, "/");
       // member lookup w/ dir path
-      files = await glob.glob(
-        `${forwardSlashPath}**/*\\(${options.member}\\)`,
-        {
-          nodir: true,
-          absolute: true,
-          nocase: true,
-        },
-      );
+      files = await glob.glob(`${normalizedPath}**/*\\(${options.member}\\)`, {
+        nodir: true,
+        absolute: true,
+        nocase: true,
+      });
     }
 
     // return first match when present


### PR DESCRIPTION
Related to PR #551 

**Problem:** Currently on Windows machines, members without DD names (ex.: ddname(member)) can't be resolved. This happens because the path we feed to the glob search.

**Fix:** Replacing the double slashes ("\\") with one forward slash in a Unix like path ("/") gives the glob search the means to return a match.