### PR TITLE
[Improvement] Absolute paths on Info Dialogue

### DIFF
--- a/packages/vscode-extension/src/common/missing-config-handler.ts
+++ b/packages/vscode-extension/src/common/missing-config-handler.ts
@@ -12,7 +12,7 @@
 import * as vscode from "vscode";
 import * as path from "node:path";
 import * as fs from "node:fs";
-import { PluginConfiguration } from "pli-language";
+import { PluginConfiguration, UriUtils } from "pli-language";
 
 let shouldShowInfoMessage = true;
 
@@ -37,10 +37,22 @@ export async function handleMissingConfig(
     return;
   }
 
-  const currentFileRelativePath = path.relative(
-    workspaceFolder,
-    textEditor.document.fileName,
+  // const currentFileRelativePath = path.relative(
+  //   workspaceFolder,
+  //   textEditor.document.fileName,
+  // );
+  const workspaceParts = UriUtils.parts(
+    UriUtils.toNormalizedKey(workspaceFolder),
   );
+  const entryParts = UriUtils.parts(
+    UriUtils.toNormalizedKey(textEditor.document.fileName),
+  );
+  const isInsideWorkspace = workspaceParts.every(
+    (part, index) => part === entryParts[index],
+  );
+  const currentFileRelativePath = isInsideWorkspace
+    ? entryParts.slice(workspaceParts.length).join("/")
+    : textEditor.document.fileName.replace(/\\/g, "/");
 
   const options = {
     DONT_SHOW_AGAIN: "Don't show again",

--- a/packages/vscode-extension/src/common/missing-config-handler.ts
+++ b/packages/vscode-extension/src/common/missing-config-handler.ts
@@ -37,10 +37,6 @@ export async function handleMissingConfig(
     return;
   }
 
-  // const currentFileRelativePath = path.relative(
-  //   workspaceFolder,
-  //   textEditor.document.fileName,
-  // );
   const workspaceParts = UriUtils.parts(
     UriUtils.toNormalizedKey(workspaceFolder),
   );


### PR DESCRIPTION
**Minor improvement** - When creating program entries from absolute paths outside the workspace via info dialogue, the fullpath is displayed on the program field.

So instead of `"../../../../../../../pli-ext-programs/remote-pgm.pli"`
we would display `"/Users/pli-ext-programs/remote-pgm.pli"`

This **does not** affect the performance of the extension. The current implementation works as expected and the program is processed the same way in both scenarios.

A suggested follow up task would be wrapping this modification into a helper and possibly replace the `.relative`, since it's used more than once throughout the codebase. 

There's no urgent character on this, nor on the potential follow up task.