### PR TITLE
Add diagnostic when procedure is not used

### DIFF
--- a/packages/language/src/validation/validator.ts
+++ b/packages/language/src/validation/validator.ts
@@ -182,7 +182,6 @@ export function linkingErrorsToDiagnostics(
   // Warn if a label is never referenced
   for (const scope of scopeCaches.regular.values()) {
     nodeLoop: for (const node of scope.symbolTable.nodeLookup.keys()) {
-      const nodeReferences = references.findReferences(node);
       if (node.kind !== SyntaxKind.LabelPrefix) {
         continue;
       }
@@ -203,6 +202,7 @@ export function linkingErrorsToDiagnostics(
       }
 
       // Ignore all `END` nodes, since a procedure will always have one `END` node referencing itself
+      const nodeReferences = references.findReferences(node);
       for (const reference of nodeReferences) {
         if (reference.owner.container?.kind !== SyntaxKind.EndStatement) {
           // The label is referenced, so we don't generate a warning

--- a/packages/language/src/validation/validator.ts
+++ b/packages/language/src/validation/validator.ts
@@ -180,7 +180,10 @@ export function linkingErrorsToDiagnostics(
   }
 
   // Warn if a label is never referenced
-  for (const [node, nodeReferences] of references.allReverseReferences()) {
+  const symbolReferences = [...scopeCaches.regular.values()]
+    .flatMap((scope) => [...scope.symbolTable.nodeLookup.keys()])
+    .map(sym => [sym, references.findReferences(sym)] as const);
+  for (const [node, nodeReferences] of symbolReferences) {
     if (node.kind !== SyntaxKind.LabelPrefix) {
       continue;
     }

--- a/packages/language/src/validation/validator.ts
+++ b/packages/language/src/validation/validator.ts
@@ -182,7 +182,7 @@ export function linkingErrorsToDiagnostics(
   // Warn if a label is never referenced
   const symbolReferences = [...scopeCaches.regular.values()]
     .flatMap((scope) => [...scope.symbolTable.nodeLookup.keys()])
-    .map(sym => [sym, references.findReferences(sym)] as const);
+    .map((sym) => [sym, references.findReferences(sym)] as const);
   for (const [node, nodeReferences] of symbolReferences) {
     if (node.kind !== SyntaxKind.LabelPrefix) {
       continue;

--- a/packages/language/src/validation/validator.ts
+++ b/packages/language/src/validation/validator.ts
@@ -37,8 +37,8 @@ export type ValidationFunction<T extends SyntaxNode> = (
 
 export type ValidationChecks = Partial<{
   [K in keyof typeof SyntaxKind as (typeof SyntaxKind)[K] extends SyntaxNode["kind"]
-    ? K
-    : never]: ValidationFunction<
+  ? K
+  : never]: ValidationFunction<
     Extract<SyntaxNode, { kind: (typeof SyntaxKind)[K] }>
   >[];
 }>;
@@ -180,40 +180,40 @@ export function linkingErrorsToDiagnostics(
   }
 
   // Warn if a label is never referenced
-  const symbolReferences = [...scopeCaches.regular.values()]
-    .flatMap((scope) => [...scope.symbolTable.nodeLookup.keys()])
-    .map((sym) => [sym, references.findReferences(sym)] as const);
-  for (const [node, nodeReferences] of symbolReferences) {
-    if (node.kind !== SyntaxKind.LabelPrefix) {
-      continue;
+  for (const scope of scopeCaches.regular.values()) {
+    for (const node of scope.symbolTable.nodeLookup.keys()) {
+      const nodeReferences = references.findReferences(node);
+      if (node.kind !== SyntaxKind.LabelPrefix) {
+        continue;
+      }
+
+      // If the node has no name token, we can't even create a diagnostic, skip it
+      if (!node.nameToken) {
+        continue;
+      }
+
+      // If the label prefix points to a package, don't warn
+      if (labelPrefixPointsToPackage(node)) {
+        continue;
+      }
+
+      // The main procedure is never directly referenced anyway, so we don't need to warn
+      if (isMainProcedure(node)) {
+        continue;
+      }
+
+      // Ignore all `END` nodes, since a procedure will always have one `END` node referencing itself
+      const actualReferences = nodeReferences.filter(
+        (reference) =>
+          reference.owner.container?.kind !== SyntaxKind.EndStatement,
+      );
+
+      // The label is referenced, so we don't generate a warning
+      if (actualReferences.length > 0) {
+        continue;
+      }
+
+      reporter.reportUnreferencedSymbol(node.nameToken);
     }
-
-    // If the node has no name token, we can't even create a diagnostic, skip it
-    if (!node.nameToken) {
-      continue;
-    }
-
-    // If the label prefix points to a package, don't warn
-    if (labelPrefixPointsToPackage(node)) {
-      continue;
-    }
-
-    // The main procedure is never directly referenced anyway, so we don't need to warn
-    if (isMainProcedure(node)) {
-      continue;
-    }
-
-    // Ignore all `END` nodes, since a procedure will always have one `END` node referencing itself
-    const actualReferences = nodeReferences.filter(
-      (reference) =>
-        reference.owner.container?.kind !== SyntaxKind.EndStatement,
-    );
-
-    // The label is referenced, so we don't generate a warning
-    if (actualReferences.length > 0) {
-      continue;
-    }
-
-    reporter.reportUnreferencedSymbol(node.nameToken);
   }
 }

--- a/packages/language/src/validation/validator.ts
+++ b/packages/language/src/validation/validator.ts
@@ -37,8 +37,8 @@ export type ValidationFunction<T extends SyntaxNode> = (
 
 export type ValidationChecks = Partial<{
   [K in keyof typeof SyntaxKind as (typeof SyntaxKind)[K] extends SyntaxNode["kind"]
-  ? K
-  : never]: ValidationFunction<
+    ? K
+    : never]: ValidationFunction<
     Extract<SyntaxNode, { kind: (typeof SyntaxKind)[K] }>
   >[];
 }>;
@@ -181,7 +181,7 @@ export function linkingErrorsToDiagnostics(
 
   // Warn if a label is never referenced
   for (const scope of scopeCaches.regular.values()) {
-    for (const node of scope.symbolTable.nodeLookup.keys()) {
+    nodeLoop: for (const node of scope.symbolTable.nodeLookup.keys()) {
       const nodeReferences = references.findReferences(node);
       if (node.kind !== SyntaxKind.LabelPrefix) {
         continue;
@@ -203,14 +203,11 @@ export function linkingErrorsToDiagnostics(
       }
 
       // Ignore all `END` nodes, since a procedure will always have one `END` node referencing itself
-      const actualReferences = nodeReferences.filter(
-        (reference) =>
-          reference.owner.container?.kind !== SyntaxKind.EndStatement,
-      );
-
-      // The label is referenced, so we don't generate a warning
-      if (actualReferences.length > 0) {
-        continue;
+      for (const reference of nodeReferences) {
+        if (reference.owner.container?.kind !== SyntaxKind.EndStatement) {
+          // The label is referenced, so we don't generate a warning
+          continue nodeLoop;
+        }
       }
 
       reporter.reportUnreferencedSymbol(node.nameToken);

--- a/packages/language/test/fourslash/linker/procedure-label-not-referenced.ts
+++ b/packages/language/test/fourslash/linker/procedure-label-not-referenced.ts
@@ -9,15 +9,13 @@
  *
  */
 
-/// <reference path="../../../framework.ts" />
+/// <reference path="../framework.ts" />
 
-//// %MYMACRO: PROC;
-////   ANSWER MARGINS (123);
-//// %END;
-//// %ACTIVATE MYMACRO;
-//// ppp: PROC OPTIONS(MAIN);
-////   MYMACRO
-//// END;
+//// <|name2|>: procedure;
+//// end <|name2>name2;
+//// <|name1|>: procedure;
+//// end;
 
-preprocessor.expectTokens("ppp: PROC OPTIONS(MAIN); END;");
-verify.noDiagnostics();
+linker.expectLinks();
+verify.expectErrorCodesAt("name2", code.Warning.IBM1213I);
+verify.expectErrorCodesAt("name1", code.Warning.IBM1213I);

--- a/packages/language/test/fourslash/preprocessor/procedures/answer/answer-builtin-macro.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/answer/answer-builtin-macro.ts
@@ -15,13 +15,13 @@
 ////   ANSWER (Counter);
 //// %END;
 //// %ACTIVATE MYMACRO;
-//// ppp: PROC;
+//// ppp: PROC OPTIONS(MAIN);
 ////    DCL VAR FIXED;
 ////    VAR = MYMACRO;
 //// END;
 
 preprocessor.expectTokens(`
-    ppp: PROC;
+    ppp: PROC OPTIONS(MAIN);
         DCL VAR FIXED;
         VAR = 00001;
     END;

--- a/packages/language/test/fourslash/preprocessor/procedures/answer/answer-builtin-macro.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/answer/answer-builtin-macro.ts
@@ -15,15 +15,11 @@
 ////   ANSWER (Counter);
 //// %END;
 //// %ACTIVATE MYMACRO;
-//// ppp: PROC OPTIONS(MAIN);
-////    DCL VAR FIXED;
-////    VAR = MYMACRO;
-//// END;
+//// DCL VAR FIXED;
+//// VAR = MYMACRO;
 
 preprocessor.expectTokens(`
-    ppp: PROC OPTIONS(MAIN);
-        DCL VAR FIXED;
-        VAR = 00001;
-    END;
+    DCL VAR FIXED;
+    VAR = 00001;
 `);
 verify.noDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/procedures/answer/answer-column.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/answer/answer-column.ts
@@ -15,9 +15,9 @@
 ////   ANSWER COLUMN (123);
 //// %END;
 //// %ACTIVATE MYMACRO;
-//// ppp: PROC;
+//// ppp: PROC OPTIONS(MAIN);
 ////   MYMACRO
 //// END;
 
-preprocessor.expectTokens("ppp: PROC; END;");
+preprocessor.expectTokens("ppp: PROC OPTIONS(MAIN); END;");
 verify.noDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/procedures/answer/answer-column.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/answer/answer-column.ts
@@ -15,9 +15,7 @@
 ////   ANSWER COLUMN (123);
 //// %END;
 //// %ACTIVATE MYMACRO;
-//// ppp: PROC OPTIONS(MAIN);
-////   MYMACRO
-//// END;
+//// MYMACRO
 
-preprocessor.expectTokens("ppp: PROC OPTIONS(MAIN); END;");
+preprocessor.expectTokens("");
 verify.noDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/procedures/answer/answer-margins-left-and-right.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/answer/answer-margins-left-and-right.ts
@@ -15,9 +15,7 @@
 ////   ANSWER MARGINS (1, 23);
 //// %END;
 //// %ACTIVATE MYMACRO;
-//// ppp: PROC OPTIONS(MAIN);
-////   MYMACRO
-//// END;
+//// MYMACRO
 
-preprocessor.expectTokens("ppp: PROC OPTIONS(MAIN); END;");
+preprocessor.expectTokens("");
 verify.noDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/procedures/answer/answer-margins-left-and-right.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/answer/answer-margins-left-and-right.ts
@@ -15,9 +15,9 @@
 ////   ANSWER MARGINS (1, 23);
 //// %END;
 //// %ACTIVATE MYMACRO;
-//// ppp: PROC;
+//// ppp: PROC OPTIONS(MAIN);
 ////   MYMACRO
 //// END;
 
-preprocessor.expectTokens("ppp: PROC; END;");
+preprocessor.expectTokens("ppp: PROC OPTIONS(MAIN); END;");
 verify.noDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/procedures/answer/answer-margins-left.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/answer/answer-margins-left.ts
@@ -15,9 +15,7 @@
 ////   ANSWER MARGINS (123);
 //// %END;
 //// %ACTIVATE MYMACRO;
-//// ppp: PROC OPTIONS(MAIN);
-////   MYMACRO
-//// END;
+//// MYMACRO
 
-preprocessor.expectTokens("ppp: PROC OPTIONS(MAIN); END;");
+preprocessor.expectTokens("");
 verify.noDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/procedures/answer/answer-page.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/answer/answer-page.ts
@@ -15,9 +15,7 @@
 ////   ANSWER PAGE;
 //// %END;
 //// %ACTIVATE MYMACRO;
-//// ppp: PROC OPTIONS(MAIN);
-////   MYMACRO
-//// END;
+//// MYMACRO
 
-preprocessor.expectTokens("ppp: PROC OPTIONS(MAIN); END;");
+preprocessor.expectTokens("");
 verify.noDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/procedures/answer/answer-page.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/answer/answer-page.ts
@@ -15,9 +15,9 @@
 ////   ANSWER PAGE;
 //// %END;
 //// %ACTIVATE MYMACRO;
-//// ppp: PROC;
+//// ppp: PROC OPTIONS(MAIN);
 ////   MYMACRO
 //// END;
 
-preprocessor.expectTokens("ppp: PROC; END;");
+preprocessor.expectTokens("ppp: PROC OPTIONS(MAIN); END;");
 verify.noDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/procedures/answer/answer-skip-no-count.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/answer/answer-skip-no-count.ts
@@ -15,9 +15,7 @@
 ////   ANSWER SKIP;
 //// %END;
 //// %ACTIVATE MYMACRO;
-//// ppp: PROC OPTIONS(MAIN);
-////   MYMACRO
-//// END;
+//// MYMACRO
 
-preprocessor.expectTokens("ppp: PROC OPTIONS(MAIN); END;");
+preprocessor.expectTokens("");
 verify.noDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/procedures/answer/answer-skip-no-count.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/answer/answer-skip-no-count.ts
@@ -15,9 +15,9 @@
 ////   ANSWER SKIP;
 //// %END;
 //// %ACTIVATE MYMACRO;
-//// ppp: PROC;
+//// ppp: PROC OPTIONS(MAIN);
 ////   MYMACRO
 //// END;
 
-preprocessor.expectTokens("ppp: PROC; END;");
+preprocessor.expectTokens("ppp: PROC OPTIONS(MAIN); END;");
 verify.noDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/procedures/answer/answer-skip-with-count.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/answer/answer-skip-with-count.ts
@@ -15,9 +15,7 @@
 ////   ANSWER SKIP (123);
 //// %END;
 //// %ACTIVATE MYMACRO;
-//// ppp: PROC OPTIONS(MAIN);
-////   MYMACRO
-//// END;
+//// MYMACRO
 
-preprocessor.expectTokens("ppp: PROC OPTIONS(MAIN); END;");
+preprocessor.expectTokens("");
 verify.noDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/procedures/answer/answer-skip-with-count.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/answer/answer-skip-with-count.ts
@@ -15,9 +15,9 @@
 ////   ANSWER SKIP (123);
 //// %END;
 //// %ACTIVATE MYMACRO;
-//// ppp: PROC;
+//// ppp: PROC OPTIONS(MAIN);
 ////   MYMACRO
 //// END;
 
-preprocessor.expectTokens("ppp: PROC; END;");
+preprocessor.expectTokens("ppp: PROC OPTIONS(MAIN); END;");
 verify.noDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/procedures/answer/answer-with-noscan-output.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/answer/answer-with-noscan-output.ts
@@ -18,20 +18,17 @@
 ////   ANSWER ('VAR = VAL;') NOSCAN;
 //// %END;
 //// %ACTIVATE MYMACRO;
-//// ppp: PROC OPTIONS(MAIN);
-////   DCL VAL FIXED;
-////   VAL = 200;
-////   DCL VAR FIXED;
-////   %ACTIVATE VAL;
-////   MYMACRO
-//// END;
+////
+//// DCL VAL FIXED;
+//// VAL = 200;
+//// DCL VAR FIXED;
+//// %ACTIVATE VAL;
+//// MYMACRO
 
 preprocessor.expectTokens(`
-    ppp: PROC OPTIONS(MAIN);
-        DCL VAL FIXED;
-        VAL = 200;
-        DCL VAR FIXED; 
-        VAR = VAL;
-    END;
+    DCL VAL FIXED;
+    VAL = 200;
+    DCL VAR FIXED; 
+    VAR = VAL;
 `);
 verify.noDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/procedures/answer/answer-with-noscan-output.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/answer/answer-with-noscan-output.ts
@@ -18,7 +18,7 @@
 ////   ANSWER ('VAR = VAL;') NOSCAN;
 //// %END;
 //// %ACTIVATE MYMACRO;
-//// ppp: PROC;
+//// ppp: PROC OPTIONS(MAIN);
 ////   DCL VAL FIXED;
 ////   VAL = 200;
 ////   DCL VAR FIXED;
@@ -27,7 +27,7 @@
 //// END;
 
 preprocessor.expectTokens(`
-    ppp: PROC;
+    ppp: PROC OPTIONS(MAIN);
         DCL VAL FIXED;
         VAL = 200;
         DCL VAR FIXED; 

--- a/packages/language/test/fourslash/preprocessor/procedures/answer/answer-with-output-and-skip-side-effect.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/answer/answer-with-output-and-skip-side-effect.ts
@@ -25,13 +25,13 @@
 ////
 //// %ACTIVATE MYMACRO;
 ////
-//// ppp: PROC;
+//// ppp: PROC OPTIONS(MAIN);
 ////   DCL VAR FIXED;
 ////   MYMACRO
 //// END;
 
 preprocessor.expectTokens(`
-    ppp: PROC;
+    ppp: PROC OPTIONS(MAIN);
         DCL VAR FIXED;
         VAR = 2;
     END;

--- a/packages/language/test/fourslash/preprocessor/procedures/answer/answer-with-output-and-skip-side-effect.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/answer/answer-with-output-and-skip-side-effect.ts
@@ -25,15 +25,11 @@
 ////
 //// %ACTIVATE MYMACRO;
 ////
-//// ppp: PROC OPTIONS(MAIN);
-////   DCL VAR FIXED;
-////   MYMACRO
-//// END;
+//// DCL VAR FIXED;
+//// MYMACRO
 
 preprocessor.expectTokens(`
-    ppp: PROC OPTIONS(MAIN);
-        DCL VAR FIXED;
-        VAR = 2;
-    END;
+ DCL VAR FIXED;
+ VAR = 2;
 `);
 verify.noDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/procedures/answer/answer-with-output-merged.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/answer/answer-with-output-merged.ts
@@ -16,12 +16,12 @@
 ////   ANSWER ('Y FIXED;');
 //// %END;
 //// %ACTIVATE MYMACRO;
-//// ppp: PROC;
+//// ppp: PROC OPTIONS(MAIN);
 ////    MYMACRO
 //// END;
 
 preprocessor.expectTokens(`
-    ppp: PROC;
+    ppp: PROC OPTIONS(MAIN);
         DCL XY FIXED; 
     END;
 `);

--- a/packages/language/test/fourslash/preprocessor/procedures/answer/answer-with-output-merged.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/answer/answer-with-output-merged.ts
@@ -16,13 +16,9 @@
 ////   ANSWER ('Y FIXED;');
 //// %END;
 //// %ACTIVATE MYMACRO;
-//// ppp: PROC OPTIONS(MAIN);
-////    MYMACRO
-//// END;
+//// MYMACRO
 
 preprocessor.expectTokens(`
-    ppp: PROC OPTIONS(MAIN);
-        DCL XY FIXED; 
-    END;
+  DCL XY FIXED; 
 `);
 verify.noDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/procedures/answer/answer-with-output-no-merge.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/answer/answer-with-output-no-merge.ts
@@ -16,12 +16,12 @@
 ////   ANSWER ('VAR FIXED;') SKIP;
 //// %END;
 //// %ACTIVATE MYMACRO;
-//// ppp: PROC;
+//// ppp: PROC OPTIONS(MAIN);
 ////    MYMACRO
 //// END;
 
 preprocessor.expectTokens(`
-    ppp: PROC;
+    ppp: PROC OPTIONS(MAIN);
         DCL VAR FIXED; 
     END;
 `);

--- a/packages/language/test/fourslash/preprocessor/procedures/answer/answer-with-output-no-merge.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/answer/answer-with-output-no-merge.ts
@@ -16,13 +16,9 @@
 ////   ANSWER ('VAR FIXED;') SKIP;
 //// %END;
 //// %ACTIVATE MYMACRO;
-//// ppp: PROC OPTIONS(MAIN);
-////    MYMACRO
-//// END;
+//// MYMACRO
 
 preprocessor.expectTokens(`
-    ppp: PROC OPTIONS(MAIN);
-        DCL VAR FIXED; 
-    END;
+  DCL VAR FIXED; 
 `);
 verify.noDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/procedures/answer/answer-with-output.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/answer/answer-with-output.ts
@@ -15,12 +15,12 @@
 ////   ANSWER ('DCL VAR FIXED;');
 //// %END;
 //// %ACTIVATE MYMACRO;
-//// ppp: PROC;
+//// ppp: PROC OPTIONS(MAIN);
 ////    MYMACRO
 //// END;
 
 preprocessor.expectTokens(`
-    ppp: PROC;
+    ppp: PROC OPTIONS(MAIN);
         DCL VAR FIXED; 
     END;
 `);

--- a/packages/language/test/fourslash/preprocessor/procedures/answer/answer-with-output.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/answer/answer-with-output.ts
@@ -15,13 +15,9 @@
 ////   ANSWER ('DCL VAR FIXED;');
 //// %END;
 //// %ACTIVATE MYMACRO;
-//// ppp: PROC OPTIONS(MAIN);
-////    MYMACRO
-//// END;
+//// MYMACRO
 
 preprocessor.expectTokens(`
-    ppp: PROC OPTIONS(MAIN);
-        DCL VAR FIXED; 
-    END;
+    DCL VAR FIXED; 
 `);
 verify.noDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/procedures/answer/answer-with-rescan-output.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/answer/answer-with-rescan-output.ts
@@ -18,20 +18,16 @@
 ////   ANSWER ('VAR = VAL;') RESCAN;
 //// %END;
 //// %ACTIVATE MYMACRO;
-//// ppp: PROC OPTIONS(MAIN);
-////   DCL VAL FIXED;
-////   VAL = 200;
-////   DCL VAR FIXED;
-////   %ACTIVATE VAL;
-////   MYMACRO
-//// END;
+//// DCL VAL FIXED;
+//// VAL = 200;
+//// DCL VAR FIXED;
+//// %ACTIVATE VAL;
+//// MYMACRO
 
 preprocessor.expectTokens(`
-    ppp: PROC OPTIONS(MAIN);
-        DCL VAL FIXED;
-        VAL = 200;
-        DCL VAR FIXED; 
-        VAR = 100;
-    END;
+    DCL VAL FIXED;
+    VAL = 200;
+    DCL VAR FIXED; 
+    VAR = 100;
 `);
 verify.noDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/procedures/answer/answer-with-rescan-output.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/answer/answer-with-rescan-output.ts
@@ -18,7 +18,7 @@
 ////   ANSWER ('VAR = VAL;') RESCAN;
 //// %END;
 //// %ACTIVATE MYMACRO;
-//// ppp: PROC;
+//// ppp: PROC OPTIONS(MAIN);
 ////   DCL VAL FIXED;
 ////   VAL = 200;
 ////   DCL VAR FIXED;
@@ -27,7 +27,7 @@
 //// END;
 
 preprocessor.expectTokens(`
-    ppp: PROC;
+    ppp: PROC OPTIONS(MAIN);
         DCL VAL FIXED;
         VAL = 200;
         DCL VAR FIXED; 

--- a/packages/language/test/fourslash/preprocessor/procedures/call/call-fibonacci.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/call/call-fibonacci.ts
@@ -32,17 +32,13 @@
 ////   CALL fibonacci(6);
 //// %END;
 //// %ACTIVATE something;
-//// ppp: PROC OPTIONS(MAIN);
-////   DCL VAR FIXED;
-////   something
-//// END;
+//// DCL VAR FIXED;
+//// something
 
 preprocessor.expectTokens(`
-    ppp: PROC OPTIONS(MAIN);
-        DCL VAR FIXED;
-        VAR =        5;
-        VAR =        8;
-        VAR =       13;
-    END;
+    DCL VAR FIXED;
+    VAR =        5;
+    VAR =        8;
+    VAR =       13;
 `);
 verify.noDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/procedures/call/call-fibonacci.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/call/call-fibonacci.ts
@@ -32,13 +32,13 @@
 ////   CALL fibonacci(6);
 //// %END;
 //// %ACTIVATE something;
-//// ppp: PROC;
+//// ppp: PROC OPTIONS(MAIN);
 ////   DCL VAR FIXED;
 ////   something
 //// END;
 
 preprocessor.expectTokens(`
-    ppp: PROC;
+    ppp: PROC OPTIONS(MAIN);
         DCL VAR FIXED;
         VAR =        5;
         VAR =        8;

--- a/packages/language/test/fourslash/preprocessor/procedures/call/call-indirect-no-params.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/call/call-indirect-no-params.ts
@@ -22,13 +22,13 @@
 ////   CALL make();
 //// %END;
 //// %ACTIVATE something;
-//// ppp: PROC;
+//// ppp: PROC OPTIONS(MAIN);
 ////   DCL VAR FIXED;
 ////   something
 //// END;
 
 preprocessor.expectTokens(`
-    ppp: PROC;
+    ppp: PROC OPTIONS(MAIN);
         DCL VAR FIXED;
         VAR = 123;
         VAR = 456;

--- a/packages/language/test/fourslash/preprocessor/procedures/call/call-indirect-no-params.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/call/call-indirect-no-params.ts
@@ -22,16 +22,12 @@
 ////   CALL make();
 //// %END;
 //// %ACTIVATE something;
-//// ppp: PROC OPTIONS(MAIN);
-////   DCL VAR FIXED;
-////   something
-//// END;
+//// DCL VAR FIXED;
+//// something
 
 preprocessor.expectTokens(`
-    ppp: PROC OPTIONS(MAIN);
-        DCL VAR FIXED;
-        VAR = 123;
-        VAR = 456;
-    END;
+    DCL VAR FIXED;
+    VAR = 123;
+    VAR = 456;
 `);
 verify.noDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/procedures/call/call-single-no-params.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/call/call-single-no-params.ts
@@ -18,13 +18,13 @@
 ////   CALL make();
 //// %END;
 //// %ACTIVATE something;
-//// ppp: PROC;
+//// ppp: PROC OPTIONS(MAIN);
 ////   DCL VAR FIXED;
 ////   something
 //// END;
 
 preprocessor.expectTokens(`
-    ppp: PROC;
+    ppp: PROC OPTIONS(MAIN);
         DCL VAR FIXED;
         VAR = 123;
     END;

--- a/packages/language/test/fourslash/preprocessor/procedures/call/call-single-no-params.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/call/call-single-no-params.ts
@@ -18,15 +18,11 @@
 ////   CALL make();
 //// %END;
 //// %ACTIVATE something;
-//// ppp: PROC OPTIONS(MAIN);
-////   DCL VAR FIXED;
-////   something
-//// END;
+//// DCL VAR FIXED;
+//// something
 
 preprocessor.expectTokens(`
-    ppp: PROC OPTIONS(MAIN);
-        DCL VAR FIXED;
-        VAR = 123;
-    END;
+    DCL VAR FIXED;
+    VAR = 123;
 `);
 verify.noDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/procedures/call/call-single-with-params.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/call/call-single-with-params.ts
@@ -20,15 +20,11 @@
 ////   CALL make(1, 2);
 //// %END;
 //// %ACTIVATE something;
-//// ppp: PROC OPTIONS(MAIN);
-////   DCL VAR FIXED;
-////   something
-//// END;
+//// DCL VAR FIXED;
+//// something
 
 preprocessor.expectTokens(`
-    ppp: PROC OPTIONS(MAIN);
-        DCL VAR FIXED;
-        VAR = 3;
-    END;
+    DCL VAR FIXED;
+    VAR = 3;
 `);
 verify.noDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/procedures/call/call-single-with-params.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/call/call-single-with-params.ts
@@ -20,13 +20,13 @@
 ////   CALL make(1, 2);
 //// %END;
 //// %ACTIVATE something;
-//// ppp: PROC;
+//// ppp: PROC OPTIONS(MAIN);
 ////   DCL VAR FIXED;
 ////   something
 //// END;
 
 preprocessor.expectTokens(`
-    ppp: PROC;
+    ppp: PROC OPTIONS(MAIN);
         DCL VAR FIXED;
         VAR = 3;
     END;

--- a/packages/language/test/fourslash/validate/label-redeclaration.ts
+++ b/packages/language/test/fourslash/validate/label-redeclaration.ts
@@ -22,4 +22,7 @@
 //// END OUTER;
 //// CALL OUTER;
 
-verify.expectExclusiveErrorCodesAt(1, [code.Severe.IBM1916I, code.Warning.IBM1213I]);
+verify.expectExclusiveErrorCodesAt(1, [
+  code.Severe.IBM1916I,
+  code.Warning.IBM1213I,
+]);

--- a/packages/language/test/fourslash/validate/label-redeclaration.ts
+++ b/packages/language/test/fourslash/validate/label-redeclaration.ts
@@ -22,4 +22,4 @@
 //// END OUTER;
 //// CALL OUTER;
 
-verify.expectExclusiveErrorCodesAt(1, code.Severe.IBM1916I);
+verify.expectExclusiveErrorCodesAt(1, [code.Severe.IBM1916I, code.Warning.IBM1213I]);


### PR DESCRIPTION
Before this fix only cross-referenced symbols were checked. The result was that symbols without any usage were hidden - so no diagnostic.
Now the code checks all symbols.