### PR TITLE
Disable SQL syntax highlighting

### DIFF
--- a/scripts/generate-tmlanguage.mts
+++ b/scripts/generate-tmlanguage.mts
@@ -27,10 +27,15 @@ const controlKeywords: string[] = [];
 const storageKeywords: string[] = [];
 
 for (const [text, type] of tokens.keywordMap.entries()) {
+  const lowerText = text.toLowerCase();
+  if (lowerText === "sql") {
+    //HACK: we exclude SQL as a keyword, because then its highlighting will be handled the same as CICS
+    continue;
+  }
   if (tokens.controlTokens.has(type)) {
-    controlKeywords.push(text.toLowerCase());
+    controlKeywords.push(lowerText);
   } else {
-    storageKeywords.push(text.toLowerCase());
+    storageKeywords.push(lowerText);
   }
 }
 

--- a/scripts/generate-tmlanguage.mts
+++ b/scripts/generate-tmlanguage.mts
@@ -28,8 +28,9 @@ const storageKeywords: string[] = [];
 
 for (const [text, type] of tokens.keywordMap.entries()) {
   const lowerText = text.toLowerCase();
-  if (lowerText === "sql") {
-    //HACK: we exclude SQL as a keyword, because then its highlighting will be handled the same as CICS
+  if (type === tokens.SQL) {
+    //we exclude SQL as a keyword, because then its highlighting will be handled the same as CICS.
+    //(the EXEC rule in the `pli.manual.json` can be applied afterwards)
     continue;
   }
   if (tokens.controlTokens.has(type)) {


### PR DESCRIPTION
This fix disables SQL as keyword for the Textmate file. Then the EXEC rule in the `pli.manual.json` can be applied.

The result is that the entire SQL statement is red now. I know that the `DECLARE` line was requested as highlighted, but I cannot imagine a quick solution here at the moment.

<img width="442" height="143" alt="image" src="https://github.com/user-attachments/assets/dc24c3c0-efd9-4d4b-a7ed-2434c55c01af" />
