### PR TITLE
Fix syntax highlighting for modifier keywords

### DIFF
--- a/packages/playground/src/config.ts
+++ b/packages/playground/src/config.ts
@@ -122,6 +122,15 @@ export const configure = async (
                 path: "./grammar.json",
               },
             ],
+            semanticTokenScopes: [
+              {
+                language: "pli",
+                scopes: {
+                  keyword: ["keyword.control.pli"],
+                  modifier: ["keyword.storage.pli"],
+                },
+              },
+            ],
           },
         },
         filesOrContents: extensionFilesOrContents,

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -65,6 +65,15 @@
         "path": "syntaxes/pli.merged.json"
       }
     ],
+    "semanticTokenScopes": [
+      {
+        "language": "pli",
+        "scopes": {
+          "keyword": ["keyword.control.pli"],
+          "modifier": ["keyword.storage.pli"]
+        }
+      }
+    ],
     "jsonValidation": [
       {
         "fileMatch": "**/.pliplugin/pgm_conf.json",


### PR DESCRIPTION
Closes https://github.com/zowe/zowe-pli-language-support/issues/661

I'm not entirely sure what changed for this to be required - but it seems like `modifier` no longer maps by default to the textmate scope `keyword.storage`. Adding a manual override seems to fix this.