### PR TITLE
Add `GlobalMutex` for LSP operations

### DIFF
--- a/packages/language/src/language-server/connection-handler.ts
+++ b/packages/language/src/language-server/connection-handler.ts
@@ -48,6 +48,7 @@ import { applyQuickFixes } from "./code-actions/apply-quick-fixes";
 import { applySourceActions } from "./code-actions/apply-source-actions";
 import { commandCreateConfig, commandResolveInclude } from "./commands";
 import { Commands, PluginConfiguration } from "./constants";
+import { GlobalMutex } from "../workspace/mutex";
 export { PluginConfiguration } from "./constants";
 
 /**
@@ -61,25 +62,27 @@ export function startLanguageServer(connection: Connection): void {
   compilationUnitHandler.listen(connection);
   let folders: WorkspaceFolder[] = [];
 
-  function withReadMutex<T>(
+  async function withReadMutex<T>(
     uri: string,
     cb: (uri: URI, unit?: CompilationUnit) => Promise<T>,
   ) {
-    const parsedUri = URI.parse(uri);
-    const compilationUnit =
-      compilationUnitHandler.getCompilationUnit(parsedUri);
-    if (!compilationUnit) {
-      return cb(parsedUri, undefined);
-    }
-    return compilationUnit.mutex.read(async () => {
-      return cb(parsedUri, compilationUnit);
+    await compilationUnitHandler.ready;
+    return GlobalMutex.read(() => {
+      const parsedUri = URI.parse(uri);
+      const compilationUnit =
+        compilationUnitHandler.getCompilationUnit(parsedUri);
+      if (!compilationUnit) {
+        return cb(parsedUri, undefined);
+      }
+      return compilationUnit.mutex.read(async () => {
+        return cb(parsedUri, compilationUnit);
+      });
     });
   }
 
   connection.onInitialize(async (params) => {
     // init the plugin config provider in reverse folder order, last plugin config encountered will take precedence
     folders = params.workspaceFolders?.reverse() ?? [];
-
     return {
       capabilities: {
         workspace: {
@@ -316,10 +319,12 @@ export function startLanguageServer(connection: Connection): void {
     );
   });
   connection.onWorkspaceSymbol(async (params) => {
-    return workspaceSymbolRequest(
-      params.query,
-      compilationUnitHandler.getAllCompilationUnits(),
-    );
+    return GlobalMutex.read(async () => {
+      return workspaceSymbolRequest(
+        params.query,
+        compilationUnitHandler.getAllCompilationUnits(),
+      );
+    });
   });
   connection.onNotification(
     WorkspaceDidChangePlipluginConfigNotification,

--- a/packages/language/src/language-server/connection-handler.ts
+++ b/packages/language/src/language-server/connection-handler.ts
@@ -48,7 +48,6 @@ import { applyQuickFixes } from "./code-actions/apply-quick-fixes";
 import { applySourceActions } from "./code-actions/apply-source-actions";
 import { commandCreateConfig, commandResolveInclude } from "./commands";
 import { Commands, PluginConfiguration } from "./constants";
-import { GlobalMutex } from "../workspace/mutex";
 export { PluginConfiguration } from "./constants";
 
 /**
@@ -67,7 +66,7 @@ export function startLanguageServer(connection: Connection): void {
     cb: (uri: URI, unit?: CompilationUnit) => Promise<T>,
   ) {
     await compilationUnitHandler.ready;
-    return GlobalMutex.read(() => {
+    return compilationUnitHandler.globalMutex.read(() => {
       const parsedUri = URI.parse(uri);
       const compilationUnit =
         compilationUnitHandler.getCompilationUnit(parsedUri);
@@ -142,7 +141,7 @@ export function startLanguageServer(connection: Connection): void {
       );
     }
     await Promise.all(promises);
-    compilationUnitHandler.finalize();
+    compilationUnitHandler.markReady();
   });
   connection.onHover(async (params) => {
     const position = params.position;
@@ -319,7 +318,7 @@ export function startLanguageServer(connection: Connection): void {
     );
   });
   connection.onWorkspaceSymbol(async (params) => {
-    return GlobalMutex.read(async () => {
+    return compilationUnitHandler.globalMutex.read(async () => {
       return workspaceSymbolRequest(
         params.query,
         compilationUnitHandler.getAllCompilationUnits(),

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -41,7 +41,7 @@ import {
   ProgramConfig,
 } from "./plugin-configuration-provider.js";
 import { EvaluationResults } from "../preprocessor/instruction-interpreter.js";
-import { createMutex, Mutex } from "./mutex.js";
+import { createMutex, GlobalMutex, Mutex } from "./mutex.js";
 import { Deferred, isOperationCancelled } from "../utils/promises.js";
 import { InstructionCache } from "../preprocessor/instruction-cache.js";
 import { TextDocument } from "vscode-languageserver-textdocument";
@@ -220,7 +220,11 @@ export async function createCompilationUnit(
 export class CompilationUnitHandler {
   private compilationUnits: Map<string, CompilationUnit> = new Map();
   private connection!: Connection;
-  private ready = new Deferred();
+  private readyDeferred = new Deferred();
+
+  get ready(): Promise<void> {
+    return this.readyDeferred.promise;
+  }
 
   getCompilationUnit(uri: URI): CompilationUnit | undefined {
     return this.compilationUnits.get(uri.toString());
@@ -276,7 +280,7 @@ export class CompilationUnitHandler {
    * **Must** be called if `listen` has been called previously.
    */
   finalize(): void {
-    this.ready.resolve();
+    this.readyDeferred.resolve();
   }
 
   listen(connection: Connection): void {
@@ -320,21 +324,28 @@ export class CompilationUnitHandler {
   }
 
   async updateUri(uri: URI): Promise<void> {
-    await this.ready.promise;
-    const unit = await this.getOrCreateCompilationUnit(uri);
-    if (!unit) {
-      // standalone library files do not synthesize new compilation units
-      return;
-    }
-    unit.mutex.run(async (cancellationToken) => {
-      const document = await EditorDocuments.get(unit.uri);
-      if (!document) {
+    await GlobalMutex.run(async () => {
+      await this.ready;
+      const unit = await this.getOrCreateCompilationUnit(uri);
+      if (!unit) {
+        // standalone library files do not synthesize new compilation units
         return;
       }
-      await this.process(unit, document, this.connection, cancellationToken);
-      // TODO: Wagner Laranjeiras -> includeCache based on changes of a specific file.
-      unit.services.includeCache.clear();
-      unit.requestCaches.revalidateAll({ connection: this.connection, unit });
+      // We do not await the compilation unit mutex operation here
+      // This ensures that we exit the global mutex as soon as possible.
+      // That way, we allow subsequent updates cancel the previous requests
+      // While ensuring that only one update runs at a time for a specific compilation unit
+      // And also ensuring that the LSP requests wait for the compilation unit to be available
+      unit.mutex.run(async (cancellationToken) => {
+        const document = await EditorDocuments.get(unit.uri);
+        if (!document) {
+          return;
+        }
+        await this.process(unit, document, this.connection, cancellationToken);
+        // TODO: Wagner Laranjeiras -> includeCache based on changes of a specific file.
+        unit.services.includeCache.clear();
+        unit.requestCaches.revalidateAll({ connection: this.connection, unit });
+      });
     });
   }
 
@@ -384,16 +395,18 @@ export class CompilationUnitHandler {
     connection: Connection,
     cancellationToken: CancellationToken,
   ): Promise<void> {
-    for (const unit of this.getAllCompilationUnits()) {
-      if (cancellationToken.isCancellationRequested) {
-        return;
-      }
-      unit.mutex.run(async (cancellationToken) => {
-        const textDocument = await TextDocuments.get(unit.uri.toString());
-        if (textDocument) {
-          this.process(unit, textDocument, connection, cancellationToken);
+    GlobalMutex.run(async () => {
+      for (const unit of this.getAllCompilationUnits()) {
+        if (cancellationToken.isCancellationRequested) {
+          return;
         }
-      });
-    }
+        unit.mutex.run(async (cancellationToken) => {
+          const textDocument = await TextDocuments.get(unit.uri.toString());
+          if (textDocument) {
+            this.process(unit, textDocument, connection, cancellationToken);
+          }
+        });
+      }
+    });
   }
 }

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -41,7 +41,7 @@ import {
   ProgramConfig,
 } from "./plugin-configuration-provider.js";
 import { EvaluationResults } from "../preprocessor/instruction-interpreter.js";
-import { createMutex, GlobalMutex, Mutex } from "./mutex.js";
+import { createMutex, Mutex } from "./mutex.js";
 import { Deferred, isOperationCancelled } from "../utils/promises.js";
 import { InstructionCache } from "../preprocessor/instruction-cache.js";
 import { TextDocument } from "vscode-languageserver-textdocument";
@@ -222,6 +222,11 @@ export class CompilationUnitHandler {
   private connection!: Connection;
   private readyDeferred = new Deferred();
 
+  /**
+   * A global mutex that ensures that retrieving compilation units happens after they are created.
+   */
+  readonly globalMutex = createMutex();
+
   get ready(): Promise<void> {
     return this.readyDeferred.promise;
   }
@@ -279,7 +284,7 @@ export class CompilationUnitHandler {
    * Marks the compilation unit handler as ready to process updates.
    * **Must** be called if `listen` has been called previously.
    */
-  finalize(): void {
+  markReady(): void {
     this.readyDeferred.resolve();
   }
 
@@ -293,18 +298,19 @@ export class CompilationUnitHandler {
     });
     textDocuments.onDidClose((event) => {
       const uri = URI.parse(event.document.uri);
-      const unit = this.compilationUnits.get(uri.toString());
-      if (unit && this.tryCloseCompilationUnit(uri)) {
-        console.debug(`Closed compilation unit for ${uri.toString()}`);
-        for (const file of unit.services.files.keys()) {
-          // Clear diagnostics for all files in the closed compilation unit
-          // Otherwise, keep the diagnostics, even if the files have been closed
-          connection.sendDiagnostics({
-            uri: file,
-            diagnostics: [],
-          });
+      this.globalMutex.read(async () => {
+        const unit = this.compilationUnits.get(uri.toString());
+        if (unit && this.tryCloseCompilationUnit(uri)) {
+          for (const file of unit.services.files.keys()) {
+            // Clear diagnostics for all files in the closed compilation unit
+            // Otherwise, keep the diagnostics, even if the files have been closed
+            connection.sendDiagnostics({
+              uri: file,
+              diagnostics: [],
+            });
+          }
         }
-      }
+      });
     });
   }
 
@@ -324,7 +330,7 @@ export class CompilationUnitHandler {
   }
 
   async updateUri(uri: URI): Promise<void> {
-    await GlobalMutex.run(async () => {
+    await this.globalMutex.run(async () => {
       await this.ready;
       const unit = await this.getOrCreateCompilationUnit(uri);
       if (!unit) {
@@ -395,18 +401,22 @@ export class CompilationUnitHandler {
     connection: Connection,
     cancellationToken: CancellationToken,
   ): Promise<void> {
-    GlobalMutex.run(async () => {
+    const promises: Promise<void>[] = [];
+    this.globalMutex.run(async () => {
       for (const unit of this.getAllCompilationUnits()) {
         if (cancellationToken.isCancellationRequested) {
           return;
         }
-        unit.mutex.run(async (cancellationToken) => {
-          const textDocument = await TextDocuments.get(unit.uri.toString());
-          if (textDocument) {
-            this.process(unit, textDocument, connection, cancellationToken);
-          }
-        });
+        promises.push(
+          unit.mutex.run(async (cancellationToken) => {
+            const textDocument = await TextDocuments.get(unit.uri.toString());
+            if (textDocument) {
+              this.process(unit, textDocument, connection, cancellationToken);
+            }
+          }),
+        );
       }
     });
+    return Promise.all(promises).then(() => undefined);
   }
 }

--- a/packages/language/src/workspace/mutex.ts
+++ b/packages/language/src/workspace/mutex.ts
@@ -71,3 +71,5 @@ class MutexImpl implements Mutex {
 export function createMutex(): Mutex {
   return new MutexImpl();
 }
+
+export const GlobalMutex = createMutex();

--- a/packages/language/src/workspace/mutex.ts
+++ b/packages/language/src/workspace/mutex.ts
@@ -71,5 +71,3 @@ class MutexImpl implements Mutex {
 export function createMutex(): Mutex {
   return new MutexImpl();
 }
-
-export const GlobalMutex = createMutex();


### PR DESCRIPTION
Fixes issue (1) of https://github.com/zowe/zowe-pli-language-support/issues/570.

Re-Introduces a `GlobalMutex` to ensure that we do not accidentally respond to LSP requests before the compilation unit is ready to accept requests. This `GlobalMutex` does not actually wait until the lifecycle of specific compilation unit is done, but instead just ensures that LSP requests are not performed on non-existing compilation units that are still in the process of being created.

The original issue is consistently reproducible by applying the following patch to the `NodeFileSystemProvider`:

```diff
class NodeFileSystemProvider implements FileSystemProvider {
  async readFile(uri: URI): Promise<string> {
+   await new Promise((resolve) => setTimeout(resolve, 500));
    return fs.promises.readFile(uri.fsPath, "utf8");
  }
```
