### PR TITLE
Refactor ProcedureCall

### DIFF
--- a/packages/language/src/language-server/signature-help-request.ts
+++ b/packages/language/src/language-server/signature-help-request.ts
@@ -19,6 +19,7 @@ import {
   LabelPrefix,
   MemberCall,
   ProcedureStatement,
+  ReferenceItem,
   SyntaxKind,
 } from "../syntax-tree/ast";
 import { extractDeclaration } from "../typesystem/stringify";
@@ -135,41 +136,42 @@ function tryGetCallInfo(
   if (!memberCall && !callStatement) {
     return null;
   }
-  if (memberCall && !callStatement) {
-    return getCallInfoFromMemberCall(memberCall, offset, unit);
+  if (memberCall && memberCall.element && !callStatement) {
+    return getCallInfoFromReferenceItem(memberCall.element, offset, unit);
   }
-  if (callStatement && !memberCall) {
-    return getCallInfoFromCallStatement(callStatement, offset, unit);
+  if (callStatement && callStatement.call && !memberCall) {
+    return getCallInfoFromReferenceItem(callStatement.call, offset, unit);
   }
   assertType<MemberCall>(memberCall);
   assertType<CallStatement>(callStatement);
-  const callStatementOffset = callStatement.call?.procedure?.token.startOffset;
+  if (memberCall.element === null || callStatement.call === null) {
+    return null;
+  }
+  const callStatementOffset = callStatement.call?.ref?.token.startOffset;
   const memberCallOffset = memberCall.element?.ref?.token.startOffset;
   if (callStatementOffset === undefined || memberCallOffset === undefined) {
     return null;
   }
   if (callStatementOffset > memberCallOffset) {
-    return getCallInfoFromCallStatement(callStatement, offset, unit);
+    return getCallInfoFromReferenceItem(callStatement.call, offset, unit);
   } else {
-    return getCallInfoFromMemberCall(memberCall, offset, unit);
+    return getCallInfoFromReferenceItem(memberCall.element, offset, unit);
   }
 }
 
-function getCallInfoFromCallStatement(
-  callStatement: CallStatement,
+function getCallInfoFromReferenceItem(
+  referenceItem: ReferenceItem,
   offset: number,
   unit: CompilationUnit,
 ): CallInfo | null {
   if (
-    !callStatement.call?.procedure?.text ||
-    !callStatement.call.procedure.node ||
-    callStatement.call.procedure.node.kind !== SyntaxKind.LabelPrefix
+    !referenceItem.ref?.text ||
+    !referenceItem.ref.node ||
+    referenceItem.ref.node.kind !== SyntaxKind.LabelPrefix
   ) {
     return null;
   }
-  const procedure = retrieveProcedureFromLabelPrefix(
-    callStatement.call.procedure.node,
-  );
+  const procedure = retrieveProcedureFromLabelPrefix(referenceItem.ref.node);
   if (!procedure) {
     return null;
   }
@@ -186,74 +188,13 @@ function getCallInfoFromCallStatement(
   }
   let parameterIndex = 0;
   const argumentsInfo: ArgumentInfo[] = [];
-  if (callStatement.call.args1) {
+  if (referenceItem.dimensions) {
     for (
       let index = 0;
-      index < callStatement.call.args1.bounds.length;
+      index < referenceItem.dimensions.dimensions.length;
       index++
     ) {
-      const bounds = callStatement.call.args1.bounds[index];
-      argumentsInfo.push({
-        startToken: bounds.startToken,
-        endToken: bounds.endToken,
-        parameterIndex,
-      });
-      if (
-        parameterIndex < parameterInfo.length &&
-        !parameterInfo[parameterIndex].variadic
-      ) {
-        parameterIndex++;
-      }
-    }
-  }
-  const argumentIndex = getArgumentIndexByOffset(argumentsInfo, offset);
-  return {
-    procedure,
-    arguments: argumentsInfo,
-    parameters: parameterInfo,
-    labelPrefix: callStatement.call.procedure.node,
-    argumentIndex,
-  };
-}
-
-function getCallInfoFromMemberCall(
-  memberCall: MemberCall,
-  offset: number,
-  unit: CompilationUnit,
-): CallInfo | null {
-  if (
-    !memberCall.element?.ref?.text ||
-    !memberCall.element.ref.node ||
-    memberCall.element.ref.node.kind !== SyntaxKind.LabelPrefix
-  ) {
-    return null;
-  }
-  const procedure = retrieveProcedureFromLabelPrefix(
-    memberCall.element.ref.node,
-  );
-  if (!procedure) {
-    return null;
-  }
-  const parameterInfo: ParameterInfo[] = [];
-  if (procedure.parameters) {
-    for (const parameter of procedure.parameters) {
-      const parameterType = unit.services.inferer.inferType(parameter, unit);
-      parameterInfo.push({
-        label: parameter?.ref?.text ?? "<unknown>",
-        variadic: parameterType.list,
-        token: parameter?.ref?.token ?? null,
-      });
-    }
-  }
-  let parameterIndex = 0;
-  const argumentsInfo: ArgumentInfo[] = [];
-  if (memberCall.element.dimensions) {
-    for (
-      let index = 0;
-      index < memberCall.element.dimensions.dimensions.length;
-      index++
-    ) {
-      const dim = memberCall.element.dimensions.dimensions[index];
+      const dim = referenceItem.dimensions.dimensions[index];
       argumentsInfo.push({
         startToken: dim.startToken,
         endToken: dim.endToken,
@@ -272,7 +213,7 @@ function getCallInfoFromMemberCall(
     procedure,
     parameters: parameterInfo,
     arguments: argumentsInfo,
-    labelPrefix: memberCall.element.ref.node,
+    labelPrefix: referenceItem.ref.node,
     argumentIndex,
   };
 }

--- a/packages/language/src/language-server/signature-help-request.ts
+++ b/packages/language/src/language-server/signature-help-request.ts
@@ -152,11 +152,13 @@ function tryGetCallInfo(
   if (callStatementOffset === undefined || memberCallOffset === undefined) {
     return null;
   }
-  if (callStatementOffset > memberCallOffset) {
-    return getCallInfoFromReferenceItem(callStatement.call, offset, unit);
-  } else {
-    return getCallInfoFromReferenceItem(memberCall.element, offset, unit);
+  if (callStatementOffset < memberCallOffset) {
+    const help = getCallInfoFromReferenceItem(memberCall.element, offset, unit);
+    return help && help.argumentIndex !== null
+      ? help
+      : getCallInfoFromReferenceItem(callStatement.call, offset, unit);
   }
+  return null;
 }
 
 function getCallInfoFromReferenceItem(

--- a/packages/language/src/language-server/signature-help-request.ts
+++ b/packages/language/src/language-server/signature-help-request.ts
@@ -137,7 +137,7 @@ function tryGetCallInfo(
     return null;
   }
   if (memberCall && memberCall.element && !callStatement) {
-    return getCallInfoFromReferenceItem(memberCall.element, offset, unit);
+    return getCallInfoFromMemberCall(memberCall, offset, unit);
   }
   if (callStatement && callStatement.call && !memberCall) {
     return getCallInfoFromReferenceItem(callStatement.call, offset, unit);
@@ -153,10 +153,26 @@ function tryGetCallInfo(
     return null;
   }
   if (callStatementOffset < memberCallOffset) {
-    const help = getCallInfoFromReferenceItem(memberCall.element, offset, unit);
+    const help = getCallInfoFromMemberCall(memberCall, offset, unit);
     return help && help.argumentIndex !== null
       ? help
       : getCallInfoFromReferenceItem(callStatement.call, offset, unit);
+  }
+  return null;
+}
+
+function getCallInfoFromMemberCall(
+  memberCall: MemberCall,
+  offset: number,
+  unit: CompilationUnit,
+): CallInfo | null {
+  let call: MemberCall | null = memberCall;
+  while (call && call.element) {
+    const callInfo = getCallInfoFromReferenceItem(call.element, offset, unit);
+    if (callInfo && callInfo.argumentIndex !== null) {
+      return callInfo;
+    }
+    call = getContainer(call.container, SyntaxKind.MemberCall);
   }
   return null;
 }

--- a/packages/language/src/language-server/signature-help-request.ts
+++ b/packages/language/src/language-server/signature-help-request.ts
@@ -188,13 +188,13 @@ function getCallInfoFromReferenceItem(
   }
   let parameterIndex = 0;
   const argumentsInfo: ArgumentInfo[] = [];
-  if (referenceItem.dimensions) {
+  if (referenceItem.dimensions.length === 1) {
     for (
       let index = 0;
-      index < referenceItem.dimensions.dimensions.length;
+      index < referenceItem.dimensions[0].dimensions.length;
       index++
     ) {
-      const dim = referenceItem.dimensions.dimensions[index];
+      const dim = referenceItem.dimensions[0].dimensions[index];
       argumentsInfo.push({
         startToken: dim.startToken,
         endToken: dim.endToken,

--- a/packages/language/src/linking/tokens.ts
+++ b/packages/language/src/linking/tokens.ts
@@ -94,8 +94,6 @@ export function getReference(node: SyntaxNode): Reference | undefined {
       return node.type ?? undefined;
     case SyntaxKind.LabelReference:
       return node.label ?? undefined;
-    case SyntaxKind.ProcedureCall:
-      return node.procedure ?? undefined;
     case SyntaxKind.ReferenceItem:
       return node.ref ?? undefined;
     case SyntaxKind.TypeAttribute:

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -1225,7 +1225,7 @@ const callStatement = rule(
   (state: ParserState): ast.CallStatement => {
     const element = ast.createCallStatement();
     state.consume(element, CstNodeKind.CallStatement_CALL, tokens.CALL);
-    element.call = procedureCall.rule(state);
+    element.call = referenceItem.rule(state);
     state.consume(
       element,
       CstNodeKind.CallStatement_Semicolon,
@@ -4478,7 +4478,7 @@ const initialAttribute = rule(
       ) {
         // INITIAL CALL variant
         element.call = true;
-        element.procedureCall = procedureCall.rule(state);
+        element.procedureCall = referenceItem.rule(state);
       } else if (
         state.tryConsume(element, CstNodeKind.InitialAttribute_To, tokens.TO)
       ) {
@@ -6366,137 +6366,6 @@ const locatorCall = rule(
     }
 
     return element;
-  },
-);
-
-const procedureCall = rule(
-  sequence(tokens.ID),
-  (state: ParserState): ast.ProcedureCall => {
-    const element = ast.createProcedureCall();
-
-    const idToken = state.consume(
-      element,
-      CstNodeKind.ProcedureCall_ProcedureRef,
-      tokens.ID,
-    );
-    if (idToken) {
-      element.procedure = ast.createReference(
-        element,
-        idToken,
-        ast.ReferenceType.Variable,
-      );
-    }
-
-    /* //TODO was this correctly translated?
-        
-        let i = 0;
-            // Use MANY to prevent grammar ambiguity
-            MANY({
-              DEF: () => {
-                SUBRULE_ASSIGN(ProcedureCallArgs, {
-                  assign: (result) => {
-                    if (i === 0) {
-                      element.args1 = result;
-                    } else {
-                      element.args2 = result;
-                    }
-                  },
-                });
-                i++;
-              },
-              // Use a gate to prevent parsing this more than twice
-              GATE: () => i < 2,
-            });
-        
-        */
-
-    // Parse optional argument lists (up to 2)
-    let argCount = 0;
-    const { inc } = state.createLoopContext("ProcedureCall");
-    while (argCount < 2 && state.canConsumeFirst(procedureCallArgs.first())) {
-      inc();
-      const args = procedureCallArgs.rule(state);
-      if (argCount === 0) {
-        element.args1 = args;
-      } else {
-        element.args2 = args;
-      }
-      argCount++;
-    }
-
-    return element;
-  },
-);
-
-const procedureCallArgs = rule(
-  sequence(tokens.OpenParen),
-  (state: ParserState): ast.ProcedureCallArgs => {
-    const element = ast.createProcedureCallArgs();
-    const bounds: ast.ProcedureCallArgumentBounds[] = [];
-    element.bounds = bounds;
-
-    let startToken = state.consume(
-      element,
-      CstNodeKind.ProcedureCallArgs_OpenParen,
-      tokens.OpenParen,
-    );
-    let endToken: Token | null = null;
-
-    // Optional argument list
-    if (!state.canConsume(tokens.CloseParen)) {
-      // Parse first argument (expression or star)
-      if (state.canConsume(tokens.Star)) {
-        state.consume(
-          element,
-          CstNodeKind.ProcedureCallArgs_Star0,
-          tokens.Star,
-        );
-        element.list.push("*");
-      } else {
-        const expr = expression.rule(state);
-        expr && element.list.push(expr);
-      }
-
-      // Parse additional comma-separated arguments
-      const { inc } = state.createLoopContext("ProcedureCallArgs");
-      while (
-        (endToken = state.tryConsume(
-          element,
-          CstNodeKind.ProcedureCallArgs_Comma,
-          tokens.Comma,
-        ))
-      ) {
-        inc();
-        if (state.canConsume(tokens.Star)) {
-          state.consume(
-            element,
-            CstNodeKind.ProcedureCallArgs_Star1,
-            tokens.Star,
-          );
-          element.list.push("*");
-        } else {
-          const expr = expression.rule(state);
-          expr && element.list.push(expr);
-        }
-        applyBounds();
-        startToken = endToken;
-      }
-    }
-
-    endToken = state.consume(
-      element,
-      CstNodeKind.ProcedureCallArgs_CloseParen,
-      tokens.CloseParen,
-    );
-    applyBounds();
-    return element;
-
-    function applyBounds() {
-      const item = ast.createProcedureCallArgumentBounds();
-      item.startToken = startToken;
-      item.endToken = endToken;
-      bounds.push(item);
-    }
   },
 );
 

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -6149,13 +6149,19 @@ const referenceItem = rule(
       );
     }
 
-    // Optional dimensions
-    if (state.canConsumeFirst(dimensions.first())) {
-      // "Normal" dimensions, that simply target variables in their references
-      element.dimensions = dimensions.rule(state);
-    } else if (state.canConsumeFirst(dimensionsWithTypes.first())) {
-      // Dimensions that can also target types in their references
-      element.dimensions = dimensionsWithTypes.rule(state);
+    while (
+      state.canConsumeFirst(dimensions.first()) ||
+      state.canConsumeFirst(dimensionsWithTypes.first())
+    ) {
+      if (state.canConsumeFirst(dimensions.first())) {
+        // "Normal" dimensions, that simply target variables in their references
+        const dim = dimensions.rule(state);
+        dim && element.dimensions.push(dim);
+      } else if (state.canConsumeFirst(dimensionsWithTypes.first())) {
+        // Dimensions that can also target types in their references
+        const dim = dimensionsWithTypes.rule(state);
+        dim && element.dimensions.push(dim);
+      }
     }
 
     return element;

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -6149,21 +6149,22 @@ const referenceItem = rule(
       );
     }
 
+    let withoutType = false;
+    let withType = false;
     while (
-      state.canConsumeFirst(dimensions.first()) ||
-      state.canConsumeFirst(dimensionsWithTypes.first())
+      (withoutType = state.canConsumeFirst(dimensions.first())) ||
+      (withType = state.canConsumeFirst(dimensionsWithTypes.first()))
     ) {
-      if (state.canConsumeFirst(dimensions.first())) {
+      if (withoutType) {
         // "Normal" dimensions, that simply target variables in their references
         const dim = dimensions.rule(state);
         dim && element.dimensions.push(dim);
-      } else if (state.canConsumeFirst(dimensionsWithTypes.first())) {
+      } else if (withType) {
         // Dimensions that can also target types in their references
         const dim = dimensionsWithTypes.rule(state);
         dim && element.dimensions.push(dim);
       }
     }
-
     return element;
   },
 );

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -5539,10 +5539,7 @@ const dimensions = rule(
         ))
       ) {
         inc();
-        if (current) {
-          current.startToken = startToken;
-          current.endToken = endToken;
-        }
+        applyBoundsTokens(current);
         startToken = endToken;
         current = dimensionBound.rule(state, ast.ReferenceType.Variable);
         current && element.dimensions.push(current);
@@ -5556,14 +5553,17 @@ const dimensions = rule(
     );
 
     if (element.dimensions.length > 0) {
-      const lastBound = element.dimensions[element.dimensions.length - 1];
-      if (lastBound) {
-        lastBound.startToken = startToken;
-        lastBound.endToken = endToken;
-      }
+      applyBoundsTokens(element.dimensions[element.dimensions.length - 1]);
     }
 
     return element;
+
+    function applyBoundsTokens(bounds: ast.DimensionBound | null) {
+      if (bounds) {
+        bounds.startToken = startToken;
+        bounds.endToken = endToken;
+      }
+    }
   },
 );
 
@@ -5597,10 +5597,7 @@ const dimensionsWithTypes = rule(
         ))
       ) {
         inc();
-        if (current) {
-          current.startToken = startToken;
-          current.endToken = endToken;
-        }
+        applyBoundsTokens(current);
         startToken = endToken;
         current = dimensionBound.rule(state, ast.ReferenceType.TypeOrVariable);
         current && element.dimensions.push(current);
@@ -5614,14 +5611,17 @@ const dimensionsWithTypes = rule(
     );
 
     if (element.dimensions.length > 0) {
-      const lastBound = element.dimensions[element.dimensions.length - 1];
-      if (lastBound) {
-        lastBound.startToken = startToken;
-        lastBound.endToken = endToken;
-      }
+      applyBoundsTokens(element.dimensions[element.dimensions.length - 1]);
     }
 
     return element;
+
+    function applyBoundsTokens(bounds: ast.DimensionBound | null) {
+      if (bounds) {
+        bounds.startToken = startToken;
+        bounds.endToken = endToken;
+      }
+    }
   },
 );
 

--- a/packages/language/src/parser/preprocessor-parser.ts
+++ b/packages/language/src/parser/preprocessor-parser.ts
@@ -353,57 +353,17 @@ function callStatement(state: ParserState): ast.CallStatement {
     CstNodeKind.ProcedureCall_ProcedureRef,
     t.ID,
   );
-  statement.call = ast.createProcedureCall();
+  statement.call = ast.createReferenceItem();
   if (nameToken) {
-    statement.call.procedure = ast.createReference(
+    statement.call.ref = ast.createReference(
       statement,
       nameToken,
       ast.ReferenceType.Variable,
     );
   }
-  let startToken = state.consume(
-    statement,
-    CstNodeKind.ProcedureCallArgs_OpenParen,
-    t.OpenParen,
-  );
-  let endToken: t.Token | null = null;
-  const bounds: ast.ProcedureCallArgumentBounds[] = [];
-
-  if (!state.canConsume(t.CloseParen)) {
-    statement.call.args1 = ast.createProcedureCallArgs();
-    statement.call.args1.bounds = bounds;
-    do {
-      if (endToken) {
-        applyBounds();
-        startToken = endToken;
-      }
-      const argument = expression(state);
-      if (argument) {
-        statement.call.args1.list.push(argument);
-      }
-    } while (
-      (endToken = state.tryConsume(
-        statement,
-        CstNodeKind.ProcedureCallArgs_Comma,
-        t.Comma,
-      ))
-    );
-  }
-  endToken = state.consume(
-    statement,
-    CstNodeKind.ProcedureCallArgs_CloseParen,
-    t.CloseParen,
-  );
-  applyBounds();
+  statement.call.dimensions = dimensions(state);
   state.consume(statement, CstNodeKind.CallStatement_Semicolon, t.Semicolon);
   return statement;
-
-  function applyBounds() {
-    const item = ast.createProcedureCallArgumentBounds();
-    item.startToken = startToken;
-    item.endToken = endToken;
-    bounds.push(item);
-  }
 }
 
 function procedureStatement(state: ParserState): ast.ProcedureStatement {

--- a/packages/language/src/parser/preprocessor-parser.ts
+++ b/packages/language/src/parser/preprocessor-parser.ts
@@ -361,7 +361,9 @@ function callStatement(state: ParserState): ast.CallStatement {
       ast.ReferenceType.Variable,
     );
   }
-  statement.call.dimensions = dimensions(state);
+  while (state.canConsume(t.OpenParen)) {
+    statement.call.dimensions.push(dimensions(state));
+  }
   state.consume(statement, CstNodeKind.CallStatement_Semicolon, t.Semicolon);
   return statement;
 }
@@ -1245,8 +1247,10 @@ function parseReferenceItem(
     variable,
     ast.ReferenceType.Variable,
   );
-  if (withDimensions && state.canConsume(t.OpenParen)) {
-    reference.dimensions = dimensions(state);
+  if (withDimensions) {
+    while (state.canConsume(t.OpenParen)) {
+      reference.dimensions.push(dimensions(state));
+    }
   }
   return reference;
 }

--- a/packages/language/src/preprocessor/instruction-generator.ts
+++ b/packages/language/src/preprocessor/instruction-generator.ts
@@ -224,19 +224,19 @@ function generateCallInstruction(
   node: ast.CallStatement,
   context: GenerateInstructionContext,
 ): inst.CallInstruction | undefined {
-  if (!node.call?.procedure?.text) {
+  if (!node.call?.ref?.text) {
     return undefined; // No procedure to call
   }
-  const args = (node.call.args1?.list ?? []).map((arg) => {
-    assertType<ast.Expression>(arg);
+  const args = (node.call.dimensions?.dimensions ?? []).map((arg) => {
+    assertType<ast.Expression>(arg.upper?.expression);
     return (
-      generateExpressionInstruction(arg) ??
+      generateExpressionInstruction(arg.upper.expression) ??
       <inst.NumberInstruction>{ kind: inst.InstructionKind.Number, value: "0" }
     );
   });
   return {
     kind: inst.InstructionKind.Call,
-    procedureName: node.call.procedure.text,
+    procedureName: node.call.ref.text,
     args,
     node,
   };

--- a/packages/language/src/preprocessor/instruction-generator.ts
+++ b/packages/language/src/preprocessor/instruction-generator.ts
@@ -227,7 +227,10 @@ function generateCallInstruction(
   if (!node.call?.ref?.text) {
     return undefined; // No procedure to call
   }
-  const args = (node.call.dimensions?.dimensions ?? []).map((arg) => {
+  if (node.call.dimensions.length !== 1) {
+    return undefined; // Only support one dimension for CALL statements
+  }
+  const args = (node.call.dimensions[0].dimensions ?? []).map((arg) => {
     assertType<ast.Expression>(arg.upper?.expression);
     return (
       generateExpressionInstruction(arg.upper.expression) ??
@@ -861,8 +864,8 @@ function generateReferenceItemInstruction(
   node: ast.ReferenceItem,
 ): inst.ReferenceItemInstruction {
   const args: inst.ExpressionInstruction[] = [];
-  if (node.dimensions) {
-    for (const dimension of node.dimensions.dimensions) {
+  if (node.dimensions.length === 1) {
+    for (const dimension of node.dimensions[0].dimensions) {
       const def: inst.StringInstruction = {
         kind: inst.InstructionKind.String,
         value: "",

--- a/packages/language/src/syntax-tree/ast-iterator.ts
+++ b/packages/language/src/syntax-tree/ast-iterator.ts
@@ -756,26 +756,6 @@ export function forEachNode(
       break;
     case SyntaxKind.PrintDirective:
       break;
-    case SyntaxKind.ProcedureCall:
-      if (node.args1) {
-        action(node.args1);
-      }
-      if (node.args2) {
-        action(node.args2);
-      }
-      break;
-    case SyntaxKind.ProcedureCallArgs:
-      for (const arg of node.list) {
-        if (arg !== "*") {
-          action(arg);
-        }
-      }
-      for (const bound of node.bounds) {
-        action(bound);
-      }
-      break;
-    case SyntaxKind.ProcedureCallArgumentBounds:
-      break;
     case SyntaxKind.ProcedureParameter:
       break;
     case SyntaxKind.ProcedureStatement:

--- a/packages/language/src/syntax-tree/ast-iterator.ts
+++ b/packages/language/src/syntax-tree/ast-iterator.ts
@@ -815,8 +815,8 @@ export function forEachNode(
       }
       break;
     case SyntaxKind.ReferenceItem:
-      if (node.dimensions) {
-        action(node.dimensions);
+      for (const dimension of node.dimensions) {
+        action(dimension);
       }
       break;
     case SyntaxKind.ReinitStatement:

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -170,9 +170,6 @@ export enum SyntaxKind {
   PopDirective,
   PrefixedAttribute,
   PrintDirective,
-  ProcedureCall,
-  ProcedureCallArgumentBounds,
-  ProcedureCallArgs,
   ProcedureParameter,
   ProcedureStatement,
   ProcedureOrderOption,
@@ -903,9 +900,6 @@ export type SyntaxNode =
   | PopDirective
   | PrefixedAttribute
   | PrintDirective
-  | ProcedureCall
-  | ProcedureCallArgs
-  | ProcedureCallArgumentBounds
   | ProcedureParameter
   | ProcedureStatement
   | ProcessDirective
@@ -1459,7 +1453,7 @@ export function createBound(): Bound {
 }
 export interface CallStatement extends AstNode {
   kind: SyntaxKind.CallStatement;
-  call: ProcedureCall | null;
+  call: ReferenceItem | null;
 }
 
 export function createCallStatement(): CallStatement {
@@ -2897,7 +2891,7 @@ export interface InitialAttribute extends AstNode {
   direct: boolean;
   items: InitialAttributeItem[];
   call: boolean;
-  procedureCall: ProcedureCall | null;
+  procedureCall: ReferenceItem | null;
   to: boolean;
   content: InitialToContent | null;
   token: Token | null;
@@ -3477,64 +3471,6 @@ export function createPrintDirective(): PrintDirective {
   return {
     kind: SyntaxKind.PrintDirective,
     container: null,
-  };
-}
-export interface ProcedureCall extends AstNode {
-  kind: SyntaxKind.ProcedureCall;
-  /**
-   * Call to a known procedure or external declaration (via a named element), does not necessarily require an arg list
-   */
-  procedure: Reference<NamedVariable> | null;
-  /**
-   * First argument list of the CALL statement.
-   * In case of a procedure array, this is the index!
-   * Use `args2` for the actual arguments (assuming there are any).
-   */
-  args1: ProcedureCallArgs | null;
-  /**
-   * Second argument list of the CALL statement.
-   * Likely empty. Only filled if the linked procedure is an array!
-   */
-  args2: ProcedureCallArgs | null;
-}
-
-export function createProcedureCall(): ProcedureCall {
-  return {
-    kind: SyntaxKind.ProcedureCall,
-    container: null,
-    procedure: null,
-    args1: null,
-    args2: null,
-  };
-}
-
-export interface ProcedureCallArgumentBounds extends AstNode {
-  kind: SyntaxKind.ProcedureCallArgumentBounds;
-  startToken: Token | null;
-  endToken: Token | null;
-}
-
-export function createProcedureCallArgumentBounds(): ProcedureCallArgumentBounds {
-  return {
-    kind: SyntaxKind.ProcedureCallArgumentBounds,
-    container: null,
-    startToken: null,
-    endToken: null,
-  };
-}
-
-export interface ProcedureCallArgs extends AstNode {
-  kind: SyntaxKind.ProcedureCallArgs;
-  list: Wildcard<Expression>[];
-  bounds: ProcedureCallArgumentBounds[];
-}
-
-export function createProcedureCallArgs(): ProcedureCallArgs {
-  return {
-    kind: SyntaxKind.ProcedureCallArgs,
-    container: null,
-    list: [],
-    bounds: [],
   };
 }
 

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -3693,14 +3693,14 @@ export function createReadStatementOption(): ReadStatementOption {
 export interface ReferenceItem extends AstNode {
   kind: SyntaxKind.ReferenceItem;
   ref: Reference<NamedElement> | null;
-  dimensions: Dimensions | null;
+  dimensions: Dimensions[];
 }
 export function createReferenceItem(): ReferenceItem {
   return {
     kind: SyntaxKind.ReferenceItem,
     container: null,
     ref: null,
-    dimensions: null,
+    dimensions: [],
   };
 }
 export interface ReinitStatement extends AstNode {

--- a/packages/language/src/validation/compiler/IBM3970-IBM3971-call-procedure.ts
+++ b/packages/language/src/validation/compiler/IBM3970-IBM3971-call-procedure.ts
@@ -19,7 +19,7 @@ export function IBM3970IS_IBM3971IS_check_pp_call_procedure(
   acceptor: ValidationAcceptor,
 ): void {
   const procedure = resolveProcedureFromCall(node);
-  const callToken = node.call?.procedure?.token;
+  const callToken = node.call?.ref?.token;
   if (!procedure || !callToken) {
     if (callToken) {
       acceptor(diagnosticFromCode(PLICodes.Severe.IBM3968I, callToken));

--- a/packages/language/src/validation/compiler/check-arguments.ts
+++ b/packages/language/src/validation/compiler/check-arguments.ts
@@ -36,8 +36,11 @@ export function CallStatement_checkArguments(
     return;
   }
   const callToken = node.call!.ref!.token;
+  if (node.call?.dimensions.length !== 1) {
+    return;
+  }
   const providedTypes =
-    node.call?.dimensions?.dimensions.map((d) => {
+    node.call?.dimensions[0].dimensions.map((d) => {
       if (d.upper?.expression === "*") {
         return TypeDescriptions.Unknown();
       }
@@ -84,8 +87,11 @@ export function MemberCall_checkArguments(
   ) {
     return;
   }
+  if (node.element.dimensions.length !== 1) {
+    return;
+  }
   const providedTypes =
-    node.element.dimensions?.dimensions.map((d) =>
+    node.element.dimensions[0].dimensions.map((d) =>
       typeof d.upper?.expression === "object" && d.upper?.expression !== null
         ? unit.services.inferer.inferType(d.upper.expression, unit)
         : TypeDescriptions.Unknown(),

--- a/packages/language/src/validation/compiler/check-arguments.ts
+++ b/packages/language/src/validation/compiler/check-arguments.ts
@@ -35,10 +35,10 @@ export function CallStatement_checkArguments(
   if (!procedure) {
     return;
   }
-  const callToken = node.call!.procedure!.token;
+  const callToken = node.call!.ref!.token;
   const providedTypes =
-    node.call?.args1?.list.map((d) => {
-      if (d === "*") {
+    node.call?.dimensions?.dimensions.map((d) => {
+      if (d.upper?.expression === "*") {
         return TypeDescriptions.Unknown();
       }
       return unit.services.inferer.inferType(d, unit);

--- a/packages/language/src/validation/language-server/call-dimensions.ts
+++ b/packages/language/src/validation/language-server/call-dimensions.ts
@@ -1,0 +1,29 @@
+import { diagnosticFromCode } from "../../language-server/types";
+import { ReferenceItem, SyntaxKind } from "../../syntax-tree/ast";
+import { CompilationUnit } from "../../workspace/compilation-unit";
+import { PLICodes } from "../pli-codes";
+import { retrieveProcedureFromLabelPrefix } from "../utils";
+import { ValidationAcceptor } from "../validator";
+
+export function checkProcedureCallsDimensions(
+  node: ReferenceItem,
+  acceptor: ValidationAcceptor,
+  compilationUnit: CompilationUnit,
+): void {
+  if (
+    node.ref &&
+    node.ref.node &&
+    node.ref.node.kind === SyntaxKind.LabelPrefix
+  ) {
+    const procedure = retrieveProcedureFromLabelPrefix(node.ref.node);
+    if (procedure && node.dimensions.length > 1) {
+      acceptor(
+        diagnosticFromCode(
+          PLICodes.Severe.IBM1704I,
+          node.ref.token,
+          node.ref.token.image,
+        ),
+      );
+    }
+  }
+}

--- a/packages/language/src/validation/language-server/call-dimensions.ts
+++ b/packages/language/src/validation/language-server/call-dimensions.ts
@@ -1,3 +1,13 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
 import { diagnosticFromCode } from "../../language-server/types";
 import { ReferenceItem, SyntaxKind } from "../../syntax-tree/ast";
 import { CompilationUnit } from "../../workspace/compilation-unit";

--- a/packages/language/src/validation/language-server/implicit-builtins.ts
+++ b/packages/language/src/validation/language-server/implicit-builtins.ts
@@ -31,7 +31,7 @@ export function checkImplicitBuiltins(
   compilationUnit: CompilationUnit,
 ): void {
   // When using dimensions, the builtin is automatically contextually declared, so we can skip the check.
-  if (node.dimensions) {
+  if (node.dimensions.length > 0) {
     return;
   }
 

--- a/packages/language/src/validation/pli-validator.ts
+++ b/packages/language/src/validation/pli-validator.ts
@@ -29,6 +29,7 @@ import {
   DeprecateVariables,
 } from "./compiler/IBM2444Iff-deprecate";
 import { IBM1213I_unreferenced_procedure } from "./compiler/IBM1213I-unreferenced-procedure";
+import { checkProcedureCallsDimensions } from "./language-server/call-dimensions";
 
 /**
  * A function that accepts a diagnostic for PL/I validation
@@ -56,7 +57,7 @@ export function registerPliValidationChecks(): ValidationChecks {
       IBM1213I_unreferenced_procedure,
       BUILTIN_NoMultipleVariadicParameters,
     ],
-    ReferenceItem: [checkImplicitBuiltins],
+    ReferenceItem: [checkImplicitBuiltins, checkProcedureCallsDimensions],
     SelectStatement: [IBM1059I_select_without_otherwise],
     Statement: [DeprecateStatements],
     // TODO @wagner-laranjeiras -> When adding ReturnStatement to this list, make sure to include comment about IBM2412/10/09I.

--- a/packages/language/src/validation/utils.ts
+++ b/packages/language/src/validation/utils.ts
@@ -31,10 +31,10 @@ export function compareIdentifiers<T extends string>(lhs: T, rhs: T) {
 export function resolveProcedureFromCall(
   node: CallStatement,
 ): ProcedureStatement | null {
-  if (!node.call?.procedure?.node) {
+  if (!node.call?.ref?.node) {
     return null;
   }
-  const labelPrefix = node.call.procedure.node;
+  const labelPrefix = node.call.ref.node;
   if (!labelPrefix || labelPrefix.kind !== SyntaxKind.LabelPrefix) {
     return null;
   }

--- a/packages/language/test/fourslash/signature-help/help-nested-function-call.ts
+++ b/packages/language/test/fourslash/signature-help/help-nested-function-call.ts
@@ -1,0 +1,40 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @filename: pli-builtin:///xxx.pli
+//// /**
+////  * XXX Description
+////  */
+//// %XXX: PROC(A, B) RETURNS(CHARACTER);
+////   DECLARE A CHARACTER;
+////   DECLARE B CHARACTER;
+//// %END;
+//// /**
+////  * YYY Description
+////  */
+//// %YYY: PROC(A, B) RETURNS(CHARACTER);
+////   DECLARE A CHARACTER;
+////   DECLARE B CHARACTER;
+//// %END;
+//// %ZZZ: PROC;
+////   DCL A CHARACTER;
+////   A = XXX(<|x0>"hallo", <|x1>YYY(<|y0>"abc", <|y1>1));
+//// %END;
+
+signatureHelp.expectMarkdownSignatureAt("x0", `XXX Description`);
+signatureHelp.expectParameterIndexAt("x0", 0);
+signatureHelp.expectParameterIndexAt("x1", 1);
+
+signatureHelp.expectMarkdownSignatureAt("y0", `YYY Description`);
+signatureHelp.expectParameterIndexAt("y0", 0);
+signatureHelp.expectParameterIndexAt("y1", 1);

--- a/packages/language/test/fourslash/signature-help/help-nested-procedure-call.ts
+++ b/packages/language/test/fourslash/signature-help/help-nested-procedure-call.ts
@@ -22,11 +22,11 @@
 //// /**
 ////  * YYY Description
 ////  */
-//// %YYY: PROC(A, B);
+//// %YYY: PROC(A, B) RETURNS(CHARACTER);
 ////   DECLARE A CHARACTER;
 ////   DECLARE B CHARACTER;
 //// %END;
-//// %YYY: PROC;
+//// %ZZZ: PROC;
 ////   CALL XXX(<|x0>"hallo", <|x1>YYY(<|y0>"abc", <|y1>1));
 //// %END;
 

--- a/packages/language/test/fourslash/signature-help/help-nested.ts
+++ b/packages/language/test/fourslash/signature-help/help-nested.ts
@@ -1,0 +1,39 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @filename: pli-builtin:///xxx.pli
+//// /**
+////  * XXX Description
+////  */
+//// %XXX: PROC(A, B);
+////   DECLARE A CHARACTER;
+////   DECLARE B CHARACTER;
+//// %END;
+//// /**
+////  * YYY Description
+////  */
+//// %YYY: PROC(A, B);
+////   DECLARE A CHARACTER;
+////   DECLARE B CHARACTER;
+//// %END;
+//// %YYY: PROC;
+////   CALL XXX(<|x0>"hallo", <|x1>YYY(<|y0>"abc", <|y1>1));
+//// %END;
+
+signatureHelp.expectMarkdownSignatureAt("x0", `XXX Description`);
+signatureHelp.expectParameterIndexAt("x0", 0);
+signatureHelp.expectParameterIndexAt("x1", 1);
+
+signatureHelp.expectMarkdownSignatureAt("y0", `YYY Description`);
+signatureHelp.expectParameterIndexAt("y0", 0);
+signatureHelp.expectParameterIndexAt("y1", 1);

--- a/packages/language/test/fourslash/validate/call-dimensions.ts
+++ b/packages/language/test/fourslash/validate/call-dimensions.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+//// XXX: PROC(LS) OPTIONS(NODESCRIPTOR) RETURNS(FIXED);
+////  DCL LS FIXED LIST;
+////  RETURN(0);
+//// END XXX;
+//// main: PROCEDURE() OPTIONS(MAIN);
+////  DCL A FIXED;
+////  A = <|XXX|>(12, 3)(1,2,3);
+//// END main;
+
+verify.expectDiagnosticsAt("XXX", code.Severe.IBM1704I);


### PR DESCRIPTION
This pull request refactors how procedure calls are represented in the language's AST and parser, unifying them under the `ReferenceItem` node and removing the older `ProcedureCall` structure. Argument lists and dimensions are now consistently handled as arrays, and related logic in the parser, AST, and code generation has been updated to match. This simplifies the codebase and makes procedure calls more flexible and uniform.