### PR TITLE
Show macro code in italic

### DIFF
--- a/packages/language/src/language-server/semantic-token-decoder.ts
+++ b/packages/language/src/language-server/semantic-token-decoder.ts
@@ -10,14 +10,14 @@
  */
 
 import { TextDocument } from "vscode-languageserver-textdocument";
-import { SemanticTokenTypes } from "./semantic-tokens";
+import { SemanticTokenModifiers, SemanticTokenTypes } from "./semantic-tokens";
 
 export namespace SemanticTokenDecoder {
   export interface DecodedSemanticToken {
     offsetStart: number;
     offsetEnd: number;
     semanticTokenType: string;
-    tokenModifiers: number;
+    tokenModifiers: string[];
     text: string;
   }
 
@@ -38,11 +38,18 @@ export namespace SemanticTokenDecoder {
       character += tokens[i + 1];
       const offset = textDocument.offsetAt({ line, character });
 
+      const modifiers = tokens[i + 4];
+      const tokenModifiers: string[] = [];
+      for (let bit = 0; bit < 32; bit++) {
+        if ((modifiers & (1 << bit)) !== 0) {
+          tokenModifiers.push(SemanticTokenModifiers[bit]);
+        }
+      }
       const decodedToken: DecodedSemanticToken = {
         offsetStart: offset,
         offsetEnd: offset + tokens[i + 2],
         semanticTokenType: SemanticTokenTypes[tokens[i + 3]],
-        tokenModifiers: tokens[i + 4],
+        tokenModifiers,
         text: textDocument.getText({
           start: { line, character },
           end: { line, character: character + tokens[i + 2] },

--- a/packages/language/src/language-server/semantic-tokens.ts
+++ b/packages/language/src/language-server/semantic-tokens.ts
@@ -17,6 +17,7 @@ import { SemanticTokensLegend } from "vscode-languageserver-types";
 import {
   DeclaredVariable,
   getContainer,
+  isPreprocessorNode,
   SyntaxKind,
   SyntaxNode,
 } from "../syntax-tree/ast";
@@ -45,13 +46,17 @@ export enum SemanticTokenTypes {
   comment,
 }
 
-const tokenModifiers = new Map<string, number>([]);
+export enum SemanticTokenModifiers {
+  preprocessor,
+}
 
 export const semanticTokenLegend: SemanticTokensLegend = {
   tokenTypes: Object.keys(SemanticTokenTypes).filter((key) =>
     isNaN(Number(key)),
   ),
-  tokenModifiers: Array.from(tokenModifiers.keys()),
+  tokenModifiers: Object.keys(SemanticTokenModifiers).filter((key) =>
+    isNaN(Number(key)),
+  ),
 };
 
 export function semanticTokens(
@@ -77,12 +82,13 @@ export function semanticTokens(
     }
     const type = tokenType(token);
     if (type !== undefined) {
+      const modifier = tokenModifier(compilationUnit, token);
       semanticTokens.push(
         token.startLine,
         token.startColumn,
         token.image.length,
         type,
-        0,
+        modifier,
       );
     }
   }
@@ -130,6 +136,18 @@ function handleCommentTokens(
       tokenBuilder.push(line, startChar, length, SemanticTokenTypes.comment, 0);
     }
   }
+}
+
+function tokenModifier(unit: CompilationUnit, token: Token): number {
+  let modifier = 0;
+  const element = token.element;
+  if (!element) {
+    return 0;
+  }
+  if (isPreprocessorNode(unit, element)) {
+    modifier |= 1 << SemanticTokenModifiers.preprocessor;
+  }
+  return modifier;
 }
 
 function tokenType(token: Token): number | undefined {

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2113,6 +2113,9 @@ function generateSyntheticRefItem(
   context: InterpreterContext,
 ): ast.ReferenceItem {
   const refItem = ast.createReferenceItem();
+  // Set the container to the preprocessor AST
+  // This ensures that the isPreprocessorNode check works correctly
+  refItem.container = context.unit.preprocessorAst;
   const ref = ast.createReference<ast.NamedVariable>(
     refItem,
     token,

--- a/packages/language/test/fourslash-harness/harness-interface.ts
+++ b/packages/language/test/fourslash-harness/harness-interface.ts
@@ -9,7 +9,6 @@
  *
  */
 
-import { SemanticTokenTypes } from "vscode-languageserver-types";
 import { CompletionKeywords } from "../../src/language-server/completion/keywords";
 import { Diagnostic, type Severity } from "../../src/language-server/types";
 import { CompilerOptionsCodes } from "../../src/preprocessor/compiler-options/codes";
@@ -50,8 +49,15 @@ import {
 import { LspCodes } from "../../src/validation/lsp-codes";
 import { PLICode, PLICodes } from "../../src/validation/pli-codes";
 import { ExpectedCompletion, Label, TestBuilder } from "../test-builder";
+import {
+  SemanticTokenModifiers,
+  SemanticTokenTypes,
+} from "../../src/language-server/semantic-tokens";
 
-type SemanticTokenTypesValues = `${SemanticTokenTypes}`;
+export type SemanticTokenTypesValues = keyof typeof SemanticTokenTypes;
+export type SemanticTokenModifiersValues =
+  | keyof typeof SemanticTokenModifiers
+  | "none";
 
 export type CompilerOptions = PliCompilerOptions & {
   macroOptions: MacroCompilerOptions;
@@ -339,6 +345,20 @@ export interface HarnessTesterInterface {
      * @param tokenType The token type to expect.
      */
     expectAt(label: Label, tokenType: SemanticTokenTypesValues): void;
+    /**
+     * Expect that the semantic tokens at the given label have the given token modifier.
+     * @param label The label to expect the semantic tokens at.
+     */
+    expectModifierAt(label: SemanticTokenModifiersValues): void;
+    /**
+     * Expect that the semantic tokens at the given label have the given token modifier.
+     * @param label The label to expect the semantic tokens at.
+     * @param modifier The token modifier to expect.
+     */
+    expectModifierAt(
+      label: Label,
+      modifier: SemanticTokenModifiersValues,
+    ): void;
   };
 
   preprocessor: {

--- a/packages/language/test/fourslash-harness/harness.test.ts
+++ b/packages/language/test/fourslash-harness/harness.test.ts
@@ -89,6 +89,7 @@ async function createTestingHarnessImplementation(
     },
     semanticTokens: {
       expectAt: listen("semanticTokens.expectAt"),
+      expectModifierAt: listen("semanticTokens.expectModifierAt"),
     },
     preprocessor: {
       not: {

--- a/packages/language/test/fourslash-harness/implementation/test-builder.ts
+++ b/packages/language/test/fourslash-harness/implementation/test-builder.ts
@@ -10,10 +10,13 @@
  */
 
 import { MarkupKind } from "vscode-languageserver";
-import { SemanticTokenTypes } from "vscode-languageserver-types";
 import { formatPliCodeBlock } from "../../../src/utils/code-block";
 import { TestBuilder } from "../../test-builder";
-import { HarnessTesterInterface } from "../harness-interface";
+import {
+  HarnessTesterInterface,
+  SemanticTokenModifiersValues,
+  SemanticTokenTypesValues,
+} from "../harness-interface";
 import { HarnessCodes } from "./codes";
 import { HarnessConstants } from "./constants";
 import { generateIncludeItemMarkup } from "../../../src/language-server/hover-request";
@@ -104,7 +107,12 @@ export function createTestBuilderHarnessImplementation(
       expectAt: (label, tokenType = label.toString()) =>
         testBuilder.expectSemanticTokens(
           label.toString(),
-          tokenType as `${SemanticTokenTypes}`,
+          tokenType as SemanticTokenTypesValues,
+        ),
+      expectModifierAt: (label, modifier = label.toString()) =>
+        testBuilder.expectSemanticTokenModifiers(
+          label.toString(),
+          modifier as SemanticTokenModifiersValues,
         ),
     },
     preprocessor: {

--- a/packages/language/test/fourslash/semantic-tokens/preprocessor-code-modifier.ts
+++ b/packages/language/test/fourslash/semantic-tokens/preprocessor-code-modifier.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// %<|preprocessor:DCL|> <|preprocessor:TEST|> <|preprocessor:INIT|>(<|preprocessor:"PP"|>);
+//// <|none:PUT|>(<|none"Hello, World!"|>);
+
+semanticTokens.expectModifierAt("preprocessor");
+semanticTokens.expectModifierAt("none");

--- a/packages/language/test/fourslash/semantic-tokens/preprocessor-procedure-ref.ts
+++ b/packages/language/test/fourslash/semantic-tokens/preprocessor-procedure-ref.ts
@@ -1,0 +1,18 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+//// %TEST_PROC: PROC; %END;
+//// %ACT TEST_PROC;
+//// <|preprocessor:TEST_PROC|>
+
+semanticTokens.expectModifierAt("preprocessor");

--- a/packages/language/test/fourslash/semantic-tokens/preprocessor-var-ref.ts
+++ b/packages/language/test/fourslash/semantic-tokens/preprocessor-var-ref.ts
@@ -1,0 +1,17 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+//// %DCL TEST_VAR FIXED(31);
+//// <|preprocessor:TEST_VAR|>
+
+semanticTokens.expectModifierAt("preprocessor");

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -29,11 +29,7 @@ import { hoverRequest } from "../src/language-server/hover-request";
 import { semanticTokens } from "../src/language-server/semantic-tokens";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { SemanticTokenDecoder } from "../src/language-server/semantic-token-decoder";
-import {
-  SemanticTokenTypes,
-  CodeAction,
-  TextEdit,
-} from "vscode-languageserver-types";
+import { CodeAction, TextEdit } from "vscode-languageserver-types";
 import { skippedCodeRanges } from "../src/language-server/skipped-code";
 import {
   PluginConfigurationProviderInstance,
@@ -48,7 +44,11 @@ import { isSyntaxNode, SyntaxKind } from "../src/syntax-tree/ast";
 import { isObject } from "../src/utils/types";
 import { format } from "util";
 import { DataType, TypeDescriptions } from "../src/typesystem/descriptions";
-import { TypeExpectation } from "./fourslash-harness/harness-interface";
+import {
+  SemanticTokenModifiersValues,
+  SemanticTokenTypesValues,
+  TypeExpectation,
+} from "./fourslash-harness/harness-interface";
 import { binaryTokenSearch } from "../src/utils/search";
 import { PluginConfiguration } from "../src/language-server/constants";
 import { DiagnosticCategory } from "../src/validation/diagnostics-store";
@@ -1130,7 +1130,7 @@ Available code actions for label "${label}" and URI "${uri}": ${codeActions.map(
    * `).expectSemanticTokens("1", "variable"); // Passes
    * ```
    */
-  expectSemanticTokens(label: string, tokenType: `${SemanticTokenTypes}`) {
+  expectSemanticTokens(label: string, tokenType: SemanticTokenTypesValues) {
     const ranges = this.getLabelRanges(label);
 
     for (const { uri, start, end } of ranges) {
@@ -1155,6 +1155,44 @@ Available code actions for label "${label}" and URI "${uri}": ${codeActions.map(
         matchingToken?.semanticTokenType,
         `Semantic token for label "${label}" (${this.createPositionMessage(start)}) has wrong token type`,
       ).toBe(tokenType);
+    }
+  }
+
+  expectSemanticTokenModifiers(
+    label: string,
+    tokenModifiers: SemanticTokenModifiersValues,
+  ) {
+    const ranges = this.getLabelRanges(label);
+
+    for (const { uri, start, end } of ranges) {
+      const file = this.files.get(uri);
+      if (!file) {
+        throw new Error(`File with URI ${uri} not found`);
+      }
+
+      const textDocument = file.textDocument;
+      const tokens = semanticTokens(textDocument, this.unit);
+      const decodedTokens = SemanticTokenDecoder.decode(tokens, textDocument);
+      const matchingToken = decodedTokens.find(
+        (t) => t.offsetStart === start && t.offsetEnd === end,
+      );
+
+      expect(
+        matchingToken,
+        `Semantic token for label "${label}" (${this.createPositionMessage(start)}) not found`,
+      ).toBeDefined();
+
+      if (tokenModifiers === "none") {
+        expect(
+          matchingToken?.tokenModifiers,
+          `Semantic token for label "${label}" (${this.createPositionMessage(start)}) has unexpected token modifiers`,
+        ).toHaveLength(0);
+      } else {
+        expect(
+          matchingToken?.tokenModifiers,
+          `Semantic token for label "${label}" (${this.createPositionMessage(start)}) has wrong token modifier`,
+        ).toContain(tokenModifiers);
+      }
     }
   }
 

--- a/packages/playground/src/config.ts
+++ b/packages/playground/src/config.ts
@@ -107,6 +107,15 @@ export const configure = async (
             vscode: "*",
           },
           contributes: {
+            configurationDefaults: {
+              "editor.semanticTokenColorCustomizations": {
+                rules: {
+                  "*.preprocessor:pli": {
+                    fontStyle: "italic",
+                  },
+                },
+              },
+            },
             languages: [
               {
                 id: "pli",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -75,6 +75,15 @@
         "url": "./schemas/proc_grps.schema.json"
       }
     ],
+    "configurationDefaults": {
+      "editor.semanticTokenColorCustomizations": {
+        "rules": {
+          "*.preprocessor:pli": {
+            "fontStyle": "italic"
+          }
+        }
+      }
+    },
     "configuration": {
       "title": "PL/I Language Support",
       "properties": {


### PR DESCRIPTION
Closes https://github.com/zowe/zowe-pli-language-support/issues/630

Adds a special token modifier to the semantic token provider that will make all preprocessor code italic. The actual italization is done in the vscode configuration, see `configurationDefaults` of the `package.json`.