### PR TITLE
Heuristically ask to set PL/I language on files

### DIFF
--- a/packages/language/src/language-server/connection-handler.ts
+++ b/packages/language/src/language-server/connection-handler.ts
@@ -56,6 +56,8 @@ export { PluginConfiguration } from "./constants";
 export const WorkspaceDidChangePlipluginConfigNotification =
   "workspace/didChangePlipluginConfig";
 
+export const ExistingFileRequest = "pli/existingFileRequest";
+
 export function startLanguageServer(connection: Connection): void {
   const compilationUnitHandler = new CompilationUnitHandler();
   compilationUnitHandler.listen(connection);
@@ -342,6 +344,11 @@ export function startLanguageServer(connection: Connection): void {
       await compilationUnitHandler.reindex(connection, CancellationToken.None);
     },
   );
+  connection.onRequest(ExistingFileRequest, (uriString: string): boolean => {
+    const uri = URI.parse(uriString);
+    const compilationUnit = compilationUnitHandler.getCompilationUnit(uri);
+    return compilationUnit !== undefined;
+  });
 
   connection.onCodeAction(async (params) => {
     const requestedKinds = params.context.only;

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -26,7 +26,6 @@ import { createLSRequestCaches, LSRequestCache } from "../utils/cache.js";
 import { Scope, ScopeCacheGroups } from "../linking/scope.js";
 import { Token } from "../parser/tokens.js";
 import {
-  BuiltinDocuments,
   EditorDocuments,
   TextDocuments,
 } from "../language-server/text-documents.js";
@@ -374,8 +373,8 @@ export class CompilationUnitHandler {
       }
       const allDiagnostics = diagnosticsToLSP(unit, unit.diagnostics.getAll());
       for (const file of unit.services.files.keys()) {
-        if (BuiltinDocuments.get(file) || !EditorDocuments.get(file)) {
-          // do not report diagnostics for built-in files or files not currently open in the editor
+        if (!EditorDocuments.get(file) || isVirtualFile(file)) {
+          // do not report diagnostics for virtual files or files not currently open in the editor
           continue;
         }
         const fileDiagnostics = allDiagnostics.get(file);
@@ -419,4 +418,10 @@ export class CompilationUnitHandler {
     });
     return Promise.all(promises).then(() => undefined);
   }
+}
+
+const virtualSchemes = ["git", "untitled", BuiltinsUriSchema];
+
+function isVirtualFile(uri: string): boolean {
+  return virtualSchemes.some((scheme) => uri.startsWith(`${scheme}:`));
 }

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -78,6 +78,11 @@
     "configuration": {
       "title": "PL/I Language Support",
       "properties": {
+        "pli.autoDetect": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable/disable automatic detection of PL/I files based on content."
+        },
         "pli.skippedCode.enabled": {
           "type": "boolean",
           "default": true,

--- a/packages/vscode-extension/src/extension/document-identification.ts
+++ b/packages/vscode-extension/src/extension/document-identification.ts
@@ -1,0 +1,90 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import * as vscode from "vscode";
+import { Settings } from "./settings";
+import { BaseLanguageClient } from "vscode-languageclient";
+
+export function registerPliDocumentIdentifier(lc: BaseLanguageClient) {
+  const proposedFiles = new Set<string>();
+  return vscode.workspace.onDidOpenTextDocument(async (document) => {
+    if (!Settings.getInstance().autoDetect) {
+      // Auto-detection is disabled, so do not propose to set language for any file.
+      return;
+    }
+    if (proposedFiles.has(document.uri.toString())) {
+      // We've already proposed to change the language for this document.
+      return;
+    }
+    if (document.languageId !== "plaintext") {
+      // Only attempt to identify PL/I documents that are currently marked as plaintext
+      return;
+    }
+    proposedFiles.add(document.uri.toString());
+    if (await isPossiblePliDocument(document, lc)) {
+      proposePliLanguage(document);
+    }
+  });
+}
+
+async function isPossiblePliDocument(
+  document: vscode.TextDocument,
+  lc: BaseLanguageClient,
+): Promise<boolean> {
+  // Try to do a simple check based on file extension first.
+  const ext = document.uri.path.split(".").pop()?.toLowerCase();
+  const possibleExt = ["pli", "pl1", "pl", "p1"];
+  if (ext && possibleExt.includes(ext)) {
+    return true;
+  }
+  // If the file extension doesn't give it away, ask the language server if it recognizes the file.
+  try {
+    const exists = await lc.sendRequest(
+      "pli/existingFileRequest",
+      document.uri.toString(),
+    );
+    if (exists) {
+      return true;
+    }
+  } catch {
+    // Ignore errors, we'll just do a heuristic check below.
+  }
+  // Then, look for PL/I specific constellations in the first 200 lines of the document.
+  const text = document.getText(
+    new vscode.Range(0, 0, Math.min(200, document.lineCount), 0),
+  );
+  const keywordRegex =
+    /\b(dcl|declare|:\s*proc(edure)?|then\s*do|else\s*do)\b/i;
+  if (keywordRegex.test(text)) {
+    return true;
+  }
+  return false;
+}
+
+async function proposePliLanguage(document: vscode.TextDocument) {
+  console.log(
+    `Proposing to set language of ${document.uri.toString(true)} to PL/I`,
+  );
+  const fileName = document.uri.path.split("/").pop();
+  const selection = await vscode.window.showInformationMessage(
+    `The file '${fileName}' looks like a PL/I source file. Do you want to set the language to PL/I?`,
+    "Yes",
+    "No",
+    "Never",
+  );
+  if (selection === "Yes") {
+    vscode.languages.setTextDocumentLanguage(document, "pli");
+  } else if (selection === "Never") {
+    // Change the settings to never recommend PL/I for any file.
+    const settings = Settings.getInstance();
+    await settings.setAutoDetect(false);
+  }
+}

--- a/packages/vscode-extension/src/extension/main.ts
+++ b/packages/vscode-extension/src/extension/main.ts
@@ -23,15 +23,18 @@ import { registerCustomDecorators } from "./decorators";
 import { WorkspaceDidChangePlipluginConfigNotification } from "pli-language";
 import { TelemetryReporter } from "@vscode/extension-telemetry";
 import { handleMissingConfig } from "../common/missing-config-handler";
+import { registerPliDocumentIdentifier } from "./document-identification";
 
 let client: LanguageClient;
 let settings: Settings;
 
 // This function is called when the extension is activated.
-export function activate(context: vscode.ExtensionContext): void {
+export async function activate(
+  context: vscode.ExtensionContext,
+): Promise<void> {
   BuiltinFileSystemProvider.register(context);
   settings = Settings.getInstance();
-  client = startLanguageClient(context);
+  client = await startLanguageClient(context);
 
   const telemetryReporter: TelemetryReporter | undefined =
     getTelemetryReporter(context);
@@ -39,6 +42,7 @@ export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     registerOnDidChangeActiveTextEditor(),
     registerOnDidOpenTextDocListener(telemetryReporter),
+    registerPliDocumentIdentifier(client),
   );
 
   const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
@@ -120,7 +124,9 @@ export async function deactivate(): Promise<void> {
   }
 }
 
-function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
+async function startLanguageClient(
+  context: vscode.ExtensionContext,
+): Promise<LanguageClient> {
   const serverModule = context.asAbsolutePath(
     path.join("out", "language", "main.cjs"),
   );
@@ -162,7 +168,7 @@ function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
   registerCustomDecorators(client, settings);
 
   // Start the client. This will also launch the server
-  client.start();
+  await client.start();
   return client;
 }
 

--- a/packages/vscode-extension/src/extension/settings.ts
+++ b/packages/vscode-extension/src/extension/settings.ts
@@ -47,11 +47,11 @@ export class Settings {
   }
 
   public get skippedCodeEnabled(): boolean {
-    return this.getConfiguration().get("skippedCode.enabled") ?? true;
+    return this.getConfiguration().get("skippedCode.enabled", true);
   }
 
   public get skippedCodeOpacity(): number {
-    return this.getConfiguration().get("skippedCode.opacity") ?? 0.55;
+    return this.getConfiguration().get("skippedCode.opacity", 0.55);
   }
 
   public get marginIndicatorRulersEnabled(): boolean {
@@ -59,6 +59,18 @@ export class Settings {
   }
 
   public get marginIndicatorRulers(): "off" | "default" | "automatic" {
-    return this.getConfiguration().get("marginIndicator.rulers") ?? "off";
+    return this.getConfiguration().get("marginIndicator.rulers", "off");
+  }
+
+  public get autoDetect(): boolean {
+    return this.getConfiguration().get("autoDetect", true);
+  }
+
+  public async setAutoDetect(value: boolean): Promise<void> {
+    await this.getConfiguration().update(
+      "autoDetect",
+      value,
+      vscode.ConfigurationTarget.Global,
+    );
   }
 }


### PR DESCRIPTION
Closes https://github.com/zowe/zowe-pli-language-support/issues/634

Proposes multiple strategies to set the editor association on files in the workspace:
1. If the extension matches on of our default extensions.
2. If the file is currently part of one of our compilation units (i.e. if it was included in some other file)
3. If the first 200 lines of content contain common (but not too common) PL/I constellations. I.e. does not contain `do` or similar, as they are too common.

Also fixes https://github.com/zowe/zowe-pli-language-support/issues/625 as a drive by. Diagnostics will no longer be reported on virtual files.