### PR TITLE
[Improvement] Implement `json-parser`, LS attachment for `.pliplugin`, and quick fixes for unresolved `proc_grps` libs

### DIFF
--- a/packages/language/package.json
+++ b/packages/language/package.json
@@ -40,6 +40,7 @@
     "@chevrotain/types": "^11.1.1",
     "@chevrotain/utils": "^11.1.1",
     "chevrotain": "^11.1.1",
+    "jsonc-parser": "^3.3.1",
     "lodash-es": "^4.17.23",
     "lru-cache": "^11.2.5",
     "minimatch": "10.2.4",

--- a/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
+++ b/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
@@ -46,30 +46,6 @@ function isProcGrpsDocumentUri(documentUri: string): boolean {
   return UriUtils.equals(documentUri, expected);
 }
 
-async function readProcGrpsText(): Promise<
-  { uri: URI; text: string } | undefined
-> {
-  const workspacePath = PluginConfigurationProviderInstance.getWorkspacePath();
-  if (!workspacePath) {
-    return undefined;
-  }
-  const procGrpsUri = UriUtils.joinPath(
-    UriUtils.toUri(workspacePath),
-    ".pliplugin",
-    "proc_grps.json",
-  );
-  try {
-    const content = await FileSystemProviderInstance.readFile(procGrpsUri);
-    if (content === undefined) {
-      return undefined;
-    }
-    return { uri: procGrpsUri, text: content };
-  } catch (err) {
-    console.error(err);
-    return undefined;
-  }
-}
-
 export async function quickFixResolveInclude(
   diagnostic: Diagnostic,
 ): Promise<CodeAction | undefined> {
@@ -303,17 +279,21 @@ export async function quickFixRemoveUnresolvedLib(
   if (!data.path) {
     return undefined;
   }
-  const read = await readProcGrpsText();
-  if (!read) {
-    return undefined;
+  const procGrpsSnapshot =
+    PluginConfigurationProviderInstance.getLastProcGrpsSnapshot();
+  if (!procGrpsSnapshot) {
+    return;
   }
-  const { uri: procGrpsUri, text } = read;
+  const { text: procGrpsText, uri: procGrpsUri } = procGrpsSnapshot;
+  if (!procGrpsText || !procGrpsUri) {
+    return;
+  }
 
   let newContent: string;
   try {
     newContent = jsoncApplyEdits(
-      text,
-      jsoncModify(text, data.path, undefined, JSONC_FORMAT),
+      procGrpsText,
+      jsoncModify(procGrpsText, data.path, undefined, JSONC_FORMAT),
     );
   } catch (err) {
     console.error("Failed to build proc_grps edit for remove lib:", err);
@@ -338,6 +318,8 @@ export async function quickFixRemoveUnresolvedLib(
  */
 export async function quickFixRemoveAllUnresolvedLibs(
   pairs: readonly PluginConfigUnresolvedLibData[],
+  procGrpsSnapshotText: string,
+  procGrpsSnapshotUri: URI,
   relatedDiagnostics: Diagnostic[],
 ): Promise<CodeAction | undefined> {
   const unique: (PluginConfigUnresolvedLibData & { path: JSONPath })[] = [];
@@ -356,13 +338,7 @@ export async function quickFixRemoveAllUnresolvedLibs(
   if (unique.length < 2) {
     return undefined;
   }
-
-  const read = await readProcGrpsText();
-  if (!read) {
-    return undefined;
-  }
-  const { uri, text: initialText } = read;
-  let text = initialText;
+  let text = procGrpsSnapshotText;
 
   unique.sort((a, b) => {
     // Sort from highest index first so earlier indices remain valid when removing right-to-left.
@@ -371,11 +347,10 @@ export async function quickFixRemoveAllUnresolvedLibs(
 
   for (const { path } of unique) {
     try {
-      text = jsoncApplyEdits(
-        text,
-        jsoncModify(text, path, undefined, JSONC_FORMAT),
-      );
+      const edits = jsoncModify(text, path, undefined, JSONC_FORMAT);
+      text = jsoncApplyEdits(text, edits);
     } catch (err) {
+      console.error("Failed at path:", JSON.stringify(path));
       console.error(
         "Failed to build proc_grps edit from unresolved lib path:",
         err,
@@ -391,7 +366,7 @@ export async function quickFixRemoveAllUnresolvedLibs(
     command: {
       title: "Remove all unresolved libs",
       command: Commands.REMOVE_DEAD_LIB,
-      arguments: [uri.toString(), text],
+      arguments: [procGrpsSnapshotUri.toString(), text],
     },
   };
 }
@@ -404,18 +379,23 @@ async function handleMultipleUnresolvedLibs(
   const unresolvedInContext = diagnostics.filter(
     (d) => d.code === unresolvedLibCode,
   );
-  const procGrpsEntries =
-    documentUri &&
-    isProcGrpsDocumentUri(documentUri) &&
-    unresolvedInContext.length > 0
-      ? PluginConfigurationProviderInstance.getLastProcGrpsUnresolvedLibEntries()
-      : [];
-  if (!procGrpsEntries.length) {
+  if (
+    !documentUri ||
+    !isProcGrpsDocumentUri(documentUri) ||
+    !unresolvedInContext.length
+  ) {
+    return;
+  }
+  const procGrpsSnapshot =
+    PluginConfigurationProviderInstance.getLastProcGrpsSnapshot();
+  if (!procGrpsSnapshot || !procGrpsSnapshot.entries) {
     return;
   }
 
   const action = await quickFixRemoveAllUnresolvedLibs(
-    procGrpsEntries,
+    procGrpsSnapshot.entries,
+    procGrpsSnapshot.text,
+    procGrpsSnapshot.uri,
     unresolvedInContext,
   );
   return action;

--- a/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
+++ b/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
@@ -9,7 +9,7 @@
  *
  */
 
-import { UriUtils } from "../../utils/uri";
+import { URI, UriUtils } from "../../utils/uri";
 import { FileSystemProviderInstance } from "../../workspace/file-system-provider";
 import {
   CodeAction,
@@ -18,6 +18,7 @@ import {
   TextEdit,
 } from "vscode-languageserver-types";
 import {
+  PluginConfigUnresolvedLibData,
   PluginConfigurationProviderInstance,
   ProcessGroup,
 } from "../../workspace/plugin-configuration-provider";
@@ -26,6 +27,48 @@ import { Commands, PluginConfiguration } from "../constants";
 import { LspCodes } from "../../validation/lsp-codes";
 import { fullCode } from "../types";
 import { PLICodes } from "../../validation/pli-codes";
+import { jsoncApplyEdits, jsoncModify, type JSONPath } from "../../utils/jsonc";
+
+const JSONC_FORMAT = {
+  formattingOptions: { tabSize: 2, insertSpaces: true },
+} as const;
+
+function isProcGrpsDocumentUri(documentUri: string): boolean {
+  const workspacePath = PluginConfigurationProviderInstance.getWorkspacePath();
+  if (!workspacePath) {
+    return false;
+  }
+  const expected = UriUtils.joinPath(
+    UriUtils.toUri(workspacePath),
+    ".pliplugin",
+    "proc_grps.json",
+  );
+  return UriUtils.equals(documentUri, expected);
+}
+
+async function readProcGrpsText(): Promise<
+  { uri: URI; text: string } | undefined
+> {
+  const workspacePath = PluginConfigurationProviderInstance.getWorkspacePath();
+  if (!workspacePath) {
+    return undefined;
+  }
+  const procGrpsUri = UriUtils.joinPath(
+    UriUtils.toUri(workspacePath),
+    ".pliplugin",
+    "proc_grps.json",
+  );
+  try {
+    const content = await FileSystemProviderInstance.readFile(procGrpsUri);
+    if (content === undefined) {
+      return undefined;
+    }
+    return { uri: procGrpsUri, text: content };
+  } catch (err) {
+    console.error(err);
+    return undefined;
+  }
+}
 
 export async function quickFixResolveInclude(
   diagnostic: Diagnostic,
@@ -250,8 +293,137 @@ export function quickFixResolveAmbiguousReference(
   }
 }
 
+export async function quickFixRemoveUnresolvedLib(
+  diagnostic: Diagnostic,
+): Promise<CodeAction | undefined> {
+  const data = diagnostic.data as PluginConfigUnresolvedLibData | undefined;
+  if (!data?.lib || !data?.pgroup) {
+    return undefined;
+  }
+  if (!data.path) {
+    return undefined;
+  }
+  const read = await readProcGrpsText();
+  if (!read) {
+    return undefined;
+  }
+  const { uri: procGrpsUri, text } = read;
+
+  let newContent: string;
+  try {
+    newContent = jsoncApplyEdits(
+      text,
+      jsoncModify(text, data.path, undefined, JSONC_FORMAT),
+    );
+  } catch (err) {
+    console.error("Failed to build proc_grps edit for remove lib:", err);
+    return undefined;
+  }
+
+  return {
+    title: `Remove unresolved library '${data.lib}'.`,
+    kind: CodeActionKind.QuickFix,
+    diagnostics: [diagnostic],
+    command: {
+      title: "Remove unresolved lib",
+      command: Commands.REMOVE_DEAD_LIB,
+      arguments: [procGrpsUri.toString(), newContent],
+    },
+  };
+}
+
+/**
+ * Removes every distinct (pgroup, lib) in one write.
+ * Applies removals right-to-left so array indices stay valid.
+ */
+export async function quickFixRemoveAllUnresolvedLibs(
+  pairs: readonly PluginConfigUnresolvedLibData[],
+  relatedDiagnostics: Diagnostic[],
+): Promise<CodeAction | undefined> {
+  const unique: (PluginConfigUnresolvedLibData & { path: JSONPath })[] = [];
+  const seen = new Set<string>();
+  for (const pair of pairs) {
+    if (!pair.path) {
+      continue;
+    }
+    const key = pair.path.join("/");
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    unique.push(pair as PluginConfigUnresolvedLibData & { path: JSONPath });
+  }
+  if (unique.length < 2) {
+    return undefined;
+  }
+
+  const read = await readProcGrpsText();
+  if (!read) {
+    return undefined;
+  }
+  const { uri, text: initialText } = read;
+  let text = initialText;
+
+  unique.sort((a, b) => {
+    // Sort from highest index first so earlier indices remain valid when removing right-to-left.
+    return Number(b.path.at(-1)) - Number(a.path.at(-1));
+  });
+
+  for (const { path } of unique) {
+    try {
+      text = jsoncApplyEdits(
+        text,
+        jsoncModify(text, path, undefined, JSONC_FORMAT),
+      );
+    } catch (err) {
+      console.error(
+        "Failed to build proc_grps edit from unresolved lib path:",
+        err,
+      );
+      return undefined;
+    }
+  }
+
+  return {
+    title: `Remove all ${unique.length} unresolved libraries`,
+    kind: CodeActionKind.QuickFix,
+    diagnostics: relatedDiagnostics,
+    command: {
+      title: "Remove all unresolved libs",
+      command: Commands.REMOVE_DEAD_LIB,
+      arguments: [uri.toString(), text],
+    },
+  };
+}
+
+async function handleMultipleUnresolvedLibs(
+  diagnostics: Diagnostic[],
+  unresolvedLibCode: string,
+  documentUri?: string,
+): Promise<CodeAction | undefined> {
+  const unresolvedInContext = diagnostics.filter(
+    (d) => d.code === unresolvedLibCode,
+  );
+  const procGrpsEntries =
+    documentUri &&
+    isProcGrpsDocumentUri(documentUri) &&
+    unresolvedInContext.length > 0
+      ? PluginConfigurationProviderInstance.getLastProcGrpsUnresolvedLibEntries()
+      : [];
+  if (!procGrpsEntries.length) {
+    return;
+  }
+
+  const action = await quickFixRemoveAllUnresolvedLibs(
+    procGrpsEntries,
+    unresolvedInContext,
+  );
+  return action;
+}
+
 export async function applyQuickFixes(
   diagnostics: Diagnostic[],
+  documentUri?: string,
 ): Promise<CodeAction[] | undefined> {
   const actions: CodeAction[] = [];
   // PLI CODES LIST
@@ -261,10 +433,19 @@ export async function applyQuickFixes(
     LspCodes.IncludeResolution.MissingConfiguration,
   ); // "Could not resolve include directive. Plugin configuration is missing"
   const CODE_MACRO_CASE = fullCode(LspCodes.UpperCase);
+  const CODE_UNRESOLVED_LIB = fullCode(
+    LspCodes.PluginConfiguration.UnresolvedEntry,
+  );
+  const hasHandledUnresolvedLibs = await handleMultipleUnresolvedLibs(
+    diagnostics,
+    CODE_UNRESOLVED_LIB,
+    documentUri,
+  );
+  if (hasHandledUnresolvedLibs) actions.push(hasHandledUnresolvedLibs);
 
   for (const diagnostic of diagnostics) {
     if (!diagnostic.code) {
-      return;
+      continue;
     }
     let action: CodeAction | undefined;
     switch (diagnostic.code) {
@@ -283,9 +464,15 @@ export async function applyQuickFixes(
         action = quickFixUppercaseText(diagnostic);
         if (action) actions.push(action);
         break;
+      case CODE_UNRESOLVED_LIB:
+        action = await quickFixRemoveUnresolvedLib(diagnostic);
+        if (action) actions.push(action);
+        break;
     }
   }
 
-  if (!actions.length) return undefined;
+  if (!actions.length) {
+    return undefined;
+  }
   return actions;
 }

--- a/packages/language/src/language-server/commands.ts
+++ b/packages/language/src/language-server/commands.ts
@@ -35,3 +35,15 @@ export async function commandCreateConfig(
   }
   await updateOrCreateConfig(programPath);
 }
+
+export async function commandRemoveUnresolvedLib(params: ExecuteCommandParams) {
+  const [uri, content] = params.arguments as string[];
+  if (!uri || content === undefined) {
+    return;
+  }
+  try {
+    await FileSystemProviderInstance.writeFile(UriUtils.toUri(uri), content);
+  } catch (err) {
+    console.error(`Failed to write file at URI: ${uri}`, err);
+  }
+}

--- a/packages/language/src/language-server/connection-handler.ts
+++ b/packages/language/src/language-server/connection-handler.ts
@@ -46,8 +46,12 @@ import { completionRequest } from "./completion/completion-request";
 import { hoverRequest } from "./hover-request";
 import { applyQuickFixes } from "./code-actions/apply-quick-fixes";
 import { applySourceActions } from "./code-actions/apply-source-actions";
-import { commandCreateConfig, commandResolveInclude } from "./commands";
-import { Commands, PluginConfiguration } from "./constants";
+import {
+  commandCreateConfig,
+  commandRemoveUnresolvedLib,
+  commandResolveInclude,
+} from "./commands";
+import { Commands } from "./constants";
 import { signatureHelpRequest } from "./signature-help-request";
 export { PluginConfiguration } from "./constants";
 
@@ -63,6 +67,17 @@ export function startLanguageServer(connection: Connection): void {
   const compilationUnitHandler = new CompilationUnitHandler();
   compilationUnitHandler.listen(connection);
   let folders: WorkspaceFolder[] = [];
+
+  function publishPluginConfigDiagnostics(
+    diagnosticsByUri: Map<string, Diagnostic[]>,
+  ): void {
+    for (const [uri, diagnostics] of diagnosticsByUri.entries()) {
+      connection.sendDiagnostics({
+        uri,
+        diagnostics,
+      });
+    }
+  }
 
   async function withReadMutex<T>(
     uri: string,
@@ -111,7 +126,11 @@ export function startLanguageServer(connection: Connection): void {
           ],
         },
         executeCommandProvider: {
-          commands: [Commands.RESOLVE_INCLUDE, Commands.CREATE_CONFIG],
+          commands: [
+            Commands.RESOLVE_INCLUDE,
+            Commands.CREATE_CONFIG,
+            Commands.REMOVE_DEAD_LIB,
+          ],
         },
         documentHighlightProvider: true,
         semanticTokensProvider: {
@@ -136,13 +155,8 @@ export function startLanguageServer(connection: Connection): void {
     for (const folder of folders) {
       promises.push(
         PluginConfigurationProviderInstance.init(folder.uri).then(
-          (diagnostics) => {
-            const ws = PluginConfigurationProviderInstance.getWorkspacePath();
-            const wsPrefix = ws.endsWith("/") ? ws : ws + "/";
-            connection.sendDiagnostics({
-              uri: wsPrefix + PluginConfiguration.PROCESS_GROUP_FILE_PATH,
-              diagnostics,
-            });
+          (diagnosticsByUri) => {
+            publishPluginConfigDiagnostics(diagnosticsByUri);
           },
         ),
       );
@@ -350,21 +364,16 @@ export function startLanguageServer(connection: Connection): void {
     WorkspaceDidChangePlipluginConfigNotification,
     async () => {
       // handle changes to the .pliplugin config folder's contents
-      const diagnostics =
+      const diagnosticsByUri =
         await PluginConfigurationProviderInstance.reloadConfigurations();
-      const ws = PluginConfigurationProviderInstance.getWorkspacePath();
-      const wsPrefix = ws.endsWith("/") ? ws : ws + "/";
-      connection.sendDiagnostics({
-        uri: wsPrefix + PluginConfiguration.PROCESS_GROUP_FILE_PATH,
-        diagnostics,
-      });
+      publishPluginConfigDiagnostics(diagnosticsByUri);
 
       // reindex reachable compilation units
       await compilationUnitHandler.reindex(connection, CancellationToken.None);
     },
   );
   connection.onRequest(ExistingFileRequest, (uriString: string): boolean => {
-    const uri = URI.parse(uriString);
+    const uri = UriUtils.toUri(uriString);
     const compilationUnit = compilationUnitHandler.getCompilationUnit(uri);
     return compilationUnit !== undefined;
   });
@@ -385,7 +394,10 @@ export function startLanguageServer(connection: Connection): void {
       const diagnostics = params.context.diagnostics as Diagnostic[];
       if (!diagnostics || !diagnostics.length) return [];
 
-      const actions = await applyQuickFixes(diagnostics);
+      const actions = await applyQuickFixes(
+        diagnostics,
+        params.textDocument.uri,
+      );
       return actions || [];
     }
   });
@@ -397,6 +409,9 @@ export function startLanguageServer(connection: Connection): void {
         break;
       case Commands.CREATE_CONFIG:
         await commandCreateConfig(params);
+        break;
+      case Commands.REMOVE_DEAD_LIB:
+        await commandRemoveUnresolvedLib(params);
         break;
     }
   });

--- a/packages/language/src/language-server/constants.ts
+++ b/packages/language/src/language-server/constants.ts
@@ -39,4 +39,5 @@ export namespace PluginConfiguration {
 export namespace Commands {
   export const RESOLVE_INCLUDE = "pli.applyQuickFixResolveInclude";
   export const CREATE_CONFIG = "pli.applyQuickFixCreateConfig";
+  export const REMOVE_DEAD_LIB = "pli.applyQuickFixRemoveUnresolvedLib";
 }

--- a/packages/language/src/language-server/types.ts
+++ b/packages/language/src/language-server/types.ts
@@ -68,9 +68,18 @@ export function tokenToUri(token: Token): string | undefined {
 }
 
 export function tokenToRange(token: Token): Range {
+  return offsetLengthToRange(
+    token.startOffset,
+    token.endOffset - token.startOffset + 1,
+  );
+}
+
+export function offsetLengthToRange(offset: number, length: number): Range {
+  const safeOffset = Math.max(0, offset);
+  const safeLength = Math.max(1, length);
   return {
-    start: token.startOffset,
-    end: token.endOffset + 1,
+    start: safeOffset,
+    end: safeOffset + safeLength,
   };
 }
 
@@ -178,6 +187,30 @@ export function diagnosticFromCode(
       code: fullCode(code),
     };
   }
+}
+
+export function diagnosticFromCodeAtRange(
+  code: SimplePLICode,
+  range: Range,
+): Diagnostic;
+export function diagnosticFromCodeAtRange<Code extends ParametricPLICode>(
+  code: Code,
+  range: Range,
+  ...args: Parameters<Code["message"]>
+): Diagnostic;
+export function diagnosticFromCodeAtRange(
+  code: SimplePLICode | ParametricPLICode,
+  range: Range,
+  ...args: unknown[]
+): Diagnostic {
+  const message =
+    typeof code.message === "string" ? code.message : code.message(...args);
+  return {
+    severity: code.severity,
+    range,
+    message,
+    code: fullCode(code),
+  };
 }
 
 export function diagnostic(

--- a/packages/language/src/utils/jsonc.ts
+++ b/packages/language/src/utils/jsonc.ts
@@ -1,0 +1,34 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import {
+  applyEdits,
+  findNodeAtLocation,
+  modify,
+  parseTree,
+  type JSONPath,
+  type Node,
+  parse,
+  printParseErrorCode,
+  type ParseError,
+} from "jsonc-parser/lib/esm/main.js";
+
+export {
+  applyEdits as jsoncApplyEdits,
+  findNodeAtLocation as jsoncFindNodeAtLocation,
+  modify as jsoncModify,
+  parseTree as jsoncParseTree,
+  type JSONPath,
+  parse as jsoncParse,
+  printParseErrorCode as jsoncPrintParseErrorCode,
+  type Node as JsonNode,
+  type ParseError,
+};

--- a/packages/language/src/validation/lsp-codes.ts
+++ b/packages/language/src/validation/lsp-codes.ts
@@ -36,9 +36,6 @@ export const LspCodes = {
     },
   },
 
-  /**
-   * Member name validation codes
-   */
   MemberValidation: {
     /**
      * Member name exceeds 8 characters
@@ -72,6 +69,29 @@ export const LspCodes = {
       severity: Severity.E,
       message: (attribute: string) =>
         `The attribute '${attribute}' is a builtin attribute and cannot be used in non-builtin files.`,
+    },
+  },
+
+  PluginConfiguration: {
+    UnresolvedEntry: {
+      code: "COPC01",
+      severity: Severity.E,
+      message: (lib: string) =>
+        `Plugin Configuration failed to resolve library entry '${lib}'`,
+    },
+
+    ParseError: {
+      code: "COPC02",
+      severity: Severity.E,
+      message: (fileName: string, parseErrorCode: string) =>
+        `Plugin Configuration parse error in ${fileName}: ${parseErrorCode}`,
+    },
+
+    InvalidStructure: {
+      code: "COPC03",
+      severity: Severity.E,
+      message: (fileName: string, expected: string) =>
+        `Plugin Configuration expected '${expected}' in ${fileName}.`,
     },
   },
 };

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -104,6 +104,15 @@ const BuiltinFileStart = `${BuiltinsUriSchema}:/`;
 const isBuiltinFile = (uri: URI) => uri.toString().startsWith(BuiltinFileStart);
 const FIVE_MINUTES = 1000 * 60 * 5;
 
+/**
+ * JSON under `.pliplugin/` is not PL/I source. The client attaches the LS there for code actions;
+ * we skip compilation so only plugin-config diagnostics (e.g. COPC*) from the plugin loader show.
+ */
+function isPluginConfigurationUri(uri: URI): boolean {
+  const path = uri.fsPath.replace(/\\/g, "/");
+  return path.includes("/.pliplugin/") && /\.json$/i.test(path);
+}
+
 function createBuiltinUnitGetter(
   builtinDocument: TextDocument,
 ): () => Promise<CompilationUnit> {
@@ -263,6 +272,9 @@ export class CompilationUnitHandler {
     if (this.compilationUnits.has(uri.toString())) {
       // existing compilation unit
       return this.compilationUnits.get(uri.toString());
+    }
+    if (isPluginConfigurationUri(uri)) {
+      return undefined;
     } else if (!PluginConfigurationProviderInstance.isLibFileCandidate(uri)) {
       // non-library files should always generate a compilation unit
       const unit = await this.createAndStoreCompilationUnit(uri);

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -10,8 +10,16 @@
  */
 
 import { minimatch } from "minimatch";
+import { TextDocument } from "vscode-languageserver-textdocument";
 import { Diagnostic as LspDiagnostic } from "vscode-languageserver-types";
-import { Diagnostic } from "../language-server/types";
+import {
+  Diagnostic,
+  Range,
+  diagnosticFromCodeAtRange,
+  offsetLengthToRange,
+  rangeToLSP,
+  severityToLsp,
+} from "../language-server/types";
 import {
   AbstractCompilerOptions,
   parseAbstractCompilerOptions,
@@ -21,11 +29,41 @@ import { URI, UriUtils } from "../utils/uri";
 import { FileSystemProviderInstance } from "./file-system-provider";
 import { MAX_INSTRUCTION_COUNTER } from "../preprocessor/instruction-interpreter";
 import { PluginConfiguration } from "../language-server/constants";
+import {
+  jsoncFindNodeAtLocation,
+  jsoncParseTree,
+  jsoncParse,
+  jsoncPrintParseErrorCode,
+  type JSONPath,
+  type JsonNode,
+  type ParseError,
+} from "../utils/jsonc";
+import { LspCodes } from "../validation/lsp-codes";
 
 /**
  * Pli options are effectively macros to set w/ the given values
  */
 export type PliOptions = Record<string, string>;
+
+/** On LSP diagnostics for {@link LspCodes.PluginConfiguration.UnresolvedEntry}; use in code actions. */
+export type PluginConfigUnresolvedLibData = {
+  lib: string;
+  pgroup: string;
+  path?: JSONPath;
+};
+
+export type JsonItem<T> = {
+  value: T;
+  meta?: JsonItemMeta;
+};
+
+export type JsonItemMeta = {
+  range: Range;
+  uri: URI;
+  path: JSONPath;
+};
+
+export type PropertyItems = Map<string, JsonItem<unknown>[]>;
 
 /**
  * Program configuration. Corresponds to the entry point of a compile unit
@@ -113,6 +151,13 @@ export interface ProcessGroup {
    * Used to avoid duplicate issue reporting later on when running translation in a program context
    */
   issueCount?: number;
+
+  /**
+   * Source metadata per property path in proc_grps.json.
+   * Example keys: "name", "libs", "include-extensions", "lsp-options.check-margins".
+   * Each key maps to all parsed occurrences so duplicates keep unique identity.
+   */
+  $propertyItems?: PropertyItems;
 }
 
 /**
@@ -150,6 +195,7 @@ export function deserializeProcessGroup(
     memberNameValidation: isBoolean(memberNameValidation)
       ? memberNameValidation
       : undefined,
+    $propertyItems: new Map<string, JsonItem<unknown>[]>(),
   };
 }
 
@@ -218,6 +264,8 @@ export type PgmsConfig = {
   pgms: ProgramEntry[];
 };
 
+export type PluginConfigDiagnostics = Map<string, LspDiagnostic[]>;
+
 /**
  * Plugin configuration provider for loading '.pliplugin/pgm_conf.json' and '.pliplugin/proc_grps.json' (when they exist),
  * processing their contents, and making those settings available to the language server.
@@ -245,6 +293,14 @@ export class PluginConfigurationProvider {
    */
   private workspacePath: string;
 
+  /**
+   * Last unresolved lib entries from the most recent postProcessProcessGroups run.
+   * Used for code actions: the editor often passes only one diagnostic in the code action request,
+   * so fixes for proc_grps.json are driven from this list.
+   */
+  private lastProcGrpsUnresolvedLibEntries: PluginConfigUnresolvedLibData[] =
+    [];
+
   constructor() {
     this.programConfigs = new Map<string, ProgramConfig>();
     this.processGroupConfigs = new Map<string, ProcessGroup>();
@@ -252,12 +308,19 @@ export class PluginConfigurationProvider {
   }
 
   /**
+   * Entries matching the last published unresolved-library diagnostics for proc_grps.json.
+   */
+  public getLastProcGrpsUnresolvedLibEntries(): ReadonlyArray<PluginConfigUnresolvedLibData> {
+    return this.lastProcGrpsUnresolvedLibEntries;
+  }
+
+  /**
    * Initializes the plugin configuration provider with a workspace path, using any plugin configs present in the workspace.
    *
    * @param workspacePath The full path to the workspace to load plugin configurations from
-   * @returns List of diagnostics encountered during loading & processing
+   * @returns Diagnostics keyed by config URI
    */
-  public async init(workspacePath: string): Promise<LspDiagnostic[]> {
+  public async init(workspacePath: string): Promise<PluginConfigDiagnostics> {
     this.workspacePath = workspacePath;
     return this.loadConfigurations();
   }
@@ -313,9 +376,9 @@ export class PluginConfigurationProvider {
   /**
    * Reloads plugin configurations from the existing workspace path.
    *
-   * @returns List of diagnostics encountered during loading & processing
+   * @returns Diagnostics keyed by config URI
    */
-  public async reloadConfigurations(): Promise<LspDiagnostic[]> {
+  public async reloadConfigurations(): Promise<PluginConfigDiagnostics> {
     console.log("Reloading .pliplugin configurations...");
     return this.loadConfigurations();
   }
@@ -323,27 +386,33 @@ export class PluginConfigurationProvider {
   /**
    * Loads the plugin configurations from the workspace path, overwriting any existing configs.
    *
-   * @returns List of diagnostics encountered during loading & processing
+   * @returns Diagnostics keyed by config URI
    */
-  private async loadConfigurations(): Promise<LspDiagnostic[]> {
+  private async loadConfigurations(): Promise<PluginConfigDiagnostics> {
     const workspaceUri = UriUtils.toUri(this.workspacePath);
 
     // load configs
-    await this.loadProgramConfig(
+    const programConfigDiagnostics = await this.loadProgramConfig(
       UriUtils.joinPath(workspaceUri, ".pliplugin", "pgm_conf.json"),
     );
 
-    const diagnostics = await this.loadProcessGroupConfig(
+    const processGroupDiagnostics = await this.loadProcessGroupConfig(
       UriUtils.joinPath(workspaceUri, ".pliplugin", "proc_grps.json"),
     );
-    return diagnostics;
+    return new Map<string, LspDiagnostic[]>([
+      [this.getConfigUri("pgm_conf.json"), programConfigDiagnostics],
+      [this.getConfigUri("proc_grps.json"), processGroupDiagnostics],
+    ]);
   }
 
   /**
    * Loads the program config from the given path, and sets it in this provider.
    * @param programConfigUri URI to the program config file
    */
-  private async loadProgramConfig(programConfigUri: URI): Promise<void> {
+  private async loadProgramConfig(
+    programConfigUri: URI,
+  ): Promise<LspDiagnostic[]> {
+    const diagnostics: LspDiagnostic[] = [];
     // attempt to read configs
     if (await FileSystemProviderInstance.fileExists(programConfigUri)) {
       const progConfig =
@@ -352,11 +421,15 @@ export class PluginConfigurationProvider {
       // add configs to our provider if they exist
       if (progConfig !== undefined) {
         if (
-          !this.parseProgramConfigs(this.workspacePath, progConfig.toString())
+          !this.parseProgramConfigs(
+            this.workspacePath,
+            progConfig.toString(),
+            diagnostics,
+          )
         ) {
           console.error("Failed to load program config, skipping.");
         } else {
-          return;
+          return diagnostics;
         }
       } else {
         console.warn("No program config found.");
@@ -366,6 +439,7 @@ export class PluginConfigurationProvider {
     // clear otherwise, no valid program config to use
     this.programConfigs.clear();
     console.warn("No program config found, clearing existing configurations.");
+    return diagnostics;
   }
 
   /**
@@ -478,7 +552,10 @@ export class PluginConfigurationProvider {
    * Populates the $computedLibs property of each process group, which is used to resolve includes
    * @returns List of diagnostics encountered during processing
    */
-  private async postProcessProcessGroups(): Promise<LspDiagnostic[]> {
+  private async postProcessProcessGroups(
+    configDocument?: TextDocument,
+  ): Promise<LspDiagnostic[]> {
+    this.lastProcGrpsUnresolvedLibEntries = [];
     const diagnostics: LspDiagnostic[] = [];
     for (const processGroup of this.processGroupConfigs.values()) {
       // all computed libs for this group, dirs + ddnames
@@ -552,16 +629,29 @@ export class PluginConfigurationProvider {
               }
             } catch (parentError) {
               // parent directory also failed to read, skip this lib & collect diagnostic
-              diagnostics.push({
-                severity: 1, // err
-                message: `Plugin Configuration failed to resolve library entry '${lib}'`,
-                code: "COPC01",
-                source: "PL/I",
-                range: {
-                  start: { line: 0, character: 0 },
-                  end: { line: 0, character: 1 },
+              const fallbackRange = offsetLengthToRange(0, 1);
+              const item = this.takeNextPropertyItem(processGroup, "libs", lib);
+              const range = item?.meta?.range ?? fallbackRange;
+              const unresolvedLibDiagnostic: Diagnostic = {
+                ...diagnosticFromCodeAtRange(
+                  LspCodes.PluginConfiguration.UnresolvedEntry,
+                  range,
+                  lib,
+                ),
+                data: {
+                  lib,
+                  pgroup: processGroup.name,
+                  path: item?.meta?.path,
                 },
+              };
+              this.lastProcGrpsUnresolvedLibEntries.push({
+                lib,
+                pgroup: processGroup.name,
+                path: item?.meta?.path,
               });
+              diagnostics.push(
+                this.toLspDiagnostic(unresolvedLibDiagnostic, configDocument),
+              );
             }
           }
         }
@@ -631,9 +721,37 @@ export class PluginConfigurationProvider {
    * @param text Program config text to parse
    * @returns Whether or not parsing & setup was successful
    */
-  parseProgramConfigs(workspacePath: string, text: string): boolean {
+  parseProgramConfigs(
+    workspacePath: string,
+    text: string,
+    diagnostics: LspDiagnostic[] = [],
+  ): boolean {
     try {
-      const serializedData: SerializedProgramConfig[] = JSON.parse(text).pgms;
+      const parseErrors: ParseError[] = [];
+      const parsed = jsoncParse(text, parseErrors) as
+        | { pgms?: SerializedProgramConfig[] }
+        | undefined;
+      const document = this.createConfigTextDocument("pgm_conf.json", text);
+      diagnostics.push(
+        ...this.createJsonParseDiagnostics(
+          document,
+          parseErrors,
+          "pgm_conf.json",
+        ),
+      );
+      if (parseErrors.length > 0 || !Array.isArray(parsed?.pgms)) {
+        if (!Array.isArray(parsed?.pgms)) {
+          diagnostics.push(
+            this.createConfigStructureDiagnostic(
+              document,
+              "pgm_conf.json",
+              "pgms array",
+            ),
+          );
+        }
+        return false;
+      }
+      const serializedData = parsed.pgms;
       const programConfigs = serializedData.map(deserializeProgramConfig);
       this.setProgramConfigs(workspacePath, programConfigs);
       return true;
@@ -697,14 +815,252 @@ export class PluginConfigurationProvider {
     text: string,
   ): Promise<LspDiagnostic[]> {
     try {
-      const serializedData: SerializedProcessGroup[] = JSON.parse(text).pgroups;
+      const diagnostics: LspDiagnostic[] = [];
+      const parseErrors: ParseError[] = [];
+      const parsed = jsoncParse(text, parseErrors) as
+        | { pgroups?: SerializedProcessGroup[] }
+        | undefined;
+      const document = this.createConfigTextDocument("proc_grps.json", text);
+      diagnostics.push(
+        ...this.createJsonParseDiagnostics(
+          document,
+          parseErrors,
+          "proc_grps.json",
+        ),
+      );
+      if (parseErrors.length > 0 || !Array.isArray(parsed?.pgroups)) {
+        if (!Array.isArray(parsed?.pgroups)) {
+          diagnostics.push(
+            this.createConfigStructureDiagnostic(
+              document,
+              "proc_grps.json",
+              "pgroups array",
+            ),
+          );
+        }
+        return diagnostics;
+      }
+      const serializedData: SerializedProcessGroup[] = parsed.pgroups;
       const groupConfigs = serializedData.map(deserializeProcessGroup);
-      const diagnostics = await this.setProcessGroupConfigs(groupConfigs);
+      this.attachProcessGroupPropertyItems(
+        text,
+        groupConfigs,
+        UriUtils.toUri(document.uri),
+      );
+      const processingDiagnostics = await this.setProcessGroupConfigs(
+        groupConfigs,
+        document,
+      );
       this.postProcessProgramConfigs();
-      return diagnostics;
+      return [...diagnostics, ...processingDiagnostics];
     } catch {
       return [];
     }
+  }
+
+  private createJsonParseDiagnostics(
+    document: TextDocument,
+    parseErrors: ParseError[],
+    fileName: string,
+  ): LspDiagnostic[] {
+    return parseErrors.map((error) => {
+      const range = offsetLengthToRange(error.offset, error.length);
+      return this.toLspDiagnostic(
+        diagnosticFromCodeAtRange(
+          LspCodes.PluginConfiguration.ParseError,
+          range,
+          fileName,
+          jsoncPrintParseErrorCode(error.error),
+        ),
+        document,
+      );
+    });
+  }
+
+  private createConfigStructureDiagnostic(
+    document: TextDocument,
+    fileName: string,
+    expected: string,
+  ): LspDiagnostic {
+    return this.toLspDiagnostic(
+      diagnosticFromCodeAtRange(
+        LspCodes.PluginConfiguration.InvalidStructure,
+        offsetLengthToRange(0, 1),
+        fileName,
+        expected,
+      ),
+      document,
+    );
+  }
+
+  private createConfigTextDocument(
+    fileName: string,
+    text: string,
+  ): TextDocument {
+    const uri = this.getConfigUri(fileName);
+    return TextDocument.create(uri, "jsonc", 0, text);
+  }
+
+  private getConfigUri(fileName: string): string {
+    return UriUtils.joinPath(
+      UriUtils.toUri(this.workspacePath),
+      ".pliplugin",
+      fileName,
+    ).toString();
+  }
+
+  private toLspDiagnostic(
+    diagnostic: Diagnostic,
+    document?: TextDocument,
+  ): LspDiagnostic {
+    const rangeFallback = {
+      start: { line: 0, character: 0 },
+      end: { line: 0, character: 1 },
+    };
+    const range =
+      diagnostic.range && document
+        ? rangeToLSP(document, diagnostic.range)
+        : rangeFallback;
+    return {
+      severity: severityToLsp(diagnostic.severity),
+      message: diagnostic.message,
+      code: diagnostic.code,
+      source: diagnostic.source ?? "PL/I",
+      range,
+      data: diagnostic.data,
+    };
+  }
+
+  private attachProcessGroupPropertyItems(
+    text: string,
+    processGroups: ProcessGroup[],
+    configUri: URI,
+  ): void {
+    const root = jsoncParseTree(text);
+    if (!root) {
+      return;
+    }
+    const pgroupsNode = jsoncFindNodeAtLocation(root, ["pgroups"]);
+    if (!pgroupsNode || !pgroupsNode.children) {
+      return;
+    }
+    const count = Math.min(processGroups.length, pgroupsNode.children.length);
+
+    for (let i = 0; i < count; i++) {
+      const groupNode = pgroupsNode.children[i];
+      if (!groupNode) {
+        continue;
+      }
+      const items: PropertyItems =
+        processGroups[i].$propertyItems ??
+        new Map<string, JsonItem<unknown>[]>();
+      this.collectJsonItems(groupNode, items, [], configUri, ["pgroups", i]);
+      processGroups[i].$propertyItems = items;
+    }
+  }
+
+  private collectJsonItems(
+    node: JsonNode | undefined,
+    items: PropertyItems,
+    pathSegments: JSONPath,
+    configUri: URI,
+    rootPrefix: JSONPath,
+  ): void {
+    if (!node) {
+      return;
+    }
+
+    if (node.type === "object" && node.children) {
+      for (const property of node.children) {
+        const keyNode = property.children?.[0];
+        const valueNode = property.children?.[1];
+
+        const key = typeof keyNode?.value === "string" ? keyNode.value : "";
+        if (!key) {
+          continue;
+        }
+
+        this.collectJsonItems(
+          valueNode,
+          items,
+          [...pathSegments, key],
+          configUri,
+          rootPrefix,
+        );
+      }
+      return;
+    }
+    if (node.type === "array" && node.children) {
+      for (let index = 0; index < node.children.length; index++) {
+        const child = node.children[index];
+        this.collectJsonItems(
+          child,
+          items,
+          [...pathSegments, index],
+          configUri,
+          rootPrefix,
+        );
+      }
+      return;
+    }
+
+    this.collectPropertyItem(node, items, pathSegments, configUri, rootPrefix);
+  }
+
+  private collectPropertyItem(
+    node: JsonNode,
+    items: PropertyItems,
+    pathSegments: JSONPath,
+    configUri: URI,
+    rootPrefix: JSONPath,
+  ): void {
+    const propertyPath = this.toPropertyPath(pathSegments);
+    if (!propertyPath) {
+      return;
+    }
+    const value = node.value;
+    if (value === undefined) {
+      return;
+    }
+    const meta: JsonItemMeta = {
+      range: offsetLengthToRange(node.offset, node.length),
+      uri: configUri,
+      path: [...rootPrefix, ...pathSegments],
+    };
+
+    const list = items.get(propertyPath) ?? [];
+    list.push({
+      value,
+      meta,
+    });
+    items.set(propertyPath, list);
+  }
+
+  private toPropertyPath(pathSegments: JSONPath): string {
+    if (!pathSegments.length) {
+      return "";
+    }
+    return pathSegments
+      .filter((segment) => typeof segment === "string")
+      .join(".");
+  }
+
+  private takeNextPropertyItem(
+    processGroup: ProcessGroup,
+    propertyPath: string,
+    value: string,
+  ): JsonItem<unknown> | undefined {
+    const items = processGroup.$propertyItems?.get(propertyPath);
+    if (!items || items.length === 0) {
+      return undefined;
+    }
+    const index = items.findIndex((item) => item.value === value);
+    if (index < 0) {
+      return undefined;
+    }
+    const [item] = items.splice(index, 1);
+    processGroup.$propertyItems?.set(propertyPath, items);
+    return item;
   }
 
   /**
@@ -716,13 +1072,14 @@ export class PluginConfigurationProvider {
    */
   public async setProcessGroupConfigs(
     processGroupConfigs: ProcessGroup[],
+    configDocument?: TextDocument,
   ): Promise<LspDiagnostic[]> {
     this.processGroupConfigs.clear();
     for (const config of processGroupConfigs) {
       this.processGroupConfigs.set(config.name, config);
     }
     this.postProcessProgramConfigs();
-    const diagnostics = await this.postProcessProcessGroups();
+    const diagnostics = await this.postProcessProcessGroups(configDocument);
     this.libFileGlobPatterns = undefined;
     return diagnostics;
   }

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -266,6 +266,12 @@ export type PgmsConfig = {
 
 export type PluginConfigDiagnostics = Map<string, LspDiagnostic[]>;
 
+type ProcGrpsSnapshot = {
+  entries: PluginConfigUnresolvedLibData[];
+  text: string;
+  uri: URI;
+};
+
 /**
  * Plugin configuration provider for loading '.pliplugin/pgm_conf.json' and '.pliplugin/proc_grps.json' (when they exist),
  * processing their contents, and making those settings available to the language server.
@@ -298,8 +304,7 @@ export class PluginConfigurationProvider {
    * Used for code actions: the editor often passes only one diagnostic in the code action request,
    * so fixes for proc_grps.json are driven from this list.
    */
-  private lastProcGrpsUnresolvedLibEntries: PluginConfigUnresolvedLibData[] =
-    [];
+  private lastProcGrpsSnapshot?: ProcGrpsSnapshot;
 
   constructor() {
     this.programConfigs = new Map<string, ProgramConfig>();
@@ -310,8 +315,8 @@ export class PluginConfigurationProvider {
   /**
    * Entries matching the last published unresolved-library diagnostics for proc_grps.json.
    */
-  public getLastProcGrpsUnresolvedLibEntries(): ReadonlyArray<PluginConfigUnresolvedLibData> {
-    return this.lastProcGrpsUnresolvedLibEntries;
+  public getLastProcGrpsSnapshot(): Readonly<ProcGrpsSnapshot> | undefined {
+    return this.lastProcGrpsSnapshot;
   }
 
   /**
@@ -555,7 +560,8 @@ export class PluginConfigurationProvider {
   private async postProcessProcessGroups(
     configDocument?: TextDocument,
   ): Promise<LspDiagnostic[]> {
-    this.lastProcGrpsUnresolvedLibEntries = [];
+    this.lastProcGrpsSnapshot = undefined;
+    const unresolvedLibEntries: PluginConfigUnresolvedLibData[] = [];
     const diagnostics: LspDiagnostic[] = [];
     for (const processGroup of this.processGroupConfigs.values()) {
       // all computed libs for this group, dirs + ddnames
@@ -644,7 +650,7 @@ export class PluginConfigurationProvider {
                   path: item?.meta?.path,
                 },
               };
-              this.lastProcGrpsUnresolvedLibEntries.push({
+              unresolvedLibEntries.push({
                 lib,
                 pgroup: processGroup.name,
                 path: item?.meta?.path,
@@ -674,6 +680,15 @@ export class PluginConfigurationProvider {
           .filter((e) => isLibsDir(e))
           .map((e) => e.dir.replace(/\\/g, "/")),
       );
+    }
+    if (configDocument) {
+      this.lastProcGrpsSnapshot = {
+        entries: unresolvedLibEntries,
+        text: configDocument.getText(),
+        uri: UriUtils.toUri(configDocument.uri),
+      };
+    } else {
+      this.lastProcGrpsSnapshot = undefined;
     }
     return diagnostics;
   }

--- a/packages/language/test/lsp/apply-quick-fixes.test.ts
+++ b/packages/language/test/lsp/apply-quick-fixes.test.ts
@@ -22,7 +22,7 @@ import {
   type PluginConfigUnresolvedLibData,
 } from "../../src/workspace/plugin-configuration-provider";
 import type { JSONPath } from "../../src/utils/jsonc";
-import { UriUtils } from "../../src/utils/uri";
+import { URI, UriUtils } from "../../src/utils/uri";
 import * as applyQuickFixes from "../../src/language-server/code-actions/apply-quick-fixes";
 import { PLICodes } from "../../src/validation/pli-codes";
 import { LspCodes } from "../../src/validation/lsp-codes";
@@ -92,23 +92,24 @@ function unresolvedLibDiagnostic(
   } as Diagnostic;
 }
 
-async function writeProcGrpsWithLibs(libs: string[]): Promise<void> {
-  await vfs.writeFile(
-    UriUtils.toUri("/workspace/.pliplugin/proc_grps.json"),
-    JSON.stringify(
-      {
-        pgroups: [
-          {
-            name: "default",
-            "include-extensions": [".inc"],
-            libs,
-          },
-        ],
-      },
-      undefined,
-      2,
-    ),
+function procGrpsJsonText(libs: string[]): string {
+  return JSON.stringify(
+    {
+      pgroups: [
+        {
+          name: "default",
+          "include-extensions": [".inc"],
+          libs,
+        },
+      ],
+    },
+    undefined,
+    2,
   );
+}
+
+function procGrpsUri(): URI {
+  return UriUtils.toUri(procGrpsDocumentUri());
 }
 
 async function setupParsedProcGrps(libs: string[]): Promise<void> {
@@ -496,11 +497,20 @@ describe("quickFixRemoveUnresolvedLib", () => {
     ).toBeUndefined();
   });
 
+  test("returns undefined when no snapshot exists", async () => {
+    const result = await applyQuickFixes.quickFixRemoveUnresolvedLib(
+      unresolvedLibDiagnostic("x", "default", ["pgroups", 0, "libs", 0]),
+    );
+    expect(result).toBeUndefined();
+  });
+
   test("returns REMOVE_DEAD_LIB action that drops the matching libs entry", async () => {
-    await writeProcGrpsWithLibs(["keep-me", "drop-me", "also-keep"]);
+    await setupParsedProcGrps(["keep-me", "drop-me", "also-keep"]);
+    const snapshot = pluginConfig.getLastProcGrpsSnapshot();
+    const badEntry = snapshot!.entries.find((e) => e.lib === "drop-me");
 
     const action = await applyQuickFixes.quickFixRemoveUnresolvedLib(
-      unresolvedLibDiagnostic("drop-me", "default", ["pgroups", 0, "libs", 1]),
+      unresolvedLibDiagnostic("drop-me", "default", badEntry!.path),
     );
     expect(action).toBeDefined();
     expect(action!.command!.command).toBe(Commands.REMOVE_DEAD_LIB);
@@ -518,9 +528,13 @@ describe("quickFixRemoveUnresolvedLib", () => {
 // ----------------------------------------------------------
 describe("quickFixRemoveAllUnresolvedLibs", () => {
   test("returns undefined when fewer than two unique entries", async () => {
+    const text = procGrpsJsonText(["a"]);
+    const uri = procGrpsUri();
     expect(
       await applyQuickFixes.quickFixRemoveAllUnresolvedLibs(
         [{ lib: "a", pgroup: "default", path: ["pgroups", 0, "libs", 0] }],
+        text,
+        uri,
         [],
       ),
     ).toBeUndefined();
@@ -539,25 +553,32 @@ describe("quickFixRemoveAllUnresolvedLibs", () => {
             path: ["pgroups", 0, "libs", 0],
           },
         ],
+        text,
+        uri,
         [],
       ),
     ).toBeUndefined();
   });
 
   test("returns undefined when entries have no paths", async () => {
+    const text = procGrpsJsonText(["a", "b"]);
+    const uri = procGrpsUri();
     expect(
       await applyQuickFixes.quickFixRemoveAllUnresolvedLibs(
         [
           { lib: "a", pgroup: "default" },
           { lib: "b", pgroup: "default" },
         ],
+        text,
+        uri,
         [],
       ),
     ).toBeUndefined();
   });
 
   test("removes every unique entry in one command and deduplicates input", async () => {
-    await writeProcGrpsWithLibs(["w", "x", "y", "z"]);
+    const text = procGrpsJsonText(["w", "x", "y", "z"]);
+    const uri = procGrpsUri();
 
     const action = await applyQuickFixes.quickFixRemoveAllUnresolvedLibs(
       [
@@ -565,6 +586,8 @@ describe("quickFixRemoveAllUnresolvedLibs", () => {
         { lib: "y", pgroup: "default", path: ["pgroups", 0, "libs", 2] },
         { lib: "x", pgroup: "default", path: ["pgroups", 0, "libs", 1] },
       ],
+      text,
+      uri,
       [],
     );
     expect(action).toBeDefined();
@@ -578,13 +601,16 @@ describe("quickFixRemoveAllUnresolvedLibs", () => {
   });
 
   test("path-aware remove-all removes duplicate libs from right to left", async () => {
-    await writeProcGrpsWithLibs(["dup", "keep", "dup"]);
+    const text = procGrpsJsonText(["dup", "keep", "dup"]);
+    const uri = procGrpsUri();
 
     const action = await applyQuickFixes.quickFixRemoveAllUnresolvedLibs(
       [
         { lib: "dup", pgroup: "default", path: ["pgroups", 0, "libs", 0] },
         { lib: "dup", pgroup: "default", path: ["pgroups", 0, "libs", 2] },
       ],
+      text,
+      uri,
       [],
     );
 
@@ -599,17 +625,18 @@ describe("quickFixRemoveAllUnresolvedLibs", () => {
 
 //
 // ----------------------------------------------------------
-// applyQuickFixes (proc_grps.json + lastProcGrpsUnresolvedLibEntries)
+// applyQuickFixes (proc_grps.json + proc_grps snapshot)
 // ----------------------------------------------------------
 describe("applyQuickFixes unresolved lib / proc_grps snapshot", () => {
   test("with proc_grps documentUri and snapshot: yields bulk remove-all from snapshot plus individual removes from context diagnostics", async () => {
     await setupParsedProcGrps(["bad-a", "bad-b", "bad-c"]);
 
-    const snapshot = pluginConfig.getLastProcGrpsUnresolvedLibEntries();
-    expect(snapshot).toHaveLength(3);
+    const snapshot = pluginConfig.getLastProcGrpsSnapshot();
+    expect(snapshot).toBeDefined();
+    expect(snapshot!.entries).toHaveLength(3);
 
     const result = await applyQuickFixes.applyQuickFixes(
-      [unresolvedLibDiagnostic("bad-a", "default", snapshot[0].path)],
+      [unresolvedLibDiagnostic("bad-a", "default", snapshot!.entries[0].path)],
       procGrpsDocumentUri(),
     );
     expect(result).toBeDefined();
@@ -631,7 +658,9 @@ describe("applyQuickFixes unresolved lib / proc_grps snapshot", () => {
   test("with proc_grps documentUri and single snapshot entry: remove-all is omitted", async () => {
     await setupParsedProcGrps(["only-bad"]);
 
-    expect(pluginConfig.getLastProcGrpsUnresolvedLibEntries()).toHaveLength(1);
+    const snapshot = pluginConfig.getLastProcGrpsSnapshot();
+    expect(snapshot).toBeDefined();
+    expect(snapshot!.entries).toHaveLength(1);
 
     const result = await applyQuickFixes.applyQuickFixes(
       [
@@ -651,10 +680,10 @@ describe("applyQuickFixes unresolved lib / proc_grps snapshot", () => {
 
   test("without proc_grps documentUri: uses per-diagnostic path only", async () => {
     await setupParsedProcGrps(["solo-bad"]);
-    const snapshot = pluginConfig.getLastProcGrpsUnresolvedLibEntries();
+    const snapshot = pluginConfig.getLastProcGrpsSnapshot();
 
     const result = await applyQuickFixes.applyQuickFixes([
-      unresolvedLibDiagnostic("solo-bad", "default", snapshot[0].path),
+      unresolvedLibDiagnostic("solo-bad", "default", snapshot!.entries[0].path),
     ]);
     expect(result).toBeDefined();
     expect(result!.length).toBe(1);
@@ -689,10 +718,11 @@ describe("applyQuickFixes unresolved lib / proc_grps snapshot", () => {
 describe("metadata-driven quick fixes via parseProcessGroupConfigs", () => {
   test("parseProcessGroupConfigs stores root-relative paths in snapshot entries", async () => {
     await setupParsedProcGrps(["nonexistent-a", "nonexistent-b"]);
-    const snapshot = pluginConfig.getLastProcGrpsUnresolvedLibEntries();
-    expect(snapshot).toHaveLength(2);
+    const snapshot = pluginConfig.getLastProcGrpsSnapshot();
+    expect(snapshot).toBeDefined();
+    expect(snapshot!.entries).toHaveLength(2);
 
-    for (const entry of snapshot) {
+    for (const entry of snapshot!.entries) {
       expect(entry.path).toBeDefined();
       expect(entry.path![0]).toBe("pgroups");
       expect(typeof entry.path![1]).toBe("number");
@@ -701,10 +731,20 @@ describe("metadata-driven quick fixes via parseProcessGroupConfigs", () => {
     }
   });
 
+  test("snapshot bundles entries, text, and uri from the same parse", async () => {
+    await setupParsedProcGrps(["bad-a", "bad-b"]);
+    const snapshot = pluginConfig.getLastProcGrpsSnapshot();
+    expect(snapshot).toBeDefined();
+    expect(snapshot!.entries).toHaveLength(2);
+    expect(snapshot!.text).toContain('"bad-a"');
+    expect(snapshot!.text).toContain('"bad-b"');
+    expect(snapshot!.uri.toString()).toContain("proc_grps.json");
+  });
+
   test("single remove via parsed metadata actually changes content", async () => {
     await setupParsedProcGrps(["keep-me", "bad-lib"]);
-    const snapshot = pluginConfig.getLastProcGrpsUnresolvedLibEntries();
-    const badEntry = snapshot.find((e) => e.lib === "bad-lib");
+    const snapshot = pluginConfig.getLastProcGrpsSnapshot();
+    const badEntry = snapshot!.entries.find((e) => e.lib === "bad-lib");
     expect(badEntry).toBeDefined();
     expect(badEntry!.path).toBeDefined();
 
@@ -724,12 +764,15 @@ describe("metadata-driven quick fixes via parseProcessGroupConfigs", () => {
 
   test("remove-all via parsed metadata removes all invalid libs", async () => {
     await setupParsedProcGrps(["bad-a", "bad-b", "bad-c"]);
-    const snapshot = pluginConfig.getLastProcGrpsUnresolvedLibEntries();
-    expect(snapshot).toHaveLength(3);
-    expect(snapshot.every((e) => e.path !== undefined)).toBe(true);
+    const snapshot = pluginConfig.getLastProcGrpsSnapshot();
+    expect(snapshot).toBeDefined();
+    expect(snapshot!.entries).toHaveLength(3);
+    expect(snapshot!.entries.every((e) => e.path !== undefined)).toBe(true);
 
     const action = await applyQuickFixes.quickFixRemoveAllUnresolvedLibs(
-      snapshot,
+      snapshot!.entries,
+      snapshot!.text,
+      snapshot!.uri,
       [],
     );
     expect(action).toBeDefined();
@@ -745,15 +788,18 @@ describe("metadata-driven quick fixes via parseProcessGroupConfigs", () => {
   test("duplicate libs via parsed metadata get distinct root-relative paths", async () => {
     await vfs.writeFile(UriUtils.toUri("/workspace/keep/.placeholder"), "");
     await setupParsedProcGrps(["dup", "keep", "dup"]);
-    const snapshot = pluginConfig.getLastProcGrpsUnresolvedLibEntries();
-    const dupEntries = snapshot.filter((e) => e.lib === "dup");
+    const snapshot = pluginConfig.getLastProcGrpsSnapshot();
+    expect(snapshot).toBeDefined();
+    const dupEntries = snapshot!.entries.filter((e) => e.lib === "dup");
     expect(dupEntries).toHaveLength(2);
 
     expect(dupEntries[0].path).toEqual(["pgroups", 0, "libs", 0]);
     expect(dupEntries[1].path).toEqual(["pgroups", 0, "libs", 2]);
 
     const action = await applyQuickFixes.quickFixRemoveAllUnresolvedLibs(
-      snapshot,
+      snapshot!.entries,
+      snapshot!.text,
+      snapshot!.uri,
       [],
     );
     expect(action).toBeDefined();
@@ -767,8 +813,9 @@ describe("metadata-driven quick fixes via parseProcessGroupConfigs", () => {
 
   test("end-to-end: applyQuickFixes with parsed metadata yields working quick fixes", async () => {
     await setupParsedProcGrps(["valid-should-fail", "another-bad"]);
-    const snapshot = pluginConfig.getLastProcGrpsUnresolvedLibEntries();
-    expect(snapshot).toHaveLength(2);
+    const snapshot = pluginConfig.getLastProcGrpsSnapshot();
+    expect(snapshot).toBeDefined();
+    expect(snapshot!.entries).toHaveLength(2);
 
     const diagA: Diagnostic = {
       code: CODE_UNRESOLVED_LIB,
@@ -777,7 +824,7 @@ describe("metadata-driven quick fixes via parseProcessGroupConfigs", () => {
         start: { line: 0, character: 0 },
         end: { line: 0, character: 1 },
       },
-      data: snapshot[0],
+      data: snapshot!.entries[0],
     } as Diagnostic;
 
     const result = await applyQuickFixes.applyQuickFixes(
@@ -838,10 +885,11 @@ describe("metadata-driven quick fixes via parseProcessGroupConfigs", () => {
       { program: "other.pli", pgroup: "group-b" },
     ]);
 
-    const snapshot = pluginConfig.getLastProcGrpsUnresolvedLibEntries();
-    expect(snapshot).toHaveLength(1);
-    expect(snapshot[0].lib).toBe("nonexistent");
-    expect(snapshot[0].pgroup).toBe("group-b");
-    expect(snapshot[0].path).toEqual(["pgroups", 1, "libs", 0]);
+    const snapshot = pluginConfig.getLastProcGrpsSnapshot();
+    expect(snapshot).toBeDefined();
+    expect(snapshot!.entries).toHaveLength(1);
+    expect(snapshot!.entries[0].lib).toBe("nonexistent");
+    expect(snapshot!.entries[0].pgroup).toBe("group-b");
+    expect(snapshot!.entries[0].path).toEqual(["pgroups", 1, "libs", 0]);
   });
 });

--- a/packages/language/test/lsp/apply-quick-fixes.test.ts
+++ b/packages/language/test/lsp/apply-quick-fixes.test.ts
@@ -19,7 +19,9 @@ import {
   PluginConfigurationProvider,
   setPluginConfigurationProvider,
   deserializeProcessGroup,
+  type PluginConfigUnresolvedLibData,
 } from "../../src/workspace/plugin-configuration-provider";
+import type { JSONPath } from "../../src/utils/jsonc";
 import { UriUtils } from "../../src/utils/uri";
 import * as applyQuickFixes from "../../src/language-server/code-actions/apply-quick-fixes";
 import { PLICodes } from "../../src/validation/pli-codes";
@@ -61,6 +63,74 @@ beforeEach(async () => {
     { program: "main.pli", pgroup: "default" },
   ]);
 });
+
+const CODE_UNRESOLVED_LIB = fullCode(
+  LspCodes.PluginConfiguration.UnresolvedEntry,
+);
+
+function procGrpsDocumentUri(): string {
+  return UriUtils.joinPath(
+    UriUtils.toUri(pluginConfig.getWorkspacePath()),
+    ".pliplugin",
+    "proc_grps.json",
+  ).toString();
+}
+
+function unresolvedLibDiagnostic(
+  lib: string,
+  pgroup = "default",
+  path?: JSONPath,
+): Diagnostic {
+  return {
+    code: CODE_UNRESOLVED_LIB,
+    message: `unresolved ${lib}`,
+    range: {
+      start: { line: 0, character: 0 },
+      end: { line: 0, character: 1 },
+    },
+    data: { lib, pgroup, path } as PluginConfigUnresolvedLibData,
+  } as Diagnostic;
+}
+
+async function writeProcGrpsWithLibs(libs: string[]): Promise<void> {
+  await vfs.writeFile(
+    UriUtils.toUri("/workspace/.pliplugin/proc_grps.json"),
+    JSON.stringify(
+      {
+        pgroups: [
+          {
+            name: "default",
+            "include-extensions": [".inc"],
+            libs,
+          },
+        ],
+      },
+      undefined,
+      2,
+    ),
+  );
+}
+
+async function setupParsedProcGrps(libs: string[]): Promise<void> {
+  const procGrpsJson = JSON.stringify(
+    {
+      pgroups: [
+        {
+          name: "default",
+          "include-extensions": [".inc"],
+          libs,
+        },
+      ],
+    },
+    undefined,
+    2,
+  );
+  await vfs.writeFile(
+    UriUtils.toUri("/workspace/.pliplugin/proc_grps.json"),
+    procGrpsJson,
+  );
+  await pluginConfig.parseProcessGroupConfigs(procGrpsJson);
+}
 
 //
 // ----------------------------------------------------------
@@ -395,5 +465,383 @@ describe("applyQuickFixes", () => {
 
     const result = await applyQuickFixes.applyQuickFixes(diagnostics);
     expect(result).toHaveLength(2);
+  });
+});
+
+//
+// ----------------------------------------------------------
+// quickFixRemoveUnresolvedLib tests
+// ----------------------------------------------------------
+describe("quickFixRemoveUnresolvedLib", () => {
+  test("returns undefined when diagnostic data omits lib or pgroup", async () => {
+    expect(
+      await applyQuickFixes.quickFixRemoveUnresolvedLib({
+        code: CODE_UNRESOLVED_LIB,
+        data: { lib: "x" },
+      } as Diagnostic),
+    ).toBeUndefined();
+    expect(
+      await applyQuickFixes.quickFixRemoveUnresolvedLib({
+        code: CODE_UNRESOLVED_LIB,
+        data: { pgroup: "default" },
+      } as Diagnostic),
+    ).toBeUndefined();
+  });
+
+  test("returns undefined when diagnostic data omits path", async () => {
+    expect(
+      await applyQuickFixes.quickFixRemoveUnresolvedLib(
+        unresolvedLibDiagnostic("x"),
+      ),
+    ).toBeUndefined();
+  });
+
+  test("returns REMOVE_DEAD_LIB action that drops the matching libs entry", async () => {
+    await writeProcGrpsWithLibs(["keep-me", "drop-me", "also-keep"]);
+
+    const action = await applyQuickFixes.quickFixRemoveUnresolvedLib(
+      unresolvedLibDiagnostic("drop-me", "default", ["pgroups", 0, "libs", 1]),
+    );
+    expect(action).toBeDefined();
+    expect(action!.command!.command).toBe(Commands.REMOVE_DEAD_LIB);
+    const newContent = action!.command!.arguments![1] as string;
+    const parsed = JSON.parse(newContent) as {
+      pgroups: { name: string; libs: string[] }[];
+    };
+    expect(parsed.pgroups[0].libs).toEqual(["keep-me", "also-keep"]);
+  });
+});
+
+//
+// ----------------------------------------------------------
+// quickFixRemoveAllUnresolvedLibs tests
+// ----------------------------------------------------------
+describe("quickFixRemoveAllUnresolvedLibs", () => {
+  test("returns undefined when fewer than two unique entries", async () => {
+    expect(
+      await applyQuickFixes.quickFixRemoveAllUnresolvedLibs(
+        [{ lib: "a", pgroup: "default", path: ["pgroups", 0, "libs", 0] }],
+        [],
+      ),
+    ).toBeUndefined();
+
+    expect(
+      await applyQuickFixes.quickFixRemoveAllUnresolvedLibs(
+        [
+          {
+            lib: "same",
+            pgroup: "default",
+            path: ["pgroups", 0, "libs", 0],
+          },
+          {
+            lib: "same",
+            pgroup: "default",
+            path: ["pgroups", 0, "libs", 0],
+          },
+        ],
+        [],
+      ),
+    ).toBeUndefined();
+  });
+
+  test("returns undefined when entries have no paths", async () => {
+    expect(
+      await applyQuickFixes.quickFixRemoveAllUnresolvedLibs(
+        [
+          { lib: "a", pgroup: "default" },
+          { lib: "b", pgroup: "default" },
+        ],
+        [],
+      ),
+    ).toBeUndefined();
+  });
+
+  test("removes every unique entry in one command and deduplicates input", async () => {
+    await writeProcGrpsWithLibs(["w", "x", "y", "z"]);
+
+    const action = await applyQuickFixes.quickFixRemoveAllUnresolvedLibs(
+      [
+        { lib: "x", pgroup: "default", path: ["pgroups", 0, "libs", 1] },
+        { lib: "y", pgroup: "default", path: ["pgroups", 0, "libs", 2] },
+        { lib: "x", pgroup: "default", path: ["pgroups", 0, "libs", 1] },
+      ],
+      [],
+    );
+    expect(action).toBeDefined();
+    expect(action!.title).toContain("Remove all 2 unresolved libraries");
+    expect(action!.command!.command).toBe(Commands.REMOVE_DEAD_LIB);
+    const newContent = action!.command!.arguments![1] as string;
+    const parsed = JSON.parse(newContent) as {
+      pgroups: { libs: string[] }[];
+    };
+    expect(parsed.pgroups[0].libs).toEqual(["w", "z"]);
+  });
+
+  test("path-aware remove-all removes duplicate libs from right to left", async () => {
+    await writeProcGrpsWithLibs(["dup", "keep", "dup"]);
+
+    const action = await applyQuickFixes.quickFixRemoveAllUnresolvedLibs(
+      [
+        { lib: "dup", pgroup: "default", path: ["pgroups", 0, "libs", 0] },
+        { lib: "dup", pgroup: "default", path: ["pgroups", 0, "libs", 2] },
+      ],
+      [],
+    );
+
+    expect(action).toBeDefined();
+    const newContent = action!.command!.arguments![1] as string;
+    const parsed = JSON.parse(newContent) as {
+      pgroups: { libs: string[] }[];
+    };
+    expect(parsed.pgroups[0].libs).toEqual(["keep"]);
+  });
+});
+
+//
+// ----------------------------------------------------------
+// applyQuickFixes (proc_grps.json + lastProcGrpsUnresolvedLibEntries)
+// ----------------------------------------------------------
+describe("applyQuickFixes unresolved lib / proc_grps snapshot", () => {
+  test("with proc_grps documentUri and snapshot: yields bulk remove-all from snapshot plus individual removes from context diagnostics", async () => {
+    await setupParsedProcGrps(["bad-a", "bad-b", "bad-c"]);
+
+    const snapshot = pluginConfig.getLastProcGrpsUnresolvedLibEntries();
+    expect(snapshot).toHaveLength(3);
+
+    const result = await applyQuickFixes.applyQuickFixes(
+      [unresolvedLibDiagnostic("bad-a", "default", snapshot[0].path)],
+      procGrpsDocumentUri(),
+    );
+    expect(result).toBeDefined();
+    expect(result!.length).toBe(2);
+
+    const removeAll = result!.find((a) =>
+      a.title.startsWith("Remove all 3 unresolved"),
+    );
+    expect(removeAll).toBeDefined();
+    const single = result!.filter((a) =>
+      a.title.startsWith("Remove unresolved library"),
+    );
+    expect(single).toHaveLength(1);
+    expect(single[0].title).toEqual("Remove unresolved library 'bad-a'.");
+    const allContent = removeAll!.command!.arguments![1] as string;
+    expect(JSON.parse(allContent).pgroups[0].libs).toEqual([]);
+  });
+
+  test("with proc_grps documentUri and single snapshot entry: remove-all is omitted", async () => {
+    await setupParsedProcGrps(["only-bad"]);
+
+    expect(pluginConfig.getLastProcGrpsUnresolvedLibEntries()).toHaveLength(1);
+
+    const result = await applyQuickFixes.applyQuickFixes(
+      [
+        unresolvedLibDiagnostic("only-bad", "default", [
+          "pgroups",
+          0,
+          "libs",
+          0,
+        ]),
+      ],
+      procGrpsDocumentUri(),
+    );
+    expect(result).toBeDefined();
+    expect(result!.length).toBe(1);
+    expect(result![0].title).toBe("Remove unresolved library 'only-bad'.");
+  });
+
+  test("without proc_grps documentUri: uses per-diagnostic path only", async () => {
+    await setupParsedProcGrps(["solo-bad"]);
+    const snapshot = pluginConfig.getLastProcGrpsUnresolvedLibEntries();
+
+    const result = await applyQuickFixes.applyQuickFixes([
+      unresolvedLibDiagnostic("solo-bad", "default", snapshot[0].path),
+    ]);
+    expect(result).toBeDefined();
+    expect(result!.length).toBe(1);
+    expect(result![0].command!.command).toBe(Commands.REMOVE_DEAD_LIB);
+  });
+
+  test("with proc_grps URI but no unresolved lib in context: no unresolved-lib actions", async () => {
+    await setupParsedProcGrps(["bad-x"]);
+
+    const result = await applyQuickFixes.applyQuickFixes(
+      [
+        {
+          code: fullCode(LspCodes.IncludeResolution.MissingConfiguration),
+          data: { entryUri: "/workspace/foo.pli" },
+        } as Diagnostic,
+      ],
+      procGrpsDocumentUri(),
+    );
+    expect(result).toBeDefined();
+    expect(result!.length).toBe(1);
+    expect(result![0].title).toContain("Create a startup configuration");
+  });
+});
+
+//
+// ----------------------------------------------------------
+// parseProcessGroupConfigs → metadata-driven quick fixes
+// These tests exercise the real parsing path to ensure
+// metadata paths are root-relative and quick fixes produce
+// actual content changes (not no-ops).
+// ----------------------------------------------------------
+describe("metadata-driven quick fixes via parseProcessGroupConfigs", () => {
+  test("parseProcessGroupConfigs stores root-relative paths in snapshot entries", async () => {
+    await setupParsedProcGrps(["nonexistent-a", "nonexistent-b"]);
+    const snapshot = pluginConfig.getLastProcGrpsUnresolvedLibEntries();
+    expect(snapshot).toHaveLength(2);
+
+    for (const entry of snapshot) {
+      expect(entry.path).toBeDefined();
+      expect(entry.path![0]).toBe("pgroups");
+      expect(typeof entry.path![1]).toBe("number");
+      expect(entry.path![2]).toBe("libs");
+      expect(typeof entry.path![3]).toBe("number");
+    }
+  });
+
+  test("single remove via parsed metadata actually changes content", async () => {
+    await setupParsedProcGrps(["keep-me", "bad-lib"]);
+    const snapshot = pluginConfig.getLastProcGrpsUnresolvedLibEntries();
+    const badEntry = snapshot.find((e) => e.lib === "bad-lib");
+    expect(badEntry).toBeDefined();
+    expect(badEntry!.path).toBeDefined();
+
+    const diag = unresolvedLibDiagnostic("bad-lib");
+    diag.data.path = badEntry!.path;
+
+    const action = await applyQuickFixes.quickFixRemoveUnresolvedLib(diag);
+    expect(action).toBeDefined();
+    expect(action!.command!.command).toBe(Commands.REMOVE_DEAD_LIB);
+
+    const newContent = action!.command!.arguments![1] as string;
+    const parsed = JSON.parse(newContent) as {
+      pgroups: { libs: string[] }[];
+    };
+    expect(parsed.pgroups[0].libs).toEqual(["keep-me"]);
+  });
+
+  test("remove-all via parsed metadata removes all invalid libs", async () => {
+    await setupParsedProcGrps(["bad-a", "bad-b", "bad-c"]);
+    const snapshot = pluginConfig.getLastProcGrpsUnresolvedLibEntries();
+    expect(snapshot).toHaveLength(3);
+    expect(snapshot.every((e) => e.path !== undefined)).toBe(true);
+
+    const action = await applyQuickFixes.quickFixRemoveAllUnresolvedLibs(
+      snapshot,
+      [],
+    );
+    expect(action).toBeDefined();
+    expect(action!.title).toContain("Remove all 3 unresolved");
+
+    const newContent = action!.command!.arguments![1] as string;
+    const parsed = JSON.parse(newContent) as {
+      pgroups: { libs: string[] }[];
+    };
+    expect(parsed.pgroups[0].libs).toEqual([]);
+  });
+
+  test("duplicate libs via parsed metadata get distinct root-relative paths", async () => {
+    await vfs.writeFile(UriUtils.toUri("/workspace/keep/.placeholder"), "");
+    await setupParsedProcGrps(["dup", "keep", "dup"]);
+    const snapshot = pluginConfig.getLastProcGrpsUnresolvedLibEntries();
+    const dupEntries = snapshot.filter((e) => e.lib === "dup");
+    expect(dupEntries).toHaveLength(2);
+
+    expect(dupEntries[0].path).toEqual(["pgroups", 0, "libs", 0]);
+    expect(dupEntries[1].path).toEqual(["pgroups", 0, "libs", 2]);
+
+    const action = await applyQuickFixes.quickFixRemoveAllUnresolvedLibs(
+      snapshot,
+      [],
+    );
+    expect(action).toBeDefined();
+
+    const newContent = action!.command!.arguments![1] as string;
+    const parsed = JSON.parse(newContent) as {
+      pgroups: { libs: string[] }[];
+    };
+    expect(parsed.pgroups[0].libs).toEqual(["keep"]);
+  });
+
+  test("end-to-end: applyQuickFixes with parsed metadata yields working quick fixes", async () => {
+    await setupParsedProcGrps(["valid-should-fail", "another-bad"]);
+    const snapshot = pluginConfig.getLastProcGrpsUnresolvedLibEntries();
+    expect(snapshot).toHaveLength(2);
+
+    const diagA: Diagnostic = {
+      code: CODE_UNRESOLVED_LIB,
+      message: "unresolved valid-should-fail",
+      range: {
+        start: { line: 0, character: 0 },
+        end: { line: 0, character: 1 },
+      },
+      data: snapshot[0],
+    } as Diagnostic;
+
+    const result = await applyQuickFixes.applyQuickFixes(
+      [diagA],
+      procGrpsDocumentUri(),
+    );
+    expect(result).toBeDefined();
+
+    const removeAll = result!.find((a) => a.title.startsWith("Remove all"));
+    expect(removeAll).toBeDefined();
+    const removeAllContent = removeAll!.command!.arguments![1] as string;
+    const parsedAll = JSON.parse(removeAllContent) as {
+      pgroups: { libs: string[] }[];
+    };
+    expect(parsedAll.pgroups[0].libs).toEqual([]);
+
+    const single = result!.filter((a) =>
+      a.title.startsWith("Remove unresolved library"),
+    );
+    expect(single).toHaveLength(1);
+    const singleContent = single[0].command!.arguments![1] as string;
+    const parsedSingle = JSON.parse(singleContent) as {
+      pgroups: { libs: string[] }[];
+    };
+    expect(parsedSingle.pgroups[0].libs).toHaveLength(1);
+  });
+
+  test("multi-pgroup parsed metadata has correct root-relative paths", async () => {
+    const procGrpsJson = JSON.stringify(
+      {
+        pgroups: [
+          {
+            name: "group-a",
+            "include-extensions": [".inc"],
+            libs: ["valid-dir"],
+          },
+          {
+            name: "group-b",
+            "include-extensions": [".inc"],
+            libs: ["nonexistent"],
+          },
+        ],
+      },
+      undefined,
+      2,
+    );
+    await vfs.writeFile(
+      UriUtils.toUri("/workspace/.pliplugin/proc_grps.json"),
+      procGrpsJson,
+    );
+    await vfs.writeFile(
+      UriUtils.toUri("/workspace/valid-dir/.placeholder"),
+      "",
+    );
+    await pluginConfig.parseProcessGroupConfigs(procGrpsJson);
+    pluginConfig.setProgramConfigs("/workspace", [
+      { program: "main.pli", pgroup: "group-a" },
+      { program: "other.pli", pgroup: "group-b" },
+    ]);
+
+    const snapshot = pluginConfig.getLastProcGrpsUnresolvedLibEntries();
+    expect(snapshot).toHaveLength(1);
+    expect(snapshot[0].lib).toBe("nonexistent");
+    expect(snapshot[0].pgroup).toBe("group-b");
+    expect(snapshot[0].path).toEqual(["pgroups", 1, "libs", 0]);
   });
 });

--- a/packages/language/test/workspace/plugin-configuration.test.ts
+++ b/packages/language/test/workspace/plugin-configuration.test.ts
@@ -99,7 +99,7 @@ describe("Plugin Configuration Tests", () => {
 
     // should generate a diagnostic for the non-existing lib
     expect(diagnostics).toHaveLength(1);
-    expect(diagnostics[0].code).toBe("COPC01");
+    expect(diagnostics[0].code).toBe("COPC01E");
     expect(diagnostics[0].message).toContain("nonexistent-libs");
     expect(diagnostics[0].severity).toBe(1); // err
   });
@@ -131,11 +131,11 @@ describe("Plugin Configuration Tests", () => {
     expect(diagnostics).toHaveLength(2);
 
     const d0 = diagnostics[0];
-    expect(d0.code).toBe("COPC01");
+    expect(d0.code).toBe("COPC01E");
     expect(diagnostics.some((d) => d.message.includes("invalid1"))).toBe(true);
 
     const d1 = diagnostics[1];
-    expect(d1.code).toBe("COPC01");
+    expect(d1.code).toBe("COPC01E");
     expect(diagnostics.some((d) => d.message.includes("invalid2"))).toBe(true);
   });
 

--- a/packages/vscode-extension/src/extension/main.ts
+++ b/packages/vscode-extension/src/extension/main.ts
@@ -153,7 +153,10 @@ async function startLanguageClient(
 
   // Options to control the language client
   const clientOptions: LanguageClientOptions = {
-    documentSelector: [{ scheme: "*", language: "pli" }],
+    documentSelector: [
+      { scheme: "*", language: "pli" },
+      { scheme: "file", pattern: "**/.pliplugin/*.json" },
+    ],
   };
 
   // Create the language client and start the client.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       chevrotain:
         specifier: ^11.1.1
         version: 11.1.1
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
       lodash-es:
         specifier: 4.18.1
         version: 4.18.1


### PR DESCRIPTION
_Closes_ #535 , _but also implement other changes. I wanted to make sure we would be able to act on the diagnostics, so I worked on implementing at least a quick fix, to make it easier to do it in the future. Turns out some other changes were necessary to accomplish it, so we ended up with such a big PR._

## Summary

This work improves how `.pliplugin` JSON files (especially `proc_grps.json`) are handled end-to-end:

- The language server can now participate in these documents **without running the PL/I pipeline**
- Plugin configuration validation surfaces **clearer diagnostics**
- Code actions can remove invalid `libs` entries:
  - Individually
  - Or in bulk
- Uses `jsonc-parser` to ensure edits remain **structural and JSONC-tolerant**

---

## What Changed

### VS Code Extension

- Extended `documentSelector` to include:
  - `**/.pliplugin/*.json`
- This allows the PL/I language client to:
  - Participate in plugin config files
  - Enable code actions and related LSP behavior

---

### Language Server – Compilation

- **`compilation-unit.ts`**
  - Skips creating compilation units for:
    - Paths under `.pliplugin/`
    - Files ending in `.json`
- Result:
  - Only plugin-related diagnostics (e.g., `COPC*`) are applied
  - PL/I compiler diagnostics are avoided for JSON files

---

### Plugin Configuration Provider

- Improved validation and diagnostics for process-group configuration:
  - Includes `COPC01`-style unresolved library entries
- Maintains a snapshot:
  - `lastProcGrpsUnresolvedLibEntries`
- Enables code actions to:
  - Access **all unresolved `(pgroup, lib)` pairs**
  - Not just those present in a single request

---

### Quick Fixes (`apply-quick-fixes.ts`)

- Uses `jsonc-parser`:
  - `parseTree`
  - `findNodeAtLocation`
  - `modify` / `applyEdits`
- Removes `libs[]` entries by **logical path**
- Ensures **stable formatting**

#### Behavior

- `applyQuickFixes(diagnostics, documentUri)`:
  - When targeting workspace `proc_grps.json`
  - And at least one unresolved-lib diagnostic is present:
    - Builds fixes from provider snapshot:
      - Per-lib removal
      - “Remove all” (if ≥ 2 distinct pairs)
  - Avoids duplicating per-diagnostic logic

---

### Connection Handler

- Passes `params.textDocument.uri` into `applyQuickFixes`
- Wires command (e.g., `REMOVE_DEAD_LIB`) through `executeCommand`

---

## Dependencies

- Adds `jsonc-parser`
- Uses bundler-safe import:
  - `jsonc-parser/lib/esm/main.js`
- Avoids runtime module resolution issues

---

## Tests

- Extended:
  - `apply-quick-fixes.test.ts`
    - `quickFixRemoveUnresolvedLib`
    - `quickFixRemoveAllUnresolvedLibsFromPairs`
    - Snapshot + `documentUri` behavior
- Adjusted plugin configuration tests as needed

---

## How to Verify

1. Open:
   - `/.pliplugin/proc_grps.json`
   - Include multiple invalid `libs` entries

2. Confirm:
   - Diagnostics are shown
   - Quick fixes include:
     - Individual removals
     - “Remove all” (when applicable)

3. Verify:
   - `.pliplugin` JSON does **not** show PL/I diagnostics