### PR TITLE
Hide symbols from outline when not in open file

### DIFF
--- a/packages/language/src/language-server/document-symbol-builder.ts
+++ b/packages/language/src/language-server/document-symbol-builder.ts
@@ -116,7 +116,9 @@ class DeclareSymbolBuilder implements SymbolBuilder {
     for (const item of declareStatement.items.filter(
       (i: DeclaredItem) => i.kind === SyntaxKind.DeclaredItem,
     )) {
-      levelSymbols.push(...this.retrieveLevelSymbols(token.uri!, item, null, childSymbols));
+      levelSymbols.push(
+        ...this.retrieveLevelSymbols(token.uri!, item, null, childSymbols),
+      );
     }
 
     for (const levelSymbol of levelSymbols) {
@@ -172,7 +174,7 @@ class DeclareSymbolBuilder implements SymbolBuilder {
           continue;
         }
 
-        if(element.nameToken.uri?.toString() !== documentUri.toString()) {
+        if (element.nameToken.uri?.toString() !== documentUri.toString()) {
           continue;
         }
 

--- a/packages/language/src/language-server/document-symbol-builder.ts
+++ b/packages/language/src/language-server/document-symbol-builder.ts
@@ -117,7 +117,7 @@ class DeclareSymbolBuilder implements SymbolBuilder {
       (i: DeclaredItem) => i.kind === SyntaxKind.DeclaredItem,
     )) {
       levelSymbols.push(
-        ...this.retrieveLevelSymbols(token.uri!, item, null, childSymbols),
+        ...this.retrieveLevelSymbols(token.uri, item, null, childSymbols),
       );
     }
 
@@ -131,7 +131,7 @@ class DeclareSymbolBuilder implements SymbolBuilder {
   }
 
   private retrieveLevelSymbols(
-    documentUri: URI,
+    documentUri: URI | undefined,
     item: DeclaredItem,
     inheritedLevel: number | null,
     children: DocumentSymbol[],
@@ -174,7 +174,11 @@ class DeclareSymbolBuilder implements SymbolBuilder {
           continue;
         }
 
-        if (element.nameToken.uri?.toString() !== documentUri.toString()) {
+        if (
+          !documentUri ||
+          !element.nameToken.uri ||
+          element.nameToken.uri.toString() !== documentUri.toString()
+        ) {
           continue;
         }
 

--- a/packages/language/src/language-server/document-symbol-builder.ts
+++ b/packages/language/src/language-server/document-symbol-builder.ts
@@ -22,6 +22,7 @@ import { Range, getSyntaxNodeRange, DocumentSymbol } from "./types";
 import { CstNodeKind } from "../syntax-tree/cst";
 import { isValidToken } from "../linking/tokens";
 import { Token } from "../parser/tokens";
+import { URI } from "vscode-uri";
 
 interface LevelSymbol {
   level: number | null;
@@ -115,7 +116,7 @@ class DeclareSymbolBuilder implements SymbolBuilder {
     for (const item of declareStatement.items.filter(
       (i: DeclaredItem) => i.kind === SyntaxKind.DeclaredItem,
     )) {
-      levelSymbols.push(...this.retrieveLevelSymbols(item, null, childSymbols));
+      levelSymbols.push(...this.retrieveLevelSymbols(token.uri!, item, null, childSymbols));
     }
 
     for (const levelSymbol of levelSymbols) {
@@ -128,6 +129,7 @@ class DeclareSymbolBuilder implements SymbolBuilder {
   }
 
   private retrieveLevelSymbols(
+    documentUri: URI,
     item: DeclaredItem,
     inheritedLevel: number | null,
     children: DocumentSymbol[],
@@ -153,6 +155,7 @@ class DeclareSymbolBuilder implements SymbolBuilder {
         // e.g., 11 (XX, ZZ) char(10).
         levelSymbols.push(
           ...this.retrieveLevelSymbols(
+            documentUri,
             element,
             item.level ?? inheritedLevel,
             children,
@@ -166,6 +169,10 @@ class DeclareSymbolBuilder implements SymbolBuilder {
         const range = getSyntaxNodeRange(element);
 
         if (!element.name || !range) {
+          continue;
+        }
+
+        if(element.nameToken.uri?.toString() !== documentUri.toString()) {
           continue;
         }
 

--- a/packages/language/test/fourslash/linker/include-split-structure.ts
+++ b/packages/language/test/fourslash/linker/include-split-structure.ts
@@ -1,0 +1,33 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @filename: cpy/lib.pli
+////    3 cust CHAR(30),
+////    3 addr,
+////      5 <|street|> CHAR(20),
+////      5 zip CHAR(5);
+
+// @filename: main.pli
+//// DCL 1 person ALIGNED,
+//// %INCLUDE "lib.pli";
+//// PUT LIST (person.addr.<|street>street);
+
+preprocessor.expectTokens(`
+  DCL 1 person ALIGNED,
+        3 cust CHAR(30), 
+        3 addr,
+          5 street CHAR(20), 
+          5 zip CHAR(5); 
+  PUT LIST (person.addr.street);
+`);
+linker.expectLinks();


### PR DESCRIPTION
Included symbols were also shown. With this fix we suppress included declarations.

Be aware of that we are scanning all file tokens, so the preprocessor included stuff is not part of the tokens. The DeclareSymbolBuilder retrieves all declarations from the root declaration (via the AST). That is were we compare the nameToken URI with the document URI.