### PR TITLE
Fix nested options' case-sensitivity

### DIFF
--- a/packages/language/src/preprocessor/compiler-options/translate.ts
+++ b/packages/language/src/preprocessor/compiler-options/translate.ts
@@ -147,7 +147,8 @@ export class CompilerOptionTranslator {
         (item.token?.startOffset ?? 0) + 1,
       );
       item.processed = true;
-      nestedOptions.options.forEach((option) =>
+      const options = this.optionsToUpperCase(nestedOptions.options);
+      options.forEach((option) =>
         ppTranslator.translate(option, configuration),
       );
       ppTranslator.diagnostics.push(...nestedOptions.issues);

--- a/packages/language/test/fourslash/validate/macro/deprecate-lowercase.ts
+++ b/packages/language/test/fourslash/validate/macro/deprecate-lowercase.ts
@@ -11,8 +11,8 @@
 
 /// <reference path="../../framework.ts" />
 
-////%PROCESS PP(MACRO('DEPRECATE(ENTRY(TEST))'));
-//// %X: <|1:TEST|>: PROC RETURNS (CHAR);
+////%PROCESS PP(MACRO('DEPRECATE(ENTRY(test))'));
+//// %<|1:TEST|>: PROC RETURNS (CHAR);
 ////   RETURN ('X');
 //// %END;
 

--- a/packages/language/test/fourslash/validate/macro/deprecate.ts
+++ b/packages/language/test/fourslash/validate/macro/deprecate.ts
@@ -13,7 +13,7 @@
 
 ////%PROCESS PP(MACRO('DEPRECATE(ENTRY(TEST))'));
 //// %<|1:TEST|>: PROC RETURNS (CHAR);
-////   RETURN (X);
+////   RETURN ('X');
 //// %END;
 
 verify.expectDiagnosticsAt(1, code.Error.IBM3660I);

--- a/packages/language/test/fourslash/validate/macro/deprecatenext.ts
+++ b/packages/language/test/fourslash/validate/macro/deprecatenext.ts
@@ -13,7 +13,7 @@
 
 ////%PROCESS PP(MACRO('DEPRECATENEXT(ENTRY(TEST))'));
 //// %<|1:TEST|>: PROC RETURNS (CHAR);
-////   RETURN (X);
+////   RETURN ('X');
 //// %END;
 
 verify.expectDiagnosticsAt(1, code.Warning.IBM3334I);


### PR DESCRIPTION
Fixes (14) of https://github.com/zowe/zowe-pli-language-support/issues/570.

Generally, compiler options are treated as upper case. However, this was not the case for nested compiler options for the preprocessors.