### PR TITLE
Fix missing parser errors on EOF

### DIFF
--- a/packages/language/src/parser/parser-types.ts
+++ b/packages/language/src/parser/parser-types.ts
@@ -140,14 +140,8 @@ export function orRule<T, Args extends any[]>(
 
 export function rule<T, Args extends any[]>(
   set: FirstSet | (() => RuleMap<any>),
-  originalAction: Rule<T, Args>,
+  action: Rule<T, Args>,
 ): RuleFirstPair<T, Args> {
-  const action = (state: ParserState, ...args: Args) => {
-    if (state.eof) {
-      return null;
-    }
-    return originalAction(state, ...args);
-  };
   if (typeof set === "function") {
     return {
       first: memoize(() => {

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -504,11 +504,6 @@ const procedureStatement = rule(
       const stmt = statement.rule(state);
       stmt && element.statements.push(stmt);
     }
-    state.tryConsume(
-      element,
-      CstNodeKind.ProcedureStatement_PROCEDURE_END,
-      tokens.PROCEDURE,
-    );
     element.end = endStatement.rule(state);
     return element;
   },

--- a/packages/language/test/parsing.test.ts
+++ b/packages/language/test/parsing.test.ts
@@ -10,28 +10,13 @@
  */
 
 import { describe, expect, test } from "vitest";
-import * as tokens from "../src/parser/tokens";
 import {
   assertNoParseErrors,
   generateAndAssertValidSymbolTable,
   parse,
   parseStmts,
 } from "./utils";
-import { PreprocessorTokens } from "../src/preprocessor/pli-preprocessor-tokens";
-import { Lexer } from "chevrotain";
-
-test("PL/I tokens are all using sticky regex", async () => {
-  for (const token of tokens.all) {
-    if (token.PATTERN instanceof RegExp && token.PATTERN !== Lexer.NA) {
-      expect(token.PATTERN.sticky).toBe(true);
-    }
-  }
-  for (const token of Object.values(PreprocessorTokens)) {
-    if (token.PATTERN instanceof RegExp && token.PATTERN !== Lexer.NA) {
-      expect(token.PATTERN.sticky).toBe(true);
-    }
-  }
-});
+import { DiagnosticCategory } from "../src/validation/diagnostics-store";
 
 describe("PL/I Parsing tests", () => {
   test("empty program parses as valid", async () => {
@@ -958,5 +943,14 @@ describe("PL/I Parsing tests", () => {
     `);
     assertNoParseErrors(doc);
     generateAndAssertValidSymbolTable(doc);
+  });
+
+  test("Expect error on EOF", async () => {
+    const doc = await parse(" MAIN: PROC OPTIONS(MAIN);");
+    const diagnostics = doc.diagnostics.get(DiagnosticCategory.Parser);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toContain(
+      'Expected token "END", but received end of file instead.',
+    );
   });
 });


### PR DESCRIPTION
I noticed during manual testing that we seem to swallow up errors in case we trigger a rule call on EOF. Instead, we should've entered the rule and run into a parser error.

This change simply adjusts the behavior and adds a test for this. It also removes a few old tests that were no longer relevant.