### PR TITLE
Fix pp parser for declare statements

### DIFF
--- a/packages/language/src/parser/preprocessor-parser.ts
+++ b/packages/language/src/parser/preprocessor-parser.ts
@@ -1456,38 +1456,29 @@ function replaceStatement(state: ParserState): ast.ReplaceStatement {
 
 function declareStatement(state: ParserState): ast.DeclareStatement {
   const statement = ast.createDeclareStatement();
-  // Only one declared item is allowed in a preprocessor declare statement
-  const declaredItem = ast.createDeclaredItem();
-  statement.items.push(declaredItem);
   state.consume(statement, CstNodeKind.DeclareStatement_DECLARE, t.DECLARE);
   do {
-    if (
-      state.tryConsume(
-        declaredItem,
-        CstNodeKind.DeclaredItem_OpenParen,
-        t.OpenParen,
-      )
-    ) {
-      do {
-        declaredItem.elements.push(declaredVariable(state));
-      } while (
-        state.tryConsume(declaredItem, CstNodeKind.DeclaredItem_Comma, t.Comma)
-      );
-      state.consume(
-        declaredItem,
-        CstNodeKind.DeclaredItem_CloseParen,
-        t.CloseParen,
-      );
-    } else {
-      declaredItem.elements.push(declaredVariable(state));
-    }
-    const attrs = attributes(state);
-    declaredItem.attributes = attrs;
+    statement.items.push(declaredItem(state));
   } while (
     state.tryConsume(statement, CstNodeKind.DeclareStatement_Comma, t.Comma)
   );
   state.consume(statement, CstNodeKind.DeclareStatement_Semicolon, t.Semicolon);
   return statement;
+}
+
+function declaredItem(state: ParserState): ast.DeclaredItem {
+  const item = ast.createDeclaredItem();
+  if (state.tryConsume(item, CstNodeKind.DeclaredItem_OpenParen, t.OpenParen)) {
+    do {
+      item.elements.push(declaredItem(state));
+    } while (state.tryConsume(item, CstNodeKind.DeclaredItem_Comma, t.Comma));
+    state.consume(item, CstNodeKind.DeclaredItem_CloseParen, t.CloseParen);
+  } else {
+    item.elements.push(declaredVariable(state));
+  }
+  const attrs = attributes(state);
+  item.attributes = attrs;
+  return item;
 }
 
 function declaredVariable(state: ParserState): ast.DeclaredVariable {

--- a/packages/language/test/fourslash/preprocessor/declare-multiple-vars-parenthesis.ts
+++ b/packages/language/test/fourslash/preprocessor/declare-multiple-vars-parenthesis.ts
@@ -1,0 +1,17 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+//// %DCL (A INIT("X"), B INIT("Y"), C INIT("Z"));
+//// A B C
+
+preprocessor.expectTokens("X Y Z");

--- a/packages/language/test/fourslash/preprocessor/declare-multiple-vars.ts
+++ b/packages/language/test/fourslash/preprocessor/declare-multiple-vars.ts
@@ -1,0 +1,17 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+//// %DCL A INIT("X"), B INIT("Y"), C INIT("Z");
+//// A B C
+
+preprocessor.expectTokens("X Y Z");


### PR DESCRIPTION
Closes https://github.com/zowe/zowe-pli-language-support/issues/623

Fixes our parser implementation for the various style of declare statements. The interpreter already works as expected, so no modification was required in there.