### PR TITLE
Fix false positive on 1213I diagnostic

### DIFF
--- a/packages/language/src/linking/error.ts
+++ b/packages/language/src/linking/error.ts
@@ -125,15 +125,6 @@ export class LinkerErrorReporter {
   }
 
   /**
-   * W IBM1213I
-   */
-  reportUnreferencedSymbol(token: Token) {
-    this.accept(
-      diagnosticFromCode(PLICodes.Warning.IBM1213I, token, token.image),
-    );
-  }
-
-  /**
    * S IBM1881I
    */
   reportAmbiguousReference(

--- a/packages/language/src/validation/compiler/IBM1213I-unreferenced-procedure.ts
+++ b/packages/language/src/validation/compiler/IBM1213I-unreferenced-procedure.ts
@@ -1,0 +1,54 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { diagnosticFromCode } from "../../language-server/types";
+import * as ast from "../../syntax-tree/ast";
+import { CompilationUnit } from "../../workspace/compilation-unit";
+import { PLICodes } from "../pli-codes";
+import { ValidationAcceptor } from "../validator";
+
+export function IBM1213I_unreferenced_procedure(
+  node: ast.ProcedureStatement,
+  acceptor: ValidationAcceptor,
+  compilationUnit: CompilationUnit,
+) {
+  const container = node.container;
+  if (container?.kind !== ast.SyntaxKind.Statement) {
+    return;
+  }
+  // Check if the procedure is part of a different procedure
+  // This indicates that the procedure is not externally visible
+  const parentProc = ast.getContainer(
+    container,
+    ast.SyntaxKind.ProcedureStatement,
+  );
+  if (!parentProc) {
+    // If none exists, we can safely assume this is an external procedure
+    return;
+  }
+  const labels = container.labels;
+  const label = labels[0];
+  if (!label || !label.nameToken || !label.name) {
+    return;
+  }
+  for (const label of labels) {
+    const references = compilationUnit.referencesCache.findReferences(label);
+    for (const ref of references) {
+      if (ref.owner.container?.kind !== ast.SyntaxKind.EndStatement) {
+        // The label is referenced somewhere, so we don't generate a warning
+        return;
+      }
+    }
+  }
+  acceptor(
+    diagnosticFromCode(PLICodes.Warning.IBM1213I, label.nameToken, label.name),
+  );
+}

--- a/packages/language/src/validation/pli-validator.ts
+++ b/packages/language/src/validation/pli-validator.ts
@@ -25,6 +25,7 @@ import {
   DeprecateStatements,
   DeprecateVariables,
 } from "./compiler/IBM2444Iff-deprecate";
+import { IBM1213I_unreferenced_procedure } from "./compiler/IBM1213I-unreferenced-procedure";
 
 /**
  * A function that accepts a diagnostic for PL/I validation
@@ -49,6 +50,7 @@ export function registerPliValidationChecks(): ValidationChecks {
     ProcedureStatement: [
       IBM1388IE_NODESCRIPTOR_attribute_is_invalid_when_any_parameter_has_NONCONNECTED_attribute,
       IBM2412I_IBM2410I_IBM2409I_handle_return_stmt_and_returns_att,
+      IBM1213I_unreferenced_procedure,
     ],
     ReferenceItem: [checkImplicitBuiltins],
     SelectStatement: [IBM1059I_select_without_otherwise],

--- a/packages/language/src/validation/validator.ts
+++ b/packages/language/src/validation/validator.ts
@@ -16,7 +16,6 @@ import { isValidToken } from "../linking/tokens";
 import { SyntaxKind, SyntaxNode } from "../syntax-tree/ast";
 import { forEachNode } from "../syntax-tree/ast-iterator";
 import { registerPliValidationChecks } from "./pli-validator";
-import { isMainProcedure, labelPrefixPointsToPackage } from "./utils";
 import { ScopeCache, ScopeCacheGroups } from "../linking/scope";
 import { LinkerErrorReporter } from "../linking/error";
 import { registerPreprocessorValidationChecks } from "./pp-validator";
@@ -129,41 +128,6 @@ export function linkingErrorsToDiagnostics(
     if (reference.node === null && isValidToken(reference.token)) {
       // Question: is reference.text and token.image the same?
       reporter.reportCannotFindSymbol(reference.token, reference.text);
-    }
-  }
-
-  // Warn if a label is never referenced
-  for (const scope of scopeCaches.regular.values()) {
-    nodeLoop: for (const node of scope.symbolTable.nodeLookup.keys()) {
-      if (node.kind !== SyntaxKind.LabelPrefix) {
-        continue;
-      }
-
-      // If the node has no name token, we can't even create a diagnostic, skip it
-      if (!node.nameToken) {
-        continue;
-      }
-
-      // If the label prefix points to a package, don't warn
-      if (labelPrefixPointsToPackage(node)) {
-        continue;
-      }
-
-      // The main procedure is never directly referenced anyway, so we don't need to warn
-      if (isMainProcedure(node)) {
-        continue;
-      }
-
-      // Ignore all `END` nodes, since a procedure will always have one `END` node referencing itself
-      const nodeReferences = references.findReferences(node);
-      for (const reference of nodeReferences) {
-        if (reference.owner.container?.kind !== SyntaxKind.EndStatement) {
-          // The label is referenced, so we don't generate a warning
-          continue nodeLoop;
-        }
-      }
-
-      reporter.reportUnreferencedSymbol(node.nameToken);
     }
   }
 }

--- a/packages/language/test/fourslash/linker/procedure-label-not-referenced.ts
+++ b/packages/language/test/fourslash/linker/procedure-label-not-referenced.ts
@@ -11,10 +11,12 @@
 
 /// <reference path="../framework.ts" />
 
-//// <|name2|>: procedure;
-//// end <|name2>name2;
-//// <|name1|>: procedure;
-//// end;
+//// MAIN: PROCEDURE OPTIONS(MAIN);
+////   <|name2|>: procedure;
+////   end <|name2>name2;
+////   <|name1|>: procedure;
+////   end;
+//// END;
 
 linker.expectLinks();
 verify.expectErrorCodesAt("name2", code.Warning.IBM1213I);

--- a/packages/language/test/validating.test.ts
+++ b/packages/language/test/validating.test.ts
@@ -109,8 +109,7 @@ describe("Validating", () => {
     });
   });
 
-  // TODO @montymxb Mar. 28th, 2025: Pending a fix to linking + scoping
-  test.fails("validates ordinal reference", async () => {
+  test("validates ordinal reference", async () => {
     const doc = await parseWithValidations(`
         define ordinal day (
             Monday,


### PR DESCRIPTION
Closes https://github.com/zowe/zowe-pli-language-support/issues/621

The `IBM1213I` warning is only supposed to trigger when the procedure is not externally visible (meaning that it is hidden inside of another procedure).

This change fixes the false positive experienced in the issue and adjusts the feature to work like the compiler does. Also moves the validation code from the linking to the validation phase.