### PR TITLE
[Improvement] Launch config public service

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "request": "launch",
             "args": [
                 "--extensionDevelopmentPath=${workspaceFolder}/packages/vscode-extension",
-                "${workspaceFolder}/code_samples"
+                "${workspaceFolder}/code_samples/plugin-example"
             ],
             "sourceMaps": true,
             "outFiles": [


### PR DESCRIPTION
While we don't deal with multiple `.pliplugin` folders (which I understand we are going to tackle soon), let's consider doing this, even if for just a few weeks.

Jokes aside, this simple PR save us from adding `"/plugin-example"` to the launch config every single day. 😄