### PR TITLE
Improve the margins diagnostic message

### DIFF
--- a/code_samples/plugin-example/.pliplugin/pgm_conf.json
+++ b/code_samples/plugin-example/.pliplugin/pgm_conf.json
@@ -2,11 +2,7 @@
   "pgms": [
     {
       "program": "*.pli",
-      "pgroup": "default",
-      "pli-options": {
-        "SYSPARM": "'from program config'",
-        "SYSTEM": "MVS"
-      }
+      "pgroup": "default"
     }
   ]
 }

--- a/code_samples/plugin-example/.pliplugin/proc_grps.json
+++ b/code_samples/plugin-example/.pliplugin/proc_grps.json
@@ -6,11 +6,6 @@
         "AGGREGATE",
         "MARGINS(2,72)"
       ],
-      "pli-options": {
-        "SYSPARM": "'from process group'",
-        "SYSTEM": "MVS",
-        "MARGINS": "2,72"
-      },
       "member-name-validation": true,
       "libs": [
         "cpy"

--- a/packages/language/src/preprocessor/pli-margins-processor.ts
+++ b/packages/language/src/preprocessor/pli-margins-processor.ts
@@ -34,8 +34,12 @@ export interface MarginsProcessor {
  * Helper class to replace text margins with space characters (characters 2-72 are normal program text)
  */
 export class PliMarginsProcessor implements MarginsProcessor {
-  static readonly MARGIN_ERROR_MESSAGE_LEFT =
-    "PL/I statements must start from column 2 or as defined in MARGINS(M,N).";
+  static readonly MARGIN_ERROR_MESSAGE_LEFT = (m: number, n: number) => {
+    if (m === 2) {
+      return `PL/I statements must start from column 2.`;
+    }
+    return `PL/I statements must start from column ${m} as defined in MARGINS(${m},${n}).`;
+  };
   static readonly MARGIN_ERROR_MESSAGE_RIGHT = Warning.IBM1084I.message;
 
   issues: Diagnostic[] = [];
@@ -90,7 +94,10 @@ export class PliMarginsProcessor implements MarginsProcessor {
         diagnostic(
           Severity.W,
           side === "left"
-            ? PliMarginsProcessor.MARGIN_ERROR_MESSAGE_LEFT
+            ? PliMarginsProcessor.MARGIN_ERROR_MESSAGE_LEFT(
+                margins.start,
+                margins.end,
+              )
             : PliMarginsProcessor.MARGIN_ERROR_MESSAGE_RIGHT,
           { start, end },
           uri.toString(),

--- a/packages/language/test/fourslash/lexer/margins-error-left-margin-default.ts
+++ b/packages/language/test/fourslash/lexer/margins-error-left-margin-default.ts
@@ -36,5 +36,5 @@
 //// END RGT005;
 
 verify.expectExclusiveDiagnosticsAt(1, {
-  message: code.Lexer.Margins.ErrorLeft,
+  message: code.Lexer.Margins.ErrorLeft(2, 72),
 });

--- a/packages/language/test/fourslash/lexer/margins-error-left-margin-directive.ts
+++ b/packages/language/test/fourslash/lexer/margins-error-left-margin-directive.ts
@@ -36,8 +36,8 @@
 ////<|2: EN|>D RGT005;
 
 verify.expectExclusiveDiagnosticsAt(1, {
-  message: code.Lexer.Margins.ErrorLeft,
+  message: code.Lexer.Margins.ErrorLeft(4, 72),
 });
 verify.expectExclusiveDiagnosticsAt(2, {
-  message: code.Lexer.Margins.ErrorLeft,
+  message: code.Lexer.Margins.ErrorLeft(4, 72),
 });


### PR DESCRIPTION
Fixes (4) of https://github.com/zowe/zowe-pli-language-support/issues/596 providing a more precise diagnostic message for the left margins.

Also removes the now obsolete `pli-options` field from our example configurations.