### PR TITLE
Introduce ANY and VARARG for builtin declarations

### DIFF
--- a/packages/language/src/linking/error.ts
+++ b/packages/language/src/linking/error.ts
@@ -26,7 +26,7 @@ import {
   SyntaxKind,
   SyntaxNode,
 } from "../syntax-tree/ast";
-import { InternalCodes } from "../validation/internal-codes";
+import { LspCodes } from "../validation/lsp-codes";
 import { PLICodes } from "../validation/pli-codes";
 import { ValidationAcceptor } from "../validation/validator";
 import { CompilationUnit } from "../workspace/compilation-unit";
@@ -125,9 +125,7 @@ export class LinkerErrorReporter {
    * Synthetic error for when we cannot find a symbol.
    */
   reportCannotFindSymbol(token: Token, name: string) {
-    this.accept(
-      diagnosticFromCode(InternalCodes.UnknownIdentifier, token, name),
-    );
+    this.accept(diagnosticFromCode(LspCodes.UnknownIdentifier, token, name));
   }
 
   /**

--- a/packages/language/src/parser/tokens/pli-tokens.ts
+++ b/packages/language/src/parser/tokens/pli-tokens.ts
@@ -151,6 +151,16 @@ export const SL_COMMENT = createToken({
   group: "comments",
 });
 // Start of keywords
+// Special builtin keywords
+export const ANY = registerKeyword({
+  name: "ANY",
+  categories: [[DefaultAttribute, ast.DefaultAttribute.ANY]],
+});
+export const VARARG = registerKeyword({
+  name: "VARARG",
+  categories: [[DefaultAttribute, ast.DefaultAttribute.VARARG]],
+});
+// Normal keywords
 export const SUBSCRIPTRANGE = registerKeyword({
   name: "SUBSCRIPTRANGE",
   categories: [[KeywordConditions, ast.KeywordConditions.SUBSCRIPTRANGE]],

--- a/packages/language/src/parser/tokens/pli-tokens.ts
+++ b/packages/language/src/parser/tokens/pli-tokens.ts
@@ -151,11 +151,19 @@ export const SL_COMMENT = createToken({
   group: "comments",
 });
 // Start of keywords
-// Special builtin keywords
+// Helper keywords outside of the PL/I specification
+/**
+ * Not part of the PL/I specification!
+ * Helps declaring parameters of any type for builtin procedures
+ */
 export const ANY = registerKeyword({
   name: "ANY",
   categories: [[DefaultAttribute, ast.DefaultAttribute.ANY]],
 });
+/**
+ * Not part of the PL/I specification!
+ * Helps declaring parameters of variadic nature for builtin procedures
+ */
 export const VARARG = registerKeyword({
   name: "VARARG",
   categories: [[DefaultAttribute, ast.DefaultAttribute.VARARG]],

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -290,15 +290,11 @@ export enum SimpleOptions {
 
 export enum DefaultAttribute {
   // special builtin attributes
-  /**
-   * Not part of the PL/I specification!
-   * Helps declaring parameters of any type for builtin procedures
-   */
+  // Not part of the PL/I specification!
+  // Helps declaring parameters of any type for builtin procedures
   ANY,
-  /**
-   * Not part of the PL/I specification!
-   * Helps declaring parameters of variadic nature for builtin procedures
-   */
+  // Not part of the PL/I specification!
+  // Helps declaring parameters of variadic nature for builtin procedures
   VARARG,
   // normal attributes
   INT,

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -290,7 +290,15 @@ export enum SimpleOptions {
 
 export enum DefaultAttribute {
   // special builtin attributes
+  /**
+   * Not part of the PL/I specification!
+   * Helps declaring parameters of any type for builtin procedures
+   */
   ANY,
+  /**
+   * Not part of the PL/I specification!
+   * Helps declaring parameters of variadic nature for builtin procedures
+   */
   VARARG,
   // normal attributes
   INT,

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -289,6 +289,10 @@ export enum SimpleOptions {
 }
 
 export enum DefaultAttribute {
+  // special builtin attributes
+  ANY,
+  VARARG,
+  // normal attributes
   INT,
   NORESCAN,
   BIT,

--- a/packages/language/src/typesystem/attribute-witnesses.ts
+++ b/packages/language/src/typesystem/attribute-witnesses.ts
@@ -199,7 +199,9 @@ export class DefaultTypeAttributeCollector implements TypeAttributeCollector {
     const type = attribute.type;
     switch (type) {
       /**
-       * Builtin attributes (only for builtin files, otherwise report error)
+       * Builtin attributes (only for builtin files, this is outside the PL/I specification
+       * in order to make it possible to declare builtin procedures with parameters of any type
+       * and variadic parameters)
        */
       case ast.DefaultAttribute.VARARG: {
         this.addAttributeWitness(

--- a/packages/language/src/typesystem/attribute-witnesses.ts
+++ b/packages/language/src/typesystem/attribute-witnesses.ts
@@ -199,6 +199,27 @@ export class DefaultTypeAttributeCollector implements TypeAttributeCollector {
     const type = attribute.type;
     switch (type) {
       /**
+       * Builtin attributes (only for builtin files, otherwise report error)
+       */
+      case ast.DefaultAttribute.VARARG: {
+        this.addAttributeWitness(
+          AttributeKind.VariadicArgument,
+          true,
+          attribute,
+          token,
+        );
+        break;
+      }
+      case ast.DefaultAttribute.ANY: {
+        this.addAttributeWitness(
+          AttributeKind.DataType,
+          DataType.Unknown,
+          attribute,
+          token,
+        );
+        break;
+      }
+      /**
        * Data type attributes
        */
       case ast.DefaultAttribute.TASK:

--- a/packages/language/src/typesystem/descriptions.ts
+++ b/packages/language/src/typesystem/descriptions.ts
@@ -141,6 +141,10 @@ export enum AttributeKind {
    * @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=attributes-variable-attribute
    */
   Variable,
+  /**
+   * Only for builtin procedure signatures
+   */
+  VariadicArgument,
   /** @see https://www.ibm.com/docs/en/epfz/6.1.0?topic=control-normal-abnormal-attributes */
   Volatility,
 }
@@ -180,6 +184,7 @@ export const AttributeKinds: AttributeKind[] = [
   AttributeKind.SetLike,
   AttributeKind.SetType,
   AttributeKind.Variable,
+  AttributeKind.VariadicArgument,
   AttributeKind.Volatility,
 ];
 
@@ -241,6 +246,7 @@ export type AttributeTypes = {
   [AttributeKind.StringBits]: StringBits;
   [AttributeKind.TransmissionDirection]: TransmissionDirection;
   [AttributeKind.Variable]: boolean;
+  [AttributeKind.VariadicArgument]: boolean;
   [AttributeKind.Volatility]: Volatility;
 };
 
@@ -284,6 +290,7 @@ export const AttributePropertyNames = {
   [AttributeKind.SetLike]: "like" as const,
   [AttributeKind.SetType]: "typeRef" as const,
   [AttributeKind.AttributeWitnesses]: "attributeWitnesses" as const,
+  [AttributeKind.VariadicArgument]: "variadicArgument" as const,
 } satisfies { [K in AttributeKind]: string };
 
 export type AttributePreprocessorValidator<K extends AttributeKind> = (
@@ -305,6 +312,7 @@ export const AttributeIsValidForPreprocessor: {
   [AttributeKind.Entry]: () => true,
   [AttributeKind.ScanMode]: () => true,
   [AttributeKind.Dimension]: () => true,
+  [AttributeKind.VariadicArgument]: () => true,
 };
 
 export function isAttributeValidForPreprocessor<K extends AttributeKind>(
@@ -322,6 +330,11 @@ export type AttributeStringifier<K extends AttributeKind> = (
 export const AttributeStringifiers: {
   [K in AttributeKind]: AttributeStringifier<K>;
 } = {
+  [AttributeKind.VariadicArgument]: function (
+    value: boolean,
+  ): string | undefined {
+    return undefined;
+  },
   [AttributeKind.BuiltIn]: function (value: boolean): string | undefined {
     return value ? "BUILTIN" : undefined;
   },
@@ -840,6 +853,7 @@ interface BaseTypeDescriptionProps {
   scope: Scope;
   storage: StorageClass;
   variable?: boolean;
+  variadicArgument: boolean;
   volatility: Volatility;
   witnesses: AttributeWitnesses;
   toString(): string;
@@ -968,6 +982,7 @@ function createBaseTypeDescription(
     optional,
     parameter,
     witnesses,
+    variadicArgument,
     toString,
   }: Partial<BaseTypeDescriptionProps>,
 ): BaseTypeDescriptionProps {
@@ -994,6 +1009,8 @@ function createBaseTypeDescription(
   parameter ??= TypeDescriptions.DefaultValues[AttributeKind.Parameter];
   initial ??= TypeDescriptions.DefaultValues[AttributeKind.Initial];
   scanMode ??= TypeDescriptions.DefaultValues[AttributeKind.ScanMode];
+  variadicArgument ??=
+    TypeDescriptions.DefaultValues[AttributeKind.VariadicArgument];
 
   if (!storage) {
     if (scope?.type === ScopeType.Internal) {
@@ -1020,6 +1037,7 @@ function createBaseTypeDescription(
     scope,
     storage,
     variable,
+    variadicArgument,
     volatility,
 
     witnesses: witnesses ?? { order: [], witnesses: {} },
@@ -1555,7 +1573,7 @@ function createUnknownTypeDescription(common?: {
   return {
     type: UnknownType,
     ...createBaseTypeDescription(UnknownType, {
-      builtIn: common?.builtIn ?? false,
+      ...common,
       toString() {
         return "<UNKNOWN>";
       },
@@ -1580,6 +1598,7 @@ interface CompositeTypeDescriptionProps extends WithMembers, WithParentType {
   alignment?: Alignment;
   toString(): string;
   witnesses: AttributeWitnesses;
+  variadicArgument: boolean;
 }
 
 interface CompositeTypeDescription extends CompositeTypeDescriptionProps {}
@@ -1697,6 +1716,7 @@ export namespace TypeDescriptions {
 
   //TODO check default values
   export const DefaultValues: AttributeTypes = {
+    [AttributeKind.VariadicArgument]: false,
     [AttributeKind.BuiltIn]: false,
     [AttributeKind.AttributeWitnesses]: {
       order: [],
@@ -1849,6 +1869,9 @@ export namespace TypeDescriptions {
         attributes[AttributeKind.Dimension]?.value ??
         DefaultValues[AttributeKind.Dimension],
       variableNode,
+      variadicArgument:
+        attributes[AttributeKind.VariadicArgument]?.value ??
+        DefaultValues[AttributeKind.VariadicArgument],
       toString: () => stringifyAttributeWitnesses(witnesses),
     };
   }
@@ -1895,6 +1918,9 @@ export namespace TypeDescriptions {
       variable:
         attributes[AttributeKind.Variable]?.value ??
         DefaultValues[AttributeKind.Variable],
+      variadicArgument:
+        attributes[AttributeKind.VariadicArgument]?.value ??
+        DefaultValues[AttributeKind.VariadicArgument],
       scanMode:
         attributes[AttributeKind.ScanMode]?.value ??
         DefaultValues[AttributeKind.ScanMode],

--- a/packages/language/src/typesystem/infer.ts
+++ b/packages/language/src/typesystem/infer.ts
@@ -72,6 +72,11 @@ export class DefaultTypeInferer implements TypeInferer {
             compilationUnit,
           );
         }
+      } else if (
+        node.kind === ast.SyntaxKind.ProcedureParameter &&
+        node.ref?.node
+      ) {
+        return this.inferType(node.ref.node, compilationUnit);
       }
       return TypeDescriptions.Unknown();
     });

--- a/packages/language/src/validation/internal-codes.ts
+++ b/packages/language/src/validation/internal-codes.ts
@@ -19,47 +19,6 @@ export const InternalCodes = {
     message: (label: string, file: string, uri: string) =>
       `Expected diagnostic at label "${label}" to be in file "${file}" but received: ${uri}`,
   },
-  UnknownIdentifier: {
-    code: "UNKNOWN_IDENTIFIER",
-    severity: Severity.E,
-    message: (name: string) => `Unknown identifier '${name}'`,
-  },
-  BuiltinAttributeUsage: {
-    code: "BUILTIN_ATTRIBUTE_USAGE",
-    severity: Severity.E,
-    message: (attribute: string) =>
-      `The attribute '${attribute}' is a builtin attribute and cannot be used in non-builtin files.`,
-  },
-  VariadicParameterNotLast: {
-    code: "VARIADIC_PARAMETER_NOT_LAST",
-    severity: Severity.E,
-    message: (name: string) =>
-      `The variadic parameter '${name}' must be the last parameter in the parameter list.`,
-  },
-  VariadicParameterMultiple: {
-    code: "VARIADIC_PARAMETER_MULTIPLE",
-    severity: Severity.E,
-    message: (name: string) =>
-      `The variadic parameter '${name}' cannot be used because there is already another variadic parameter in the parameter list.`,
-  },
-  VariadicParameterIsFixedArray: {
-    code: "VARIADIC_PARAMETER_IS_FIXED_ARRAY",
-    severity: Severity.E,
-    message: (name: string) =>
-      `The variadic parameter '${name}' cannot be a fixed array. Variadic parameters must be declared with an assumed size (e.g. (*)) and cannot specify a size.`,
-  },
-  VariadicParameterNotAnArray: {
-    code: "VARIADIC_PARAMETER_NOT_AN_ARRAY",
-    severity: Severity.E,
-    message: (name: string) =>
-      `The variadic parameter '${name}' must be an array. Variadic parameters must be declared with parentheses to indicate they are arrays (e.g. (*)).`,
-  },
-  VariadicNonParameter: {
-    code: "VARIADIC_NON_PARAMETER",
-    severity: Severity.E,
-    message: (name: string) =>
-      `The variadic parameter '${name}' is not a parameter. Only parameters can be variadic.`,
-  },
 };
 
 export const TypeSystemCodes: PLICode[] = [

--- a/packages/language/src/validation/internal-codes.ts
+++ b/packages/language/src/validation/internal-codes.ts
@@ -24,6 +24,12 @@ export const InternalCodes = {
     severity: Severity.E,
     message: (name: string) => `Unknown identifier '${name}'`,
   },
+  BuiltinAttributeUsage: {
+    code: "BUILTIN_ATTRIBUTE_USAGE",
+    severity: Severity.E,
+    message: (attribute: string) =>
+      `The attribute '${attribute}' is a builtin attribute and cannot be used in non-builtin files.`,
+  },
 };
 
 export const TypeSystemCodes: PLICode[] = [

--- a/packages/language/src/validation/internal-codes.ts
+++ b/packages/language/src/validation/internal-codes.ts
@@ -12,6 +12,10 @@
 import { Severity } from "../language-server/types";
 import { PLICode, Error, Severe } from "./pli-codes";
 
+/**
+ * InternalCodes are used for diagnostics that are not intended to be exposed to users, but are used internally for testing and other purposes.
+ * These codes will be never shown to users, and are not intended to be used in any user-facing diagnostics.
+ */
 export const InternalCodes = {
   DiagnosticURIMismatch: {
     code: "_TB0001", // TestBuilder diagnostic code

--- a/packages/language/src/validation/internal-codes.ts
+++ b/packages/language/src/validation/internal-codes.ts
@@ -30,6 +30,36 @@ export const InternalCodes = {
     message: (attribute: string) =>
       `The attribute '${attribute}' is a builtin attribute and cannot be used in non-builtin files.`,
   },
+  VariadicParameterNotLast: {
+    code: "VARIADIC_PARAMETER_NOT_LAST",
+    severity: Severity.E,
+    message: (name: string) =>
+      `The variadic parameter '${name}' must be the last parameter in the parameter list.`,
+  },
+  VariadicParameterMultiple: {
+    code: "VARIADIC_PARAMETER_MULTIPLE",
+    severity: Severity.E,
+    message: (name: string) =>
+      `The variadic parameter '${name}' cannot be used because there is already another variadic parameter in the parameter list.`,
+  },
+  VariadicParameterIsFixedArray: {
+    code: "VARIADIC_PARAMETER_IS_FIXED_ARRAY",
+    severity: Severity.E,
+    message: (name: string) =>
+      `The variadic parameter '${name}' cannot be a fixed array. Variadic parameters must be declared with an assumed size (e.g. (*)) and cannot specify a size.`,
+  },
+  VariadicParameterNotAnArray: {
+    code: "VARIADIC_PARAMETER_NOT_AN_ARRAY",
+    severity: Severity.E,
+    message: (name: string) =>
+      `The variadic parameter '${name}' must be an array. Variadic parameters must be declared with parentheses to indicate they are arrays (e.g. (*)).`,
+  },
+  VariadicNonParameter: {
+    code: "VARIADIC_NON_PARAMETER",
+    severity: Severity.E,
+    message: (name: string) =>
+      `The variadic parameter '${name}' is not a parameter. Only parameters can be variadic.`,
+  },
 };
 
 export const TypeSystemCodes: PLICode[] = [

--- a/packages/language/src/validation/lsp-codes.ts
+++ b/packages/language/src/validation/lsp-codes.ts
@@ -61,45 +61,46 @@ export const LspCodes = {
   },
 
   UnknownIdentifier: {
-    code: "UNKNOWN_IDENTIFIER",
+    code: "LSPUI001",
     severity: Severity.E,
     message: (name: string) => `Unknown identifier '${name}'`,
   },
 
   BuiltinAttributes: {
     IsForbiddenUsage: {
-      code: "BUILTIN_ATTRIBUTE_USAGE",
+      code: "LSPTS001",
       severity: Severity.E,
       message: (attribute: string) =>
         `The attribute '${attribute}' is a builtin attribute and cannot be used in non-builtin files.`,
     },
+    //TODO @tag(#issue-656) Remove this group of errors once all builtin procedures signatures are setup
     VariadicParameter: {
       IsNotLastParameter: {
-        code: "VARIADIC_PARAMETER_NOT_LAST",
+        code: "LSPTS002",
         severity: Severity.E,
         message: (name: string) =>
           `The variadic parameter '${name}' must be the last parameter in the parameter list.`,
       },
       HasMultipleParameters: {
-        code: "VARIADIC_PARAMETER_MULTIPLE",
+        code: "LSPTS003",
         severity: Severity.E,
         message: (name: string) =>
           `The variadic parameter '${name}' cannot be used because there is already another variadic parameter in the parameter list.`,
       },
       IsAFixedArray: {
-        code: "VARIADIC_PARAMETER_IS_FIXED_ARRAY",
+        code: "LSPTS004",
         severity: Severity.E,
         message: (name: string) =>
           `The variadic parameter '${name}' cannot be a fixed array. Variadic parameters must be declared with an assumed size (e.g. (*)) and cannot specify a size.`,
       },
       IsNotAnArray: {
-        code: "VARIADIC_PARAMETER_NOT_AN_ARRAY",
+        code: "LSPTS005",
         severity: Severity.E,
         message: (name: string) =>
           `The variadic parameter '${name}' must be an array. Variadic parameters must be declared with parentheses to indicate they are arrays (e.g. (*)).`,
       },
       IsNotAParameter: {
-        code: "VARIADIC_NON_PARAMETER",
+        code: "LSPTS006",
         severity: Severity.E,
         message: (name: string) =>
           `The variadic parameter '${name}' is not a parameter. Only parameters can be variadic.`,

--- a/packages/language/src/validation/lsp-codes.ts
+++ b/packages/language/src/validation/lsp-codes.ts
@@ -59,4 +59,51 @@ export const LspCodes = {
         "Member must start with a letter, followed by letters, numbers, @, #, _, or $.",
     },
   },
+
+  UnknownIdentifier: {
+    code: "UNKNOWN_IDENTIFIER",
+    severity: Severity.E,
+    message: (name: string) => `Unknown identifier '${name}'`,
+  },
+
+  BuiltinAttributes: {
+    IsForbiddenUsage: {
+      code: "BUILTIN_ATTRIBUTE_USAGE",
+      severity: Severity.E,
+      message: (attribute: string) =>
+        `The attribute '${attribute}' is a builtin attribute and cannot be used in non-builtin files.`,
+    },
+    VariadicParameter: {
+      IsNotLastParameter: {
+        code: "VARIADIC_PARAMETER_NOT_LAST",
+        severity: Severity.E,
+        message: (name: string) =>
+          `The variadic parameter '${name}' must be the last parameter in the parameter list.`,
+      },
+      HasMultipleParameters: {
+        code: "VARIADIC_PARAMETER_MULTIPLE",
+        severity: Severity.E,
+        message: (name: string) =>
+          `The variadic parameter '${name}' cannot be used because there is already another variadic parameter in the parameter list.`,
+      },
+      IsAFixedArray: {
+        code: "VARIADIC_PARAMETER_IS_FIXED_ARRAY",
+        severity: Severity.E,
+        message: (name: string) =>
+          `The variadic parameter '${name}' cannot be a fixed array. Variadic parameters must be declared with an assumed size (e.g. (*)) and cannot specify a size.`,
+      },
+      IsNotAnArray: {
+        code: "VARIADIC_PARAMETER_NOT_AN_ARRAY",
+        severity: Severity.E,
+        message: (name: string) =>
+          `The variadic parameter '${name}' must be an array. Variadic parameters must be declared with parentheses to indicate they are arrays (e.g. (*)).`,
+      },
+      IsNotAParameter: {
+        code: "VARIADIC_NON_PARAMETER",
+        severity: Severity.E,
+        message: (name: string) =>
+          `The variadic parameter '${name}' is not a parameter. Only parameters can be variadic.`,
+      },
+    },
+  },
 };

--- a/packages/language/src/validation/pli-validator.ts
+++ b/packages/language/src/validation/pli-validator.ts
@@ -16,7 +16,10 @@ import { IBM1388IE_NODESCRIPTOR_attribute_is_invalid_when_any_parameter_has_NONC
 import { IBM2615I_do_loops_execute_once } from "./compiler/IBM2615I-do-loops-execute-once";
 import { ValidationChecks } from "./validator";
 import { IBM2412I_IBM2410I_IBM2409I_handle_return_stmt_and_returns_att } from "./compiler/IBM2412I-IBM2410I-IBM2409I-handle-return-stmt-and-returns-att";
-import { typeCheck } from "./type-check-validator";
+import {
+  BUILTIN_NoMultipleVariadicParameters,
+  typeCheck,
+} from "./type-check-validator";
 import { checkImplicitBuiltins } from "./language-server/implicit-builtins";
 import { IBM1376IE_attributes_in_declaration_lists } from "./compiler/IBM1376IE-attributes-in-declaration-lists";
 import { IBM3323I_IBM3324I_check_argument_count } from "./compiler/IBM3323I-IBM3324I-check-argument-count";
@@ -51,6 +54,7 @@ export function registerPliValidationChecks(): ValidationChecks {
       IBM1388IE_NODESCRIPTOR_attribute_is_invalid_when_any_parameter_has_NONCONNECTED_attribute,
       IBM2412I_IBM2410I_IBM2409I_handle_return_stmt_and_returns_att,
       IBM1213I_unreferenced_procedure,
+      BUILTIN_NoMultipleVariadicParameters,
     ],
     ReferenceItem: [checkImplicitBuiltins],
     SelectStatement: [IBM1059I_select_without_otherwise],

--- a/packages/language/src/validation/pp-validator.ts
+++ b/packages/language/src/validation/pp-validator.ts
@@ -17,7 +17,10 @@ import { ValidationChecks } from "./validator";
 import { IBM1352IE_declared_item_pp_scan_repetition } from "./compiler/IBM1352IE-declare-item-scan-repetition";
 import { LSPIS001_standalone_skip_directive_not_supported } from "./language-server/LSPIS001-skip-statement-not-supported";
 import { DeprecateIncludes } from "./compiler/IBM2444Iff-deprecate";
-import { typeCheck } from "./type-check-validator";
+import {
+  BUILTIN_NoMultipleVariadicParameters,
+  typeCheck,
+} from "./type-check-validator";
 
 export function registerPreprocessorValidationChecks(): ValidationChecks {
   return {
@@ -29,7 +32,11 @@ export function registerPreprocessorValidationChecks(): ValidationChecks {
     DeclaredVariable: [MACRO_NamePrefix, typeCheck],
     IncludeDirective: [DeprecateIncludes],
     Program: [MACRO_Case],
-    ProcedureStatement: [MACRO_Deprecate, MACRO_NamePrefix],
+    ProcedureStatement: [
+      MACRO_Deprecate,
+      MACRO_NamePrefix,
+      BUILTIN_NoMultipleVariadicParameters,
+    ],
     SkipDirective: [LSPIS001_standalone_skip_directive_not_supported],
   };
 }

--- a/packages/language/src/validation/type-check-validator.ts
+++ b/packages/language/src/validation/type-check-validator.ts
@@ -42,60 +42,8 @@ export function typeCheck(
   );
 
   if (compilationUnit.uri.scheme === BuiltinsUriSchema) {
-    if (description.variadicArgument) {
-      const token =
-        description.witnesses.witnesses[AttributeKind.VariadicArgument]?.token;
-      if (token) {
-        const parameter = tryGetParameter(stmt);
-        if (!parameter) {
-          acceptor(
-            diagnosticFromCode(
-              LspCodes.BuiltinAttributes.VariadicParameter.IsNotAParameter,
-              token,
-              token.image,
-            ),
-          );
-        } else {
-          assertType<ast.DeclaredVariable>(stmt);
-          if (stmt.nameToken) {
-            if (!description.dimension) {
-              acceptor(
-                diagnosticFromCode(
-                  LspCodes.BuiltinAttributes.VariadicParameter.IsNotAnArray,
-                  stmt.nameToken,
-                  stmt.nameToken.image,
-                ),
-              );
-            } else {
-              if (
-                description.dimension.length >= 1 &&
-                description.dimension.some(
-                  (dim) => dim.upperBound.value !== "*" || dim.lowerBound.value,
-                )
-              ) {
-                acceptor(
-                  diagnosticFromCode(
-                    LspCodes.BuiltinAttributes.VariadicParameter.IsAFixedArray,
-                    stmt.nameToken,
-                    stmt.nameToken.image,
-                  ),
-                );
-              }
-            }
-            if (parameter.index !== parameter.count - 1) {
-              acceptor(
-                diagnosticFromCode(
-                  LspCodes.BuiltinAttributes.VariadicParameter
-                    .IsNotLastParameter,
-                  stmt.nameToken,
-                  stmt.nameToken.image,
-                ),
-              );
-            }
-          }
-        }
-      }
-    }
+    //TODO @tag(#issue-656) Remove the then branch once all builtin procedures signatures are setup
+    checkUsageForBuiltinFilesIsCorrect(description, stmt, acceptor);
   } else {
     if (description.variadicArgument) {
       const token =
@@ -184,6 +132,71 @@ export function typeCheck(
           acceptor(diagnosticFromCode(PLICodes.Error.IBM2436I, witness.token));
         } else if (description.scale === ScaleMode.Float) {
           acceptor(diagnosticFromCode(PLICodes.Error.IBM2424I, witness.token));
+        }
+      }
+    }
+  }
+}
+
+function checkUsageForBuiltinFilesIsCorrect(
+  description: TypeDescriptions.Any,
+  stmt:
+    | ast.DeclaredVariable
+    | ast.DeclareStatement
+    | ast.DeclaredItem
+    | ast.DefineAliasStatement
+    | ast.DefineOrdinalStatement,
+  acceptor: ValidationAcceptor,
+) {
+  if (description.variadicArgument) {
+    const token =
+      description.witnesses.witnesses[AttributeKind.VariadicArgument]?.token;
+    if (token) {
+      const parameter = tryGetParameter(stmt);
+      if (!parameter) {
+        acceptor(
+          diagnosticFromCode(
+            LspCodes.BuiltinAttributes.VariadicParameter.IsNotAParameter,
+            token,
+            token.image,
+          ),
+        );
+      } else {
+        assertType<ast.DeclaredVariable>(stmt);
+        if (stmt.nameToken) {
+          if (!description.dimension) {
+            acceptor(
+              diagnosticFromCode(
+                LspCodes.BuiltinAttributes.VariadicParameter.IsNotAnArray,
+                stmt.nameToken,
+                stmt.nameToken.image,
+              ),
+            );
+          } else {
+            if (
+              description.dimension.length >= 1 &&
+              description.dimension.some(
+                (dim) => dim.upperBound.value !== "*" || dim.lowerBound.value,
+              )
+            ) {
+              acceptor(
+                diagnosticFromCode(
+                  LspCodes.BuiltinAttributes.VariadicParameter.IsAFixedArray,
+                  stmt.nameToken,
+                  stmt.nameToken.image,
+                ),
+              );
+            }
+          }
+          if (parameter.index !== parameter.count - 1) {
+            acceptor(
+              diagnosticFromCode(
+                LspCodes.BuiltinAttributes.VariadicParameter.IsNotLastParameter,
+                stmt.nameToken,
+                stmt.nameToken.image,
+              ),
+            );
+          }
         }
       }
     }

--- a/packages/language/src/validation/type-check-validator.ts
+++ b/packages/language/src/validation/type-check-validator.ts
@@ -24,6 +24,7 @@ import { InternalCodes } from "./internal-codes";
 import { PLICodes } from "./pli-codes";
 import { ValidationAcceptor } from "./validator";
 import * as tokens from "../parser/tokens";
+import { assertType } from "../preprocessor/util";
 
 export function typeCheck(
   stmt:
@@ -41,6 +42,59 @@ export function typeCheck(
   );
 
   if (compilationUnit.uri.scheme === BuiltinsUriSchema) {
+    if (description.variadicArgument) {
+      const token =
+        description.witnesses.witnesses[AttributeKind.VariadicArgument]?.token;
+      if (token) {
+        const parameter = tryGetParameter(stmt);
+        if (!parameter) {
+          acceptor(
+            diagnosticFromCode(
+              InternalCodes.VariadicNonParameter,
+              token,
+              token.image,
+            ),
+          );
+        } else {
+          assertType<ast.DeclaredVariable>(stmt);
+          if (stmt.nameToken) {
+            if (!description.dimension) {
+              acceptor(
+                diagnosticFromCode(
+                  InternalCodes.VariadicParameterNotAnArray,
+                  stmt.nameToken,
+                  stmt.nameToken.image,
+                ),
+              );
+            } else {
+              if (
+                description.dimension.length >= 1 &&
+                description.dimension.some(
+                  (dim) => dim.upperBound.value !== "*" || dim.lowerBound.value,
+                )
+              ) {
+                acceptor(
+                  diagnosticFromCode(
+                    InternalCodes.VariadicParameterIsFixedArray,
+                    stmt.nameToken,
+                    stmt.nameToken.image,
+                  ),
+                );
+              }
+            }
+            if (parameter.index !== parameter.count - 1) {
+              acceptor(
+                diagnosticFromCode(
+                  InternalCodes.VariadicParameterNotLast,
+                  stmt.nameToken,
+                  stmt.nameToken.image,
+                ),
+              );
+            }
+          }
+        }
+      }
+    }
   } else {
     if (description.variadicArgument) {
       const token =
@@ -193,4 +247,66 @@ function validateBound(
     }
   }
   return undefined;
+}
+
+type ParameterResult = {
+  procedure: ast.ProcedureStatement;
+  index: number;
+  count: number;
+};
+
+function tryGetParameter(node: ast.SyntaxNode): ParameterResult | undefined {
+  if (node.kind !== ast.SyntaxKind.DeclaredVariable) {
+    return undefined;
+  }
+  const procedureStmt = ast.getContainer(
+    node,
+    ast.SyntaxKind.ProcedureStatement,
+  );
+  if (!procedureStmt) {
+    return undefined;
+  }
+  const index = procedureStmt.parameters.findIndex(
+    (param) => param.ref?.node === node,
+  );
+  if (index === -1) {
+    return undefined;
+  }
+  return {
+    procedure: procedureStmt,
+    index,
+    count: procedureStmt.parameters.length,
+  };
+}
+
+export function BUILTIN_NoMultipleVariadicParameters(
+  stmt: ast.ProcedureStatement,
+  acceptor: ValidationAcceptor,
+  compilationUnit: CompilationUnit,
+) {
+  let foundVarArg = false;
+  for (const parameter of stmt.parameters) {
+    const description = compilationUnit.services.inferer.inferType(
+      parameter,
+      compilationUnit,
+    );
+    if (description.variadicArgument) {
+      if (foundVarArg) {
+        const token =
+          description.witnesses.witnesses[AttributeKind.VariadicArgument]
+            ?.token;
+        if (token) {
+          acceptor(
+            diagnosticFromCode(
+              InternalCodes.VariadicParameterMultiple,
+              token,
+              token.image,
+            ),
+          );
+        }
+      } else {
+        foundVarArg = true;
+      }
+    }
+  }
 }

--- a/packages/language/src/validation/type-check-validator.ts
+++ b/packages/language/src/validation/type-check-validator.ts
@@ -18,9 +18,12 @@ import {
   StringKind,
   TypeDescriptions,
 } from "../typesystem/descriptions";
+import { BuiltinsUriSchema } from "../workspace/builtins";
 import { CompilationUnit } from "../workspace/compilation-unit";
+import { InternalCodes } from "./internal-codes";
 import { PLICodes } from "./pli-codes";
 import { ValidationAcceptor } from "./validator";
+import * as tokens from "../parser/tokens";
 
 export function typeCheck(
   stmt:
@@ -36,9 +39,36 @@ export function typeCheck(
     stmt,
     compilationUnit,
   );
-  if (TypeDescriptions.isUnknown(description)) {
-    // ignore further type checking
-    return;
+
+  if (compilationUnit.uri.scheme === BuiltinsUriSchema) {
+  } else {
+    if (description.variadicArgument) {
+      const token =
+        description.witnesses.witnesses[AttributeKind.VariadicArgument]?.token;
+      if (token) {
+        acceptor(
+          diagnosticFromCode(
+            InternalCodes.BuiltinAttributeUsage,
+            token,
+            token.image,
+          ),
+        );
+      }
+    }
+    if (TypeDescriptions.isUnknown(description)) {
+      const witness = description.witnesses.witnesses[AttributeKind.DataType];
+      if (witness?.token.tokenType === tokens.ANY) {
+        acceptor(
+          diagnosticFromCode(
+            InternalCodes.BuiltinAttributeUsage,
+            witness.token,
+            witness.token.image,
+          ),
+        );
+      }
+      // ignore further type checking
+      return;
+    }
   }
 
   if (description.dimension) {

--- a/packages/language/src/validation/type-check-validator.ts
+++ b/packages/language/src/validation/type-check-validator.ts
@@ -293,11 +293,15 @@ function tryGetParameter(node: ast.SyntaxNode): ParameterResult | undefined {
   };
 }
 
+//TODO @tag(#issue-656) Remove this validation once all builtin procedures signatures are setup
 export function BUILTIN_NoMultipleVariadicParameters(
   stmt: ast.ProcedureStatement,
   acceptor: ValidationAcceptor,
   compilationUnit: CompilationUnit,
 ) {
+  if (compilationUnit.uri.scheme !== BuiltinsUriSchema) {
+    return;
+  }
   let foundVarArg = false;
   for (const parameter of stmt.parameters) {
     const description = compilationUnit.services.inferer.inferType(

--- a/packages/language/src/validation/type-check-validator.ts
+++ b/packages/language/src/validation/type-check-validator.ts
@@ -20,11 +20,11 @@ import {
 } from "../typesystem/descriptions";
 import { BuiltinsUriSchema } from "../workspace/builtins";
 import { CompilationUnit } from "../workspace/compilation-unit";
-import { InternalCodes } from "./internal-codes";
 import { PLICodes } from "./pli-codes";
 import { ValidationAcceptor } from "./validator";
 import * as tokens from "../parser/tokens";
 import { assertType } from "../preprocessor/util";
+import { LspCodes } from "./lsp-codes";
 
 export function typeCheck(
   stmt:
@@ -50,7 +50,7 @@ export function typeCheck(
         if (!parameter) {
           acceptor(
             diagnosticFromCode(
-              InternalCodes.VariadicNonParameter,
+              LspCodes.BuiltinAttributes.VariadicParameter.IsNotAParameter,
               token,
               token.image,
             ),
@@ -61,7 +61,7 @@ export function typeCheck(
             if (!description.dimension) {
               acceptor(
                 diagnosticFromCode(
-                  InternalCodes.VariadicParameterNotAnArray,
+                  LspCodes.BuiltinAttributes.VariadicParameter.IsNotAnArray,
                   stmt.nameToken,
                   stmt.nameToken.image,
                 ),
@@ -75,7 +75,7 @@ export function typeCheck(
               ) {
                 acceptor(
                   diagnosticFromCode(
-                    InternalCodes.VariadicParameterIsFixedArray,
+                    LspCodes.BuiltinAttributes.VariadicParameter.IsAFixedArray,
                     stmt.nameToken,
                     stmt.nameToken.image,
                   ),
@@ -85,7 +85,8 @@ export function typeCheck(
             if (parameter.index !== parameter.count - 1) {
               acceptor(
                 diagnosticFromCode(
-                  InternalCodes.VariadicParameterNotLast,
+                  LspCodes.BuiltinAttributes.VariadicParameter
+                    .IsNotLastParameter,
                   stmt.nameToken,
                   stmt.nameToken.image,
                 ),
@@ -102,7 +103,7 @@ export function typeCheck(
       if (token) {
         acceptor(
           diagnosticFromCode(
-            InternalCodes.BuiltinAttributeUsage,
+            LspCodes.BuiltinAttributes.IsForbiddenUsage,
             token,
             token.image,
           ),
@@ -114,7 +115,7 @@ export function typeCheck(
       if (witness?.token.tokenType === tokens.ANY) {
         acceptor(
           diagnosticFromCode(
-            InternalCodes.BuiltinAttributeUsage,
+            LspCodes.BuiltinAttributes.IsForbiddenUsage,
             witness.token,
             witness.token.image,
           ),
@@ -298,7 +299,8 @@ export function BUILTIN_NoMultipleVariadicParameters(
         if (token) {
           acceptor(
             diagnosticFromCode(
-              InternalCodes.VariadicParameterMultiple,
+              LspCodes.BuiltinAttributes.VariadicParameter
+                .HasMultipleParameters,
               token,
               token.image,
             ),

--- a/packages/language/test/fourslash-harness/harness-interface.ts
+++ b/packages/language/test/fourslash-harness/harness-interface.ts
@@ -83,10 +83,10 @@ export type PrimitiveTypeExpectation =
   | EditComputedAttributes<TypeDescriptions.Ordinal>
   | EditComputedAttributes<TypeDescriptions.Picture>
   | EditComputedAttributes<TypeDescriptions.String>
-  | EditComputedAttributes<TypeDescriptions.Task>;
+  | EditComputedAttributes<TypeDescriptions.Task>
+  | EditComputedAttributes<TypeDescriptions.Unknown>;
 export type TypeExpectation =
   | Partial<PrimitiveTypeExpectation>
-  | Partial<TypeDescriptions.Unknown>
   | ({
       type: DataType.Structure;
       members: Record<string, TypeExpectation>;

--- a/packages/language/test/fourslash-harness/harness-parser.ts
+++ b/packages/language/test/fourslash-harness/harness-parser.ts
@@ -213,7 +213,7 @@ class HarnessTestParser {
         const uri =
           fileName === UnnamedFile
             ? DEFAULT_FILE_URI
-            : URI.file(fileName).toString();
+            : URI.parse(fileName).toString();
 
         if (files.get(uri) !== undefined) {
           throw new Error(`Duplicate file name: '${uri}'`);

--- a/packages/language/test/fourslash-harness/harness-parser.ts
+++ b/packages/language/test/fourslash-harness/harness-parser.ts
@@ -213,7 +213,8 @@ class HarnessTestParser {
         const uri =
           fileName === UnnamedFile
             ? DEFAULT_FILE_URI
-            : URI.parse(fileName).toString();
+            : //TODO @tag(#issue-656) Change this back to `URI.file(fileName).toString()` once all builtin procedures signatures are setup
+              URI.parse(fileName).toString();
 
         if (files.get(uri) !== undefined) {
           throw new Error(`Duplicate file name: '${uri}'`);

--- a/packages/language/test/fourslash/preprocessor/builtins/any-array-builtin.ts
+++ b/packages/language/test/fourslash/preprocessor/builtins/any-array-builtin.ts
@@ -17,29 +17,8 @@
 ////   RETURN(12);
 //// END;
 
-// @filename: file:///yyy.pli
-//// YYY: PROCEDURE (Y) RETURNS(FIXED);
-////   DCL <|Y|>(10) <|2:ANY|>;
-////   RETURN(34);
-//// END;
-
 verify.noDiagnostics("1");
 types.expectTypeAt("X", {
-  type: types.dataTypes.Unknown,
-  dimension: [
-    {
-      lowerBound: {
-        value: 1,
-      },
-      upperBound: {
-        value: 10,
-      },
-    },
-  ],
-});
-
-verify.expectDiagnosticsAt("2", code.Internal.BuiltinAttributeUsage);
-types.expectTypeAt("Y", {
   type: types.dataTypes.Unknown,
   dimension: [
     {

--- a/packages/language/test/fourslash/preprocessor/builtins/any-array-builtin.ts
+++ b/packages/language/test/fourslash/preprocessor/builtins/any-array-builtin.ts
@@ -11,6 +11,8 @@
 
 /// <reference path="../../framework.ts" />
 
+//TODO @tag(#issue-656) Remove this file once all builtin procedures signatures are setup
+
 // @filename: pli-builtin:///xxx.pli
 //// XXX: PROCEDURE (X) RETURNS(FIXED);
 ////   DCL <|X|>(10) <|1:ANY|>;

--- a/packages/language/test/fourslash/preprocessor/builtins/any-array-non-builtin.ts
+++ b/packages/language/test/fourslash/preprocessor/builtins/any-array-non-builtin.ts
@@ -1,0 +1,33 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: file:///yyy.pli
+//// XXX: PROCEDURE (X) RETURNS(FIXED);
+////   DCL <|X|>(10) <|1:ANY|>;
+////   RETURN(34);
+//// END;
+
+verify.expectDiagnosticsAt("1", code.Internal.BuiltinAttributeUsage);
+types.expectTypeAt("X", {
+  type: types.dataTypes.Unknown,
+  dimension: [
+    {
+      lowerBound: {
+        value: 1,
+      },
+      upperBound: {
+        value: 10,
+      },
+    },
+  ],
+});

--- a/packages/language/test/fourslash/preprocessor/builtins/any-array-non-builtin.ts
+++ b/packages/language/test/fourslash/preprocessor/builtins/any-array-non-builtin.ts
@@ -17,7 +17,7 @@
 ////   RETURN(34);
 //// END;
 
-verify.expectDiagnosticsAt("1", code.Internal.BuiltinAttributeUsage);
+verify.expectDiagnosticsAt("1", code.LSP.BuiltinAttributes.IsForbiddenUsage);
 types.expectTypeAt("X", {
   type: types.dataTypes.Unknown,
   dimension: [

--- a/packages/language/test/fourslash/preprocessor/builtins/any-array.ts
+++ b/packages/language/test/fourslash/preprocessor/builtins/any-array.ts
@@ -1,0 +1,54 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: pli-builtin:///xxx.pli
+//// XXX: PROCEDURE (X) RETURNS(FIXED);
+////   DCL <|X|>(10) <|1:ANY|>;
+////   RETURN(12);
+//// END;
+
+// @filename: file:///yyy.pli
+//// YYY: PROCEDURE (Y) RETURNS(FIXED);
+////   DCL <|Y|>(10) <|2:ANY|>;
+////   RETURN(34);
+//// END;
+
+verify.noDiagnostics("1");
+types.expectTypeAt("X", {
+  type: types.dataTypes.Unknown,
+  dimension: [
+    {
+      lowerBound: {
+        value: 1,
+      },
+      upperBound: {
+        value: 10,
+      },
+    },
+  ],
+});
+
+verify.expectDiagnosticsAt("2", code.Internal.BuiltinAttributeUsage);
+types.expectTypeAt("Y", {
+  type: types.dataTypes.Unknown,
+  dimension: [
+    {
+      lowerBound: {
+        value: 1,
+      },
+      upperBound: {
+        value: 10,
+      },
+    },
+  ],
+});

--- a/packages/language/test/fourslash/preprocessor/builtins/any-builtin.ts
+++ b/packages/language/test/fourslash/preprocessor/builtins/any-builtin.ts
@@ -11,6 +11,8 @@
 
 /// <reference path="../../framework.ts" />
 
+//TODO @tag(#issue-656) Remove this file once all builtin procedures signatures are setup
+
 // @filename: pli-builtin:///xxx.pli
 //// XXX: PROCEDURE (X) RETURNS(FIXED);
 ////   DCL <|X|> <|1:ANY|>;

--- a/packages/language/test/fourslash/preprocessor/builtins/any-builtin.ts
+++ b/packages/language/test/fourslash/preprocessor/builtins/any-builtin.ts
@@ -11,10 +11,13 @@
 
 /// <reference path="../../framework.ts" />
 
-// @filename: /xxx.pli
+// @filename: pli-builtin:///xxx.pli
 //// XXX: PROCEDURE (X) RETURNS(FIXED);
-////   DCL X(10) FIXED <|VARARG|>;
+////   DCL <|X|> <|1:ANY|>;
 ////   RETURN(12);
 //// END;
 
-verify.expectDiagnosticsAt("VARARG", code.Internal.BuiltinAttributeUsage);
+verify.noDiagnostics("1");
+types.expectTypeAt("X", {
+  type: types.dataTypes.Unknown,
+});

--- a/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin-before-last-parameter.ts
+++ b/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin-before-last-parameter.ts
@@ -18,4 +18,7 @@
 ////   RETURN(12);
 //// END;
 
-verify.expectDiagnosticsAt("X", code.Internal.VariadicParameterNotLast);
+verify.expectDiagnosticsAt(
+  "X",
+  code.LSP.BuiltinAttributes.VariadicParameter.IsNotLastParameter,
+);

--- a/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin-before-last-parameter.ts
+++ b/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin-before-last-parameter.ts
@@ -11,6 +11,8 @@
 
 /// <reference path="../../framework.ts" />
 
+//TODO @tag(#issue-656) Remove this file once all builtin procedures signatures are setup
+
 // @filename: pli-builtin:///xxx.pli
 //// XXX: PROCEDURE (X, Y) RETURNS(FIXED);
 ////   DCL <|X|>(*) FIXED VARARG;

--- a/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin-before-last-parameter.ts
+++ b/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin-before-last-parameter.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: pli-builtin:///xxx.pli
+//// XXX: PROCEDURE (X, Y) RETURNS(FIXED);
+////   DCL <|X|>(*) FIXED VARARG;
+////   DCL Y FIXED;
+////   RETURN(12);
+//// END;
+
+verify.expectDiagnosticsAt("X", code.Internal.VariadicParameterNotLast);

--- a/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin-fixed-array.ts
+++ b/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin-fixed-array.ts
@@ -17,4 +17,7 @@
 ////   RETURN(12);
 //// END;
 
-verify.expectDiagnosticsAt("X", code.Internal.VariadicParameterIsFixedArray);
+verify.expectDiagnosticsAt(
+  "X",
+  code.LSP.BuiltinAttributes.VariadicParameter.IsAFixedArray,
+);

--- a/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin-fixed-array.ts
+++ b/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin-fixed-array.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: pli-builtin:///xxx.pli
+//// XXX: PROCEDURE (X) RETURNS(FIXED);
+////   DCL <|X|>(20) FIXED VARARG;
+////   RETURN(12);
+//// END;
+
+verify.expectDiagnosticsAt("X", code.Internal.VariadicParameterIsFixedArray);

--- a/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin-fixed-array.ts
+++ b/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin-fixed-array.ts
@@ -11,6 +11,8 @@
 
 /// <reference path="../../framework.ts" />
 
+//TODO @tag(#issue-656) Remove this file once all builtin procedures signatures are setup
+
 // @filename: pli-builtin:///xxx.pli
 //// XXX: PROCEDURE (X) RETURNS(FIXED);
 ////   DCL <|X|>(20) FIXED VARARG;

--- a/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin-multiple-varargs.ts
+++ b/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin-multiple-varargs.ts
@@ -19,7 +19,19 @@
 ////   RETURN(12);
 //// END;
 
-verify.expectDiagnosticsAt("X", code.Internal.VariadicParameterNotLast);
-verify.expectDiagnosticsAt("Y", code.Internal.VariadicParameterNotLast);
-verify.expectDiagnosticsAt("YArgs", code.Internal.VariadicParameterMultiple);
-verify.expectDiagnosticsAt("ZArgs", code.Internal.VariadicParameterMultiple);
+verify.expectDiagnosticsAt(
+  "X",
+  code.LSP.BuiltinAttributes.VariadicParameter.IsNotLastParameter,
+);
+verify.expectDiagnosticsAt(
+  "Y",
+  code.LSP.BuiltinAttributes.VariadicParameter.IsNotLastParameter,
+);
+verify.expectDiagnosticsAt(
+  "YArgs",
+  code.LSP.BuiltinAttributes.VariadicParameter.HasMultipleParameters,
+);
+verify.expectDiagnosticsAt(
+  "ZArgs",
+  code.LSP.BuiltinAttributes.VariadicParameter.HasMultipleParameters,
+);

--- a/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin-multiple-varargs.ts
+++ b/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin-multiple-varargs.ts
@@ -11,6 +11,8 @@
 
 /// <reference path="../../framework.ts" />
 
+//TODO @tag(#issue-656) Remove this file once all builtin procedures signatures are setup
+
 // @filename: pli-builtin:///xxx.pli
 //// XXX: PROCEDURE (X, Y, Z) RETURNS(FIXED);
 ////   DCL <|X|>(*) FIXED VARARG;

--- a/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin-multiple-varargs.ts
+++ b/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin-multiple-varargs.ts
@@ -1,0 +1,25 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: pli-builtin:///xxx.pli
+//// XXX: PROCEDURE (X, Y, Z) RETURNS(FIXED);
+////   DCL <|X|>(*) FIXED VARARG;
+////   DCL <|Y|>(*) FIXED <|YArgs:VARARG|>;
+////   DCL Z(*) FIXED <|ZArgs:VARARG|>;
+////   RETURN(12);
+//// END;
+
+verify.expectDiagnosticsAt("X", code.Internal.VariadicParameterNotLast);
+verify.expectDiagnosticsAt("Y", code.Internal.VariadicParameterNotLast);
+verify.expectDiagnosticsAt("YArgs", code.Internal.VariadicParameterMultiple);
+verify.expectDiagnosticsAt("ZArgs", code.Internal.VariadicParameterMultiple);

--- a/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin-non-array.ts
+++ b/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin-non-array.ts
@@ -11,6 +11,8 @@
 
 /// <reference path="../../framework.ts" />
 
+//TODO @tag(#issue-656) Remove this file once all builtin procedures signatures are setup
+
 // @filename: pli-builtin:///xxx.pli
 //// XXX: PROCEDURE (X) RETURNS(FIXED);
 ////   DCL <|X|> FIXED VARARG;

--- a/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin-non-array.ts
+++ b/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin-non-array.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: pli-builtin:///xxx.pli
+//// XXX: PROCEDURE (X) RETURNS(FIXED);
+////   DCL <|X|> FIXED VARARG;
+////   RETURN(12);
+//// END;
+
+verify.expectDiagnosticsAt("X", code.Internal.VariadicParameterNotAnArray);

--- a/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin-non-array.ts
+++ b/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin-non-array.ts
@@ -17,4 +17,7 @@
 ////   RETURN(12);
 //// END;
 
-verify.expectDiagnosticsAt("X", code.Internal.VariadicParameterNotAnArray);
+verify.expectDiagnosticsAt(
+  "X",
+  code.LSP.BuiltinAttributes.VariadicParameter.IsNotAnArray,
+);

--- a/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin-non-parameter.ts
+++ b/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin-non-parameter.ts
@@ -1,0 +1,17 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: pli-builtin:///xxx.pli
+//// DCL X(*) FIXED <|VARARG|>;
+
+verify.expectDiagnosticsAt("VARARG", code.Internal.VariadicNonParameter);

--- a/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin-non-parameter.ts
+++ b/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin-non-parameter.ts
@@ -14,4 +14,7 @@
 // @filename: pli-builtin:///xxx.pli
 //// DCL X(*) FIXED <|VARARG|>;
 
-verify.expectDiagnosticsAt("VARARG", code.Internal.VariadicNonParameter);
+verify.expectDiagnosticsAt(
+  "VARARG",
+  code.LSP.BuiltinAttributes.VariadicParameter.IsNotAParameter,
+);

--- a/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin-non-parameter.ts
+++ b/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin-non-parameter.ts
@@ -11,6 +11,8 @@
 
 /// <reference path="../../framework.ts" />
 
+//TODO @tag(#issue-656) Remove this file once all builtin procedures signatures are setup
+
 // @filename: pli-builtin:///xxx.pli
 //// DCL X(*) FIXED <|VARARG|>;
 

--- a/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin.ts
+++ b/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin.ts
@@ -1,0 +1,32 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: pli-builtin:///xxx.pli
+//// XXX: PROCEDURE (X) RETURNS(FIXED);
+////   DCL <|X|>(*) FIXED <|VARARG|>;
+////   RETURN(12);
+//// END;
+
+verify.noDiagnostics("VARARG");
+types.expectTypeAt("X", {
+  type: types.dataTypes.Arithmetic,
+  scale: types.scales.Fixed,
+  dimension: [
+    {
+      lowerBound: {},
+      upperBound: {
+        value: "*",
+      },
+    },
+  ],
+});

--- a/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin.ts
+++ b/packages/language/test/fourslash/preprocessor/builtins/vararg-builtin.ts
@@ -11,6 +11,8 @@
 
 /// <reference path="../../framework.ts" />
 
+//TODO @tag(#issue-656) Remove this file once all builtin procedures signatures are setup
+
 // @filename: pli-builtin:///xxx.pli
 //// XXX: PROCEDURE (X) RETURNS(FIXED);
 ////   DCL <|X|>(*) FIXED <|VARARG|>;

--- a/packages/language/test/fourslash/preprocessor/builtins/vararg-non-builtin.ts
+++ b/packages/language/test/fourslash/preprocessor/builtins/vararg-non-builtin.ts
@@ -17,4 +17,7 @@
 ////   RETURN(12);
 //// END;
 
-verify.expectDiagnosticsAt("VARARG", code.Internal.BuiltinAttributeUsage);
+verify.expectDiagnosticsAt(
+  "VARARG",
+  code.LSP.BuiltinAttributes.IsForbiddenUsage,
+);

--- a/packages/language/test/fourslash/preprocessor/builtins/vararg-non-builtin.ts
+++ b/packages/language/test/fourslash/preprocessor/builtins/vararg-non-builtin.ts
@@ -1,0 +1,34 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: /xxx.pli
+//// XXX: PROCEDURE (X) RETURNS(FIXED);
+////   DCL <|X|>(10) FIXED <|VARARG|>;
+////   RETURN(12);
+//// END;
+
+verify.expectDiagnosticsAt("VARARG", code.Internal.BuiltinAttributeUsage);
+types.expectTypeAt("X", {
+  type: types.dataTypes.Arithmetic,
+  scale: types.scales.Fixed,
+  dimension: [
+    {
+      lowerBound: {
+        value: 1,
+      },
+      upperBound: {
+        value: 10,
+      },
+    },
+  ],
+});

--- a/packages/language/test/fourslash/preprocessor/replace-by-number-before-add.ts
+++ b/packages/language/test/fourslash/preprocessor/replace-by-number-before-add.ts
@@ -16,4 +16,4 @@
 //// %NOTE('A+B = ', (A+B));
 
 preprocessor.expectTokens("");
-verify.noDiagnostics(undefined, code.Internal.UnknownIdentifier);
+verify.noDiagnostics(undefined, code.LSP.UnknownIdentifier);


### PR DESCRIPTION
ANY shall indicate that we accept any type as parameter.
VARARG shall indicate that the parameter is variadic. This implies it must be an array and that it only can be placed once at last parameter if a procedure.

Both KEYWORDS are not inside the PL/I language spec. They will be only used for builtin procedures.