### PR TITLE
Remove completely closed compilation units

### DIFF
--- a/packages/language/src/language-server/text-documents.ts
+++ b/packages/language/src/language-server/text-documents.ts
@@ -219,6 +219,10 @@ export class NormalizedTextDocuments<
     return this._onDidClose.event;
   }
 
+  public has(uri: string | URI): boolean {
+    return this._syncedDocuments.has(UriUtils.normalize(uri));
+  }
+
   public async get(uri: string | URI): Promise<T | undefined> {
     let syncedDocument = this._syncedDocuments.get(UriUtils.normalize(uri));
     if (syncedDocument === undefined && this._loadFromURI) {

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -310,17 +310,13 @@ export class CompilationUnitHandler {
       // Nothing to close
       return false;
     }
-    let isOpen = false;
     for (const file of unit.services.files.keys()) {
       if (EditorDocuments.has(file)) {
-        isOpen = true;
-        break;
+        // Return early if any file is still open
+        return false;
       }
     }
-    if (!isOpen) {
-      return this.deleteCompilationUnit(uri);
-    }
-    return false;
+    return this.deleteCompilationUnit(uri);
   }
 
   async updateUri(uri: URI): Promise<void> {

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -288,11 +288,39 @@ export class CompilationUnitHandler {
       this.updateUri(uri);
     });
     textDocuments.onDidClose((event) => {
-      connection.sendDiagnostics({
-        uri: event.document.uri,
-        diagnostics: [],
-      });
+      const uri = URI.parse(event.document.uri);
+      const unit = this.compilationUnits.get(uri.toString());
+      if (unit && this.tryCloseCompilationUnit(uri)) {
+        console.debug(`Closed compilation unit for ${uri.toString()}`);
+        for (const file of unit.services.files.keys()) {
+          // Clear diagnostics for all files in the closed compilation unit
+          // Otherwise, keep the diagnostics, even if the files have been closed
+          connection.sendDiagnostics({
+            uri: file,
+            diagnostics: [],
+          });
+        }
+      }
     });
+  }
+
+  private tryCloseCompilationUnit(uri: URI): boolean {
+    const unit = this.compilationUnits.get(uri.toString());
+    if (!unit) {
+      // Nothing to close
+      return false;
+    }
+    let isOpen = false;
+    for (const file of unit.services.files.keys()) {
+      if (EditorDocuments.has(file)) {
+        isOpen = true;
+        break;
+      }
+    }
+    if (!isOpen) {
+      return this.deleteCompilationUnit(uri);
+    }
+    return false;
   }
 
   async updateUri(uri: URI): Promise<void> {


### PR DESCRIPTION
Fixes (2) of #570. The fix is rather trivial: If a file closes, check whether all files of that compilation unit are now closed - if they are, completely discard the compilation unit. This removes the whole compilation unit from memory and prevents the error seen in the issue.

This can be manually tested by opening a workspace with a `.pliplugin` config directory:
1. Open, edit (making sure that the file has an error diagnostic) and then close a `.pli` file associated to a config group in the `.pliplugin` directory.
2. The errors should disappear from the problem view.
3. Edit the program config - the errors should not appear again in the view.