### PR TITLE
Polish sysparm, system, lp evaluation

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "pnpm": {
     "overrides": {
-      "isexe": "3.1.1", 
+      "isexe": "3.1.1",
       "minimatch": "10.2.4",
       "lodash-es": "4.18.1"
     }

--- a/packages/language/src/parser/binary-expressions.ts
+++ b/packages/language/src/parser/binary-expressions.ts
@@ -84,6 +84,10 @@ const binaryPrecedence = buildPrecendenceMap([
   [BinaryOperator.Pipe, BinaryOperator.Not],
 ]);
 
+const rightAssociativeOperators = new Set<BinaryOperator>([
+  BinaryOperator.StarStar,
+]);
+
 /**
  * Constructs a binary expression from an intermediate representation,
  * used when popping infix exprs from the stack,
@@ -111,10 +115,14 @@ export function constructBinaryExpression(
   for (let i = 0; i < obj.operators.length; i++) {
     const operator = obj.operators[i];
     const precedenceValue = binaryPrecedence.get(operator) ?? Infinity;
+    const isRightAssociative = rightAssociativeOperators.has(operator);
 
-    // If we find an operator with lower precedence or equal precedence
-    // (for left-to-right evaluation), update our tracking
-    if (precedenceValue > lowestPrecedenceValue) {
+    // Pick right-to-left/left-to-right based on operator associativity.
+    const shouldUpdate = isRightAssociative
+      ? precedenceValue > lowestPrecedenceValue
+      : precedenceValue >= lowestPrecedenceValue;
+
+    if (shouldUpdate) {
       lowestPrecedenceValue = precedenceValue;
       lowestPrecedenceIdx = i;
     }

--- a/packages/language/src/preprocessor/compiler-options/options-pli.ts
+++ b/packages/language/src/preprocessor/compiler-options/options-pli.ts
@@ -1458,6 +1458,7 @@ export function getDefaultCompilerOptions(): CompilerOptions {
       string: 32 * $1K,
     },
     lineCount: 31415,
+    LP: CompilerOptions.LP.LP32,
     initAuto: CompilerOptions.InitAuto.FULL,
     margini: " ",
     margins: {

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -403,8 +403,10 @@ export class CompilationUnitHandler {
       }
       const allDiagnostics = diagnosticsToLSP(unit, unit.diagnostics.getAll());
       for (const file of unit.services.files.keys()) {
-        if (!EditorDocuments.get(file) || isVirtualFile(file)) {
-          // do not report diagnostics for virtual files or files not currently open in the editor
+        // Check synchronously if the file is currently open in the editor.
+        // Use has() not get() - we don't want to load from disk, just check if already open.
+        // Do not report diagnostics for virtual files or files not currently open in the editor.
+        if (!EditorDocuments.has(file) || isVirtualFile(file)) {
           continue;
         }
         const fileDiagnostics = allDiagnostics.get(file);
@@ -440,7 +442,15 @@ export class CompilationUnitHandler {
           unit.mutex.run(async (cancellationToken) => {
             const textDocument = await TextDocuments.get(unit.uri.toString());
             if (textDocument) {
-              this.process(unit, textDocument, connection, cancellationToken);
+              await this.process(
+                unit,
+                textDocument,
+                connection,
+                cancellationToken,
+              );
+              // Revalidate request caches (margins, skipped code, etc.)
+              // This is necessary so that changes to the plugin configuration are reflected immediately.
+              unit.requestCaches.revalidateAll({ connection, unit });
             }
           }),
         );

--- a/packages/language/test/fourslash/preprocessor/expressions/addition-left-associative.ts
+++ b/packages/language/test/fourslash/preprocessor/expressions/addition-left-associative.ts
@@ -9,10 +9,10 @@
  *
  */
 
-/// <reference path="../framework.ts" />
+/// <reference path="../../framework.ts" />
 
 //// %DCL X FIXED;
-//// %X = -123;
+//// %X = 1 + 2 + 3 + 4;
 //// X
 
-preprocessor.expectTokens("-123");
+preprocessor.expectTokens("10");

--- a/packages/language/test/fourslash/preprocessor/expressions/division-left-associative.ts
+++ b/packages/language/test/fourslash/preprocessor/expressions/division-left-associative.ts
@@ -9,11 +9,10 @@
  *
  */
 
-/// <reference path="../../../framework.ts" />
+/// <reference path="../../framework.ts" />
 
-////*PROCESS SYSPARM(TEST_VAR);
-//// %DCL Y CHAR;
-//// %Y = SYSPARM;
-//// Y
+//// %DCL X FIXED;
+//// %X = 100 / 5 / 2;
+//// X
 
-preprocessor.expectTokens("TEST_VAR");
+preprocessor.expectTokens("10");

--- a/packages/language/test/fourslash/preprocessor/expressions/exponentiation-right-associative.ts
+++ b/packages/language/test/fourslash/preprocessor/expressions/exponentiation-right-associative.ts
@@ -9,11 +9,10 @@
  *
  */
 
-/// <reference path="../../../framework.ts" />
+/// <reference path="../../framework.ts" />
 
-////*PROCESS SYSPARM(TEST_VAR);
-//// %DCL Y CHAR;
-//// %Y = SYSPARM;
-//// Y
+//// %DCL X FIXED;
+//// %X = 2 ** 3 ** 2;
+//// X
 
-preprocessor.expectTokens("TEST_VAR");
+preprocessor.expectTokens("512");

--- a/packages/language/test/fourslash/preprocessor/expressions/mixed-operators-precedence.ts
+++ b/packages/language/test/fourslash/preprocessor/expressions/mixed-operators-precedence.ts
@@ -9,11 +9,10 @@
  *
  */
 
-/// <reference path="../../../framework.ts" />
+/// <reference path="../../framework.ts" />
 
-////*PROCESS SYSPARM(TEST_VAR);
-//// %DCL Y CHAR;
-//// %Y = SYSPARM;
-//// Y
+//// %DCL X FIXED;
+//// %X = 2 + 3 * 4 - 5;
+//// X
 
-preprocessor.expectTokens("TEST_VAR");
+preprocessor.expectTokens("9");

--- a/packages/language/test/fourslash/preprocessor/expressions/mixed-subtraction-addition.ts
+++ b/packages/language/test/fourslash/preprocessor/expressions/mixed-subtraction-addition.ts
@@ -9,11 +9,10 @@
  *
  */
 
-/// <reference path="../../../framework.ts" />
+/// <reference path="../../framework.ts" />
 
-////*PROCESS SYSPARM(TEST_VAR);
-//// %DCL Y CHAR;
-//// %Y = SYSPARM;
-//// Y
+//// %DCL X FIXED;
+//// %X = 10 + 5 - 3 + 2;
+//// X
 
-preprocessor.expectTokens("TEST_VAR");
+preprocessor.expectTokens("14");

--- a/packages/language/test/fourslash/preprocessor/expressions/multiplication-left-associative.ts
+++ b/packages/language/test/fourslash/preprocessor/expressions/multiplication-left-associative.ts
@@ -9,11 +9,10 @@
  *
  */
 
-/// <reference path="../../../framework.ts" />
+/// <reference path="../../framework.ts" />
 
-////*PROCESS SYSPARM(TEST_VAR);
-//// %DCL Y CHAR;
-//// %Y = SYSPARM;
-//// Y
+//// %DCL X FIXED;
+//// %X = 2 * 3 * 4;
+//// X
 
-preprocessor.expectTokens("TEST_VAR");
+preprocessor.expectTokens("24");

--- a/packages/language/test/fourslash/preprocessor/expressions/subtraction-left-associative.ts
+++ b/packages/language/test/fourslash/preprocessor/expressions/subtraction-left-associative.ts
@@ -9,11 +9,10 @@
  *
  */
 
-/// <reference path="../../../framework.ts" />
+/// <reference path="../../framework.ts" />
 
-////*PROCESS SYSPARM(TEST_VAR);
-//// %DCL Y CHAR;
-//// %Y = SYSPARM;
-//// Y
+//// %DCL X FIXED;
+//// %X = 10 - 5 - 2;
+//// X
 
-preprocessor.expectTokens("TEST_VAR");
+preprocessor.expectTokens("3");

--- a/packages/language/test/fourslash/preprocessor/expressions/sysparm-expression-case.ts
+++ b/packages/language/test/fourslash/preprocessor/expressions/sysparm-expression-case.ts
@@ -9,11 +9,15 @@
  *
  */
 
-/// <reference path="../../../framework.ts" />
+/// <reference path="../../framework.ts" />
 
-////*PROCESS SYSPARM(TEST_VAR);
-//// %DCL Y CHAR;
-//// %Y = SYSPARM;
-//// Y
+//// %DCL X FIXED;
+//// %DCL POS FIXED;
+//// %POS = 26;
+//// %X = 34 - POS - 5;
+//// X
 
-preprocessor.expectTokens("TEST_VAR");
+// This tests the bug scenario associated with #633.
+// Left-associative: (34 - 26) - 5 = 8 - 5 = 3
+// NOT right-associative: 34 - (26 - 5) = 34 - 21 = 13
+preprocessor.expectTokens("3");

--- a/packages/language/test/fourslash/preprocessor/expressions/unary-expression.ts
+++ b/packages/language/test/fourslash/preprocessor/expressions/unary-expression.ts
@@ -9,11 +9,10 @@
  *
  */
 
-/// <reference path="../../../framework.ts" />
+/// <reference path="../../framework.ts" />
 
-////*PROCESS SYSPARM(TEST_VAR);
-//// %DCL Y CHAR;
-//// %Y = SYSPARM;
-//// Y
+//// %DCL X FIXED;
+//// %X = -123;
+//// X
 
-preprocessor.expectTokens("TEST_VAR");
+preprocessor.expectTokens("-123");

--- a/packages/language/test/fourslash/preprocessor/procedures/builtins/sysparm-conditional.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/builtins/sysparm-conditional.ts
@@ -11,9 +11,11 @@
 
 /// <reference path="../../../framework.ts" />
 
-////*PROCESS SYSPARM(TEST_VAR);
-//// %DCL Y CHAR;
-//// %Y = SYSPARM;
-//// Y
+////*PROCESS SYSPARM(DEBUG);
+//// %IF SYSPARM = 'DEBUG' %THEN DO;
+////   %DCL MODE CHAR;
+////   %MODE = 'DEBUGGING';
+////   MODE
+//// %END;
 
-preprocessor.expectTokens("TEST_VAR");
+preprocessor.expectTokens("DEBUGGING");

--- a/packages/language/test/fourslash/preprocessor/procedures/builtins/system-cics.ts
+++ b/packages/language/test/fourslash/preprocessor/procedures/builtins/system-cics.ts
@@ -11,9 +11,12 @@
 
 /// <reference path="../../../framework.ts" />
 
-////*PROCESS SYSPARM(TEST_VAR);
+////*PROCESS SYSTEM(CICS);
 //// %DCL Y CHAR;
-//// %Y = SYSPARM;
+//// %Y = SYSTEM();
 //// Y
 
-preprocessor.expectTokens("TEST_VAR");
+// MVS is the default SYSTEM compiler option
+preprocessor.expectTokens(`
+  CICS
+`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "Preserve",
     "moduleResolution": "Bundler",
     "lib": ["ESNext"],
+    "types": ["node"],
     "sourceMap": true,
     "strict": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
Fixes https://github.com/zowe/zowe-pli-language-support/issues/633

The builtins functionality was already implemented, however there were some minor issues that prevented the provided code to pass correctly, which should be fixed in this update:

- Subtractions were evaluated right-to-left
- Changes to the plugin config (compiler options) did not automatically update all compilation units (caches)
- Set LP default value
- Enabled the existing test case and added new ones for #633 and binary expressions
- Added node types to the tsconfig to eliminate the `console` errors in the IDE.

The test code was shared internally.