### PR TITLE
Fix ambiguity quick fix action

### DIFF
--- a/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
+++ b/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
@@ -178,7 +178,11 @@ export function quickFixUppercaseText(
 }
 
 export type AmbiguousReferenceData = {
-  symbols: string[][];
+  symbols: {
+    nameChain: string[];
+    /** hide this option, when the symbol is not from the same structure */
+    visible: boolean;
+  }[];
   uri: string;
 };
 
@@ -187,25 +191,26 @@ export function quickFixResolveAmbiguousReference(
 ): CodeAction[] {
   const { symbols, uri } = diagnostic.data as AmbiguousReferenceData;
   let current = symbols.map(
-    (sym) => [sym.slice(0, -1), sym[sym.length - 1]] as const,
+    (sym) => [sym.visible, sym.nameChain.slice(0, -1), sym.nameChain[sym.nameChain.length - 1]] as const,
   );
   const names = new Set<string>();
   do {
     names.clear();
-    for (const [, name] of current) {
+    for (const [, , name] of current) {
       names.add(name);
     }
     if (
       names.size === current.length ||
-      current.every(([parent]) => parent.length === 0)
+      current.every(([, parent]) => parent.length === 0)
     ) {
       break;
     }
-    current = current.map(([parent, name]) => {
+    current = current.map(([visible, parent, name]) => {
       if (parent.length === 0) {
-        return [[], name] as const;
+        return [visible, [], name] as const;
       }
       return [
+        visible,
         parent.slice(0, -1),
         `${parent[parent.length - 1]}.${name}`,
       ] as const;
@@ -221,9 +226,9 @@ export function quickFixResolveAmbiguousReference(
     const isSuffixOf = (suffix: string, str: string) =>
       str.endsWith("." + suffix) || str === suffix;
     const whereNameIsNotASuffix = (name: string, index: number): boolean =>
-      !current.some(([_, n], i) => i !== index && isSuffixOf(name, n));
-    for (const [, fullName] of current.filter(([, name], index) =>
-      whereNameIsNotASuffix(name, index),
+      !current.some(([_, __, n], i) => i !== index && isSuffixOf(name, n));
+    for (const [, , fullName] of current.filter(([visible, , name], index) =>
+      whereNameIsNotASuffix(name, index) && visible
     )) {
       const action: CodeAction = {
         title: `Change to "${fullName}"`,

--- a/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
+++ b/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
@@ -186,34 +186,46 @@ export type AmbiguousReferenceData = {
   uri: string;
 };
 
+type ReferenceData = {
+  visible: boolean;
+  parentsLeft: string[];
+  replaceText: string;
+};
+
 export function quickFixResolveAmbiguousReference(
   diagnostic: Diagnostic,
 ): CodeAction[] {
   const { symbols, uri } = diagnostic.data as AmbiguousReferenceData;
-  let current = symbols.map(
-    (sym) => [sym.visible, sym.nameChain.slice(0, -1), sym.nameChain[sym.nameChain.length - 1]] as const,
+  let current: ReferenceData[] = symbols.map(
+    (sym) => ({
+      visible: sym.visible,
+      parentsLeft: sym.nameChain.slice(0, -1),
+      replaceText: sym.nameChain[sym.nameChain.length - 1],
+    }),
   );
   const names = new Set<string>();
   do {
     names.clear();
-    for (const [, , name] of current) {
-      names.add(name);
+    for (const { replaceText } of current) {
+      names.add(replaceText);
     }
     if (
       names.size === current.length ||
-      current.every(([, parent]) => parent.length === 0)
+      current.every(({ parentsLeft }) => parentsLeft.length === 0)
     ) {
       break;
     }
-    current = current.map(([visible, parent, name]) => {
-      if (parent.length === 0) {
-        return [visible, [], name] as const;
+    current = current.map(({ visible, parentsLeft, replaceText }) => {
+      if (parentsLeft.length === 0) {
+        return { visible, parentsLeft: [], replaceText } as const;
       }
-      return [
+      const parent = parentsLeft.slice(0, -1);
+      const name = replaceText;
+      return {
         visible,
-        parent.slice(0, -1),
-        `${parent[parent.length - 1]}.${name}`,
-      ] as const;
+        parentsLeft: parent,
+        replaceText: `${parentsLeft[parentsLeft.length - 1]}.${name}`,
+      } as const;
     });
   } while (true);
   if (names.size !== current.length) {
@@ -226,17 +238,17 @@ export function quickFixResolveAmbiguousReference(
     const isSuffixOf = (suffix: string, str: string) =>
       str.endsWith("." + suffix) || str === suffix;
     const whereNameIsNotASuffix = (name: string, index: number): boolean =>
-      !current.some(([_, __, n], i) => i !== index && isSuffixOf(name, n));
-    for (const [, , fullName] of current.filter(([visible, , name], index) =>
-      whereNameIsNotASuffix(name, index) && visible
+      !current.some(({ replaceText }, i) => i !== index && isSuffixOf(name, replaceText));
+    for (const { replaceText } of current.filter(({ visible, replaceText }, index) =>
+      whereNameIsNotASuffix(replaceText, index) && visible
     )) {
       const action: CodeAction = {
-        title: `Change to "${fullName}"`,
+        title: `Change to "${replaceText}"`,
         kind: CodeActionKind.QuickFix,
         diagnostics: [diagnostic],
         edit: {
           changes: {
-            [uri]: [TextEdit.replace(diagnostic.range, fullName)],
+            [uri]: [TextEdit.replace(diagnostic.range, replaceText)],
           },
         },
       };

--- a/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
+++ b/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
@@ -196,13 +196,11 @@ export function quickFixResolveAmbiguousReference(
   diagnostic: Diagnostic,
 ): CodeAction[] {
   const { symbols, uri } = diagnostic.data as AmbiguousReferenceData;
-  let current: ReferenceData[] = symbols.map(
-    (sym) => ({
-      visible: sym.visible,
-      parentsLeft: sym.nameChain.slice(0, -1),
-      replaceText: sym.nameChain[sym.nameChain.length - 1],
-    }),
-  );
+  let current: ReferenceData[] = symbols.map((sym) => ({
+    visible: sym.visible,
+    parentsLeft: sym.nameChain.slice(0, -1),
+    replaceText: sym.nameChain[sym.nameChain.length - 1],
+  }));
   const names = new Set<string>();
   do {
     names.clear();
@@ -238,9 +236,12 @@ export function quickFixResolveAmbiguousReference(
     const isSuffixOf = (suffix: string, str: string) =>
       str.endsWith("." + suffix) || str === suffix;
     const whereNameIsNotASuffix = (name: string, index: number): boolean =>
-      !current.some(({ replaceText }, i) => i !== index && isSuffixOf(name, replaceText));
-    for (const { replaceText } of current.filter(({ visible, replaceText }, index) =>
-      whereNameIsNotASuffix(replaceText, index) && visible
+      !current.some(
+        ({ replaceText }, i) => i !== index && isSuffixOf(name, replaceText),
+      );
+    for (const { replaceText } of current.filter(
+      ({ visible, replaceText }, index) =>
+        whereNameIsNotASuffix(replaceText, index) && visible,
     )) {
       const action: CodeAction = {
         title: `Change to "${replaceText}"`,

--- a/packages/language/src/linking/error.ts
+++ b/packages/language/src/linking/error.ts
@@ -132,16 +132,6 @@ export class LinkerErrorReporter {
     name: string,
     symbols: QualifiedSyntaxNode[],
   ) {
-    function fullName(symbol: QualifiedSyntaxNode): string[] {
-      let current: QualifiedSyntaxNode | null = symbol;
-      const parts: string[] = [];
-      while (current) {
-        parts.push(current.name);
-        current = current.parent;
-      }
-      return parts.reverse();
-    }
-
     const range =
       getQualifiedReferenceRange(reference.owner) ??
       tokenToRange(reference.token);
@@ -149,7 +139,10 @@ export class LinkerErrorReporter {
 
     const data: AmbiguousReferenceData | undefined = uri
       ? {
-          symbols: symbols.map(fullName),
+          symbols: symbols.map((sym) => ({
+            nameChain: fullName(sym),
+            visible: excludeForeignComposites(sym),
+          })),
           uri: uri,
         }
       : undefined;
@@ -161,6 +154,31 @@ export class LinkerErrorReporter {
       code: fullCode(PLICodes.Severe.IBM1881I),
       data,
     });
+    return;
+    function excludeForeignComposites(start: QualifiedSyntaxNode): boolean {
+      const declaredItemParents = new Set<SyntaxNode>();
+      let node: SyntaxNode | null = reference.owner;
+      while(node?.container) {
+        if (node.kind === SyntaxKind.DeclareStatement) {
+          declaredItemParents.add(node);
+        }
+        node = node.container;
+      }
+      node = start.node;
+      while(node && !declaredItemParents.has(node)) {
+        node = node.container;
+      }
+      return !!node && declaredItemParents.has(node);
+    }
+    function fullName(symbol: QualifiedSyntaxNode): string[] {
+      let current: QualifiedSyntaxNode | null = symbol;
+      const parts: string[] = [];
+      while (current) {
+        parts.push(current.name);
+        current = current.parent;
+      }
+      return parts.reverse();
+    }
   }
 
   /**

--- a/packages/language/src/linking/error.ts
+++ b/packages/language/src/linking/error.ts
@@ -158,14 +158,14 @@ export class LinkerErrorReporter {
     function excludeForeignComposites(start: QualifiedSyntaxNode): boolean {
       const declaredItemParents = new Set<SyntaxNode>();
       let node: SyntaxNode | null = reference.owner;
-      while(node?.container) {
+      while (node?.container) {
         if (node.kind === SyntaxKind.DeclareStatement) {
           declaredItemParents.add(node);
         }
         node = node.container;
       }
       node = start.node;
-      while(node && !declaredItemParents.has(node)) {
+      while (node && !declaredItemParents.has(node)) {
         node = node.container;
       }
       return !!node && declaredItemParents.has(node);

--- a/packages/language/src/linking/error.ts
+++ b/packages/language/src/linking/error.ts
@@ -19,7 +19,13 @@ import {
   tokenToUri,
 } from "../language-server/types";
 import { Token } from "../parser/tokens";
-import { DeclaredItem, DeclareStatement, Reference, SyntaxKind, SyntaxNode } from "../syntax-tree/ast";
+import {
+  DeclaredItem,
+  DeclareStatement,
+  Reference,
+  SyntaxKind,
+  SyntaxNode,
+} from "../syntax-tree/ast";
 import { InternalCodes } from "../validation/internal-codes";
 import { PLICodes } from "../validation/pli-codes";
 import { ValidationAcceptor } from "../validation/validator";
@@ -83,7 +89,7 @@ export class LinkerErrorReporter {
   constructor(
     private readonly unit: CompilationUnit,
     protected readonly accept: ValidationAcceptor,
-  ) { }
+  ) {}
 
   /**
    * E IBM1363I
@@ -139,12 +145,12 @@ export class LinkerErrorReporter {
 
     const data: AmbiguousReferenceData | undefined = uri
       ? {
-        symbols: symbols.map((sym) => ({
-          nameChain: fullName(sym),
-          visible: excludeForeignComposites(sym),
-        })),
-        uri: uri,
-      }
+          symbols: symbols.map((sym) => ({
+            nameChain: fullName(sym),
+            visible: excludeForeignComposites(sym),
+          })),
+          uri: uri,
+        }
       : undefined;
     this.accept({
       message: PLICodes.Severe.IBM1881I.message(name),
@@ -165,15 +171,16 @@ export class LinkerErrorReporter {
         }
         node = node.container;
       }
-      if(!node || !lastDeclaredItem) {
+      if (!node || !lastDeclaredItem) {
         return false;
       }
       const currentItemIndex = node.items.indexOf(lastDeclaredItem);
-      if(currentItemIndex > itemIndex) {
+      if (currentItemIndex > itemIndex) {
         return false;
-      } else if(currentItemIndex === itemIndex) {
+      } else if (currentItemIndex === itemIndex) {
         return true;
-      } else { // currentItemIndex < itemIndex
+      } else {
+        // currentItemIndex < itemIndex
         //Case 1:
         //  DCL 1 A,     //not passing this declaration (level=1) makes result true
         //        2 B,   //<--currentItemIndex
@@ -182,11 +189,11 @@ export class LinkerErrorReporter {
         //Case 2:
         //  DCL 1 X,
         //        2 Y,   //<--currentItemIndex
-        //      1 A,     //passing this declaration (level=1) makes result false   
+        //      1 A,     //passing this declaration (level=1) makes result false
         //        2 B,
         //          3 C; //<--itemIndex
-        for(let index = itemIndex; index > currentItemIndex; index--) {
-          if(node.items[index].level === 1) {
+        for (let index = itemIndex; index > currentItemIndex; index--) {
+          if (node.items[index].level === 1) {
             return false;
           }
         }
@@ -206,7 +213,10 @@ export class LinkerErrorReporter {
         }
         node = node.container;
       }
-      return { declareStatement, itemIndex: declareStatement?.items.indexOf(lastDeclaredItem!) ?? -1 };
+      return {
+        declareStatement,
+        itemIndex: declareStatement?.items.indexOf(lastDeclaredItem!) ?? -1,
+      };
     }
     function fullName(symbol: QualifiedSyntaxNode): string[] {
       let current: QualifiedSyntaxNode | null = symbol;

--- a/packages/language/src/linking/error.ts
+++ b/packages/language/src/linking/error.ts
@@ -19,7 +19,7 @@ import {
   tokenToUri,
 } from "../language-server/types";
 import { Token } from "../parser/tokens";
-import { Reference, SyntaxKind, SyntaxNode } from "../syntax-tree/ast";
+import { DeclaredItem, DeclareStatement, Reference, SyntaxKind, SyntaxNode } from "../syntax-tree/ast";
 import { InternalCodes } from "../validation/internal-codes";
 import { PLICodes } from "../validation/pli-codes";
 import { ValidationAcceptor } from "../validation/validator";
@@ -83,7 +83,7 @@ export class LinkerErrorReporter {
   constructor(
     private readonly unit: CompilationUnit,
     protected readonly accept: ValidationAcceptor,
-  ) {}
+  ) { }
 
   /**
    * E IBM1363I
@@ -139,12 +139,12 @@ export class LinkerErrorReporter {
 
     const data: AmbiguousReferenceData | undefined = uri
       ? {
-          symbols: symbols.map((sym) => ({
-            nameChain: fullName(sym),
-            visible: excludeForeignComposites(sym),
-          })),
-          uri: uri,
-        }
+        symbols: symbols.map((sym) => ({
+          nameChain: fullName(sym),
+          visible: excludeForeignComposites(sym),
+        })),
+        uri: uri,
+      }
       : undefined;
     this.accept({
       message: PLICodes.Severe.IBM1881I.message(name),
@@ -156,19 +156,57 @@ export class LinkerErrorReporter {
     });
     return;
     function excludeForeignComposites(start: QualifiedSyntaxNode): boolean {
-      const declaredItemParents = new Set<SyntaxNode>();
-      let node: SyntaxNode | null = reference.owner;
-      while (node?.container) {
-        if (node.kind === SyntaxKind.DeclareStatement) {
-          declaredItemParents.add(node);
+      var { declareStatement, itemIndex } = getReferencedDeclaration();
+      let node: SyntaxNode | null = start.node;
+      let lastDeclaredItem: DeclaredItem | null = null;
+      while (node && node != declareStatement) {
+        if (node.kind === SyntaxKind.DeclaredItem) {
+          lastDeclaredItem = node;
         }
         node = node.container;
       }
-      node = start.node;
-      while (node && !declaredItemParents.has(node)) {
+      if(!node || !lastDeclaredItem) {
+        return false;
+      }
+      const currentItemIndex = node.items.indexOf(lastDeclaredItem);
+      if(currentItemIndex > itemIndex) {
+        return false;
+      } else if(currentItemIndex === itemIndex) {
+        return true;
+      } else { // currentItemIndex < itemIndex
+        //Case 1:
+        //  DCL 1 A,     //not passing this declaration (level=1) makes result true
+        //        2 B,   //<--currentItemIndex
+        //          3 C; //<--itemIndex
+
+        //Case 2:
+        //  DCL 1 X,
+        //        2 Y,   //<--currentItemIndex
+        //      1 A,     //passing this declaration (level=1) makes result false   
+        //        2 B,
+        //          3 C; //<--itemIndex
+        for(let index = itemIndex; index > currentItemIndex; index--) {
+          if(node.items[index].level === 1) {
+            return false;
+          }
+        }
+        return true;
+      }
+    }
+    function getReferencedDeclaration() {
+      let node: SyntaxNode | null = reference.owner;
+      let declareStatement: DeclareStatement | null = null;
+      let lastDeclaredItem: SyntaxNode | null = null;
+      while (node?.container) {
+        if (node.kind === SyntaxKind.DeclaredItem) {
+          lastDeclaredItem = node;
+        }
+        if (node.kind === SyntaxKind.DeclareStatement) {
+          declareStatement = node as DeclareStatement;
+        }
         node = node.container;
       }
-      return !!node && declaredItemParents.has(node);
+      return { declareStatement, itemIndex: declareStatement?.items.indexOf(lastDeclaredItem!) ?? -1 };
     }
     function fullName(symbol: QualifiedSyntaxNode): string[] {
       let current: QualifiedSyntaxNode | null = symbol;

--- a/packages/language/test/fourslash-harness/harness-interface.ts
+++ b/packages/language/test/fourslash-harness/harness-interface.ts
@@ -262,6 +262,13 @@ export interface HarnessTesterInterface {
       expectedActionLabel: string,
       expectedCodeAfter: string,
     ): Promise<void>;
+
+    /**
+     * Expect that the number of code actions at the given label is the given count.
+     * @param label The label to expect the code actions at.
+     * @param count The expected number of code actions.
+     */
+    expectCodeActionCountAt(label: Label, count: number): Promise<void>;
   };
 
   linker: {

--- a/packages/language/test/fourslash-harness/harness-interface.ts
+++ b/packages/language/test/fourslash-harness/harness-interface.ts
@@ -180,11 +180,6 @@ export interface HarnessTesterInterface {
         | PLICode[],
     ): void;
     /**
-     * Expect that there are no code actions at the given label.
-     * @param label The label to expect no code actions at.
-     */
-    noCodeActions(label: Label): Promise<void>;
-    /**
      * Expect that the compilation unit has no diagnostics.
      *
      * @param label The label to expect no diagnostics at. If not provided, all diagnostics are expected to be absent.

--- a/packages/language/test/fourslash-harness/harness.test.ts
+++ b/packages/language/test/fourslash-harness/harness.test.ts
@@ -71,6 +71,7 @@ async function createTestingHarnessImplementation(
       expectAst: listen("verify.expectAst"),
       expectPPAst: listen("verify.expectPPAst"),
       expectCodeActionAt: listen("verify.expectCodeActionAt"),
+      expectCodeActionCountAt: listen("verify.expectCodeActionCountAt"),
       noCodeActions: listen("verify.noCodeActions"),
     },
     types: {

--- a/packages/language/test/fourslash-harness/harness.test.ts
+++ b/packages/language/test/fourslash-harness/harness.test.ts
@@ -72,7 +72,6 @@ async function createTestingHarnessImplementation(
       expectPPAst: listen("verify.expectPPAst"),
       expectCodeActionAt: listen("verify.expectCodeActionAt"),
       expectCodeActionCountAt: listen("verify.expectCodeActionCountAt"),
-      noCodeActions: listen("verify.noCodeActions"),
     },
     types: {
       ...HarnessTypeAttributes,

--- a/packages/language/test/fourslash-harness/implementation/test-builder.ts
+++ b/packages/language/test/fourslash-harness/implementation/test-builder.ts
@@ -74,6 +74,8 @@ export function createTestBuilderHarnessImplementation(
           expectedCodeAfter,
         ),
       noCodeActions: (label) => testBuilder.noCodeActions(label.toString()),
+      expectCodeActionCountAt: (label, expectedCount) =>
+        testBuilder.expectCodeActionCountAt(label.toString(), expectedCount),
     },
     completion: {
       expectAt: (label, content) =>

--- a/packages/language/test/fourslash-harness/implementation/test-builder.ts
+++ b/packages/language/test/fourslash-harness/implementation/test-builder.ts
@@ -73,7 +73,6 @@ export function createTestBuilderHarnessImplementation(
           expectedActionLabel,
           expectedCodeAfter,
         ),
-      noCodeActions: (label) => testBuilder.noCodeActions(label.toString()),
       expectCodeActionCountAt: (label, expectedCount) =>
         testBuilder.expectCodeActionCountAt(label.toString(), expectedCount),
     },

--- a/packages/language/test/fourslash/quick-fixes/macro-case.ts
+++ b/packages/language/test/fourslash/quick-fixes/macro-case.ts
@@ -23,6 +23,7 @@ verify.expectCompilerOptions({
     },
   },
 });
+await verify.expectCodeActionCountAt("variable1", 1);
 await verify.expectCodeActionAt(
   "variable1",
   "Convert to uppercase",

--- a/packages/language/test/fourslash/quick-fixes/resolve-ambiguous-reference/different-declare-statement.ts
+++ b/packages/language/test/fourslash/quick-fixes/resolve-ambiguous-reference/different-declare-statement.ts
@@ -19,6 +19,7 @@
 ////       2 C (S REFER(<|B|>));
 
 verify.expectDiagnosticsAt("B", code.Severe.IBM1881I);
+await verify.expectCodeActionCountAt("B", 1);
 await verify.expectCodeActionAt(
   "B",
   'Change to "AA.B"',

--- a/packages/language/test/fourslash/quick-fixes/resolve-ambiguous-reference/different-source-hierarchy.ts
+++ b/packages/language/test/fourslash/quick-fixes/resolve-ambiguous-reference/different-source-hierarchy.ts
@@ -21,6 +21,7 @@
 ////       2 BBB (P REFER(<|D|>));
 
 verify.expectDiagnosticsAt("D", code.Severe.IBM1881I);
+await verify.expectCodeActionCountAt("D", 2);
 await verify.expectCodeActionAt(
   "D",
   'Change to "B.BB.D"',

--- a/packages/language/test/fourslash/quick-fixes/resolve-ambiguous-reference/no-quickfixes-different-declare-statements.ts
+++ b/packages/language/test/fourslash/quick-fixes/resolve-ambiguous-reference/no-quickfixes-different-declare-statements.ts
@@ -21,4 +21,4 @@
 ////       2 Y3 (P REFER(<|Z|>));
 
 verify.expectDiagnosticsAt("Z", code.Severe.IBM1881I);
-await verify.noCodeActions("Z");
+await verify.expectCodeActionCountAt("Z", 0);

--- a/packages/language/test/fourslash/quick-fixes/resolve-ambiguous-reference/no-quickfixes-same-declare-statements.ts
+++ b/packages/language/test/fourslash/quick-fixes/resolve-ambiguous-reference/no-quickfixes-same-declare-statements.ts
@@ -20,4 +20,4 @@
 ////       2 Y3 (P REFER(<|Z|>));
 
 verify.expectDiagnosticsAt("Z", code.Severe.IBM1881I);
-await verify.noCodeActions("Z");
+await verify.expectCodeActionCountAt("Z", 0);

--- a/packages/language/test/fourslash/quick-fixes/resolve-ambiguous-reference/same-declare-statement.ts
+++ b/packages/language/test/fourslash/quick-fixes/resolve-ambiguous-reference/same-declare-statement.ts
@@ -19,6 +19,7 @@
 ////       2 C (S REFER(<|B|>));
 
 verify.expectDiagnosticsAt("B", code.Severe.IBM1881I);
+await verify.expectCodeActionCountAt("B", 1);
 await verify.expectCodeActionAt(
   "B",
   'Change to "AA.B"',

--- a/packages/language/test/fourslash/quick-fixes/resolve-ambiguous-reference/simple.ts
+++ b/packages/language/test/fourslash/quick-fixes/resolve-ambiguous-reference/simple.ts
@@ -20,6 +20,7 @@
 ////       2 Y3 (P REFER(<|Z|>));
 
 verify.expectDiagnosticsAt("Z", code.Severe.IBM1881I);
+await verify.expectCodeActionCountAt("Z", 2);
 await verify.expectCodeActionAt(
   "Z",
   'Change to "Y1.Z"',

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -491,13 +491,6 @@ Available code actions for label "${label}" and URI "${uri}": ${codeActions.map(
     return codeActions;
   }
 
-  async noCodeActions(label: string): Promise<void> {
-    const codeActions = await this.getCodeActions(label);
-    if (codeActions.some((ca) => ca[1].length > 0)) {
-      fail(`Expected no code actions at label "${label}", but found some.`);
-    }
-  }
-
   expectAst(statements: any[]): void {
     const actualStatements = this.unit.ast.statements;
     this.matchStatements(statements, actualStatements);

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -450,6 +450,21 @@ Available code actions for label "${label}" and URI "${uri}": ${codeActions.map(
     }
   }
 
+  async expectCodeActionCountAt(
+    label: string,
+    expectedCount: number,
+  ): Promise<void> {
+    const codeActions = await this.getCodeActions(label);
+    const actualCount = codeActions.reduce(
+      (acc, [, actions]) => acc + actions.length,
+      0,
+    );
+    expect(
+      actualCount,
+      `Expected ${expectedCount} code actions at label "${label}", but found ${actualCount}.`,
+    ).toBe(expectedCount);
+  }
+
   private async getCodeActions(label: string) {
     let codeActions = this.codeActionCacheByLabel.get(label);
     if (!codeActions) {


### PR DESCRIPTION
Fixes #636 

There are two cases according to the nesting of a declare statement:

Case 1:

```
DCL X CHAR(300);
 DCL CT BIN FIXED(31);
 DCL 1 A BASED(ADDR(X)),
       5 B BIN FIXED(31),
       5 C (CT REFER(B)),
         10* CHAR(1);
 DCL 1 AA BASED(ADDR(X)),  //splitted into two or more statements
       5 B1,
         10 B BIN FIXED(31),
       5 B2,
         10 B BIN FIXED(31), 
        5 C (CT REFER(B));
```

Case 2:

```
 DCL X CHAR(300);
 DCL CT BIN FIXED(31);
 DCL 1 A BASED(ADDR(X)), //everything in one statement
       5 B BIN FIXED(31),
       5 C (CT REFER(B)),
         10* CHAR(1),
     1 AA BASED(ADDR(X)),
       5 B1,
         10 B BIN FIXED(31),
       5 B2,
         10 B BIN FIXED(31), 
        5 C (CT REFER(B));
```

In case 2 we need to take care of the original structure, where the quickfix action or reference is coming from.