### PR TITLE
Provide semantic highlighting for all tokens

### DIFF
--- a/packages/language/src/language-server/semantic-token-decoder.ts
+++ b/packages/language/src/language-server/semantic-token-decoder.ts
@@ -10,6 +10,7 @@
  */
 
 import { TextDocument } from "vscode-languageserver-textdocument";
+import { SemanticTokenTypes } from "./semantic-tokens";
 
 export namespace SemanticTokenDecoder {
   export interface DecodedSemanticToken {
@@ -22,15 +23,9 @@ export namespace SemanticTokenDecoder {
 
   export function decode(
     tokens: number[],
-    tokenTypes: Map<string, number>,
     textDocument: TextDocument,
   ): DecodedSemanticToken[] {
     const decodedTokens: DecodedSemanticToken[] = [];
-    const reverseTokenTypes = new Map<number, string>();
-
-    for (const [key, value] of tokenTypes.entries()) {
-      reverseTokenTypes.set(value, key);
-    }
 
     let line = 0;
     let character = 0;
@@ -46,7 +41,7 @@ export namespace SemanticTokenDecoder {
       const decodedToken: DecodedSemanticToken = {
         offsetStart: offset,
         offsetEnd: offset + tokens[i + 2],
-        semanticTokenType: reverseTokenTypes.get(tokens[i + 3])!,
+        semanticTokenType: SemanticTokenTypes[tokens[i + 3]],
         tokenModifiers: tokens[i + 4],
         text: textDocument.getText({
           start: { line, character },

--- a/packages/language/src/language-server/semantic-tokens.ts
+++ b/packages/language/src/language-server/semantic-tokens.ts
@@ -13,10 +13,7 @@ import { SemanticTokensBuilder } from "vscode-languageserver";
 import { CompilationUnit } from "../workspace/compilation-unit";
 import { Range } from "./types";
 import { TextDocument } from "vscode-languageserver-textdocument";
-import {
-  SemanticTokensLegend,
-  SemanticTokenTypes,
-} from "vscode-languageserver-types";
+import { SemanticTokensLegend } from "vscode-languageserver-types";
 import {
   DeclaredVariable,
   getContainer,
@@ -24,29 +21,35 @@ import {
   SyntaxNode,
 } from "../syntax-tree/ast";
 import { CstNodeKind } from "../syntax-tree/cst";
-import { Token } from "../parser/tokens";
+import {
+  controlTokens,
+  modifierTokens,
+  NUMBER,
+  STRING_TERM,
+  Token,
+} from "../parser/tokens";
 import { getFirstStructureVariable } from "../syntax-tree/ast-utils";
 
-export const semanticTokenTypes = [
-  SemanticTokenTypes.variable,
-  SemanticTokenTypes.keyword,
-  SemanticTokenTypes.number,
-  SemanticTokenTypes.function,
-  SemanticTokenTypes.parameter,
-  SemanticTokenTypes.enum,
-  SemanticTokenTypes.enumMember,
-  SemanticTokenTypes.class,
-  SemanticTokenTypes.type,
-];
-
-export const tokenTypes = new Map<string, number>(
-  semanticTokenTypes.map((type, index) => [type, index]),
-);
+export enum SemanticTokenTypes {
+  variable,
+  keyword,
+  modifier,
+  number,
+  function,
+  parameter,
+  enum,
+  enumMember,
+  class,
+  type,
+  string,
+}
 
 const tokenModifiers = new Map<string, number>([]);
 
 export const semanticTokenLegend: SemanticTokensLegend = {
-  tokenTypes: Array.from(tokenTypes.keys()),
+  tokenTypes: Object.keys(SemanticTokenTypes).filter((key) =>
+    isNaN(Number(key)),
+  ),
   tokenModifiers: Array.from(tokenModifiers.keys()),
 };
 
@@ -67,7 +70,7 @@ export function semanticTokens(
         token.startLine,
         token.startColumn,
         token.image.length,
-        tokenTypes.get(type)!,
+        type,
         0,
       );
     }
@@ -75,7 +78,7 @@ export function semanticTokens(
   return semanticTokens.build().data;
 }
 
-function tokenType(token: Token): string | undefined {
+function tokenType(token: Token): number | undefined {
   const referenceTarget = getReferenceTarget(token);
   if (referenceTarget) {
     switch (referenceTarget.kind) {
@@ -114,9 +117,22 @@ function tokenType(token: Token): string | undefined {
   } else if (token.kind === CstNodeKind.ProcedureParameter_Id) {
     return SemanticTokenTypes.parameter;
   } else if (token.kind === CstNodeKind.CompilerOption_Name) {
-    return SemanticTokenTypes.keyword;
+    return SemanticTokenTypes.modifier;
   } else if (token.kind === CstNodeKind.CompilerOption_Number) {
     return SemanticTokenTypes.number;
+  }
+
+  if (token.tokenTypeIdx === STRING_TERM.tokenTypeIdx) {
+    return SemanticTokenTypes.string;
+  } else if (token.tokenTypeIdx === NUMBER.tokenTypeIdx) {
+    return SemanticTokenTypes.number;
+  }
+
+  // If the token has no semantic meaning based on the CST, check if it's a keyword
+  if (controlTokens.has(token.tokenType)) {
+    return SemanticTokenTypes.keyword;
+  } else if (modifierTokens.has(token.tokenType)) {
+    return SemanticTokenTypes.modifier;
   }
 
   return undefined;
@@ -126,28 +142,25 @@ function tokenType(token: Token): string | undefined {
  * If the specified token represents a reference, this function returns the target SyntaxNode of that reference.
  */
 function getReferenceTarget(token: Token): SyntaxNode | undefined {
-  if (
-    token.kind === CstNodeKind.ReferenceItem_Ref &&
-    token.element?.kind === SyntaxKind.ReferenceItem
-  ) {
-    return token.element.ref?.node ?? undefined;
-  } else if (
-    token.kind === CstNodeKind.LabelReference_LabelRef &&
-    token.element?.kind === SyntaxKind.LabelReference
-  ) {
-    return token.element.label?.node ?? undefined;
-  } else if (
-    (token.kind === CstNodeKind.TypeAttribute_TypeId0 ||
-      token.kind === CstNodeKind.TypeAttribute_TypeId1) &&
-    token.element?.kind === SyntaxKind.TypeAttribute
-  ) {
-    return token.element.type?.node ?? undefined;
-  } else if (
-    (token.kind === CstNodeKind.HandleAttribute_TypeId0 ||
-      token.kind === CstNodeKind.HandleAttribute_TypeId1) &&
-    token.element?.kind === SyntaxKind.HandleAttribute
-  ) {
-    return token.element.type?.node ?? undefined;
+  switch (token.kind) {
+    case CstNodeKind.ReferenceItem_Ref:
+      if (token.element?.kind === SyntaxKind.ReferenceItem) {
+        return token.element.ref?.node ?? undefined;
+      }
+    case CstNodeKind.LabelReference_LabelRef:
+      if (token.element?.kind === SyntaxKind.LabelReference) {
+        return token.element.label?.node ?? undefined;
+      }
+    case CstNodeKind.TypeAttribute_TypeId0:
+    case CstNodeKind.TypeAttribute_TypeId1:
+      if (token.element?.kind === SyntaxKind.TypeAttribute) {
+        return token.element.type?.node ?? undefined;
+      }
+    case CstNodeKind.HandleAttribute_TypeId0:
+    case CstNodeKind.HandleAttribute_TypeId1:
+      if (token.element?.kind === SyntaxKind.HandleAttribute) {
+        return token.element.type?.node ?? undefined;
+      }
   }
   return undefined;
 }
@@ -169,18 +182,12 @@ function isProcedureKind(container: SyntaxNode | null | undefined): boolean {
 }
 
 function isProcedureType(token: Token): boolean {
-  const kind = token.kind;
-  if (
-    kind === CstNodeKind.LabelPrefix_Name &&
-    isProcedurePrefix(token.element)
-  ) {
-    return true;
-  }
-  if (kind === CstNodeKind.ProcedureCall_ProcedureRef) {
-    return true;
-  }
-  if (kind === CstNodeKind.Exports_Procedure) {
-    return true;
+  switch (token.kind) {
+    case CstNodeKind.ProcedureCall_ProcedureRef:
+    case CstNodeKind.Exports_Procedure:
+      return true;
+    case CstNodeKind.LabelPrefix_Name:
+      return isProcedurePrefix(token.element);
   }
   return false;
 }

--- a/packages/language/src/language-server/semantic-tokens.ts
+++ b/packages/language/src/language-server/semantic-tokens.ts
@@ -147,20 +147,24 @@ function getReferenceTarget(token: Token): SyntaxNode | undefined {
       if (token.element?.kind === SyntaxKind.ReferenceItem) {
         return token.element.ref?.node ?? undefined;
       }
+      break;
     case CstNodeKind.LabelReference_LabelRef:
       if (token.element?.kind === SyntaxKind.LabelReference) {
         return token.element.label?.node ?? undefined;
       }
+      break;
     case CstNodeKind.TypeAttribute_TypeId0:
     case CstNodeKind.TypeAttribute_TypeId1:
       if (token.element?.kind === SyntaxKind.TypeAttribute) {
         return token.element.type?.node ?? undefined;
       }
+      break;
     case CstNodeKind.HandleAttribute_TypeId0:
     case CstNodeKind.HandleAttribute_TypeId1:
       if (token.element?.kind === SyntaxKind.HandleAttribute) {
         return token.element.type?.node ?? undefined;
       }
+      break;
   }
   return undefined;
 }

--- a/packages/language/src/parser/tokens.ts
+++ b/packages/language/src/parser/tokens.ts
@@ -128,7 +128,9 @@ export function createTokenInstance(
 }
 
 export const keywordMap = new Map<string, TokenType>();
-const keywords: TokenType[] = [];
+export const keywords = new Set<TokenType>();
+export const controlTokens = new Set<TokenType>();
+export const modifierTokens = new Set<TokenType>();
 //combination name -> {mapTo: keyword index -> enum value, mapFrom: enum value -> keyword name}
 const mappings = new Map<
   string,
@@ -138,11 +140,20 @@ const mappings = new Map<
   }
 >();
 
+enum KeywordType {
+  Control,
+  Modifier,
+}
+
 interface KeywordConfig {
   /**
    * The keyword name or names (aliases). The first name is the canonical name.
    */
   name: string | string[];
+  /**
+   * The type of the keyword, used for semantic highlighting. Optional, will use `KeywordType.Modifier` if not specified.
+   */
+  type?: KeywordType;
   categories?: [MappableTokenType, number][];
 }
 
@@ -164,7 +175,15 @@ function registerKeyword(config: KeywordConfig): TokenType {
     keywordMap.set(alias, tokenType);
   }
   assignToMappings(tokenType, config.categories ?? [], names);
-  keywords.push(tokenType);
+  keywords.add(tokenType);
+  switch (config.type) {
+    case KeywordType.Control:
+      controlTokens.add(tokenType);
+      break;
+    default:
+      modifierTokens.add(tokenType);
+      break;
+  }
   return tokenType;
 }
 
@@ -749,6 +768,7 @@ export const UNDERFLOW = registerKeyword({
 });
 export const OTHERWISE = registerKeyword({
   name: ["OTHERWISE", "OTHER"],
+  type: KeywordType.Control,
 });
 export const DIMENSION = registerKeyword({
   name: ["DIMENSION", "DIM"],
@@ -869,13 +889,17 @@ export const DOWNTHRU = registerKeyword({
 });
 export const INCLUDE = registerKeyword({
   name: ["INCLUDE", "XINCLUDE"],
+  type: KeywordType.Control,
 });
 export const INCLUDE_ALT = createToken({
   name: "INCLUDE_ALT",
   pattern: Lexer.NA,
 });
+// Manually adding the INCLUDE_ALT token here, due to special semantics
+controlTokens.add(INCLUDE_ALT);
 export const INSCAN = registerKeyword({
   name: ["INSCAN", "XINSCAN"],
+  type: KeywordType.Control,
 });
 export const REPLACE = registerKeyword({
   name: "REPLACE",
@@ -905,6 +929,7 @@ export const NULLINIT = registerKeyword({
 });
 export const PROCESS = registerKeyword({
   name: "PROCESS",
+  type: KeywordType.Control,
 });
 export const PROCINC = registerKeyword({
   name: "PROCINC",
@@ -1286,9 +1311,11 @@ export const REINIT = registerKeyword({
 });
 export const RETURN = registerKeyword({
   name: "RETURN",
+  type: KeywordType.Control,
 });
 export const SELECT = registerKeyword({
   name: "SELECT",
+  type: KeywordType.Control,
 });
 export const SIGNAL = registerKeyword({
   name: "SIGNAL",
@@ -1346,6 +1373,7 @@ export const FALSE = registerKeyword({
 });
 export const BEGIN = registerKeyword({
   name: "BEGIN",
+  type: KeywordType.Control,
 });
 export const CLOSE = registerKeyword({
   name: "CLOSE",
@@ -1417,6 +1445,7 @@ export const REPLY = registerKeyword({
 });
 export const WHILE = registerKeyword({
   name: "WHILE",
+  type: KeywordType.Control,
 });
 export const UNTIL = registerKeyword({
   name: "UNTIL",
@@ -1560,12 +1589,15 @@ export const COPY = registerKeyword({
 });
 export const GOTO = registerKeyword({
   name: "GOTO",
+  type: KeywordType.Control,
 });
 export const THEN = registerKeyword({
   name: "THEN",
+  type: KeywordType.Control,
 });
 export const ELSE = registerKeyword({
   name: "ELSE",
+  type: KeywordType.Control,
 });
 export const SNAP = registerKeyword({
   name: "SNAP",
@@ -1608,6 +1640,7 @@ export const LOOP = registerKeyword({
 });
 export const WHEN = registerKeyword({
   name: "WHEN",
+  type: KeywordType.Control,
 });
 export const STOP = registerKeyword({
   name: "STOP",
@@ -1649,6 +1682,7 @@ export const StarStarEquals = registerOperator({
 });
 export const END = registerKeyword({
   name: "END",
+  type: KeywordType.Control,
 });
 export const AND = registerKeyword({
   name: "AND",
@@ -1741,18 +1775,23 @@ export const OR = registerKeyword({
 });
 export const DO = registerKeyword({
   name: "DO",
+  type: KeywordType.Control,
 });
 export const TO = registerKeyword({
   name: "TO",
+  type: KeywordType.Control,
 });
 export const GO = registerKeyword({
   name: "GO",
+  type: KeywordType.Control,
 });
 export const IF = registerKeyword({
   name: "IF",
+  type: KeywordType.Control,
 });
 export const ON = registerKeyword({
   name: "ON",
+  type: KeywordType.Control,
 });
 export const NotLessThan = registerOperator({
   name: "^<",

--- a/packages/language/src/preprocessor/compiler-options/parser.ts
+++ b/packages/language/src/preprocessor/compiler-options/parser.ts
@@ -290,6 +290,9 @@ export function parseAbstractCompilerOptions(
   if (uri) {
     for (const token of tokens) {
       token.uri = uri;
+      token.startLine -= 1;
+      token.startColumn -= 1;
+      token.endLine -= 1;
     }
   }
   parser.input = tokens;

--- a/packages/language/test/fourslash/semantic-tokens/package.ts
+++ b/packages/language/test/fourslash/semantic-tokens/package.ts
@@ -11,11 +11,17 @@
 
 /// <reference path="../framework.ts" />
 
-//// <|1:RGT005|>: PACKAGE EXPORTS(<|2:RGT005|>);
-//// <|3:RGT005|>: PROCEDURE() OPTIONS(MAIN);
-////   DCL SYSNULL BUILTIN;
+//// <|1:RGT005|>: <|PACKAGE|> <|EXPORTS|>(<|2:RGT005|>);
+//// <|3:RGT005|>: <|PROCEDURE|>() OPTIONS(MAIN);
+////   <|DCL|> SYSNULL <|BUILTIN|>;
 //// END <|4:RGT005|>;
 //// END <|5:RGT005|>;
+
+semanticTokens.expectAt("PACKAGE", "modifier");
+semanticTokens.expectAt("PROCEDURE", "modifier");
+semanticTokens.expectAt("EXPORTS", "modifier");
+semanticTokens.expectAt("DCL", "modifier");
+semanticTokens.expectAt("BUILTIN", "modifier");
 
 semanticTokens.expectAt(1, "function");
 semanticTokens.expectAt(2, "function");

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -25,10 +25,7 @@ import { completionRequest } from "../src/language-server/completion/completion-
 import { AssertionError, fail } from "assert";
 import { MarkupContent, Position } from "vscode-languageserver";
 import { hoverRequest } from "../src/language-server/hover-request";
-import {
-  semanticTokens,
-  tokenTypes,
-} from "../src/language-server/semantic-tokens";
+import { semanticTokens } from "../src/language-server/semantic-tokens";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { SemanticTokenDecoder } from "../src/language-server/semantic-token-decoder";
 import { SemanticTokenTypes } from "vscode-languageserver-types";
@@ -965,11 +962,7 @@ export class TestBuilder {
       const textDocument = file.textDocument;
 
       const tokens = semanticTokens(textDocument, this.unit);
-      const decodedTokens = SemanticTokenDecoder.decode(
-        tokens,
-        tokenTypes,
-        textDocument,
-      );
+      const decodedTokens = SemanticTokenDecoder.decode(tokens, textDocument);
 
       for (const [start, end] of ranges) {
         const matchingToken = decodedTokens.find(

--- a/scripts/generate-tmlanguage.mts
+++ b/scripts/generate-tmlanguage.mts
@@ -16,38 +16,14 @@ import * as tokens from '../packages/language/src/parser/tokens.js';
 const keywords = Array.from(tokens.keywordMap, ([key]) => key.toLowerCase()).sort();
 const manual = JSON.parse(await fs.readFile('./packages/vscode-extension/syntaxes/pli.manual.json', 'utf8'));
 
-const controlKeywords = [
-    'if',
-    'else',
-    'then',
-    'do',
-    'end',
-    'select',
-    'otherwise',
-    'on',
-    'while',
-    'next',
-    'go',
-    'to',
-    'goto',
-    'return',
-    'when',
-    'begin',
-    'process',
-    'include',
-    'xinclude',
-    'inscan',
-    'xinscan',
-    'deactivate',
-    'deact',
-    'activate',
-    'act',
-].sort();
-
+const controlKeywords: string[] = [];
 const storageKeywords: string[] = [];
-for (const keyword of keywords) {
-    if (!controlKeywords.includes(keyword)) {
-        storageKeywords.push(keyword);
+
+for (const [text, type] of tokens.keywordMap.entries()) {
+    if (tokens.controlTokens.has(type)) {
+        controlKeywords.push(text.toLowerCase());
+    } else {
+        storageKeywords.push(text.toLowerCase());
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/zowe/zowe-pli-language-support/issues/579

Attempts to provide highlighting for all text in the document. Can be theoretically tested on VS Code by removing the `pli.merged.json` after building the project - however, this seems to disable the `modifier` type highlighting (for some reason?).

Also fixes a minor issue in the compiler options lexer that led to highlighting bleeding into the second editor line.