### PR TITLE
Support include alt at inconly

### DIFF
--- a/packages/language/src/parser/parser-entry.ts
+++ b/packages/language/src/parser/parser-entry.ts
@@ -53,18 +53,26 @@ function createPreprocessorHandler(): StatementParser {
 
 function createIncOnlyPreprocessorHandler(): StatementParser {
   return (state) => {
-    if (state.token?.tokenTypeIdx !== t.Percent.tokenTypeIdx) {
-      return undefined; // Not a preprocessor statement
+    // If it is not a preprocessor statement and also not an include alternate,
+    // return undefined to let other handlers process it.
+    if (
+      state.token?.tokenTypeIdx !== t.Percent.tokenTypeIdx &&
+      state.token?.tokenTypeIdx !== t.INCLUDE_ALT.tokenTypeIdx
+    ) {
+      return undefined;
     }
+
     const nextToken = state.peek(2);
     const isInclude =
       nextToken &&
       (nextToken.tokenTypeIdx === t.INCLUDE.tokenTypeIdx ||
         nextToken.tokenTypeIdx === t.INSCAN.tokenTypeIdx);
-    if (!isInclude) {
-      return undefined; // Not an include, let token statement handle it
+    if (isInclude) {
+      // Only process include statements.
+      return statement(state);
     }
-    return statement(state);
+
+    return undefined;
   };
 }
 

--- a/packages/language/src/preprocessor/compiler-options/translate.ts
+++ b/packages/language/src/preprocessor/compiler-options/translate.ts
@@ -60,7 +60,11 @@ export class CompilerOptionTranslator {
     const options = this.optionsToUpperCase(input.options);
     if (options.some((option) => option.name === "PP")) {
       // If there are PP compiler options, ignore the defaults, because the settings in PP start empty and are accumulated.
-      this.translator.options.pp = { items: [] };
+      // Keep the ppInclude value that might have been set previously.
+      this.translator.options.pp = {
+        items: [],
+        ppInclude: this.translator.options.pp?.ppInclude,
+      };
     }
     for (const option of options) {
       this.translator.translate(option, configuration);

--- a/packages/language/src/preprocessor/compiler-options/translator-pli.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator-pli.ts
@@ -2221,6 +2221,7 @@ translator.rule(
     ensureArguments(option, 0, 0);
     options.pp = { items: [] };
   },
+  { allowDuplicates: true },
 );
 
 /** {@link CompilerOptions.ppCics} */

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-macro/incOnly-behavior-alt.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-macro/incOnly-behavior-alt.ts
@@ -1,0 +1,46 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+
+// @filename: cpy/lib.pli
+//// DCL LIB_VAR FIXED;
+
+// @filename: main.pli
+////*PROCESS PP(INCLUDE('ID(++INCLUDE)'));
+////*PROCESS PP(MACRO("INCONLY"));
+//// %DECLARE X FIXED;
+//// %X = 123;
+//// ++INCLUDE lib;
+//// %ACTIVATE X;
+//// %DO I = 1 TO 10;
+////   DCL VAR%;I FIXED;
+//// %END;
+//// %IF 1 %THEN DO;
+////   DCL Y FIXED;
+//// %END;
+
+// When incOnly is active, all preprocessor statements except INCLUDE and INSCAN
+// should be passed through unchanged (as token statements)
+preprocessor.expectTokens(`
+  %DECLARE X FIXED;
+  %X = 123;
+  DCL LIB_VAR FIXED;
+  %ACTIVATE X;
+  %DO I = 1 TO 10;
+    DCL VAR%;I FIXED;
+  %END;
+  %IF 1 %THEN DO;
+    DCL Y FIXED;
+  %END;
+`);


### PR DESCRIPTION
Enables include alt support when using inconly. 

Also fixes a bug that overrides the `ppInclude` field when multiple PP directives are present, essentially losing the include alt token when not the last directive.

Removes the PP duplicate warning. Note that individual PP items can still throw duplication warnings, meaning that two `*PROCESS PP(MACRO('INCONLY'));` will show a warning at the `INCONLY` but not at the `PP`.