### PR TITLE
[Bugfix] Config creation via Quick Fix

### DIFF
--- a/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
+++ b/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
@@ -98,10 +98,15 @@ export async function quickFixResolveInclude(
 export async function quickFixCreateConfig(
   diagnostic: Diagnostic,
 ): Promise<CodeAction | undefined> {
-  const entryUri = UriUtils.basename(URI.parse(diagnostic.data.entryUri));
-  if (!diagnostic.data.entryUri || !entryUri) {
+  const workspace = PluginConfigurationProviderInstance.getWorkspacePath();
+  const entryUri = diagnostic.data.entryUri;
+  if (!workspace || !entryUri) {
     return undefined;
   }
+  const programPath = URI.parse(
+    diagnostic.data.entryUri.replace(workspace, ""),
+  ).path.replace(/^\//, "");
+
   const action: CodeAction = {
     title: `Create a plugin configuration folder for this file.`,
     kind: CodeActionKind.QuickFix,
@@ -109,7 +114,7 @@ export async function quickFixCreateConfig(
     command: {
       title: "Create configuration folder",
       command: Commands.CREATE_CONFIG,
-      arguments: [entryUri],
+      arguments: [programPath],
     },
   };
 

--- a/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
+++ b/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
@@ -115,7 +115,7 @@ export async function quickFixCreateConfig(
     command: {
       title: "Create configuration folder",
       command: Commands.CREATE_CONFIG,
-      arguments: [programPath, entryUri],
+      arguments: [programPath],
     },
   };
 

--- a/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
+++ b/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
@@ -126,11 +126,11 @@ export async function quickFixCreateConfig(
     : rawPath;
 
   const action: CodeAction = {
-    title: `Create an startup configuration for this file.`,
+    title: `Create a startup configuration for this file.`,
     kind: CodeActionKind.QuickFix,
     diagnostics: [diagnostic],
     command: {
-      title: "Create an startup configuration",
+      title: "Create a startup configuration",
       command: Commands.CREATE_CONFIG,
       arguments: [programPath],
     },

--- a/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
+++ b/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
@@ -100,7 +100,7 @@ export async function quickFixCreateConfig(
 ): Promise<CodeAction | undefined> {
   const workspace = PluginConfigurationProviderInstance.getWorkspacePath();
   const entryUri = diagnostic.data.entryUri as string;
-  if (!workspace.length || !entryUri || !entryUri.length) {
+  if (!workspace || !entryUri) {
     return;
   }
   const resolvedEntry = entryUri.startsWith("file://")

--- a/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
+++ b/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
@@ -107,12 +107,18 @@ export async function quickFixCreateConfig(
     ? URI.parse(entryUri).fsPath.replace(/\\/g, "/")
     : entryUri.replace(/\\/g, "/");
 
-  const normalizedWorkspace = workspace.replace(/\\/g, "/");
-  const workspacePrefix = normalizedWorkspace + "/";
+  const workspaceParts = workspace
+    .replace(/\\/g, "/")
+    .split("/")
+    .filter((e) => e.length > 0);
+  const entryParts = resolvedEntry.split("/").filter((e) => e.length > 0);
 
-  const isInsideWorkspace = resolvedEntry.startsWith(workspacePrefix);
+  const isInsideWorkspace = workspaceParts.every(
+    (part, index) => part === entryParts[index],
+  );
+
   const rawPath = isInsideWorkspace
-    ? resolvedEntry.slice(workspacePrefix.length)
+    ? entryParts.slice(workspaceParts.length).join("/")
     : resolvedEntry;
 
   const programPath = UriUtils.processDriveLetter(rawPath).drive

--- a/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
+++ b/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
@@ -120,11 +120,11 @@ export async function quickFixCreateConfig(
     : rawPath;
 
   const action: CodeAction = {
-    title: `Create a plugin configuration for this file.`,
+    title: `Create an startup configuration for this file.`,
     kind: CodeActionKind.QuickFix,
     diagnostics: [diagnostic],
     command: {
-      title: "Create configuration folder",
+      title: "Create an startup configuration",
       command: Commands.CREATE_CONFIG,
       arguments: [programPath],
     },

--- a/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
+++ b/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
@@ -107,8 +107,8 @@ export async function quickFixCreateConfig(
     ? URI.parse(entryUri).fsPath.replace(/\\/g, "/")
     : entryUri.replace(/\\/g, "/");
 
-  const workspaceParts = workspace
-    .replace(/\\/g, "/")
+  const workspaceParts = URI.parse(workspace)
+    .fsPath.replace(/\\/g, "/")
     .split("/")
     .filter((e) => e.length > 0);
   const entryParts = resolvedEntry.split("/").filter((e) => e.length > 0);

--- a/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
+++ b/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
@@ -100,16 +100,24 @@ export async function quickFixCreateConfig(
 ): Promise<CodeAction | undefined> {
   const workspace = PluginConfigurationProviderInstance.getWorkspacePath();
   const entryUri = diagnostic.data.entryUri as string;
-  if (!workspace || !entryUri) {
+  if (!workspace.length || !entryUri || !entryUri.length) {
     return;
   }
-  const workspaceStrippedUri = entryUri.startsWith(workspace)
-    ? entryUri.replace(workspace, "")
-    : entryUri;
-  const programPath = URI.parse(workspaceStrippedUri).path.replace(/^\//, "");
-  if (!programPath.length) {
-    return;
-  }
+  const resolvedEntry = entryUri.startsWith("file://")
+    ? URI.parse(entryUri).fsPath.replace(/\\/g, "/")
+    : entryUri.replace(/\\/g, "/");
+
+  const normalizedWorkspace = workspace.replace(/\\/g, "/");
+  const workspacePrefix = normalizedWorkspace + "/";
+
+  const isInsideWorkspace = resolvedEntry.startsWith(workspacePrefix);
+  const rawPath = isInsideWorkspace
+    ? resolvedEntry.slice(workspacePrefix.length)
+    : resolvedEntry;
+
+  const programPath = UriUtils.processDriveLetter(rawPath).drive
+    ? rawPath[0].toUpperCase() + rawPath.slice(1)
+    : rawPath;
 
   const action: CodeAction = {
     title: `Create a plugin configuration for this file.`,

--- a/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
+++ b/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
@@ -99,14 +99,14 @@ export async function quickFixCreateConfig(
   diagnostic: Diagnostic,
 ): Promise<CodeAction | undefined> {
   const workspace = PluginConfigurationProviderInstance.getWorkspacePath();
-  const entryUri = diagnostic.data.entryUri;
+  const entryUri = diagnostic.data.entryUri as string;
   if (!workspace || !entryUri) {
     return;
   }
-  const programPath = URI.parse(entryUri.replace(workspace, "")).path.replace(
-    /^\//,
-    "",
-  );
+  const workspaceStrippedUri = entryUri.startsWith(workspace)
+    ? entryUri.replace(workspace, "")
+    : entryUri;
+  const programPath = URI.parse(workspaceStrippedUri).path.replace(/^\//, "");
   if (!programPath.length) {
     return;
   }

--- a/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
+++ b/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
@@ -101,12 +101,15 @@ export async function quickFixCreateConfig(
   const workspace = PluginConfigurationProviderInstance.getWorkspacePath();
   const entryUri = diagnostic.data.entryUri;
   if (!workspace || !entryUri) {
-    return undefined;
+    return;
   }
   const programPath = URI.parse(entryUri.replace(workspace, "")).path.replace(
     /^\//,
     "",
   );
+  if (!programPath.length) {
+    return;
+  }
 
   const action: CodeAction = {
     title: `Create a plugin configuration for this file.`,

--- a/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
+++ b/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
@@ -103,18 +103,19 @@ export async function quickFixCreateConfig(
   if (!workspace || !entryUri) {
     return undefined;
   }
-  const programPath = URI.parse(
-    diagnostic.data.entryUri.replace(workspace, ""),
-  ).path.replace(/^\//, "");
+  const programPath = URI.parse(entryUri.replace(workspace, "")).path.replace(
+    /^\//,
+    "",
+  );
 
   const action: CodeAction = {
-    title: `Create a plugin configuration folder for this file.`,
+    title: `Create a plugin configuration for this file.`,
     kind: CodeActionKind.QuickFix,
     diagnostics: [diagnostic],
     command: {
       title: "Create configuration folder",
       command: Commands.CREATE_CONFIG,
-      arguments: [programPath],
+      arguments: [programPath, entryUri],
     },
   };
 

--- a/packages/language/src/language-server/commands.ts
+++ b/packages/language/src/language-server/commands.ts
@@ -15,7 +15,7 @@ import { PluginConfigurationProviderInstance } from "../workspace/plugin-configu
 import { ExecuteCommandParams } from "vscode-languageserver";
 import { UriUtils } from "../utils/uri";
 import { PluginConfiguration } from "./constants";
-import { updateExistingConfig, createNewConfig } from "../utils/config";
+import { updateOrCreateConfig } from "../utils/config";
 
 export async function commandResolveInclude(params: ExecuteCommandParams) {
   const [uri, content] = params.arguments as string[];
@@ -55,16 +55,12 @@ export async function commandCreateConfig(
     );
   }
 
-  if (progConfigFile) {
-    await updateExistingConfig(
-      workspaceFolderUri,
-      configFilePath,
-      progConfigFile,
-      programPath,
-    );
-  } else {
-    await createNewConfig(workspaceFolderUri, programPath);
-  }
+  await updateOrCreateConfig(
+    workspaceFolderUri,
+    configFilePath,
+    progConfigFile,
+    programPath,
+  );
 
   if (!returnUpdatedFile) {
     return;

--- a/packages/language/src/language-server/commands.ts
+++ b/packages/language/src/language-server/commands.ts
@@ -32,8 +32,39 @@ export async function commandCreateConfig(params: ExecuteCommandParams) {
   if (!workspaceFolderUri || !params.arguments) {
     return;
   }
+  const programPath = params.arguments[0];
+  const entryUri = URI.parse(params.arguments[1]);
+  const test = PluginConfigurationProviderInstance.getProgramConfig(entryUri);
+  console.log(test);
+  const test2 = PluginConfigurationProviderInstance.pushConfigProgram(
+    workspaceFolderUri.path,
+    programPath,
+  );
+  console.log(test2);
+  // hasProgramConfig(entryUri);
+  if (test2) {
+    const FILE = await FileSystemProviderInstance.readFile(
+      UriUtils.joinPath(
+        workspaceFolderUri,
+        PluginConfiguration.PROGRAM_FILE_PATH,
+      ),
+    );
+    if (!FILE) return;
+    const textContent = JSON.parse(FILE);
+    console.log(textContent);
+    textContent.pgms.push({
+      program: programPath,
+      pgroup: "default",
+    });
+    await FileSystemProviderInstance.writeFile(
+      UriUtils.joinPath(
+        workspaceFolderUri,
+        PluginConfiguration.PROGRAM_FILE_PATH,
+      ),
+      JSON.stringify(textContent, null, 2));
+      return;
+  }
   try {
-    const entryUri = params.arguments[0];
     await FileSystemProviderInstance.writeFile(
       UriUtils.joinPath(
         workspaceFolderUri,
@@ -45,7 +76,7 @@ export async function commandCreateConfig(params: ExecuteCommandParams) {
           pgms: [
             {
               ...PluginConfiguration.DEFAULT_PROGRAM_FILE_CONTENT.pgms[0],
-              program: entryUri,
+              program: programPath,
             },
           ],
         },

--- a/packages/language/src/language-server/commands.ts
+++ b/packages/language/src/language-server/commands.ts
@@ -44,10 +44,11 @@ export async function commandCreateConfig(
 
   let progConfigFile: string | undefined;
   try {
-   progConfigFile =
-    await FileSystemProviderInstance.readFile(configFilePath);
+    progConfigFile = await FileSystemProviderInstance.readFile(configFilePath);
   } catch {
-    console.info(`[Info] No existing "pgm_conf.json" found in workspace — a new configuration file will be created.`);
+    console.info(
+      `[Info] No existing "pgm_conf.json" found in workspace — a new configuration file will be created.`,
+    );
   }
 
   if (progConfigFile) {

--- a/packages/language/src/language-server/commands.ts
+++ b/packages/language/src/language-server/commands.ts
@@ -26,15 +26,16 @@ export async function commandResolveInclude(params: ExecuteCommandParams) {
   }
 }
 
-export async function commandCreateConfig(params: ExecuteCommandParams) {
-  const workspaceFolderUri = URI.parse(
-    PluginConfigurationProviderInstance.getWorkspacePath(),
-  );
-
-  if (!workspaceFolderUri || !params.arguments) {
+export async function commandCreateConfig(
+  params: ExecuteCommandParams,
+  returnUpdatedFile = false,
+): Promise<string | undefined> {
+  const workspacePath = PluginConfigurationProviderInstance.getWorkspacePath();
+  if (!workspacePath.length || !params.arguments) {
     return;
   }
 
+  const workspaceFolderUri = URI.parse(workspacePath);
   const programPath = params.arguments[0];
   const configFilePath = UriUtils.joinPath(
     workspaceFolderUri,
@@ -54,4 +55,15 @@ export async function commandCreateConfig(params: ExecuteCommandParams) {
   } else {
     await createNewConfig(workspaceFolderUri, programPath);
   }
+
+  if (!returnUpdatedFile) {
+    return;
+  }
+
+  const fileContent = JSON.stringify(
+    await FileSystemProviderInstance.readFile(configFilePath),
+    null,
+    2,
+  );
+  return fileContent;
 }

--- a/packages/language/src/language-server/commands.ts
+++ b/packages/language/src/language-server/commands.ts
@@ -37,6 +37,10 @@ export async function commandCreateConfig(
 
   const workspaceFolderUri = URI.parse(workspacePath);
   const programPath = params.arguments[0];
+  if (!programPath.length) {
+    return;
+  }
+
   const configFilePath = UriUtils.joinPath(
     workspaceFolderUri,
     PluginConfiguration.PROGRAM_FILE_PATH,
@@ -66,10 +70,5 @@ export async function commandCreateConfig(
     return;
   }
 
-  const fileContent = JSON.stringify(
-    await FileSystemProviderInstance.readFile(configFilePath),
-    null,
-    2,
-  );
-  return fileContent;
+  return await FileSystemProviderInstance.readFile(configFilePath);
 }

--- a/packages/language/src/language-server/commands.ts
+++ b/packages/language/src/language-server/commands.ts
@@ -15,6 +15,7 @@ import { PluginConfigurationProviderInstance } from "../workspace/plugin-configu
 import { ExecuteCommandParams } from "vscode-languageserver";
 import { UriUtils } from "../utils/uri";
 import { PluginConfiguration } from "./constants";
+import { updateExistingConfig, createNewConfig } from "../utils/config";
 
 export async function commandResolveInclude(params: ExecuteCommandParams) {
   const [uri, content] = params.arguments as string[];
@@ -29,73 +30,28 @@ export async function commandCreateConfig(params: ExecuteCommandParams) {
   const workspaceFolderUri = URI.parse(
     PluginConfigurationProviderInstance.getWorkspacePath(),
   );
+
   if (!workspaceFolderUri || !params.arguments) {
     return;
   }
+
   const programPath = params.arguments[0];
-  const entryUri = URI.parse(params.arguments[1]);
-  const test = PluginConfigurationProviderInstance.getProgramConfig(entryUri);
-  console.log(test);
-  const test2 = PluginConfigurationProviderInstance.pushConfigProgram(
-    workspaceFolderUri.path,
-    programPath,
+  const configFilePath = UriUtils.joinPath(
+    workspaceFolderUri,
+    PluginConfiguration.PROGRAM_FILE_PATH,
   );
-  console.log(test2);
-  // hasProgramConfig(entryUri);
-  if (test2) {
-    const FILE = await FileSystemProviderInstance.readFile(
-      UriUtils.joinPath(
-        workspaceFolderUri,
-        PluginConfiguration.PROGRAM_FILE_PATH,
-      ),
+
+  const progConfigFile =
+    await FileSystemProviderInstance.readFile(configFilePath);
+
+  if (progConfigFile) {
+    await updateExistingConfig(
+      workspaceFolderUri,
+      configFilePath,
+      progConfigFile,
+      programPath,
     );
-    if (!FILE) return;
-    const textContent = JSON.parse(FILE);
-    console.log(textContent);
-    textContent.pgms.push({
-      program: programPath,
-      pgroup: "default",
-    });
-    await FileSystemProviderInstance.writeFile(
-      UriUtils.joinPath(
-        workspaceFolderUri,
-        PluginConfiguration.PROGRAM_FILE_PATH,
-      ),
-      JSON.stringify(textContent, null, 2));
-      return;
-  }
-  try {
-    await FileSystemProviderInstance.writeFile(
-      UriUtils.joinPath(
-        workspaceFolderUri,
-        PluginConfiguration.PROGRAM_FILE_PATH,
-      ),
-      JSON.stringify(
-        {
-          ...PluginConfiguration.DEFAULT_PROGRAM_FILE_CONTENT,
-          pgms: [
-            {
-              ...PluginConfiguration.DEFAULT_PROGRAM_FILE_CONTENT.pgms[0],
-              program: programPath,
-            },
-          ],
-        },
-        null,
-        2,
-      ),
-    );
-    await FileSystemProviderInstance.writeFile(
-      UriUtils.joinPath(
-        workspaceFolderUri,
-        PluginConfiguration.PROCESS_GROUP_FILE_PATH,
-      ),
-      JSON.stringify(
-        PluginConfiguration.DEFAULT_PROCESS_GROUP_FILE_CONTENT,
-        null,
-        2,
-      ),
-    );
-  } catch (err) {
-    console.error("Failed to create configuration: ", err);
+  } else {
+    await createNewConfig(workspaceFolderUri, programPath);
   }
 }

--- a/packages/language/src/language-server/commands.ts
+++ b/packages/language/src/language-server/commands.ts
@@ -28,8 +28,7 @@ export async function commandResolveInclude(params: ExecuteCommandParams) {
 
 export async function commandCreateConfig(
   params: ExecuteCommandParams,
-  returnUpdatedFile = false,
-): Promise<string | undefined> {
+): Promise<undefined> {
   const workspacePath = PluginConfigurationProviderInstance.getWorkspacePath();
   if (!workspacePath.length || !params.arguments) {
     return;
@@ -61,10 +60,4 @@ export async function commandCreateConfig(
     progConfigFile,
     programPath,
   );
-
-  if (!returnUpdatedFile) {
-    return;
-  }
-
-  return await FileSystemProviderInstance.readFile(configFilePath);
 }

--- a/packages/language/src/language-server/commands.ts
+++ b/packages/language/src/language-server/commands.ts
@@ -11,10 +11,7 @@
 
 import { URI } from "vscode-uri";
 import { FileSystemProviderInstance } from "../workspace/file-system-provider";
-import { PluginConfigurationProviderInstance } from "../workspace/plugin-configuration-provider";
 import { ExecuteCommandParams } from "vscode-languageserver";
-import { UriUtils } from "../utils/uri";
-import { PluginConfiguration } from "./constants";
 import { updateOrCreateConfig } from "../utils/config";
 
 export async function commandResolveInclude(params: ExecuteCommandParams) {
@@ -28,36 +25,14 @@ export async function commandResolveInclude(params: ExecuteCommandParams) {
 
 export async function commandCreateConfig(
   params: ExecuteCommandParams,
-): Promise<undefined> {
-  const workspacePath = PluginConfigurationProviderInstance.getWorkspacePath();
-  if (!workspacePath || !params.arguments) {
+): Promise<void> {
+  if (!params.arguments) {
     return;
   }
-
-  const workspaceFolderUri = URI.parse(workspacePath);
   const programPath = params.arguments[0];
   if (!programPath) {
     return;
   }
 
-  const configFilePath = UriUtils.joinPath(
-    workspaceFolderUri,
-    PluginConfiguration.PROGRAM_FILE_PATH,
-  );
-
-  let progConfigFile: string | undefined;
-  try {
-    progConfigFile = await FileSystemProviderInstance.readFile(configFilePath);
-  } catch {
-    console.info(
-      `[Info] No existing "pgm_conf.json" found in workspace — a new configuration file will be created.`,
-    );
-  }
-
-  await updateOrCreateConfig(
-    workspaceFolderUri,
-    configFilePath,
-    progConfigFile,
-    programPath,
-  );
+  await updateOrCreateConfig(programPath);
 }

--- a/packages/language/src/language-server/commands.ts
+++ b/packages/language/src/language-server/commands.ts
@@ -42,8 +42,13 @@ export async function commandCreateConfig(
     PluginConfiguration.PROGRAM_FILE_PATH,
   );
 
-  const progConfigFile =
+  let progConfigFile: string | undefined;
+  try {
+   progConfigFile =
     await FileSystemProviderInstance.readFile(configFilePath);
+  } catch {
+    console.info(`[Info] No existing "pgm_conf.json" found in workspace — a new configuration file will be created.`);
+  }
 
   if (progConfigFile) {
     await updateExistingConfig(

--- a/packages/language/src/language-server/commands.ts
+++ b/packages/language/src/language-server/commands.ts
@@ -30,13 +30,13 @@ export async function commandCreateConfig(
   params: ExecuteCommandParams,
 ): Promise<undefined> {
   const workspacePath = PluginConfigurationProviderInstance.getWorkspacePath();
-  if (!workspacePath.length || !params.arguments) {
+  if (!workspacePath || !params.arguments) {
     return;
   }
 
   const workspaceFolderUri = URI.parse(workspacePath);
   const programPath = params.arguments[0];
-  if (!programPath.length) {
+  if (!programPath) {
     return;
   }
 

--- a/packages/language/src/language-server/commands.ts
+++ b/packages/language/src/language-server/commands.ts
@@ -19,7 +19,7 @@ export async function commandResolveInclude(params: ExecuteCommandParams) {
   try {
     await FileSystemProviderInstance.writeFile(URI.parse(uri), content);
   } catch (err) {
-    console.error("Failed to write proc_grps.json:", err);
+    console.error(`Failed to write file at URI: ${uri}`, err);
   }
 }
 
@@ -33,6 +33,5 @@ export async function commandCreateConfig(
   if (!programPath) {
     return;
   }
-
   await updateOrCreateConfig(programPath);
 }

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2231,6 +2231,8 @@ async function runInclude(
         item.token,
       );
     } else {
+      // TODO: @wagner-laranjeiras - in case we have a config file with the right program but the wrong pgroup,
+      // it triggers IBM1848I instead of offering to create a new config.
       diagnostic = diagnosticFromCode(
         PLICodes.Severe.IBM1848I,
         item.token,

--- a/packages/language/src/utils/config.ts
+++ b/packages/language/src/utils/config.ts
@@ -1,0 +1,91 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { URI } from "vscode-uri";
+import { PluginConfiguration } from "../language-server/constants";
+import { FileSystemProviderInstance } from "../workspace/file-system-provider";
+import { PluginConfigurationProviderInstance } from "../workspace/plugin-configuration-provider";
+import { UriUtils } from "../utils/uri";
+
+export async function updateExistingConfig(
+  workspaceFolderUri: URI,
+  configFilePath: URI,
+  progConfigFile: string,
+  programPath: string,
+): Promise<boolean> {
+  const canAddToExistingConfig =
+    PluginConfigurationProviderInstance.pushConfigProgram(
+      workspaceFolderUri.path,
+      { program: programPath, pgroup: "default" },
+    );
+
+  if (!canAddToExistingConfig) {
+    return false;
+  }
+
+  const textContent = JSON.parse(progConfigFile);
+  textContent.pgms.push({
+    program: programPath,
+    pgroup: "default",
+  });
+
+  try {
+    await FileSystemProviderInstance.writeFile(
+      configFilePath,
+      JSON.stringify(textContent, null, 2),
+    );
+    return true;
+  } catch (err) {
+    console.error("Failed to create configuration: ", err);
+    return false;
+  }
+}
+
+export async function createNewConfig(
+  workspaceFolderUri: URI,
+  programPath: string,
+) {
+  try {
+    await FileSystemProviderInstance.writeFile(
+      UriUtils.joinPath(
+        workspaceFolderUri,
+        PluginConfiguration.PROGRAM_FILE_PATH,
+      ),
+      JSON.stringify(
+        {
+          ...PluginConfiguration.DEFAULT_PROGRAM_FILE_CONTENT,
+          pgms: [
+            {
+              ...PluginConfiguration.DEFAULT_PROGRAM_FILE_CONTENT.pgms[0],
+              program: programPath,
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+    );
+
+    await FileSystemProviderInstance.writeFile(
+      UriUtils.joinPath(
+        workspaceFolderUri,
+        PluginConfiguration.PROCESS_GROUP_FILE_PATH,
+      ),
+      JSON.stringify(
+        PluginConfiguration.DEFAULT_PROCESS_GROUP_FILE_CONTENT,
+        null,
+        2,
+      ),
+    );
+  } catch (err) {
+    console.error("Failed to create configuration: ", err);
+  }
+}

--- a/packages/language/src/utils/config.ts
+++ b/packages/language/src/utils/config.ts
@@ -16,31 +16,31 @@ import { UriUtils } from "./uri";
 import { PluginConfiguration } from "../language-server/constants";
 
 export async function updateOrCreateConfig(programPath: string): Promise<void> {
-  const hasExistingConfigs = PluginConfigurationProviderInstance.hasRegisteredProgramConfigs();
-  console.log(hasExistingConfigs);
-  const workspaceFolderUri = URI.parse(
-    PluginConfigurationProviderInstance.getWorkspacePath(),
-  );
-  
-  const configFilePath = UriUtils.joinPath(
-    workspaceFolderUri,
-    PluginConfiguration.PROGRAM_FILE_PATH,
-  );
-  let progConfigFile: string | undefined;
-  try {
-    progConfigFile = await FileSystemProviderInstance.readFile(configFilePath);
-  } catch {
-    console.info(
-      `[Info] No existing "pgm_conf.json" found in workspace — a new configuration file will be created.`,
-    );
-  }
-  const canAddToExistingConfig =
-    PluginConfigurationProviderInstance.addProgramConfig(
-      workspaceFolderUri.path,
-      { program: programPath, pgroup: "default" },
-    );
+  const hasExistingConfigs =
+    PluginConfigurationProviderInstance.hasRegisteredProgramConfigs();
 
-  if (!canAddToExistingConfig) {
+  if (hasExistingConfigs) {
+    const workspaceFolderUri = URI.parse(
+      PluginConfigurationProviderInstance.getWorkspacePath(),
+    );
+    const configFilePath = UriUtils.joinPath(
+      workspaceFolderUri,
+      PluginConfiguration.PROGRAM_FILE_PATH,
+    );
+    const progConfigFile =
+      await FileSystemProviderInstance.readFile(configFilePath);
+    if (!progConfigFile) {
+      return;
+    }
+    const textContent = JSON.parse(progConfigFile);
+
+    PluginConfigurationProviderInstance.addProgramConfig(
+      workspaceFolderUri,
+      { program: programPath, pgroup: "default" },
+      programPath,
+      textContent,
+    );
+  } else {
     try {
       await PluginConfigurationProviderInstance.writeProgramConfigFile(
         programPath,
@@ -50,31 +50,5 @@ export async function updateOrCreateConfig(programPath: string): Promise<void> {
       console.error(err);
       return;
     }
-  }
-
-  if (!progConfigFile) {
-    return;
-  }
-  try {
-    const textContent = JSON.parse(progConfigFile);
-    if (
-      !textContent ||
-      typeof textContent !== "object" ||
-      !Array.isArray(textContent.pgms)
-    ) {
-      console.error("Invalid configuration file format");
-      return;
-    }
-    textContent.pgms.push({
-      program: programPath,
-      pgroup: "default",
-    });
-    await PluginConfigurationProviderInstance.writeProgramConfigFile(
-      configFilePath.path,
-      textContent,
-    );
-  } catch (err) {
-    console.error("Failed to create configuration: ", err);
-    return;
   }
 }

--- a/packages/language/src/utils/config.ts
+++ b/packages/language/src/utils/config.ts
@@ -10,11 +10,23 @@
  */
 
 import { URI } from "vscode-uri";
-import { PluginConfigurationProviderInstance } from "../workspace/plugin-configuration-provider";
+import {
+  PgmsConfig,
+  PluginConfigurationProviderInstance,
+} from "../workspace/plugin-configuration-provider";
 import { FileSystemProviderInstance } from "../workspace/file-system-provider";
 import { UriUtils } from "./uri";
 import { PluginConfiguration } from "../language-server/constants";
 
+/**
+ * Creates or updates the program configuration for the given program path.
+ *
+ * If no existing configs are registered, both the program config file and
+ * process groups file are created from scratch. Otherwise, the existing
+ * program config file is read and updated with the new program entry.
+ *
+ * @param programPath - Absolute path to the program to register.
+ */
 export async function updateOrCreateConfig(programPath: string): Promise<void> {
   const hasExistingConfigs =
     PluginConfigurationProviderInstance.hasRegisteredProgramConfigs();
@@ -26,10 +38,12 @@ export async function updateOrCreateConfig(programPath: string): Promise<void> {
       );
       await PluginConfigurationProviderInstance.writeProcessGroupsFile();
     } catch (err) {
-      console.error(err);
+      console.error("Failed to create initial config files:", err);
+      throw err;
     }
     return;
   }
+
   const workspaceFolderUri = URI.parse(
     PluginConfigurationProviderInstance.getWorkspacePath(),
   );
@@ -37,17 +51,42 @@ export async function updateOrCreateConfig(programPath: string): Promise<void> {
     workspaceFolderUri,
     PluginConfiguration.PROGRAM_FILE_PATH,
   );
-  const progConfigFile =
-    await FileSystemProviderInstance.readFile(configFilePath);
-  if (!progConfigFile) {
+
+  const fileExists =
+    await FileSystemProviderInstance.fileExists(configFilePath);
+  if (!fileExists) {
+    try {
+      await PluginConfigurationProviderInstance.writeProgramConfigFile(
+        programPath,
+      );
+    } catch (err) {
+      console.error("Failed to create program config file:", err);
+      throw err;
+    }
     return;
   }
-  const textContent = JSON.parse(progConfigFile);
 
-  PluginConfigurationProviderInstance.addProgramConfig(
-    workspaceFolderUri,
-    { program: programPath, pgroup: "default" },
-    programPath,
-    textContent,
-  );
+  try {
+    const progConfigFile =
+      await FileSystemProviderInstance.readFile(configFilePath);
+    if (!progConfigFile) {
+      return;
+    }
+    const parsedTextContent = JSON.parse(progConfigFile);
+    if (!parsedTextContent || !Array.isArray(parsedTextContent.pgms)) {
+      console.error("Unexpected format in program config file");
+      return;
+    }
+    const textContent: PgmsConfig = parsedTextContent;
+
+    PluginConfigurationProviderInstance.addProgramConfig(
+      workspaceFolderUri,
+      { program: programPath, pgroup: "default" },
+      programPath,
+      textContent,
+    );
+  } catch (err) {
+    console.error("Failed to read or update program config file:", err);
+    throw err;
+  }
 }

--- a/packages/language/src/utils/config.ts
+++ b/packages/language/src/utils/config.ts
@@ -20,7 +20,7 @@ export async function updateExistingConfig(
   configFilePath: URI,
   progConfigFile: string,
   programPath: string,
-): Promise<boolean> {
+) {
   const canAddToExistingConfig =
     PluginConfigurationProviderInstance.pushConfigProgram(
       workspaceFolderUri.path,
@@ -28,7 +28,7 @@ export async function updateExistingConfig(
     );
 
   if (!canAddToExistingConfig) {
-    return false;
+    return;
   }
 
   const textContent = JSON.parse(progConfigFile);
@@ -42,10 +42,9 @@ export async function updateExistingConfig(
       configFilePath,
       JSON.stringify(textContent, null, 2),
     );
-    return true;
   } catch (err) {
     console.error("Failed to create configuration: ", err);
-    return false;
+    return;
   }
 }
 

--- a/packages/language/src/utils/config.ts
+++ b/packages/language/src/utils/config.ts
@@ -19,28 +19,7 @@ export async function updateOrCreateConfig(programPath: string): Promise<void> {
   const hasExistingConfigs =
     PluginConfigurationProviderInstance.hasRegisteredProgramConfigs();
 
-  if (hasExistingConfigs) {
-    const workspaceFolderUri = URI.parse(
-      PluginConfigurationProviderInstance.getWorkspacePath(),
-    );
-    const configFilePath = UriUtils.joinPath(
-      workspaceFolderUri,
-      PluginConfiguration.PROGRAM_FILE_PATH,
-    );
-    const progConfigFile =
-      await FileSystemProviderInstance.readFile(configFilePath);
-    if (!progConfigFile) {
-      return;
-    }
-    const textContent = JSON.parse(progConfigFile);
-
-    PluginConfigurationProviderInstance.addProgramConfig(
-      workspaceFolderUri,
-      { program: programPath, pgroup: "default" },
-      programPath,
-      textContent,
-    );
-  } else {
+  if (!hasExistingConfigs) {
     try {
       await PluginConfigurationProviderInstance.writeProgramConfigFile(
         programPath,
@@ -48,7 +27,27 @@ export async function updateOrCreateConfig(programPath: string): Promise<void> {
       await PluginConfigurationProviderInstance.writeProcessGroupsFile();
     } catch (err) {
       console.error(err);
-      return;
     }
+    return;
   }
+  const workspaceFolderUri = URI.parse(
+    PluginConfigurationProviderInstance.getWorkspacePath(),
+  );
+  const configFilePath = UriUtils.joinPath(
+    workspaceFolderUri,
+    PluginConfiguration.PROGRAM_FILE_PATH,
+  );
+  const progConfigFile =
+    await FileSystemProviderInstance.readFile(configFilePath);
+  if (!progConfigFile) {
+    return;
+  }
+  const textContent = JSON.parse(progConfigFile);
+
+  PluginConfigurationProviderInstance.addProgramConfig(
+    workspaceFolderUri,
+    { program: programPath, pgroup: "default" },
+    programPath,
+    textContent,
+  );
 }

--- a/packages/language/src/utils/config.ts
+++ b/packages/language/src/utils/config.ts
@@ -11,13 +11,29 @@
 
 import { URI } from "vscode-uri";
 import { PluginConfigurationProviderInstance } from "../workspace/plugin-configuration-provider";
+import { FileSystemProviderInstance } from "../workspace/file-system-provider";
+import { UriUtils } from "./uri";
+import { PluginConfiguration } from "../language-server/constants";
 
-export async function updateOrCreateConfig(
-  workspaceFolderUri: URI,
-  configFilePath: URI,
-  progConfigFile: string | undefined,
-  programPath: string,
-) {
+export async function updateOrCreateConfig(programPath: string): Promise<void> {
+  const hasExistingConfigs = PluginConfigurationProviderInstance.hasRegisteredProgramConfigs();
+  console.log(hasExistingConfigs);
+  const workspaceFolderUri = URI.parse(
+    PluginConfigurationProviderInstance.getWorkspacePath(),
+  );
+  
+  const configFilePath = UriUtils.joinPath(
+    workspaceFolderUri,
+    PluginConfiguration.PROGRAM_FILE_PATH,
+  );
+  let progConfigFile: string | undefined;
+  try {
+    progConfigFile = await FileSystemProviderInstance.readFile(configFilePath);
+  } catch {
+    console.info(
+      `[Info] No existing "pgm_conf.json" found in workspace — a new configuration file will be created.`,
+    );
+  }
   const canAddToExistingConfig =
     PluginConfigurationProviderInstance.addProgramConfig(
       workspaceFolderUri.path,
@@ -41,6 +57,14 @@ export async function updateOrCreateConfig(
   }
   try {
     const textContent = JSON.parse(progConfigFile);
+    if (
+      !textContent ||
+      typeof textContent !== "object" ||
+      !Array.isArray(textContent.pgms)
+    ) {
+      console.error("Invalid configuration file format");
+      return;
+    }
     textContent.pgms.push({
       program: programPath,
       pgroup: "default",

--- a/packages/language/src/utils/config.ts
+++ b/packages/language/src/utils/config.ts
@@ -10,10 +10,7 @@
  */
 
 import { URI } from "vscode-uri";
-import { PluginConfiguration } from "../language-server/constants";
-import { FileSystemProviderInstance } from "../workspace/file-system-provider";
 import { PluginConfigurationProviderInstance } from "../workspace/plugin-configuration-provider";
-import { UriUtils } from "../utils/uri";
 
 export async function updateOrCreateConfig(
   workspaceFolderUri: URI,
@@ -29,40 +26,12 @@ export async function updateOrCreateConfig(
 
   if (!canAddToExistingConfig) {
     try {
-      await FileSystemProviderInstance.writeFile(
-        UriUtils.joinPath(
-          workspaceFolderUri,
-          PluginConfiguration.PROGRAM_FILE_PATH,
-        ),
-        JSON.stringify(
-          {
-            ...PluginConfiguration.DEFAULT_PROGRAM_FILE_CONTENT,
-            pgms: [
-              {
-                ...PluginConfiguration.DEFAULT_PROGRAM_FILE_CONTENT.pgms[0],
-                program: programPath,
-              },
-            ],
-          },
-          null,
-          2,
-        ),
+      await PluginConfigurationProviderInstance.writeProgramConfigFile(
+        programPath,
       );
-
-      await FileSystemProviderInstance.writeFile(
-        UriUtils.joinPath(
-          workspaceFolderUri,
-          PluginConfiguration.PROCESS_GROUP_FILE_PATH,
-        ),
-        JSON.stringify(
-          PluginConfiguration.DEFAULT_PROCESS_GROUP_FILE_CONTENT,
-          null,
-          2,
-        ),
-      );
-      return;
+      await PluginConfigurationProviderInstance.writeProcessGroupsFile();
     } catch (err) {
-      console.error("Failed to create configuration: ", err);
+      console.error(err);
       return;
     }
   }
@@ -76,9 +45,9 @@ export async function updateOrCreateConfig(
       program: programPath,
       pgroup: "default",
     });
-    await FileSystemProviderInstance.writeFile(
-      configFilePath,
-      JSON.stringify(textContent, null, 2),
+    await PluginConfigurationProviderInstance.writeProgramConfigFile(
+      configFilePath.path,
+      textContent,
     );
   } catch (err) {
     console.error("Failed to create configuration: ", err);

--- a/packages/language/src/utils/config.ts
+++ b/packages/language/src/utils/config.ts
@@ -22,7 +22,7 @@ export async function updateExistingConfig(
   programPath: string,
 ) {
   const canAddToExistingConfig =
-    PluginConfigurationProviderInstance.pushConfigProgram(
+    PluginConfigurationProviderInstance.addProgramConfig(
       workspaceFolderUri.path,
       { program: programPath, pgroup: "default" },
     );
@@ -31,13 +31,12 @@ export async function updateExistingConfig(
     return;
   }
 
-  const textContent = JSON.parse(progConfigFile);
-  textContent.pgms.push({
-    program: programPath,
-    pgroup: "default",
-  });
-
   try {
+    const textContent = JSON.parse(progConfigFile);
+    textContent.pgms.push({
+      program: programPath,
+      pgroup: "default",
+    });
     await FileSystemProviderInstance.writeFile(
       configFilePath,
       JSON.stringify(textContent, null, 2),

--- a/packages/language/src/utils/config.ts
+++ b/packages/language/src/utils/config.ts
@@ -10,10 +10,7 @@
  */
 
 import { URI } from "vscode-uri";
-import {
-  PgmsConfig,
-  PluginConfigurationProviderInstance,
-} from "../workspace/plugin-configuration-provider";
+import { PluginConfigurationProviderInstance } from "../workspace/plugin-configuration-provider";
 import { FileSystemProviderInstance } from "../workspace/file-system-provider";
 import { UriUtils } from "./uri";
 import { PluginConfiguration } from "../language-server/constants";
@@ -77,12 +74,15 @@ export async function updateOrCreateConfig(programPath: string): Promise<void> {
       console.error("Unexpected format in program config file");
       return;
     }
-    const textContent: PgmsConfig = parsedTextContent;
 
-    PluginConfigurationProviderInstance.addProgramConfig(
-      workspaceFolderUri,
-      { program: programPath, pgroup: "default" },
-      textContent,
+    PluginConfigurationProviderInstance.addProgramConfig(workspaceFolderUri, {
+      program: programPath,
+      pgroup: "default",
+    });
+
+    parsedTextContent.pgms.push({ program: programPath, pgroup: "default" });
+    await PluginConfigurationProviderInstance.writeProgramConfigFile(
+      parsedTextContent,
     );
   } catch (err) {
     console.error("Failed to read or update program config file:", err);

--- a/packages/language/src/utils/config.ts
+++ b/packages/language/src/utils/config.ts
@@ -34,7 +34,9 @@ export async function updateOrCreateConfig(programPath: string): Promise<void> {
   if (!hasExistingConfigs) {
     try {
       await PluginConfigurationProviderInstance.writeProgramConfigFile(
-        programPath,
+        PluginConfigurationProviderInstance.defaultProgramConfigContent(
+          programPath,
+        ),
       );
       await PluginConfigurationProviderInstance.writeProcessGroupsFile();
     } catch (err) {
@@ -56,9 +58,7 @@ export async function updateOrCreateConfig(programPath: string): Promise<void> {
     await FileSystemProviderInstance.fileExists(configFilePath);
   if (!fileExists) {
     try {
-      await PluginConfigurationProviderInstance.writeProgramConfigFile(
-        programPath,
-      );
+      await PluginConfigurationProviderInstance.writeProgramConfigFile();
     } catch (err) {
       console.error("Failed to create program config file:", err);
       throw err;

--- a/packages/language/src/utils/config.ts
+++ b/packages/language/src/utils/config.ts
@@ -82,7 +82,6 @@ export async function updateOrCreateConfig(programPath: string): Promise<void> {
     PluginConfigurationProviderInstance.addProgramConfig(
       workspaceFolderUri,
       { program: programPath, pgroup: "default" },
-      programPath,
       textContent,
     );
   } catch (err) {

--- a/packages/language/src/utils/config.ts
+++ b/packages/language/src/utils/config.ts
@@ -15,10 +15,10 @@ import { FileSystemProviderInstance } from "../workspace/file-system-provider";
 import { PluginConfigurationProviderInstance } from "../workspace/plugin-configuration-provider";
 import { UriUtils } from "../utils/uri";
 
-export async function updateExistingConfig(
+export async function updateOrCreateConfig(
   workspaceFolderUri: URI,
   configFilePath: URI,
-  progConfigFile: string,
+  progConfigFile: string | undefined,
   programPath: string,
 ) {
   const canAddToExistingConfig =
@@ -28,9 +28,48 @@ export async function updateExistingConfig(
     );
 
   if (!canAddToExistingConfig) {
-    return;
+    try {
+      await FileSystemProviderInstance.writeFile(
+        UriUtils.joinPath(
+          workspaceFolderUri,
+          PluginConfiguration.PROGRAM_FILE_PATH,
+        ),
+        JSON.stringify(
+          {
+            ...PluginConfiguration.DEFAULT_PROGRAM_FILE_CONTENT,
+            pgms: [
+              {
+                ...PluginConfiguration.DEFAULT_PROGRAM_FILE_CONTENT.pgms[0],
+                program: programPath,
+              },
+            ],
+          },
+          null,
+          2,
+        ),
+      );
+
+      await FileSystemProviderInstance.writeFile(
+        UriUtils.joinPath(
+          workspaceFolderUri,
+          PluginConfiguration.PROCESS_GROUP_FILE_PATH,
+        ),
+        JSON.stringify(
+          PluginConfiguration.DEFAULT_PROCESS_GROUP_FILE_CONTENT,
+          null,
+          2,
+        ),
+      );
+      return;
+    } catch (err) {
+      console.error("Failed to create configuration: ", err);
+      return;
+    }
   }
 
+  if (!progConfigFile) {
+    return;
+  }
   try {
     const textContent = JSON.parse(progConfigFile);
     textContent.pgms.push({
@@ -44,46 +83,5 @@ export async function updateExistingConfig(
   } catch (err) {
     console.error("Failed to create configuration: ", err);
     return;
-  }
-}
-
-export async function createNewConfig(
-  workspaceFolderUri: URI,
-  programPath: string,
-) {
-  try {
-    await FileSystemProviderInstance.writeFile(
-      UriUtils.joinPath(
-        workspaceFolderUri,
-        PluginConfiguration.PROGRAM_FILE_PATH,
-      ),
-      JSON.stringify(
-        {
-          ...PluginConfiguration.DEFAULT_PROGRAM_FILE_CONTENT,
-          pgms: [
-            {
-              ...PluginConfiguration.DEFAULT_PROGRAM_FILE_CONTENT.pgms[0],
-              program: programPath,
-            },
-          ],
-        },
-        null,
-        2,
-      ),
-    );
-
-    await FileSystemProviderInstance.writeFile(
-      UriUtils.joinPath(
-        workspaceFolderUri,
-        PluginConfiguration.PROCESS_GROUP_FILE_PATH,
-      ),
-      JSON.stringify(
-        PluginConfiguration.DEFAULT_PROCESS_GROUP_FILE_CONTENT,
-        null,
-        2,
-      ),
-    );
-  } catch (err) {
-    console.error("Failed to create configuration: ", err);
   }
 }

--- a/packages/language/src/utils/uri.ts
+++ b/packages/language/src/utils/uri.ts
@@ -44,13 +44,6 @@ export namespace UriUtils {
     path: string;
     drive: string | null;
   } {
-    if (!UriUtils.isWindows) {
-      return {
-        path: path,
-        drive: null,
-      };
-    }
-
     // Check for leading slash before drive: /C:/ or /c:/
     if (/^\/[a-zA-Z]:\//.test(path)) {
       const drive = path.substring(1, 3); // Extract "C:" and lowercase

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -742,7 +742,7 @@ export class PluginConfigurationProvider {
   ) {
     if (this.programConfigs.has(programConfig.program)) {
       console.error(
-        `The following configuration entry already exists: ${programPath}`,
+        `The following configuration entry already exists: ${programConfig.program}`,
       );
       return;
     }

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -653,6 +653,22 @@ export class PluginConfigurationProvider {
     return diagnostics;
   }
 
+  public pushConfigProgram(workspacePath: string, programConfigPath: string) {
+    if (this.programConfigs.size === 0) {
+      return false;
+    }
+    this.programConfigs.set(programConfigPath, {
+      program: programConfigPath,
+      pgroup: "default",
+    });
+    this.setProgramConfigs(
+      workspacePath,
+      [...this.programConfigs.values()].map(deserializeProgramConfig),
+    );
+    return true;
+  }
+  // uma função só p pushar pra o negocio. a função em si é privada e a gente faz a checagem da config dentro dela
+
   /**
    * Returns the program config for the given program URI.
    * Lookup order:

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -726,10 +726,9 @@ export class PluginConfigurationProvider {
     textContent: PgmsConfig,
   ) {
     this.programConfigs.set(programConfig.program, programConfig);
-    this.setProgramConfigs(
-      workspacePath.path,
-      [...this.programConfigs.values()],
-    );
+    this.setProgramConfigs(workspacePath.path, [
+      ...this.programConfigs.values(),
+    ]);
     if (!textContent || !Array.isArray(textContent.pgms)) {
       console.error("Invalid configuration file format");
       return;

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -208,15 +208,12 @@ export function isLibsDir(entry: LibsEntry): entry is LibsDirEntry {
   return (entry as LibsDirEntry).dir !== undefined;
 }
 
-/**
- * Program Configuration types
- * ProgramEntry: Represents a single program entry in the program configuration file.
- * ProgramConfig: Represents the structure of the program configuration file.
- */
+/** ProgramEntry: Represents a single program entry in the program configuration file. */
 export type ProgramEntry = {
   program: string;
   pgroup: string;
 };
+/** ProgramConfig: Represents the structure of the program configuration file. */
 export type PgmsConfig = {
   pgms: ProgramEntry[];
 };
@@ -730,19 +727,22 @@ export class PluginConfigurationProvider {
   }
 
   /**
-   * Adds or updates a ProgramConfig in the internal map and persists
-   * the updated configuration set for the given workspace.
+   * Adds a program entry to the in-memory config and persists it to disk.
    *
    * @param workspacePath - Absolute path to the workspace.
-   * @param programConfig - The program configuration to add.
+   * @param programConfig - The program configuration to register.
+   * @param programPath - Path of the program to append to the config file.
+   * @param textContent - Parsed contents of the existing program config file.
    */
-
   public async addProgramConfig(
     workspacePath: URI,
     programConfig: ProgramConfig,
     programPath: string,
     textContent: PgmsConfig,
   ) {
+    if (this.programConfigs.has(programConfig.program)) {
+      return;
+    }
     this.programConfigs.set(programConfig.program, programConfig);
     this.setProgramConfigs(workspacePath.path, [
       ...this.programConfigs.values(),

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -208,12 +208,16 @@ export function isLibsDir(entry: LibsEntry): entry is LibsDirEntry {
   return (entry as LibsDirEntry).dir !== undefined;
 }
 
-type ProgramEntry = {
+/**
+ * Program Configuration types
+ * ProgramEntry: Represents a single program entry in the program configuration file.
+ * ProgramConfig: Represents the structure of the program configuration file.
+ */
+export type ProgramEntry = {
   program: string;
   pgroup: string;
 };
-
-type PgmsConfig = {
+export type PgmsConfig = {
   pgms: ProgramEntry[];
 };
 
@@ -367,9 +371,18 @@ export class PluginConfigurationProvider {
     console.warn("No program config found, clearing existing configurations.");
   }
 
+  /**
+   * Writes the process groups configuration file to the workspace.
+   *
+   * Uses the default process group content unless an override is provided.
+   * Throws if the file cannot be written, so callers can handle the failure
+   * appropriately.
+   *
+   * @param content - Process groups content to serialize and write.
+   */
   public async writeProcessGroupsFile(
     content = PluginConfiguration.DEFAULT_PROCESS_GROUP_FILE_CONTENT,
-  ) {
+  ): Promise<void> {
     const workspaceUri = URI.parse(this.getWorkspacePath());
     try {
       await FileSystemProviderInstance.writeFile(
@@ -380,9 +393,9 @@ export class PluginConfigurationProvider {
         JSON.stringify(content, null, 2),
       );
     } catch (err) {
-      return err;
+      console.error("Failed to write process groups file:", err);
+      throw err;
     }
-    return;
   }
 
   private static defaultProgramConfigContent(programPath: string) {
@@ -397,12 +410,21 @@ export class PluginConfigurationProvider {
     };
   }
 
+  /**
+   * Writes the program configuration file to the workspace.
+   *
+   * Uses a default content derived from the given program path unless an
+   * override is provided. Throws if the file cannot be written.
+   *
+   * @param programPath - Path of the program, used to generate default content.
+   * @param content - Configuration content to serialize and write.
+   */
   public async writeProgramConfigFile(
     programPath: string,
     content = PluginConfigurationProvider.defaultProgramConfigContent(
       programPath,
     ),
-  ) {
+  ): Promise<void> {
     const workspaceUri = URI.parse(this.getWorkspacePath());
     try {
       await FileSystemProviderInstance.writeFile(
@@ -410,9 +432,9 @@ export class PluginConfigurationProvider {
         JSON.stringify(content, null, 2),
       );
     } catch (err) {
-      return err;
+      console.error("Failed to write program config file:", err);
+      throw err;
     }
-    return;
   }
 
   /**
@@ -729,10 +751,6 @@ export class PluginConfigurationProvider {
     this.setProgramConfigs(workspacePath.path, [
       ...this.programConfigs.values(),
     ]);
-    if (!textContent || !Array.isArray(textContent.pgms)) {
-      console.error("Invalid configuration file format");
-      return;
-    }
     textContent.pgms.push({
       program: programPath,
       pgroup: "default",

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -20,6 +20,7 @@ import { isBoolean, isNumber, isStringArray } from "../utils/types";
 import { URI, UriUtils } from "../utils/uri";
 import { FileSystemProviderInstance } from "./file-system-provider";
 import { MAX_INSTRUCTION_COUNTER } from "../preprocessor/instruction-interpreter";
+import { PluginConfiguration } from "../language-server/constants";
 
 /**
  * Pli options are effectively macros to set w/ the given values
@@ -355,6 +356,54 @@ export class PluginConfigurationProvider {
     // clear otherwise, no valid program config to use
     this.programConfigs.clear();
     console.warn("No program config found, clearing existing configurations.");
+  }
+
+  public async writeProcessGroupsFile(
+    content = PluginConfiguration.DEFAULT_PROCESS_GROUP_FILE_CONTENT,
+  ) {
+    const workspaceUri = URI.parse(this.getWorkspacePath());
+    try {
+      await FileSystemProviderInstance.writeFile(
+        UriUtils.joinPath(
+          workspaceUri,
+          PluginConfiguration.PROCESS_GROUP_FILE_PATH,
+        ),
+        JSON.stringify(content, null, 2),
+      );
+    } catch (err) {
+      return err;
+    }
+    return;
+  }
+
+  private static defaultProgramConfigContent(programPath: string) {
+    return {
+      ...PluginConfiguration.DEFAULT_PROGRAM_FILE_CONTENT,
+      pgms: [
+        {
+          ...PluginConfiguration.DEFAULT_PROGRAM_FILE_CONTENT.pgms[0],
+          program: programPath,
+        },
+      ],
+    };
+  }
+
+  public async writeProgramConfigFile(
+    programPath: string,
+    content = PluginConfigurationProvider.defaultProgramConfigContent(
+      programPath,
+    ),
+  ) {
+    const workspaceUri = URI.parse(this.getWorkspacePath());
+    try {
+      await FileSystemProviderInstance.writeFile(
+        UriUtils.joinPath(workspaceUri, PluginConfiguration.PROGRAM_FILE_PATH),
+        JSON.stringify(content, null, 2),
+      );
+    } catch (err) {
+      return err;
+    }
+    return;
   }
 
   /**

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -662,7 +662,7 @@ export class PluginConfigurationProvider {
    * @returns `true` if the configuration was pushed successfully,
    *          `false` if no existing configurations are present.
    */
-  public pushConfigProgram(
+  public addProgramConfig(
     workspacePath: string,
     programConfig: ProgramConfig,
   ): boolean {

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -398,7 +398,7 @@ export class PluginConfigurationProvider {
     }
   }
 
-  private static defaultProgramConfigContent(programPath: string) {
+  public defaultProgramConfigContent(programPath: string): PgmsConfig {
     return {
       ...PluginConfiguration.DEFAULT_PROGRAM_FILE_CONTENT,
       pgms: [
@@ -413,17 +413,13 @@ export class PluginConfigurationProvider {
   /**
    * Writes the program configuration file to the workspace.
    *
-   * Uses a default content derived from the given program path unless an
-   * override is provided. Throws if the file cannot be written.
+   * Uses the provided content, or falls back to the default program config
+   * content if none is given. Throws if the file cannot be written.
    *
-   * @param programPath - Path of the program, used to generate default content.
    * @param content - Configuration content to serialize and write.
    */
   public async writeProgramConfigFile(
-    programPath: string,
-    content = PluginConfigurationProvider.defaultProgramConfigContent(
-      programPath,
-    ),
+    content: PgmsConfig = PluginConfiguration.DEFAULT_PROGRAM_FILE_CONTENT,
   ): Promise<void> {
     const workspaceUri = URI.parse(this.getWorkspacePath());
     try {
@@ -756,8 +752,6 @@ export class PluginConfigurationProvider {
       pgroup: "default",
     });
     await PluginConfigurationProviderInstance.writeProgramConfigFile(
-      UriUtils.joinPath(workspacePath, PluginConfiguration.PROGRAM_FILE_PATH)
-        .path,
       textContent,
     );
   }

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -653,21 +653,29 @@ export class PluginConfigurationProvider {
     return diagnostics;
   }
 
-  public pushConfigProgram(workspacePath: string, programConfigPath: string) {
+  /**
+   * Adds or updates a ProgramConfig in the internal map and persists
+   * the updated configuration set for the given workspace.
+   *
+   * @param workspacePath - Absolute path to the workspace.
+   * @param programConfig - The program configuration to add.
+   * @returns `true` if the configuration was pushed successfully,
+   *          `false` if no existing configurations are present.
+   */
+  public pushConfigProgram(
+    workspacePath: string,
+    programConfig: ProgramConfig,
+  ): boolean {
     if (this.programConfigs.size === 0) {
       return false;
     }
-    this.programConfigs.set(programConfigPath, {
-      program: programConfigPath,
-      pgroup: "default",
-    });
+    this.programConfigs.set(programConfig.program, programConfig);
     this.setProgramConfigs(
       workspacePath,
       [...this.programConfigs.values()].map(deserializeProgramConfig),
     );
     return true;
   }
-  // uma função só p pushar pra o negocio. a função em si é privada e a gente faz a checagem da config dentro dela
 
   /**
    * Returns the program config for the given program URI.

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -731,7 +731,6 @@ export class PluginConfigurationProvider {
    *
    * @param workspacePath - Absolute path to the workspace.
    * @param programConfig - The program configuration to register.
-   * @param programPath - Path of the program to append to the config file.
    * @param textContent - Parsed contents of the existing program config file.
    */
   public async addProgramConfig(

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -208,6 +208,15 @@ export function isLibsDir(entry: LibsEntry): entry is LibsDirEntry {
   return (entry as LibsDirEntry).dir !== undefined;
 }
 
+type ProgramEntry = {
+  program: string;
+  pgroup: string;
+};
+
+type PgmsConfig = {
+  pgms: ProgramEntry[];
+};
+
 /**
  * Plugin configuration provider for loading '.pliplugin/pgm_conf.json' and '.pliplugin/proc_grps.json' (when they exist),
  * processing their contents, and making those settings available to the language server.
@@ -708,22 +717,32 @@ export class PluginConfigurationProvider {
    *
    * @param workspacePath - Absolute path to the workspace.
    * @param programConfig - The program configuration to add.
-   * @returns `true` if the configuration was pushed successfully,
-   *          `false` if no existing configurations are present.
    */
-  public addProgramConfig(
-    workspacePath: string,
+
+  public async addProgramConfig(
+    workspacePath: URI,
     programConfig: ProgramConfig,
-  ): boolean {
-    if (this.programConfigs.size === 0) {
-      return false;
-    }
+    programPath: string,
+    textContent: PgmsConfig,
+  ) {
     this.programConfigs.set(programConfig.program, programConfig);
     this.setProgramConfigs(
-      workspacePath,
+      workspacePath.path,
       [...this.programConfigs.values()].map(deserializeProgramConfig),
     );
-    return true;
+    if (!textContent || !Array.isArray(textContent.pgms)) {
+      console.error("Invalid configuration file format");
+      return;
+    }
+    textContent.pgms.push({
+      program: programPath,
+      pgroup: "default",
+    });
+    await PluginConfigurationProviderInstance.writeProgramConfigFile(
+      UriUtils.joinPath(workspacePath, PluginConfiguration.PROGRAM_FILE_PATH)
+        .path,
+      textContent,
+    );
   }
 
   /**

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -741,6 +741,9 @@ export class PluginConfigurationProvider {
     textContent: PgmsConfig,
   ) {
     if (this.programConfigs.has(programConfig.program)) {
+      console.error(
+        `The following configuration entry already exists: ${programPath}`,
+      );
       return;
     }
     this.programConfigs.set(programConfig.program, programConfig);

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -728,7 +728,7 @@ export class PluginConfigurationProvider {
     this.programConfigs.set(programConfig.program, programConfig);
     this.setProgramConfigs(
       workspacePath.path,
-      [...this.programConfigs.values()].map(deserializeProgramConfig),
+      [...this.programConfigs.values()],
     );
     if (!textContent || !Array.isArray(textContent.pgms)) {
       console.error("Invalid configuration file format");

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -731,31 +731,22 @@ export class PluginConfigurationProvider {
    *
    * @param workspacePath - Absolute path to the workspace.
    * @param programConfig - The program configuration to register.
-   * @param textContent - Parsed contents of the existing program config file.
    */
   public async addProgramConfig(
     workspacePath: URI,
     programConfig: ProgramConfig,
-    textContent: PgmsConfig,
   ) {
     const existing = this.programConfigs.get(programConfig.program);
-    if (existing && existing.pgroup === programConfig.pgroup) {
+    if (existing) {
       console.error(
         `The following configuration entry already exists: ${existing}`,
       );
       return;
     }
-    this.programConfigs.set(programConfig.program, programConfig);
     this.setProgramConfigs(workspacePath.path, [
       ...this.programConfigs.values(),
+      programConfig,
     ]);
-    textContent.pgms.push({
-      program: programConfig.program,
-      pgroup: "default",
-    });
-    await PluginConfigurationProviderInstance.writeProgramConfigFile(
-      textContent,
-    );
   }
 
   /**

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -737,12 +737,12 @@ export class PluginConfigurationProvider {
   public async addProgramConfig(
     workspacePath: URI,
     programConfig: ProgramConfig,
-    programPath: string,
     textContent: PgmsConfig,
   ) {
-    if (this.programConfigs.has(programConfig.program)) {
+    const existing = this.programConfigs.get(programConfig.program);
+    if (existing && existing.pgroup === programConfig.pgroup) {
       console.error(
-        `The following configuration entry already exists: ${programConfig.program}`,
+        `The following configuration entry already exists: ${existing}`,
       );
       return;
     }
@@ -751,7 +751,7 @@ export class PluginConfigurationProvider {
       ...this.programConfigs.values(),
     ]);
     textContent.pgms.push({
-      program: programPath,
+      program: programConfig.program,
       pgroup: "default",
     });
     await PluginConfigurationProviderInstance.writeProgramConfigFile(

--- a/packages/language/test/lsp/apply-quick-fixes.test.ts
+++ b/packages/language/test/lsp/apply-quick-fixes.test.ts
@@ -146,7 +146,7 @@ describe("quickFixCreateConfig", () => {
     const result = await applyQuickFixes.quickFixCreateConfig(diagnostic);
 
     expect(result).toBeDefined();
-    expect(result!.title).toContain("Create an startup configuration ");
+    expect(result!.title).toContain("Create a startup configuration");
     expect(result!.kind).toBe("quickfix");
     expect(result!.command!.arguments![0]).toBe("foo.pli");
     expect(result!.command!.command).toBe(Commands.CREATE_CONFIG);
@@ -159,7 +159,7 @@ describe("quickFixCreateConfig", () => {
     const result = await applyQuickFixes.quickFixCreateConfig(diagnostic);
 
     expect(result).toBeDefined();
-    expect(result!.title).toContain("Create an startup configuration ");
+    expect(result!.title).toContain("Create a startup configuration");
     expect(result!.kind).toBe("quickfix");
     expect(result!.command!.arguments![0]).toBe("nested/foo.pli");
     expect(result!.command!.command).toBe(Commands.CREATE_CONFIG);
@@ -172,7 +172,7 @@ describe("quickFixCreateConfig", () => {
     const result = await applyQuickFixes.quickFixCreateConfig(diagnostic);
 
     expect(result).toBeDefined();
-    expect(result!.title).toContain("Create an startup configuration ");
+    expect(result!.title).toContain("Create a startup configuration");
     expect(result!.kind).toBe("quickfix");
     expect(result!.command!.arguments![0]).toBe(
       "/Users/mockUser/mockFolder/foo.pli",
@@ -187,7 +187,7 @@ describe("quickFixCreateConfig", () => {
     const result = await applyQuickFixes.quickFixCreateConfig(diagnostic);
 
     expect(result).toBeDefined();
-    expect(result!.title).toContain("Create an startup configuration ");
+    expect(result!.title).toContain("Create a startup configuration");
     expect(result!.kind).toBe("quickfix");
     expect(result!.command!.arguments![0]).toBe(
       "/Users/mockUser/mockFolder/foo.pli",
@@ -202,7 +202,7 @@ describe("quickFixCreateConfig", () => {
     const result = await applyQuickFixes.quickFixCreateConfig(diagnostic);
 
     expect(result).toBeDefined();
-    expect(result!.title).toContain("Create an startup configuration ");
+    expect(result!.title).toContain("Create a startup configuration");
     expect(result!.kind).toBe("quickfix");
     expect(result!.command!.arguments![0]).toBe(
       "C:/Users/mockUser/mockFolder/foo.pli",
@@ -217,7 +217,7 @@ describe("quickFixCreateConfig", () => {
     const result = await applyQuickFixes.quickFixCreateConfig(diagnostic);
 
     expect(result).toBeDefined();
-    expect(result!.title).toContain("Create an startup configuration ");
+    expect(result!.title).toContain("Create a startup configuration");
     expect(result!.kind).toBe("quickfix");
     expect(result!.command!.arguments![0]).toBe(
       "C:/Users/mockUser/mockFolder/foo.pli",
@@ -231,7 +231,7 @@ describe("quickFixCreateConfig", () => {
     const result = await applyQuickFixes.quickFixCreateConfig(diagnostic);
 
     expect(result).toBeDefined();
-    expect(result!.title).toContain("Create an startup configuration ");
+    expect(result!.title).toContain("Create a startup configuration");
     expect(result!.kind).toBe("quickfix");
     expect(result!.command!.arguments![0]).toBe(
       "C:/Users/mockUser/mockFolder/foo.pli",
@@ -281,7 +281,9 @@ describe("applyQuickFixes", () => {
 
     const result = await applyQuickFixes.applyQuickFixes(diagnostics);
     expect(result).toHaveLength(1);
-    expect(result![0].title).toContain("Create an startup configuration ");
+    expect(result![0].title).toContain(
+      "Create a startup configuration for this file.",
+    );
   });
 
   test("returns undefined when no recognized diagnostics", async () => {

--- a/packages/language/test/lsp/apply-quick-fixes.test.ts
+++ b/packages/language/test/lsp/apply-quick-fixes.test.ts
@@ -180,6 +180,36 @@ describe("quickFixCreateConfig", () => {
     expect(result!.command!.command).toBe(Commands.CREATE_CONFIG);
   });
 
+  test("returns valid CodeAction when absolute UNIX entryUri with file schema is provided", async () => {
+    const diagnostic = {
+      data: { entryUri: "file:///Users/mockUser/mockFolder/foo.pli" },
+    } as Diagnostic;
+    const result = await applyQuickFixes.quickFixCreateConfig(diagnostic);
+
+    expect(result).toBeDefined();
+    expect(result!.title).toContain("Create a plugin configuration ");
+    expect(result!.kind).toBe("quickfix");
+    expect(result!.command!.arguments![0]).toBe(
+      "/Users/mockUser/mockFolder/foo.pli",
+    );
+    expect(result!.command!.command).toBe(Commands.CREATE_CONFIG);
+  });
+
+  test("returns valid CodeAction when absolute Windows entryUri with schema provided already normalized", async () => {
+    const diagnostic = {
+      data: { entryUri: "file:///C:/Users/mockUser/mockFolder/foo.pli" },
+    } as Diagnostic;
+    const result = await applyQuickFixes.quickFixCreateConfig(diagnostic);
+
+    expect(result).toBeDefined();
+    expect(result!.title).toContain("Create a plugin configuration ");
+    expect(result!.kind).toBe("quickfix");
+    expect(result!.command!.arguments![0]).toBe(
+      "C:/Users/mockUser/mockFolder/foo.pli",
+    );
+    expect(result!.command!.command).toBe(Commands.CREATE_CONFIG);
+  });
+
   test("returns valid CodeAction when absolute Windows entryUri provided", async () => {
     const diagnostic = {
       data: { entryUri: "C:\\Users\\mockUser\\mockFolder\\foo.pli" },

--- a/packages/language/test/lsp/apply-quick-fixes.test.ts
+++ b/packages/language/test/lsp/apply-quick-fixes.test.ts
@@ -164,6 +164,50 @@ describe("quickFixCreateConfig", () => {
     expect(result!.command!.arguments![0]).toBe("nested/foo.pli");
     expect(result!.command!.command).toBe(Commands.CREATE_CONFIG);
   });
+
+  test("returns valid CodeAction when absolute UNIX entryUri provided", async () => {
+    const diagnostic = {
+      data: { entryUri: "/Users/mockUser/mockFolder/foo.pli" },
+    } as Diagnostic;
+    const result = await applyQuickFixes.quickFixCreateConfig(diagnostic);
+
+    expect(result).toBeDefined();
+    expect(result!.title).toContain("Create a plugin configuration ");
+    expect(result!.kind).toBe("quickfix");
+    expect(result!.command!.arguments![0]).toBe(
+      "/Users/mockUser/mockFolder/foo.pli",
+    );
+    expect(result!.command!.command).toBe(Commands.CREATE_CONFIG);
+  });
+
+  test("returns valid CodeAction when absolute Windows entryUri provided", async () => {
+    const diagnostic = {
+      data: { entryUri: "C:\\Users\\mockUser\\mockFolder\\foo.pli" },
+    } as Diagnostic;
+    const result = await applyQuickFixes.quickFixCreateConfig(diagnostic);
+
+    expect(result).toBeDefined();
+    expect(result!.title).toContain("Create a plugin configuration ");
+    expect(result!.kind).toBe("quickfix");
+    expect(result!.command!.arguments![0]).toBe(
+      "C:/Users/mockUser/mockFolder/foo.pli",
+    );
+    expect(result!.command!.command).toBe(Commands.CREATE_CONFIG);
+  });
+  test("returns valid CodeAction when absolute Windows entryUri provided already normalized", async () => {
+    const diagnostic = {
+      data: { entryUri: "C:/Users/mockUser/mockFolder/foo.pli" },
+    } as Diagnostic;
+    const result = await applyQuickFixes.quickFixCreateConfig(diagnostic);
+
+    expect(result).toBeDefined();
+    expect(result!.title).toContain("Create a plugin configuration ");
+    expect(result!.kind).toBe("quickfix");
+    expect(result!.command!.arguments![0]).toBe(
+      "C:/Users/mockUser/mockFolder/foo.pli",
+    );
+    expect(result!.command!.command).toBe(Commands.CREATE_CONFIG);
+  });
 });
 
 //

--- a/packages/language/test/lsp/apply-quick-fixes.test.ts
+++ b/packages/language/test/lsp/apply-quick-fixes.test.ts
@@ -148,6 +148,20 @@ describe("quickFixCreateConfig", () => {
     expect(result).toBeDefined();
     expect(result!.title).toContain("Create a plugin configuration folder");
     expect(result!.kind).toBe("quickfix");
+    expect(result!.command!.arguments![0]).toBe("foo.pli");
+    expect(result!.command!.command).toBe(Commands.CREATE_CONFIG);
+  });
+
+  test("returns valid CodeAction when nested entryUri provided", async () => {
+    const diagnostic = {
+      data: { entryUri: "/workspace/nested/foo.pli" },
+    } as Diagnostic;
+    const result = await applyQuickFixes.quickFixCreateConfig(diagnostic);
+
+    expect(result).toBeDefined();
+    expect(result!.title).toContain("Create a plugin configuration folder");
+    expect(result!.kind).toBe("quickfix");
+    expect(result!.command!.arguments![0]).toBe("nested/foo.pli");
     expect(result!.command!.command).toBe(Commands.CREATE_CONFIG);
   });
 });

--- a/packages/language/test/lsp/apply-quick-fixes.test.ts
+++ b/packages/language/test/lsp/apply-quick-fixes.test.ts
@@ -238,6 +238,21 @@ describe("quickFixCreateConfig", () => {
     );
     expect(result!.command!.command).toBe(Commands.CREATE_CONFIG);
   });
+  test("returns valid CodeAction when entryUri is outside (above) the workspace", async () => {
+    pluginConfig.setProgramConfigs("/Users/mockUser/workspace", [
+      { program: "main.pli", pgroup: "default" },
+    ]);
+    const diagnostic = {
+      data: { entryUri: "/Users/mockUser/foo.pli" },
+    } as Diagnostic;
+    const result = await applyQuickFixes.quickFixCreateConfig(diagnostic);
+
+    expect(result).toBeDefined();
+    expect(result!.title).toContain("Create a startup configuration");
+    expect(result!.kind).toBe("quickfix");
+    expect(result!.command!.arguments![0]).toBe("/Users/mockUser/foo.pli");
+    expect(result!.command!.command).toBe(Commands.CREATE_CONFIG);
+  });
 });
 
 //

--- a/packages/language/test/lsp/apply-quick-fixes.test.ts
+++ b/packages/language/test/lsp/apply-quick-fixes.test.ts
@@ -146,7 +146,7 @@ describe("quickFixCreateConfig", () => {
     const result = await applyQuickFixes.quickFixCreateConfig(diagnostic);
 
     expect(result).toBeDefined();
-    expect(result!.title).toContain("Create a plugin configuration ");
+    expect(result!.title).toContain("Create an startup configuration ");
     expect(result!.kind).toBe("quickfix");
     expect(result!.command!.arguments![0]).toBe("foo.pli");
     expect(result!.command!.command).toBe(Commands.CREATE_CONFIG);
@@ -159,7 +159,7 @@ describe("quickFixCreateConfig", () => {
     const result = await applyQuickFixes.quickFixCreateConfig(diagnostic);
 
     expect(result).toBeDefined();
-    expect(result!.title).toContain("Create a plugin configuration ");
+    expect(result!.title).toContain("Create an startup configuration ");
     expect(result!.kind).toBe("quickfix");
     expect(result!.command!.arguments![0]).toBe("nested/foo.pli");
     expect(result!.command!.command).toBe(Commands.CREATE_CONFIG);
@@ -172,7 +172,7 @@ describe("quickFixCreateConfig", () => {
     const result = await applyQuickFixes.quickFixCreateConfig(diagnostic);
 
     expect(result).toBeDefined();
-    expect(result!.title).toContain("Create a plugin configuration ");
+    expect(result!.title).toContain("Create an startup configuration ");
     expect(result!.kind).toBe("quickfix");
     expect(result!.command!.arguments![0]).toBe(
       "/Users/mockUser/mockFolder/foo.pli",
@@ -187,7 +187,7 @@ describe("quickFixCreateConfig", () => {
     const result = await applyQuickFixes.quickFixCreateConfig(diagnostic);
 
     expect(result).toBeDefined();
-    expect(result!.title).toContain("Create a plugin configuration ");
+    expect(result!.title).toContain("Create an startup configuration ");
     expect(result!.kind).toBe("quickfix");
     expect(result!.command!.arguments![0]).toBe(
       "/Users/mockUser/mockFolder/foo.pli",
@@ -202,7 +202,7 @@ describe("quickFixCreateConfig", () => {
     const result = await applyQuickFixes.quickFixCreateConfig(diagnostic);
 
     expect(result).toBeDefined();
-    expect(result!.title).toContain("Create a plugin configuration ");
+    expect(result!.title).toContain("Create an startup configuration ");
     expect(result!.kind).toBe("quickfix");
     expect(result!.command!.arguments![0]).toBe(
       "C:/Users/mockUser/mockFolder/foo.pli",
@@ -217,7 +217,7 @@ describe("quickFixCreateConfig", () => {
     const result = await applyQuickFixes.quickFixCreateConfig(diagnostic);
 
     expect(result).toBeDefined();
-    expect(result!.title).toContain("Create a plugin configuration ");
+    expect(result!.title).toContain("Create an startup configuration ");
     expect(result!.kind).toBe("quickfix");
     expect(result!.command!.arguments![0]).toBe(
       "C:/Users/mockUser/mockFolder/foo.pli",
@@ -231,7 +231,7 @@ describe("quickFixCreateConfig", () => {
     const result = await applyQuickFixes.quickFixCreateConfig(diagnostic);
 
     expect(result).toBeDefined();
-    expect(result!.title).toContain("Create a plugin configuration ");
+    expect(result!.title).toContain("Create an startup configuration ");
     expect(result!.kind).toBe("quickfix");
     expect(result!.command!.arguments![0]).toBe(
       "C:/Users/mockUser/mockFolder/foo.pli",
@@ -281,7 +281,7 @@ describe("applyQuickFixes", () => {
 
     const result = await applyQuickFixes.applyQuickFixes(diagnostics);
     expect(result).toHaveLength(1);
-    expect(result![0].title).toContain("Create a plugin configuration ");
+    expect(result![0].title).toContain("Create an startup configuration ");
   });
 
   test("returns undefined when no recognized diagnostics", async () => {

--- a/packages/language/test/lsp/apply-quick-fixes.test.ts
+++ b/packages/language/test/lsp/apply-quick-fixes.test.ts
@@ -146,7 +146,7 @@ describe("quickFixCreateConfig", () => {
     const result = await applyQuickFixes.quickFixCreateConfig(diagnostic);
 
     expect(result).toBeDefined();
-    expect(result!.title).toContain("Create a plugin configuration folder");
+    expect(result!.title).toContain("Create a plugin configuration ");
     expect(result!.kind).toBe("quickfix");
     expect(result!.command!.arguments![0]).toBe("foo.pli");
     expect(result!.command!.command).toBe(Commands.CREATE_CONFIG);
@@ -159,7 +159,7 @@ describe("quickFixCreateConfig", () => {
     const result = await applyQuickFixes.quickFixCreateConfig(diagnostic);
 
     expect(result).toBeDefined();
-    expect(result!.title).toContain("Create a plugin configuration folder");
+    expect(result!.title).toContain("Create a plugin configuration ");
     expect(result!.kind).toBe("quickfix");
     expect(result!.command!.arguments![0]).toBe("nested/foo.pli");
     expect(result!.command!.command).toBe(Commands.CREATE_CONFIG);
@@ -207,7 +207,7 @@ describe("applyQuickFixes", () => {
 
     const result = await applyQuickFixes.applyQuickFixes(diagnostics);
     expect(result).toHaveLength(1);
-    expect(result![0].title).toContain("Create a plugin configuration folder");
+    expect(result![0].title).toContain("Create a plugin configuration ");
   });
 
   test("returns undefined when no recognized diagnostics", async () => {

--- a/packages/language/test/lsp/command-create-config.test.ts
+++ b/packages/language/test/lsp/command-create-config.test.ts
@@ -11,16 +11,18 @@
 
 import { beforeEach, describe, expect, test } from "vitest";
 import {
-  URI,
+  FileSystemProviderInstance,
   VirtualFileSystemProvider,
   setFileSystemProvider,
-} from "../../src";
+} from "../../src/workspace/file-system-provider";
+
 import {
   PluginConfigurationProvider,
   setPluginConfigurationProvider,
 } from "../../src/workspace/plugin-configuration-provider";
 import { commandCreateConfig } from "../../src/language-server/commands";
 import { Commands } from "../../src/language-server/constants";
+import { URI } from "../../src/utils/uri";
 
 const WORKSPACE_PATH = "/workspace";
 const CONFIG_FILE_PATH = "/workspace/.pliplugin/pgm_conf.json";
@@ -44,14 +46,14 @@ describe("commandCreateConfig", () => {
     await vfs.writeFile(URI.parse(CONFIG_FILE_PATH), INITIAL_CONFIG);
     await pluginConfig.setProgramConfigs(WORKSPACE_PATH, [INITIAL_PROGRAM]);
 
-    const result = await commandCreateConfig(
-      {
-        command: Commands.CREATE_CONFIG,
-        arguments: ["b.pli"],
-      },
-      true,
-    );
+    await commandCreateConfig({
+      command: Commands.CREATE_CONFIG,
+      arguments: ["b.pli"],
+    });
 
+    const result = await FileSystemProviderInstance.readFile(
+      URI.parse(CONFIG_FILE_PATH),
+    );
     expect(result).toBeDefined();
     expect(JSON.parse(result!)).toEqual({
       pgms: [
@@ -64,14 +66,13 @@ describe("commandCreateConfig", () => {
       await vfs.writeFile(URI.parse(CONFIG_FILE_PATH), INITIAL_CONFIG);
       await pluginConfig.setProgramConfigs(WORKSPACE_PATH, [INITIAL_PROGRAM]);
 
-      const result = await commandCreateConfig(
-        {
-          command: Commands.CREATE_CONFIG,
-          arguments: ["nested/b.pli"],
-        },
-        true,
+      await commandCreateConfig({
+        command: Commands.CREATE_CONFIG,
+        arguments: ["nested/b.pli"],
+      });
+      const result = await FileSystemProviderInstance.readFile(
+        URI.parse(CONFIG_FILE_PATH),
       );
-
       expect(result).toBeDefined();
       expect(JSON.parse(result!)).toEqual({
         pgms: [
@@ -82,14 +83,14 @@ describe("commandCreateConfig", () => {
     }));
 
   test("creates a new config file when none exists", async () => {
-    const result = await commandCreateConfig(
-      {
-        command: Commands.CREATE_CONFIG,
-        arguments: ["a.pli"],
-      },
-      true,
-    );
+    await commandCreateConfig({
+      command: Commands.CREATE_CONFIG,
+      arguments: ["a.pli"],
+    });
 
+    const result = await FileSystemProviderInstance.readFile(
+      URI.parse(CONFIG_FILE_PATH),
+    );
     expect(result).toBeDefined();
     expect(JSON.parse(result!)).toEqual({
       pgms: [{ program: "a.pli", pgroup: "default" }],

--- a/packages/language/test/lsp/command-create-config.test.ts
+++ b/packages/language/test/lsp/command-create-config.test.ts
@@ -42,7 +42,7 @@ describe("commandCreateConfig", () => {
     await pluginConfig.init(WORKSPACE_PATH);
   });
 
-  (test("appends a new program to an existing config file", async () => {
+  test("appends a new program to an existing config file", async () => {
     await vfs.writeFile(URI.parse(CONFIG_FILE_PATH), INITIAL_CONFIG);
     await pluginConfig.setProgramConfigs(WORKSPACE_PATH, [INITIAL_PROGRAM]);
 
@@ -61,26 +61,26 @@ describe("commandCreateConfig", () => {
         { program: "b.pli", pgroup: "default" },
       ],
     });
-  }),
-    test("appends a new nested program to an existing config file", async () => {
-      await vfs.writeFile(URI.parse(CONFIG_FILE_PATH), INITIAL_CONFIG);
-      await pluginConfig.setProgramConfigs(WORKSPACE_PATH, [INITIAL_PROGRAM]);
+  });
+  test("appends a new nested program to an existing config file", async () => {
+    await vfs.writeFile(URI.parse(CONFIG_FILE_PATH), INITIAL_CONFIG);
+    await pluginConfig.setProgramConfigs(WORKSPACE_PATH, [INITIAL_PROGRAM]);
 
-      await commandCreateConfig({
-        command: Commands.CREATE_CONFIG,
-        arguments: ["nested/b.pli"],
-      });
-      const result = await FileSystemProviderInstance.readFile(
-        URI.parse(CONFIG_FILE_PATH),
-      );
-      expect(result).toBeDefined();
-      expect(JSON.parse(result!)).toEqual({
-        pgms: [
-          { program: "a.pli", pgroup: "default" },
-          { program: "nested/b.pli", pgroup: "default" },
-        ],
-      });
-    }));
+    await commandCreateConfig({
+      command: Commands.CREATE_CONFIG,
+      arguments: ["nested/b.pli"],
+    });
+    const result = await FileSystemProviderInstance.readFile(
+      URI.parse(CONFIG_FILE_PATH),
+    );
+    expect(result).toBeDefined();
+    expect(JSON.parse(result!)).toEqual({
+      pgms: [
+        { program: "a.pli", pgroup: "default" },
+        { program: "nested/b.pli", pgroup: "default" },
+      ],
+    });
+  });
 
   test("creates a new config file when none exists", async () => {
     await commandCreateConfig({

--- a/packages/language/test/lsp/command-create-config.test.ts
+++ b/packages/language/test/lsp/command-create-config.test.ts
@@ -82,19 +82,17 @@ describe("commandCreateConfig", () => {
     }));
 
   test("creates a new config file when none exists", async () => {
-      const result = await commandCreateConfig(
-        {
-          command: Commands.CREATE_CONFIG,
-          arguments: ["a.pli"],
-        },
-        true,
-      );
+    const result = await commandCreateConfig(
+      {
+        command: Commands.CREATE_CONFIG,
+        arguments: ["a.pli"],
+      },
+      true,
+    );
 
-      expect(result).toBeDefined();
-      expect(JSON.parse(JSON.parse(result!))).toEqual({
-        pgms: [
-          { program: "a.pli", pgroup: "default" }
-        ],
-      });
+    expect(result).toBeDefined();
+    expect(JSON.parse(JSON.parse(result!))).toEqual({
+      pgms: [{ program: "a.pli", pgroup: "default" }],
     });
+  });
 });

--- a/packages/language/test/lsp/command-create-config.test.ts
+++ b/packages/language/test/lsp/command-create-config.test.ts
@@ -81,7 +81,20 @@ describe("commandCreateConfig", () => {
       });
     }));
 
-  test.todo("creates a new config file when none exists");
-  test.todo("does nothing when program already exists in config");
-  test.todo("handles write errors gracefully");
+  test("creates a new config file when none exists", async () => {
+      const result = await commandCreateConfig(
+        {
+          command: Commands.CREATE_CONFIG,
+          arguments: ["a.pli"],
+        },
+        true,
+      );
+
+      expect(result).toBeDefined();
+      expect(JSON.parse(JSON.parse(result!))).toEqual({
+        pgms: [
+          { program: "a.pli", pgroup: "default" }
+        ],
+      });
+    });
 });

--- a/packages/language/test/lsp/command-create-config.test.ts
+++ b/packages/language/test/lsp/command-create-config.test.ts
@@ -53,7 +53,7 @@ describe("commandCreateConfig", () => {
     );
 
     expect(result).toBeDefined();
-    expect(JSON.parse(JSON.parse(result!))).toEqual({
+    expect(JSON.parse(result!)).toEqual({
       pgms: [
         { program: "a.pli", pgroup: "default" },
         { program: "b.pli", pgroup: "default" },
@@ -73,7 +73,7 @@ describe("commandCreateConfig", () => {
       );
 
       expect(result).toBeDefined();
-      expect(JSON.parse(JSON.parse(result!))).toEqual({
+      expect(JSON.parse(result!)).toEqual({
         pgms: [
           { program: "a.pli", pgroup: "default" },
           { program: "nested/b.pli", pgroup: "default" },
@@ -91,7 +91,7 @@ describe("commandCreateConfig", () => {
     );
 
     expect(result).toBeDefined();
-    expect(JSON.parse(JSON.parse(result!))).toEqual({
+    expect(JSON.parse(result!)).toEqual({
       pgms: [{ program: "a.pli", pgroup: "default" }],
     });
   });

--- a/packages/language/test/lsp/command-create-config.test.ts
+++ b/packages/language/test/lsp/command-create-config.test.ts
@@ -1,0 +1,87 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { beforeEach, describe, expect, test } from "vitest";
+import {
+  URI,
+  VirtualFileSystemProvider,
+  setFileSystemProvider,
+} from "../../src";
+import {
+  PluginConfigurationProvider,
+  setPluginConfigurationProvider,
+} from "../../src/workspace/plugin-configuration-provider";
+import { commandCreateConfig } from "../../src/language-server/commands";
+import { Commands } from "../../src/language-server/constants";
+
+const WORKSPACE_PATH = "/workspace";
+const CONFIG_FILE_PATH = "/workspace/.pliplugin/pgm_conf.json";
+
+const INITIAL_PROGRAM = { program: "a.pli", pgroup: "default" };
+const INITIAL_CONFIG = JSON.stringify({ pgms: [INITIAL_PROGRAM] }, null, 2);
+
+describe("commandCreateConfig", () => {
+  let vfs: VirtualFileSystemProvider;
+  let pluginConfig: PluginConfigurationProvider;
+
+  beforeEach(async () => {
+    vfs = new VirtualFileSystemProvider();
+    pluginConfig = new PluginConfigurationProvider();
+    setFileSystemProvider(vfs);
+    setPluginConfigurationProvider(pluginConfig);
+    await pluginConfig.init(WORKSPACE_PATH);
+  });
+
+  (test("appends a new program to an existing config file", async () => {
+    await vfs.writeFile(URI.parse(CONFIG_FILE_PATH), INITIAL_CONFIG);
+    await pluginConfig.setProgramConfigs(WORKSPACE_PATH, [INITIAL_PROGRAM]);
+
+    const result = await commandCreateConfig(
+      {
+        command: Commands.CREATE_CONFIG,
+        arguments: ["b.pli"],
+      },
+      true,
+    );
+
+    expect(result).toBeDefined();
+    expect(JSON.parse(JSON.parse(result!))).toEqual({
+      pgms: [
+        { program: "a.pli", pgroup: "default" },
+        { program: "b.pli", pgroup: "default" },
+      ],
+    });
+  }),
+    test("appends a new nested program to an existing config file", async () => {
+      await vfs.writeFile(URI.parse(CONFIG_FILE_PATH), INITIAL_CONFIG);
+      await pluginConfig.setProgramConfigs(WORKSPACE_PATH, [INITIAL_PROGRAM]);
+
+      const result = await commandCreateConfig(
+        {
+          command: Commands.CREATE_CONFIG,
+          arguments: ["nested/b.pli"],
+        },
+        true,
+      );
+
+      expect(result).toBeDefined();
+      expect(JSON.parse(JSON.parse(result!))).toEqual({
+        pgms: [
+          { program: "a.pli", pgroup: "default" },
+          { program: "nested/b.pli", pgroup: "default" },
+        ],
+      });
+    }));
+
+  test.todo("creates a new config file when none exists");
+  test.todo("does nothing when program already exists in config");
+  test.todo("handles write errors gracefully");
+});


### PR DESCRIPTION
Issue #570 , item 9.

**Problem:**
When creating a plugin folder via Quick Fix from a nested file, only the filename was added to the program field in the program configuration file. The intermediate folders between the workspace root and the target file were not included in the computed path. As a result, the generated program entry point was invalid, preventing the program from resolving correctly.

**Solution:**
This change ensures that the full relative path (from the workspace root to the target file) is properly computed and written to the program field, so the generated entry point resolves as expected.


**Follow up task** (already in progress):
A follow-up task will introduce support for creating additional program entries via Quick Fix. This will allow new entries to be added without overwriting or altering any existing program configuration, thereby preserving current setups.

**EDIT:**
The follow-up task has now also been incorporated into this PR. With this enhancement, we first check for any existing program configurations and, if present, append the new program configuration alongside the existing ones rather than replacing them.
This ensures that previously defined program entries are preserved while allowing additional configurations to be added seamlessly.