### PR TITLE
Support forward declarations using `ENTRY`

### DIFF
--- a/packages/language/src/language-server/definition-request.ts
+++ b/packages/language/src/language-server/definition-request.ts
@@ -20,7 +20,7 @@ import {
   isReferenceToken,
 } from "../linking/tokens";
 import { URI } from "../utils/uri";
-import { SyntaxKind } from "../syntax-tree/ast";
+import { SyntaxKind, iterateReferenceNodes } from "../syntax-tree/ast";
 
 export function definitionRequest(
   compilationUnit: CompilationUnit,
@@ -28,46 +28,45 @@ export function definitionRequest(
   offset: number,
 ): Location[] {
   const tokens = compilationUnit.services.files.getTokens(uri);
+  const locations: Location[] = [];
   if (!tokens) {
-    return [];
+    return locations;
   }
   const token = binaryTokenSearch(tokens, offset);
   if (!token) {
-    return [];
+    return locations;
   }
   if (isNameToken(token.kind) && token.uri) {
-    return [
-      {
-        uri: token.uri.toString(),
-        range: {
-          start: token.startOffset,
-          end: token.endOffset + 1,
-        },
+    locations.push({
+      uri: token.uri.toString(),
+      range: {
+        start: token.startOffset,
+        end: token.endOffset + 1,
       },
-    ];
+    });
   } else if (isReferenceToken(token.kind) && token.element) {
     const ref = getReference(token.element);
     if (!ref || !ref.node) {
-      return [];
+      return locations;
     }
     // If we're looking at ourselves, we don't report the definition.
     if (ref.node === token.element) {
-      return [];
+      return locations;
     }
-    const nameToken = getNameToken(ref.node);
-    if (!nameToken?.uri) {
-      return [];
-    }
-    return [
-      {
+    for (const node of iterateReferenceNodes(ref)) {
+      const nameToken = getNameToken(node);
+      if (!nameToken?.uri) {
+        continue;
+      }
+      locations.push({
         uri: nameToken.uri.toString(),
         range: {
           start: nameToken.startOffset,
           end: nameToken.endOffset + 1,
         },
         source: tokenToRange(token),
-      },
-    ];
+      });
+    }
   } else if (
     isIncludeItemToken(token.kind) &&
     (token.element?.kind === SyntaxKind.IncludeItemFile ||
@@ -84,17 +83,15 @@ export function definitionRequest(
     // allow jumping to the resolved file when present
     const filePath = token.element.filePath;
     if (filePath) {
-      return [
-        {
-          uri: filePath,
-          range: {
-            start: 0,
-            end: 0,
-          },
-          source: sourceRange,
+      locations.push({
+        uri: filePath,
+        range: {
+          start: 0,
+          end: 0,
         },
-      ];
+        source: sourceRange,
+      });
     }
   }
-  return [];
+  return locations;
 }

--- a/packages/language/src/linking/resolver.ts
+++ b/packages/language/src/linking/resolver.ts
@@ -13,6 +13,7 @@ import { Location, tokenToRange } from "../language-server/types";
 import { Token } from "../parser/tokens";
 import {
   getContainer,
+  iterateReferenceNodes,
   MemberCall,
   ProcedureParameter,
   Reference,
@@ -32,8 +33,13 @@ import { CompilationUnit } from "../workspace/compilation-unit";
 import { QualifiedSyntaxNode } from "./qualified-syntax-node";
 import { LinkerErrorReporter } from "./error";
 import { Scope } from "./scope";
-import { getPriorityReferenceElement, reiterateSymbols } from "./symbol-table";
+import {
+  checkRedeclaration,
+  getPriorityReferenceElement,
+  reiterateSymbols,
+} from "./symbol-table";
 import { DiagnosticCategory } from "../validation/diagnostics-store";
+import { MultiMap } from "../utils/collections";
 
 function getParentStatement(node: SyntaxNode): SyntaxNode {
   if (node.container?.kind === SyntaxKind.Statement) {
@@ -103,7 +109,7 @@ export class ReferencesCache {
    */
   private priorityList: Reference[] = [];
   private list: Reference[] = [];
-  private reverseMap = new Map<SyntaxNode, Reference[]>();
+  private reverseMap = new MultiMap<SyntaxNode, Reference>();
 
   clear(): void {
     this.priorityList = [];
@@ -124,18 +130,13 @@ export class ReferencesCache {
   }
 
   addInverse(reference: Reference): void {
-    if (reference.node) {
-      let list = this.reverseMap.get(reference.node);
-      if (!list) {
-        list = [];
-        this.reverseMap.set(reference.node, list);
-      }
-      list.push(reference);
+    for (const node of iterateReferenceNodes(reference)) {
+      this.reverseMap.add(node, reference);
     }
   }
 
-  findReferences(node: SyntaxNode): Reference[] {
-    return this.reverseMap.get(node) || [];
+  findReferences(node: SyntaxNode): readonly Reference[] {
+    return this.reverseMap.get(node);
   }
 
   priorityReferences(): Reference[] {
@@ -151,7 +152,7 @@ export class ReferencesCache {
     yield* this.list;
   }
 
-  allReverseReferences(): Map<SyntaxNode, Reference[]> {
+  allReverseReferences(): MultiMap<SyntaxNode, Reference> {
     return this.reverseMap;
   }
 }
@@ -189,6 +190,7 @@ function assignQualifiedReference(
   reference: Reference,
   memberCall: MemberCall,
   resolved: QualifiedSyntaxNode,
+  matchingSymbols?: readonly QualifiedSyntaxNode[],
 ) {
   // The names are not matching, this is a partial qualification.
   if (reference.text !== resolved.name) {
@@ -204,6 +206,9 @@ function assignQualifiedReference(
   }
 
   reference.node = resolved.node;
+  if (matchingSymbols) {
+    reference.nodes = matchingSymbols.map((symbol) => symbol.node);
+  }
 
   // There are more qualified names to resolve, continue up the chain.
   if (memberCall.previous?.element?.ref && resolved.parent) {
@@ -215,17 +220,25 @@ function assignReference(
   unit: CompilationUnit,
   reference: Reference<SyntaxNode>,
   resolved: QualifiedSyntaxNode,
+  matchingSymbols?: readonly QualifiedSyntaxNode[],
 ) {
   // Special handling for member calls and qualification.
   // We want to assign the resolved references to the entire chain of references.
   if (reference.owner.container?.kind === SyntaxKind.MemberCall) {
     const memberCall = reference.owner.container;
-    assignQualifiedReference(unit, reference, memberCall, resolved);
-
-    return;
+    assignQualifiedReference(
+      unit,
+      reference,
+      memberCall,
+      resolved,
+      matchingSymbols,
+    );
+  } else {
+    reference.node = resolved.node;
+    if (matchingSymbols) {
+      reference.nodes = matchingSymbols.map((symbol) => symbol.node);
+    }
   }
-
-  reference.node = resolved.node;
 }
 
 export const isProcedureParameterReference = (
@@ -276,7 +289,7 @@ function getMatchingSymbols(
     })
     .filter((symbol) => !symbol.isRedeclared); // Don't resolve reference to redeclared symbols.
 
-  const isAmbiguous = explicitlyDeclaredSymbols.length > 1;
+  const isAmbiguous = checkRedeclaration(explicitlyDeclaredSymbols);
   if (isAmbiguous) {
     reporter.reportAmbiguousReference(
       reference,
@@ -328,6 +341,30 @@ function getMatchingSymbols(
   return [firstImplicitSymbol];
 }
 
+function getRelevantSymbol(
+  reference: Reference,
+  nodes: readonly QualifiedSyntaxNode[],
+): QualifiedSyntaxNode | undefined {
+  if (nodes.length < 2) {
+    return nodes[0];
+  }
+  if (
+    reference.owner.kind === SyntaxKind.LabelReference &&
+    reference.owner.container?.kind === SyntaxKind.EndStatement
+  ) {
+    // In case of a label reference in an END statement
+    // We want to link to the label declaration
+    // and not to any potential variable with the same name (like a forward declaration)
+    for (const node of nodes) {
+      if (node.node.kind === SyntaxKind.LabelPrefix) {
+        return node;
+      }
+    }
+  }
+
+  return nodes[0];
+}
+
 function resolveReference(
   unit: CompilationUnit,
   reference: Reference,
@@ -351,9 +388,7 @@ function resolveReference(
     reporter,
   );
 
-  // We take the first symbol, even if there are multiple matching.
-  // Ideally, we'd want to reference all matching symbols, but the AST currently only supports a single reference per symbol.
-  const symbol = matchingSymbols[0];
+  const symbol = getRelevantSymbol(reference, matchingSymbols);
   if (!symbol) {
     reference.node = null;
     return;
@@ -361,7 +396,7 @@ function resolveReference(
 
   // Assign the resolved symbol to the reference.
   // This function handles assigning references to member calls.
-  assignReference(unit, reference, symbol);
+  assignReference(unit, reference, symbol, matchingSymbols);
 }
 
 export function resolveReferences(unit: CompilationUnit): void {
@@ -428,7 +463,7 @@ export function findTokenElementReference(
 export function findElementReferences(
   unit: CompilationUnit,
   element: SyntaxNode,
-): Reference<SyntaxNode>[] {
+): readonly Reference<SyntaxNode>[] {
   return unit.referencesCache.findReferences(element);
 }
 

--- a/packages/language/src/linking/symbol-table.ts
+++ b/packages/language/src/linking/symbol-table.ts
@@ -10,6 +10,7 @@
  */
 
 import {
+  DeclaredVariable,
   DeclareStatement,
   DefineAliasStatement,
   DefineOrdinalStatement,
@@ -320,8 +321,7 @@ function assignRedeclaredSymbols(scopeCache: ScopeCache) {
           symbol.node.kind !== SyntaxKind.WildcardItem, // Wildcard items are not checked for redeclarations.
       );
 
-      // A group of symbols is colliding if it contains more than one symbol.
-      const isColliding = filteredSymbols.length > 1;
+      const isColliding = checkRedeclaration(filteredSymbols);
       for (const symbol of filteredSymbols) {
         symbol.isRedeclared = isColliding;
       }
@@ -344,6 +344,57 @@ function assignRedeclaredSymbols(scopeCache: ScopeCache) {
         item.isRedeclared = false;
       }
     }
+  }
+}
+
+/**
+ * Checks whether the given symbols are conflicting declarations.
+ * Has special handling for forward declarations of procedures using the ENTRY attribute.
+ * These are not considered redeclarations, even though they have the same name and are in the same scope,
+ * because they are semantically connected.
+ */
+export function checkRedeclaration(symbols: QualifiedSyntaxNode[]): boolean {
+  if (symbols.length < 2) {
+    // No redeclaration if there is only one symbol
+    return false;
+  } else if (symbols.length > 2) {
+    // More than 2 symbols with the same name is always a redeclaration
+    return true;
+  } else {
+    // In case of 2 symbols with the same name, we have to check whether:
+    // 1. One of them is a procedure
+    // 2. The other one is a forward declaration of that procedure using the ENTRY attribute
+    const declaredVariable = symbols.find(
+      (symbol) => symbol.node.kind === SyntaxKind.DeclaredVariable,
+    );
+    if (!declaredVariable) {
+      // No variable found
+      return true;
+    }
+    const entryProcedure = symbols.find(
+      (symbol) =>
+        symbol.node.kind === SyntaxKind.LabelPrefix &&
+        symbol.node.container?.kind === SyntaxKind.Statement &&
+        symbol.node.container?.value?.kind === SyntaxKind.ProcedureStatement,
+    );
+    if (!entryProcedure) {
+      // No entry procedure found
+      return true;
+    }
+    const variable = declaredVariable.node as DeclaredVariable;
+    let item = variable.container;
+    while (item?.kind === SyntaxKind.DeclaredItem) {
+      for (const attribute of item.attributes) {
+        if (attribute.kind === SyntaxKind.EntryAttribute) {
+          // We found an entry attribute for the variable
+          // Therefore, this variable is a forward declaration
+          // Show no redeclaration error
+          return false;
+        }
+      }
+      item = item.container;
+    }
+    return true;
   }
 }
 

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -657,11 +657,23 @@ export interface Reference<T extends SyntaxNode = SyntaxNode> {
   owner: SyntaxNode;
   text: string;
   token: Token;
+  /**
+   * This is the main target of the reference.
+   *
+   * If the reference hasn't been resolved yet, this will be `undefined`.
+   * If the reference resolution has failed (i.e. the reference doesn't actually point to any element in the code), this will be `null`.
+   * In all other cases, this will be the resolved target of the reference.
+   */
   node: T | null | undefined;
   /**
-   * PLI generally only allows a reference to resolve to a single element.
+   * PL/I generally only allows a reference to resolve to a single element.
    * However, for the purpose of the language server, we want to be able to reference multiple elements at once.
    * For example, in the case of ambiguous reference or when encountering a procedure and its forward declaration.
+   * This field is only really useful for selected LSP services - other features should use the `node` field instead.
+   *
+   * Note that the `nodes` might not always be filled, even when the `node` field is set.
+   * However, when the `nodes` are filled, they should always also contain the value of the `node` field as one of their elements.
+   * Use the `iterateReferenceNodes` helper to iterate over all possible nodes of a reference, regardless of how they are stored.
    */
   nodes: T[];
   type: ReferenceType;
@@ -697,6 +709,7 @@ export function createReference<T extends SyntaxNode>(
 
 export function* iterateReferenceNodes(ref: Reference): Iterable<SyntaxNode> {
   if (ref.nodes.length > 0) {
+    // If any nodes are set, they automatically include the `node` field as well.
     yield* ref.nodes;
   } else if (ref.node) {
     yield ref.node;

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -658,6 +658,12 @@ export interface Reference<T extends SyntaxNode = SyntaxNode> {
   text: string;
   token: Token;
   node: T | null | undefined;
+  /**
+   * PLI generally only allows a reference to resolve to a single element.
+   * However, for the purpose of the language server, we want to be able to reference multiple elements at once.
+   * For example, in the case of ambiguous reference or when encountering a procedure and its forward declaration.
+   */
+  nodes: T[];
   type: ReferenceType;
 }
 
@@ -683,9 +689,18 @@ export function createReference<T extends SyntaxNode>(
     owner,
     text: token.image,
     token,
+    nodes: [],
     node: undefined,
     type,
   };
+}
+
+export function* iterateReferenceNodes(ref: Reference): Iterable<SyntaxNode> {
+  if (ref.nodes.length > 0) {
+    yield* ref.nodes;
+  } else if (ref.node) {
+    yield ref.node;
+  }
 }
 
 export function isPreprocessorNode(

--- a/packages/language/test/fourslash/linker/ambiguous-linking.ts
+++ b/packages/language/test/fourslash/linker/ambiguous-linking.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// In case of a linking ambiguity, ensure that the LSP links to all possible targets.
+
+// @wrap: main
+//// DCL 1 A, 2 <|C|>;
+//// DCL 1 B, 2 <|C|>;
+//// PUT(<|C>C);
+
+linker.expectLinks();

--- a/packages/language/test/fourslash/linker/entry-forward-declaration.ts
+++ b/packages/language/test/fourslash/linker/entry-forward-declaration.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// In case of a linking ambiguity, ensure that the LSP links to all possible targets.
+
+// @wrap: main
+//// DCL <|TEST_PROC|> ENTRY();
+//// <|TEST_PROC|>: PROC;
+////   PUT("HELLO WORLD");
+//// END TEST_PROC;
+//// CALL <|TEST_PROC>TEST_PROC();
+
+linker.expectLinks();

--- a/packages/language/test/fourslash/validate/entry-forward-declaration-no-ambiguity.ts
+++ b/packages/language/test/fourslash/validate/entry-forward-declaration-no-ambiguity.ts
@@ -1,0 +1,24 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// DCL TEST_PROC ENTRY();
+//// TEST_PROC: PROC;
+////   PUT("HELLO WORLD");
+//// END TEST_PROC;
+//// CALL <|TEST_PROC|>();
+
+// This file contains the `TEST_PROC` definition twice.
+// Once as a forward declaration with the ENTRY attribute, and once as a procedure definition.
+// The validator should not produce an ambiguity error when resolving the TEST_PROC reference.
+verify.noDiagnostics(["TEST_PROC"], code.Severe.IBM1881I);

--- a/packages/language/test/fourslash/validate/entry-forward-declaration-succeeds.ts
+++ b/packages/language/test/fourslash/validate/entry-forward-declaration-succeeds.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// DCL <|dcl:TEST_PROC|> ENTRY();
+//// <|proc:TEST_PROC|>: PROC;
+////   PUT("HELLO WORLD");
+//// END TEST_PROC;
+
+// This file contains the `TEST_PROC` definition twice.
+// Once as a forward declaration with the ENTRY attribute, and once as a procedure definition.
+// This is valid in PL/I, and should not produce a redeclaration error.
+verify.noDiagnostics(["dcl", "proc"], code.Error.IBM1306I);

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -925,7 +925,17 @@ export class TestBuilder {
       expect(result, message).toHaveLength(rangeIndex.length);
 
       if (rangeIndex.length > 1) {
-        throw new Error("TODO: Range index is not supported yet");
+        for (const expected of rangeIndex) {
+          const [start, end] = expected;
+          const exists = result.some(
+            (definition) =>
+              definition.range.start === start && definition.range.end === end,
+          );
+          expect(
+            exists,
+            `Expected definition at range [${start}, ${end}] for label "${label}" (${this.createLabelPositionMessage(label)}) not found`,
+          ).toBeTruthy();
+        }
       } else if (rangeIndex.length === 1) {
         const [singleRangeIndex] = rangeIndex;
         const [definition] = result;


### PR DESCRIPTION
Closes https://github.com/zowe/zowe-pli-language-support/issues/534

Adds two features to the language server:
1. Ambiguous references and duplicate declarations are no longer reported when encountering forward declarations with `ENTRY`. Meaning that a variable with `ENTRY` and a procedure with the same name are semantically the same element.
2. In addition to the `node` of a `Reference` object, the reference resolver can also now populate the `nodes` field (only in addition - not as an alternative). This field is used for LSP features to point to duplicate/ambiguous references to improve the user experience. This feature is also used for the feature in point 1, where we want to reference both the procedure as well as the `ENTRY` declaration.

Updates our test engine to support testing ambiguous references.