### PR TITLE
Fix diagnostic loss on config parser error

### DIFF
--- a/packages/language/src/preprocessor/compiler-options-processor.ts
+++ b/packages/language/src/preprocessor/compiler-options-processor.ts
@@ -73,7 +73,7 @@ export class CompilerOptionsProcessor {
     const programConfig =
       PluginConfigurationProviderInstance.getProgramConfig(uri);
 
-    if (programConfig?.abstractOptions) {
+    if (programConfig) {
       if (ranges.length === 0) {
         // If there is no anchor in the current file, diagnostics are not added at all.
         // Just run the compiler options translation.
@@ -93,10 +93,15 @@ export class CompilerOptionsProcessor {
       }
 
       // Add the compiler option parser issues and start the translation.
-      this.translator.addIssues(programConfig.issues || []);
-      this.translator.translateCompilerOptions(programConfig.abstractOptions, {
-        source: CompilerOptionSource.PLUGIN_CONFIG,
-      });
+      this.translator.addIssues(programConfig?.issues || []);
+      if (programConfig.abstractOptions) {
+        this.translator.translateCompilerOptions(
+          programConfig.abstractOptions,
+          {
+            source: CompilerOptionSource.PLUGIN_CONFIG,
+          },
+        );
+      }
     }
 
     // Now translate all options from the source file.

--- a/packages/language/src/preprocessor/compiler-options/translate.ts
+++ b/packages/language/src/preprocessor/compiler-options/translate.ts
@@ -212,6 +212,6 @@ export class CompilerOptionTranslator {
   }
 
   addIssues(issues: Diagnostic[]): void {
-    this.result.issues.push(...issues);
+    this.result.issues.push(...this.applyDiagnosticAnchor(issues));
   }
 }

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -528,27 +528,31 @@ export class PluginConfigurationProvider {
    * updates abstractOptions & issue counts, sourcing from the associated process group config as well.
    */
   private postProcessProgramConfigs() {
-    const programConfigs = this.programConfigs.values();
-    for (const programConfig of programConfigs) {
-      // get the process group config for this program
+    for (const programConfig of this.programConfigs.values()) {
       const processGroupConfig = this.getProcessGroupConfig(
         programConfig.pgroup,
       );
 
-      // collect raw compiler options from the group
-      const rawCompilerOptions = [
-        ...(programConfig.compilerOptions || []),
-        ...(processGroupConfig?.compilerOptions || []),
-      ].join(" ");
-      // combine them and pass them all together to parse and translate
-      const abstractOptions = parseAbstractCompilerOptions(
-        `${rawCompilerOptions} ${rawCompilerOptions}`,
-      );
-      for (const issue of abstractOptions.issues) {
-        console.error(
-          `Error in compiler options for program config "${programConfig.program}": ${issue}`,
-        );
+      // Collect and parse compiler options from both program and process group
+      // and parse them individually to accept working ones even if some have parser errors.
+      const compilerOptions = [
+        ...(programConfig.compilerOptions ?? []),
+        ...(processGroupConfig?.compilerOptions ?? []),
+      ];
+
+      const abstractOptions: AbstractCompilerOptions = {
+        options: [],
+        tokens: [],
+        issues: [],
+      };
+
+      for (const option of compilerOptions) {
+        const parsed = parseAbstractCompilerOptions(option);
+        abstractOptions.options.push(...parsed.options);
+        abstractOptions.tokens.push(...parsed.tokens);
+        abstractOptions.issues.push(...parsed.issues);
       }
+
       programConfig.abstractOptions = abstractOptions;
       programConfig.issues = abstractOptions.issues;
     }

--- a/packages/language/test/fourslash/preprocessor/compiler-options/parser-error-placement.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/parser-error-placement.ts
@@ -1,0 +1,42 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////         "name": "default",
+////         "compiler-options": [
+////             "AGGREGATE",
+////             "MARGINS(2,7)",
+////             "AGGREGATE,"
+////         ]
+////         }
+////     ]
+//// }
+
+// @filename: main.pli
+////%<|process|> <|aggregate|>;
+////  HELLO:
+////    PROCEDURE OPTIONS(MAIN);
+////    /*A PROGRAM TO OUTPUT HELLO WORLD*/  ;
+////    PUT LIST ('HELLO, WELCOME TO PLI/1 WORLD ');
+////  END HELLO;
+
+verify.expectDiagnosticsAt("process", {
+  message:
+    "PLI Plugin Config: Expecting token of type --> value <-- but found --> '' <--",
+});
+verify.expectDiagnosticsAt("aggregate", {
+  message: code.CompilerOptions.DupeOptionIssue.message("AGGREGATE"),
+});


### PR DESCRIPTION
Fixes (3) of https://github.com/zowe/zowe-pli-language-support/issues/570. 

The fix adds parser issues in the config files to the diagnostic list even when no options were parsed. Also, the options coming from the config files are now parsed individually. This way, only the lines with parser errors are affected, while the other options still work.