### PR TITLE
[Bugfix] Windows absolute path programs match

### DIFF
--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -598,7 +598,7 @@ export class PluginConfigurationProvider {
   private resolveProgramPath(programPath: string, workspaceUri: URI): URI {
     const normalizedProgramPath = programPath.replace(/\\/g, "/");
     if (this.isAbsolutePath(normalizedProgramPath)) {
-      return URI.parse(normalizedProgramPath);
+      return URI.file(normalizedProgramPath);
     }
     return UriUtils.joinPath(workspaceUri, normalizedProgramPath);
   }

--- a/packages/language/test/lsp/get-prog-config.test.ts
+++ b/packages/language/test/lsp/get-prog-config.test.ts
@@ -28,7 +28,7 @@ async function setupConfig(
 describe("Check if `getProgramConfig` inside `PluginConfigurationProvider` retrieve proper values.", () => {
   (test("Matches workspace-relative program - most common use case", async () => {
     await setupConfig([{ program: "*.pli", pgroup: "default" }]);
-    const testUri = URI.parse("workspace/a.pli");
+    const testUri = URI.file("workspace/a.pli");
     const config =
       PluginConfigurationProviderInstance.getProgramConfig(testUri);
 
@@ -36,7 +36,7 @@ describe("Check if `getProgramConfig` inside `PluginConfigurationProvider` retri
   }),
     test("does NOT match absolute path outside workspace that isn't explicitely included as program", async () => {
       await setupConfig([{ program: "*.pli", pgroup: "default" }]);
-      const testUri = URI.parse("C:/Users/pgm/ext-pgm.pli");
+      const testUri = URI.file("C:/Users/pgm/ext-pgm.pli");
       const config =
         PluginConfigurationProviderInstance.getProgramConfig(testUri);
 
@@ -47,7 +47,7 @@ describe("Check if `getProgramConfig` inside `PluginConfigurationProvider` retri
         { program: "*.pli", pgroup: "default" },
         { program: "C:/Users/pgm/ext-pgm.pli", pgroup: "default" },
       ]);
-      const testUri = URI.parse("C:/Users/pgm/ext-pgm.pli");
+      const testUri = URI.file("C:/Users/pgm/ext-pgm.pli");
       const config =
         PluginConfigurationProviderInstance.getProgramConfig(testUri);
 
@@ -58,7 +58,7 @@ describe("Check if `getProgramConfig` inside `PluginConfigurationProvider` retri
         { program: "*.pli", pgroup: "default" },
         { program: "C:\\Users\\pgm\\ext-pgm.pli", pgroup: "default" },
       ]);
-      const testUri = URI.parse("C:/Users/pgm/ext-pgm.pli");
+      const testUri = URI.file("C:/Users/pgm/ext-pgm.pli");
       const config =
         PluginConfigurationProviderInstance.getProgramConfig(testUri);
 
@@ -69,7 +69,7 @@ describe("Check if `getProgramConfig` inside `PluginConfigurationProvider` retri
         { program: "*.pli", pgroup: "default" },
         { program: "/Users/pgm/ext-pgm.pli", pgroup: "default" },
       ]);
-      const testUri = URI.parse("/Users/pgm/ext-pgm.pli");
+      const testUri = URI.file("/Users/pgm/ext-pgm.pli");
       const config =
         PluginConfigurationProviderInstance.getProgramConfig(testUri);
 


### PR DESCRIPTION
This is a follow up on PR #569.

Absolute Windows paths added as program entry point were not being properly prefixed (missing `file:///`) and encoded (`:` after drive letter), which caused the match from such programs to fail.

This change standardize the path processing, so the matches should happen across different OSs without any complications.