### PR TITLE
[Bugfix] Fix overwritten process configs.

### DIFF
--- a/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
+++ b/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
@@ -20,7 +20,7 @@ import {
 } from "vscode-languageserver-types";
 import {
   PluginConfigurationProviderInstance,
-  serializeProcessGroup,
+  ProcessGroup,
 } from "../../workspace/plugin-configuration-provider";
 
 import { Commands, PluginConfiguration } from "../constants";
@@ -54,32 +54,36 @@ export async function quickFixResolveInclude(
     PluginConfigurationProviderInstance.getWorkspacePath(),
   );
 
-  let parentFolder = UriUtils.computeWorkspaceRelativeParentFolder(
+  const parentFolder = UriUtils.computeWorkspaceRelativeParentFolder(
     unresolvedFilePath,
     workspaceFolderUri,
   );
   if (!parentFolder || procGrpsConfig.$computedLibsSet.has(parentFolder)) {
     return undefined;
   }
-
-  const serializedProcGrpsConfig = serializeProcessGroup(procGrpsConfig);
-  const newContent = JSON.stringify(
-    {
-      pgroups: [
-        {
-          ...serializedProcGrpsConfig,
-          libs: [...(serializedProcGrpsConfig.libs ?? []), parentFolder],
-        },
-      ],
-    },
-    undefined,
-    2,
-  );
-
   const procGrpsFileUri = UriUtils.joinPath(
     workspaceFolderUri,
     PluginConfiguration.PROCESS_GROUP_FILE_PATH,
   );
+  let newFileContent;
+  try {
+    const originalFileContent =
+      await FileSystemProviderInstance.readFile(procGrpsFileUri);
+    if (!originalFileContent) return;
+    newFileContent = JSON.parse(originalFileContent);
+    if (!newFileContent) return;
+  } catch (err) {
+    console.error("Error reading configuration file: ", err);
+    return;
+  }
+  const groupToUpdate = newFileContent.pgroups.find(
+    (g: ProcessGroup) => g.name === progConfig.pgroup,
+  );
+  if (!groupToUpdate) {
+    return;
+  }
+  groupToUpdate.libs.push(parentFolder);
+  const newContent = JSON.stringify(newFileContent, undefined, 2);
 
   const action: CodeAction = {
     title: `Add '${parentFolder}' to INCLUDE libs.`,

--- a/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
+++ b/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
@@ -69,11 +69,20 @@ export async function quickFixResolveInclude(
   try {
     const originalFileContent =
       await FileSystemProviderInstance.readFile(procGrpsFileUri);
-    if (!originalFileContent) return;
+    if (!originalFileContent) {
+      console.error("Missing 'proc_grps.json' file content.");
+      return;
+    }
     newFileContent = JSON.parse(originalFileContent);
-    if (!newFileContent) return;
+    if (!newFileContent.pgroups) {
+      console.error("Missing 'pgroups' property under 'proc_grps.json' file");
+      return;
+    }
   } catch (err) {
-    console.error("Error reading configuration file: ", err);
+    console.error(
+      "Error reading or parsing configuration 'proc_grps.json' file: ",
+      err,
+    );
     return;
   }
   const groupToUpdate = newFileContent.pgroups.find(

--- a/packages/language/test/lsp/apply-quick-fixes.test.ts
+++ b/packages/language/test/lsp/apply-quick-fixes.test.ts
@@ -9,7 +9,7 @@
  *
  */
 
-import { describe, test, expect, beforeEach, vi } from "vitest";
+import { describe, test, expect, beforeEach } from "vitest";
 import { Diagnostic } from "vscode-languageserver-types";
 import {
   VirtualFileSystemProvider,
@@ -43,6 +43,18 @@ beforeEach(async () => {
     "include-extensions": [".inc"],
     libs: [],
   });
+  await vfs.writeFile(
+    URI.parse("/workspace/.pliplugin/proc_grps.json"),
+    JSON.stringify({
+      pgroups: [
+        {
+          name: "default",
+          "include-extensions": [".inc"],
+          libs: [],
+        },
+      ],
+    }),
+  );
   await pluginConfig.init("/workspace");
   await pluginConfig.setProcessGroupConfigs([processGroup]);
   pluginConfig.setProgramConfigs("/workspace", [
@@ -110,18 +122,6 @@ describe("quickFixResolveInclude", () => {
 
   test("returns valid CodeAction when all conditions are met", async () => {
     await vfs.writeFile(URI.parse("/workspace/libs/missing.inc"), "");
-    vfs.readFile = vi.fn().mockResolvedValue(
-      JSON.stringify({
-        pgroups: [
-          {
-            name: "default",
-            libs: [],
-            "include-extensions": [".inc"],
-          },
-        ],
-      }),
-    );
-
     const diagnostic = {
       data: {
         unresolvedFile: "file:///missing.inc",
@@ -134,6 +134,59 @@ describe("quickFixResolveInclude", () => {
     expect(result!.kind).toBe("quickfix");
     expect(result!.title).toContain("Add");
     expect(result!.command!.command).toBe(Commands.RESOLVE_INCLUDE);
+  });
+
+  test("returns valid CodeAction when all conditions are met", async () => {
+    await vfs.writeFile(URI.parse("/workspace/nested/missing.inc"), "");
+    await vfs.writeFile(
+      URI.parse("/workspace/.pliplugin/proc_grps.json"),
+      JSON.stringify({
+        pgroups: [
+          {
+            name: "default",
+            "include-extensions": [".inc"],
+            libs: [],
+          },
+          {
+            name: "custom",
+            "include-extensions": [".inc"],
+            libs: [],
+          },
+        ],
+      }),
+    );
+    const diagnostic = {
+      data: {
+        unresolvedFile: "file:///workspace/nested/missing.inc",
+        entryUri: "file:///workspace/main.pli",
+      },
+    } as Diagnostic;
+    const result = await applyQuickFixes.quickFixResolveInclude(diagnostic);
+
+    expect(result).toBeDefined();
+    expect(result!.kind).toBe("quickfix");
+    expect(result!.title).toContain("Add");
+    expect(result!.command!.command).toBe(Commands.RESOLVE_INCLUDE);
+    expect(result!.command!.arguments![1]).toEqual(
+      JSON.stringify(
+        {
+          pgroups: [
+            {
+              name: "default",
+              "include-extensions": [".inc"],
+              libs: ["nested"],
+            },
+            {
+              name: "custom",
+              "include-extensions": [".inc"],
+              libs: [],
+            },
+          ],
+        },
+        undefined,
+        2,
+      ),
+    );
   });
 });
 
@@ -272,18 +325,6 @@ describe("applyQuickFixes", () => {
   test("returns code actions only for unresolved include (IBM3841I) diagnostics", async () => {
     await vfs.writeFile(URI.parse("/workspace/some/file1.inc"), "");
     await vfs.writeFile(URI.parse("/workspace/some/file2.inc"), "");
-    vfs.readFile = vi.fn().mockResolvedValue(
-      JSON.stringify({
-        pgroups: [
-          {
-            name: "default",
-            libs: [],
-            "include-extensions": [".inc"],
-          },
-        ],
-      }),
-    );
-
     const diagnostics = [
       {
         code: fullCode(PLICodes.Severe.IBM1848I),
@@ -333,18 +374,6 @@ describe("applyQuickFixes", () => {
 
   test("combines multiple quick fixes (include(IBM3841I) + config(LSPIR001) and a diagnostic with no quick fix.)", async () => {
     await vfs.writeFile(URI.parse("/workspace/libs/missing.inc"), "");
-    vfs.readFile = vi.fn().mockResolvedValue(
-      JSON.stringify({
-        pgroups: [
-          {
-            name: "default",
-            libs: [],
-            "include-extensions": [".inc"],
-          },
-        ],
-      }),
-    );
-
     const diagnostics = [
       {
         code: fullCode(PLICodes.Severe.IBM1848I),

--- a/packages/language/test/lsp/apply-quick-fixes.test.ts
+++ b/packages/language/test/lsp/apply-quick-fixes.test.ts
@@ -9,7 +9,7 @@
  *
  */
 
-import { describe, test, expect, beforeEach } from "vitest";
+import { describe, test, expect, beforeEach, vi } from "vitest";
 import { Diagnostic } from "vscode-languageserver-types";
 import {
   VirtualFileSystemProvider,
@@ -37,24 +37,14 @@ beforeEach(async () => {
   setFileSystemProvider(vfs);
   setPluginConfigurationProvider(pluginConfig);
 
-  await pluginConfig.init("/workspace");
-
   // Base config setup
   const processGroup = deserializeProcessGroup({
     name: "default",
     "include-extensions": [".inc"],
     libs: [],
   });
-
+  await pluginConfig.init("/workspace");
   await pluginConfig.setProcessGroupConfigs([processGroup]);
-  await vfs.writeFile(
-    URI.parse("/workspace/.pliplugin/proc_grps.json"),
-    JSON.stringify({
-    name: "default",
-    "include-extensions": [".inc"],
-    libs: [],
-  }),
-  );
   pluginConfig.setProgramConfigs("/workspace", [
     { program: "main.pli", pgroup: "default" },
   ]);
@@ -120,6 +110,17 @@ describe("quickFixResolveInclude", () => {
 
   test("returns valid CodeAction when all conditions are met", async () => {
     await vfs.writeFile(URI.parse("/workspace/libs/missing.inc"), "");
+    vfs.readFile = vi.fn().mockResolvedValue(
+      JSON.stringify({
+        pgroups: [
+          {
+            name: "default",
+            libs: [],
+            "include-extensions": [".inc"],
+          },
+        ],
+      }),
+    );
 
     const diagnostic = {
       data: {
@@ -271,6 +272,17 @@ describe("applyQuickFixes", () => {
   test("returns code actions only for unresolved include (IBM3841I) diagnostics", async () => {
     await vfs.writeFile(URI.parse("/workspace/some/file1.inc"), "");
     await vfs.writeFile(URI.parse("/workspace/some/file2.inc"), "");
+    vfs.readFile = vi.fn().mockResolvedValue(
+      JSON.stringify({
+        pgroups: [
+          {
+            name: "default",
+            libs: [],
+            "include-extensions": [".inc"],
+          },
+        ],
+      }),
+    );
 
     const diagnostics = [
       {
@@ -321,6 +333,17 @@ describe("applyQuickFixes", () => {
 
   test("combines multiple quick fixes (include(IBM3841I) + config(LSPIR001) and a diagnostic with no quick fix.)", async () => {
     await vfs.writeFile(URI.parse("/workspace/libs/missing.inc"), "");
+    vfs.readFile = vi.fn().mockResolvedValue(
+      JSON.stringify({
+        pgroups: [
+          {
+            name: "default",
+            libs: [],
+            "include-extensions": [".inc"],
+          },
+        ],
+      }),
+    );
 
     const diagnostics = [
       {

--- a/packages/language/test/lsp/apply-quick-fixes.test.ts
+++ b/packages/language/test/lsp/apply-quick-fixes.test.ts
@@ -136,7 +136,7 @@ describe("quickFixResolveInclude", () => {
     expect(result!.command!.command).toBe(Commands.RESOLVE_INCLUDE);
   });
 
-  test("returns valid CodeAction when all conditions are met", async () => {
+  test("returns valid CodeAction when all conditions are met and there are more than one pgroup entry", async () => {
     await vfs.writeFile(URI.parse("/workspace/nested/missing.inc"), "");
     await vfs.writeFile(
       URI.parse("/workspace/.pliplugin/proc_grps.json"),

--- a/packages/language/test/lsp/apply-quick-fixes.test.ts
+++ b/packages/language/test/lsp/apply-quick-fixes.test.ts
@@ -47,6 +47,14 @@ beforeEach(async () => {
   });
 
   await pluginConfig.setProcessGroupConfigs([processGroup]);
+  await vfs.writeFile(
+    URI.parse("/workspace/.pliplugin/proc_grps.json"),
+    JSON.stringify({
+    name: "default",
+    "include-extensions": [".inc"],
+    libs: [],
+  }),
+  );
   pluginConfig.setProgramConfigs("/workspace", [
     { program: "main.pli", pgroup: "default" },
   ]);


### PR DESCRIPTION
### Changes
- Reads and parses `proc_grps.json` from the workspace
- Updates the `libs` of the matching process group only, preserving all others
- Adds tests covering the happy path and multi-group scenarios