### PR TITLE
Allow up to 7 character for NOT and OR options

### DIFF
--- a/packages/language/src/preprocessor/compiler-options/codes.ts
+++ b/packages/language/src/preprocessor/compiler-options/codes.ts
@@ -702,8 +702,8 @@ export const CompilerOptionsCodes = {
     InvalidParameterLength: {
       code: "CONO01",
       severity: Severity.W,
-      message: (value: string) =>
-        `Expected a single character, but received '${value}'.`,
+      message: (value: number) =>
+        `Expected up to seven characters, but received ${value} characters.`,
     },
     InvalidParameterCharacter: {
       code: "CONO02",
@@ -754,8 +754,8 @@ export const CompilerOptionsCodes = {
     InvalidParameterLength: {
       code: "COOR01",
       severity: Severity.W,
-      message: (value: string) =>
-        `Expected a single character, but received '${value}'.`,
+      message: (value: number) =>
+        `Expected up to seven characters, but received ${value} characters.`,
     },
     InvalidParameterCharacter: {
       code: "COOR02",

--- a/packages/language/src/preprocessor/compiler-options/translator-pli.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator-pli.ts
@@ -1985,22 +1985,21 @@ translator.rule(["NOT"], (option, options) => {
   ensureArguments(option, 1, 1);
   const value = option.values[0];
   ensureType(value, "string");
-  if (value.value.length !== 1) {
+  if (value.value.length > 7) {
     throw diagnosticFromCode(
       CompilerOptionsCodes.Not.InvalidParameterLength,
       value.token,
-      value.value,
+      value.value.length,
     );
   }
-  if (
-    value.value !== NOT_CHARACTER &&
-    Options.PLI_CHARACTER_REGEX.test(value.value)
-  ) {
-    throw diagnosticFromCode(
-      CompilerOptionsCodes.Not.InvalidParameterCharacter,
-      value.token,
-      value.value,
-    );
+  for (const char of value.value) {
+    if (char !== NOT_CHARACTER && Options.PLI_CHARACTER_SET.has(char)) {
+      throw diagnosticFromCode(
+        CompilerOptionsCodes.Not.InvalidParameterCharacter,
+        value.token,
+        char,
+      );
+    }
   }
   options.not = value.value;
 });
@@ -2140,19 +2139,21 @@ translator.rule(["OR"], (option, options) => {
   ensureArguments(option, 1, 1);
   const value = option.values[0];
   ensureType(value, "string");
-  if (value.value.length !== 1) {
+  if (value.value.length > 7) {
     throw diagnosticFromCode(
       CompilerOptionsCodes.Or.InvalidParameterLength,
       value.token,
-      value.value,
+      value.value.length,
     );
   }
-  if (value.value !== "|" && Options.PLI_CHARACTER_REGEX.test(value.value)) {
-    throw diagnosticFromCode(
-      CompilerOptionsCodes.Or.InvalidParameterCharacter,
-      value.token,
-      value.value,
-    );
+  for (const char of value.value) {
+    if (char !== "|" && Options.PLI_CHARACTER_SET.has(char)) {
+      throw diagnosticFromCode(
+        CompilerOptionsCodes.Or.InvalidParameterCharacter,
+        value.token,
+        char,
+      );
+    }
   }
   options.or = value.value;
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/not/multiple-not-char.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/not/multiple-not-char.ts
@@ -1,0 +1,22 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @filename: main.pli
+////%process NOT("!~");
+//// MAIN: PROCEDURE OPTIONS(MAIN);
+////   DCL (A, B) BIT(1);
+////   A = 1 != B;
+////   B = A ~= B;
+//// END MAIN;
+
+verify.noParserDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/not.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/not.ts
@@ -15,10 +15,11 @@
 ////*PROCESS <|2:NOT|>;
 ////*PROCESS <|4:NOT|>(<|5:)|>;
 ////*PROCESS <|6:NOT|>(<|7:INVALID|>);
-////*PROCESS <|8:NOT|>(<|9:'##'|>);
+////*PROCESS <|8:NOT|>(<|9:'0123456789'|>);
 ////*PROCESS <|10:NOT|>(<|11:'z'|>);
 ////*PROCESS <|12:NOT|>(<|13:'¬'|>);
-////*PROCESS <|14:NOT|>('$');
+////*PROCESS <|14:NOT|>(<|15:'¬~'|>);
+////*PROCESS <|16:NOT|>(<|17:'$'|>);
 
 verify.expectDiagnosticsAt(2, {
   message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
@@ -33,12 +34,12 @@ verify.expectDiagnosticsAt(7, {
   message: code.CompilerOptions.ExpectedString.message(),
 });
 verify.expectDiagnosticsAt(9, {
-  message: code.CompilerOptions.Not.InvalidParameterLength.message("##"),
+  message: code.CompilerOptions.Not.InvalidParameterLength.message(10),
 });
 verify.expectDiagnosticsAt(11, {
   message: code.CompilerOptions.Not.InvalidParameterCharacter.message("z"),
 });
-verify.noDiagnostics(13);
+verify.noDiagnostics([13, 15, 17]);
 verify.expectCompilerOptions({
   not: "$",
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/or.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/or.ts
@@ -15,10 +15,11 @@
 ////*PROCESS <|2:OR|>;
 ////*PROCESS <|4:OR|>(<|5:)|>;
 ////*PROCESS <|6:OR|>(<|7:INVALID|>);
-////*PROCESS <|8:OR|>(<|9:'##'|>);
+////*PROCESS <|8:OR|>(<|9:'0123456789'|>);
 ////*PROCESS <|10:OR|>(<|11:'z'|>);
 ////*PROCESS <|12:OR|>(<|13:'|'|>);
-////*PROCESS <|14:OR|>('$');
+////*PROCESS <|14:OR|>(<|15:'|~'|>);
+////*PROCESS <|16:OR|>(<|17:'$'|>);
 
 verify.expectDiagnosticsAt(2, {
   message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
@@ -33,12 +34,12 @@ verify.expectDiagnosticsAt(7, {
   message: code.CompilerOptions.ExpectedString.message(),
 });
 verify.expectDiagnosticsAt(9, {
-  message: code.CompilerOptions.Or.InvalidParameterLength.message("##"),
+  message: code.CompilerOptions.Or.InvalidParameterLength.message(10),
 });
 verify.expectDiagnosticsAt(11, {
   message: code.CompilerOptions.Or.InvalidParameterCharacter.message("z"),
 });
-verify.noDiagnostics(13);
+verify.noDiagnostics([13, 15, 17]);
 verify.expectCompilerOptions({
   or: "$",
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/or/multiple-or-char.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/or/multiple-or-char.ts
@@ -1,0 +1,22 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @filename: main.pli
+////%process OR("|~");
+//// MAIN: PROCEDURE OPTIONS(MAIN);
+////   DCL (A, B) CHAR(10);
+////   A = "X" | B;
+////   B = A ~ B;
+//// END MAIN;
+
+verify.noParserDiagnostics();


### PR DESCRIPTION
Closes https://github.com/zowe/zowe-pli-language-support/issues/624

We previously assumed that only a single character was allowed for the `NOT` and `OR` options. However, the programming guide indicates that up to 7 characters are fine for both of them. This simply updates our compiler options parsing code to accept up 7 characters.