### PR TITLE
Improve error messages for qualified names

### DIFF
--- a/packages/language/src/linking/error.ts
+++ b/packages/language/src/linking/error.ts
@@ -12,6 +12,7 @@
 import { AmbiguousReferenceData } from "../language-server/code-actions/apply-quick-fixes";
 import {
   diagnosticFromCode,
+  diagnosticFromCodeAtRange,
   fullCode,
   Range,
   Severity,
@@ -126,6 +127,24 @@ export class LinkerErrorReporter {
    */
   reportCannotFindSymbol(token: Token, name: string) {
     this.accept(diagnosticFromCode(LspCodes.UnknownIdentifier, token, name));
+  }
+
+  /**
+   * S IBM1623I
+   */
+  reportFqnReferenceNotFound(
+    uri: string,
+    fqn: string,
+    start: number,
+    end: number,
+  ) {
+    const diagnostic = diagnosticFromCodeAtRange(
+      PLICodes.Severe.IBM1623I,
+      { start, end },
+      fqn,
+    );
+    diagnostic.uri = uri;
+    this.accept(diagnostic);
   }
 
   /**

--- a/packages/language/src/validation/validator.ts
+++ b/packages/language/src/validation/validator.ts
@@ -10,10 +10,10 @@
  */
 
 import { CompilationUnit } from "../workspace/compilation-unit";
-import { Diagnostic } from "../language-server/types";
+import { Diagnostic, tokenToUri } from "../language-server/types";
 import { ReferencesCache } from "../linking/resolver";
 import { isValidToken } from "../linking/tokens";
-import { SyntaxKind, SyntaxNode } from "../syntax-tree/ast";
+import { Reference, SyntaxKind, SyntaxNode } from "../syntax-tree/ast";
 import { forEachNode } from "../syntax-tree/ast-iterator";
 import { registerPliValidationChecks } from "./pli-validator";
 import { ScopeCache, ScopeCacheGroups } from "../linking/scope";
@@ -126,8 +126,62 @@ export function linkingErrorsToDiagnostics(
 
   for (const reference of references.allReferences()) {
     if (reference.node === null && isValidToken(reference.token)) {
-      // Question: is reference.text and token.image the same?
-      reporter.reportCannotFindSymbol(reference.token, reference.text);
+      // If a specific linking diagnostic can be generated for this reference, generate it and return,
+      // otherwise report a generic "cannot find symbol" error
+      if (generateLinkingDiagnostic(reporter, unit, reference)) {
+        reporter.reportCannotFindSymbol(reference.token, reference.text);
+      }
     }
   }
+}
+
+function generateLinkingDiagnostic(
+  reporter: LinkerErrorReporter,
+  unit: CompilationUnit,
+  reference: Reference,
+): boolean {
+  const owner = reference.owner;
+  const uri = tokenToUri(reference.token);
+  if (!uri) {
+    return false;
+  }
+  // 1. check if the reference is part of a member call
+  // highlight the entire member call if it is, otherwise just the reference token
+  if (
+    owner.kind === SyntaxKind.ReferenceItem &&
+    owner.container?.kind === SyntaxKind.MemberCall
+  ) {
+    const isTopMost = owner.container.container?.kind !== SyntaxKind.MemberCall;
+    if (!isTopMost) {
+      // Do not report the error on this reference, it will be reported on the top-most member call
+      return false;
+    }
+    let currentNode = owner.container;
+    if (currentNode.previous === null) {
+      // Top most + no previous means this is just a simple reference, report a generic error
+      return true;
+    }
+    const names: string[] = [reference.text];
+    // Traverse through the previous items to get the full chain
+    while (currentNode.previous !== null) {
+      const name = currentNode.previous.element?.ref?.text;
+      if (name) {
+        names.push(name);
+      } else {
+        // Likely a parser error, do not report the linking error
+        return false;
+      }
+      currentNode = currentNode.previous;
+    }
+    const start = currentNode.element?.ref?.token.startOffset;
+    const end = reference.token.endOffset + 1;
+    if (start !== undefined) {
+      // Report the name and return
+      const fqn = names.reverse().join(".");
+      reporter.reportFqnReferenceNotFound(uri, fqn, start, end);
+    }
+    return false;
+  }
+  // Report the error
+  return true;
 }

--- a/packages/language/test/fourslash/linker/partial-declared-qualified.ts
+++ b/packages/language/test/fourslash/linker/partial-declared-qualified.ts
@@ -13,6 +13,9 @@
 
 // @wrap: main
 //// DCL A FIXED BIN;
+//// DCL 1 X, 2 Y FIXED BIN;
 //// <|A.B|> = 1;
+//// <|X.Y.Z.W|> = 1;
 
 verify.expectExclusiveDiagnosticsAt("A.B", code.Severe.IBM1623I);
+verify.expectExclusiveDiagnosticsAt("X.Y.Z.W", code.Severe.IBM1623I);

--- a/packages/language/test/fourslash/linker/partial-declared-qualified.ts
+++ b/packages/language/test/fourslash/linker/partial-declared-qualified.ts
@@ -12,6 +12,7 @@
 /// <reference path="../framework.ts" />
 
 // @wrap: main
+//// DCL A FIXED BIN;
 //// <|A.B|> = 1;
 
 verify.expectExclusiveDiagnosticsAt("A.B", code.Severe.IBM1623I);


### PR DESCRIPTION
Closes https://github.com/zowe/zowe-pli-language-support/issues/671

Simply adds additional checking for member calls/qualified name calls that improve the error message. Previously, we generated an error on each segment of a member call. Now we simply generate a single error for the whole reference.