### PR TITLE
Add RULES(MULTICLOSE) implementation

### DIFF
--- a/packages/language/src/parser/parser-lookahead.ts
+++ b/packages/language/src/parser/parser-lookahead.ts
@@ -123,37 +123,60 @@ function performIfLookahead(state: ParserState): boolean {
   return false;
 }
 
+/**
+ * Performs lookahead to detect END statement and its optional label.
+ * Skips any label prefixes (e.g., "FOO: END") before the END keyword.
+ * 
+ * @returns 
+ *   - `false` if no END statement found
+ *   - `true` if unlabeled END found (e.g., "END;")
+ *   - `string` if labeled END found (e.g., "END FOO;" returns "FOO")
+ */
 export function performEndStatementLookahead(
   state: ParserState,
-): { hasEnd: true; label: string | null } | { hasEnd: false } {
+): boolean | string {
   const lookahead = (la: number) => state.peek(la);
   let index: number = 1;
   let token: tokens.Token | undefined = undefined;
-
+  
   while ((token = lookahead(index)) && !tokenMatcher(token, tokens.END)) {
     const idToken = lookahead(index);
     const colonToken = lookahead(index + 1);
     if (!idToken || !colonToken) {
-      return { hasEnd: false };
+      return false;
     }
     if (
       !tokenMatcher(idToken, tokens.ID) ||
       !tokenMatcher(colonToken, tokens.Colon)
     ) {
-      return { hasEnd: false };
+      return false;
     }
     index += 2;
   }
-
+  
   if (!token || !tokenMatcher(token, tokens.END)) {
-    return { hasEnd: false };
+    return false;
   }
-
-  // Check for label reference after END
-  const labelToken = lookahead(index + 1);
-  if (labelToken && tokenMatcher(labelToken, tokens.ID)) {
-    return { hasEnd: true, label: labelToken.image };
-  } else {
-    return { hasEnd: true, label: null };
+  
+  // To verify that the end is actually an END statement and not part of an expression,
+  // we check for the semicolon, potentially preceded by an ID label.
+  let nextToken = lookahead(index + 1);
+  if (!nextToken) {
+    return false; 
   }
+  
+  if (tokenMatcher(nextToken, tokens.Semicolon)) {
+    return true;
+  }
+  
+  if (!tokenMatcher(nextToken, tokens.ID)) {
+    return false;
+  }
+  
+  const semicolonToken = lookahead(index + 2);
+  if (!semicolonToken || !tokenMatcher(semicolonToken, tokens.Semicolon)) {
+    return false; 
+  }
+  
+  return nextToken.image;
 }

--- a/packages/language/src/parser/parser-lookahead.ts
+++ b/packages/language/src/parser/parser-lookahead.ts
@@ -124,59 +124,81 @@ function performIfLookahead(state: ParserState): boolean {
 }
 
 /**
+ * Simple check for whether an END statement is present in the lookahead.
+ * Use this when you just need to know if an END is coming.
+ *
+ * @returns true if an END statement is found, false otherwise
+ */
+export function hasEndStatementLookahead(state: ParserState): boolean {
+  return performEndStatementLookahead(state).endStatement !== false;
+}
+
+export interface EndStatementLookahead {
+  /**
+   * Information about the END statement:
+   * - `false` if no END statement found
+   * - `true` if unlabeled END found (e.g., "END;")
+   * - `string` if labeled END found (e.g., "END FOO;" returns "FOO")
+   */
+  endStatement: boolean | string;
+  /**
+   * The lookahead index of the END token, if found.
+   * Undefined if no END statement was found.
+   */
+  endTokenIndex?: number;
+}
+
+/**
  * Performs lookahead to detect END statement and its optional label.
  * Skips any label prefixes (e.g., "FOO: END") before the END keyword.
- * 
- * @returns 
- *   - `false` if no END statement found
- *   - `true` if unlabeled END found (e.g., "END;")
- *   - `string` if labeled END found (e.g., "END FOO;" returns "FOO")
+ *
+ * @returns Object containing END statement information and token position
  */
 export function performEndStatementLookahead(
   state: ParserState,
-): boolean | string {
+): EndStatementLookahead {
   const lookahead = (la: number) => state.peek(la);
   let index: number = 1;
   let token: tokens.Token | undefined = undefined;
-  
+
   while ((token = lookahead(index)) && !tokenMatcher(token, tokens.END)) {
     const idToken = lookahead(index);
     const colonToken = lookahead(index + 1);
     if (!idToken || !colonToken) {
-      return false;
+      return { endStatement: false };
     }
     if (
       !tokenMatcher(idToken, tokens.ID) ||
       !tokenMatcher(colonToken, tokens.Colon)
     ) {
-      return false;
+      return { endStatement: false };
     }
     index += 2;
   }
-  
+
   if (!token || !tokenMatcher(token, tokens.END)) {
-    return false;
+    return { endStatement: false };
   }
-  
+
   // To verify that the end is actually an END statement and not part of an expression,
   // we check for the semicolon, potentially preceded by an ID label.
   let nextToken = lookahead(index + 1);
   if (!nextToken) {
-    return false; 
+    return { endStatement: false };
   }
-  
+
   if (tokenMatcher(nextToken, tokens.Semicolon)) {
-    return true;
+    return { endStatement: true, endTokenIndex: index };
   }
-  
+
   if (!tokenMatcher(nextToken, tokens.ID)) {
-    return false;
+    return { endStatement: false };
   }
-  
+
   const semicolonToken = lookahead(index + 2);
   if (!semicolonToken || !tokenMatcher(semicolonToken, tokens.Semicolon)) {
-    return false; 
+    return { endStatement: false };
   }
-  
-  return nextToken.image;
+
+  return { endStatement: nextToken.image, endTokenIndex: index };
 }

--- a/packages/language/src/parser/parser-lookahead.ts
+++ b/packages/language/src/parser/parser-lookahead.ts
@@ -123,23 +123,37 @@ function performIfLookahead(state: ParserState): boolean {
   return false;
 }
 
-export function performEndStatementLookahead(state: ParserState): boolean {
+export function performEndStatementLookahead(
+  state: ParserState,
+): { hasEnd: true; label: string | null } | { hasEnd: false } {
   const lookahead = (la: number) => state.peek(la);
   let index: number = 1;
   let token: tokens.Token | undefined = undefined;
+
   while ((token = lookahead(index)) && !tokenMatcher(token, tokens.END)) {
     const idToken = lookahead(index);
     const colonToken = lookahead(index + 1);
     if (!idToken || !colonToken) {
-      return false;
+      return { hasEnd: false };
     }
     if (
       !tokenMatcher(idToken, tokens.ID) ||
       !tokenMatcher(colonToken, tokens.Colon)
     ) {
-      return false;
+      return { hasEnd: false };
     }
     index += 2;
   }
-  return token !== undefined && tokenMatcher(token, tokens.END);
+
+  if (!token || !tokenMatcher(token, tokens.END)) {
+    return { hasEnd: false };
+  }
+
+  // Check for label reference after END
+  const labelToken = lookahead(index + 1);
+  if (labelToken && tokenMatcher(labelToken, tokens.ID)) {
+    return { hasEnd: true, label: labelToken.image };
+  } else {
+    return { hasEnd: true, label: null };
+  }
 }

--- a/packages/language/src/parser/parser-state.ts
+++ b/packages/language/src/parser/parser-state.ts
@@ -10,7 +10,7 @@
  */
 
 import { tokenMatcher, TokenType } from "chevrotain";
-import { SyntaxNode } from "../syntax-tree/ast";
+import { SyntaxNode, LabelPrefix } from "../syntax-tree/ast";
 import { CstNodeKind } from "../syntax-tree/cst";
 import * as t from "./tokens";
 import {
@@ -29,6 +29,7 @@ import {
 } from "../validation/pli-codes";
 import { tokenIdxToClass } from "./token-type-factory";
 import * as environment from "../workspace/environment";
+import { CompilerOptions } from "../preprocessor/compiler-options/options-pli";
 
 export enum RecoveryResult {
   /**
@@ -50,14 +51,16 @@ export type RecoveryFunction = () => RecoveryResult;
 export class ParserState {
   readonly tokens: t.Token[];
   readonly diagnostics: Diagnostic[];
+  readonly compilerOptions?: CompilerOptions;
+  private inProcedure = false;
   public index: number;
   public inError = false;
+  public currentStatementLabels: LabelPrefix[] = [];
 
-  private inProcedure = false;
-
-  constructor(tokens: t.Token[]) {
+  constructor(tokens: t.Token[], compilerOptions?: CompilerOptions) {
     this.tokens = tokens;
     this.diagnostics = [];
+    this.compilerOptions = compilerOptions;
     this.index = 0;
   }
 
@@ -131,6 +134,20 @@ export class ParserState {
 
   isInProcedure() {
     return this.inProcedure;
+  }
+
+  isEndOptional(): boolean {
+    return this.compilerOptions?.rules?.multiClose ?? false;
+  }
+
+  endLabelMatches(endLabel: string | null): boolean {
+    if (endLabel === null) {
+      // Unlabeled END matches any statement
+      return true;
+    }
+    return this.currentStatementLabels.some(
+      (labelPrefix) => labelPrefix.name === endLabel,
+    );
   }
 
   /**

--- a/packages/language/src/parser/parser-state.ts
+++ b/packages/language/src/parser/parser-state.ts
@@ -140,8 +140,8 @@ export class ParserState {
     return this.compilerOptions?.rules?.multiClose ?? false;
   }
 
-  endLabelMatches(endLabel: string | null): boolean {
-    if (endLabel === null) {
+  endLabelMatches(endLabel: true | string): boolean {
+    if (endLabel === true) {
       // Unlabeled END matches any statement
       return true;
     }

--- a/packages/language/src/parser/parser-state.ts
+++ b/packages/language/src/parser/parser-state.ts
@@ -151,6 +151,38 @@ export class ParserState {
   }
 
   /**
+   * Emits a diagnostic without setting the parser in error state.
+   * Use this for warnings, info diagnostics, or any diagnostic that shouldn't
+   * trigger error recovery.
+   */
+  diagnostic(message: SimplePLICode, token?: t.Token): void;
+  diagnostic<T extends ParametricPLICode>(
+    message: T,
+    args: Parameters<T["message"]>,
+    token?: t.Token,
+  ): void;
+  diagnostic(
+    message: SimplePLICode | ParametricPLICode,
+    tokenOrArgs?: t.Token | Parameters<ParametricPLICode["message"]>,
+    token?: t.Token,
+  ): void {
+    if (isParametricPLICode(message)) {
+      // Cast the args and token parameters to fit with the parametric code signature
+      const args = tokenOrArgs as Parameters<ParametricPLICode["message"]>;
+      const finalToken = (token || this.token || this.last) as
+        | t.Token
+        | undefined;
+      this.diagnostics.push(diagnosticFromCode(message, finalToken, ...args));
+    } else if (isSimplePLICode(message)) {
+      // Cast the token parameter to fit with the simple code signature
+      const finalToken = (tokenOrArgs || this.token || this.last) as
+        | t.Token
+        | undefined;
+      this.diagnostics.push(diagnosticFromCode(message, finalToken));
+    }
+  }
+
+  /**
    * Generates an error diagnostic at the current token or the last token if at EOF
    * and sets the parser in error state to avoid multiple errors for the same issue.
    * The parser will try to continue parsing, but no further errors will be reported
@@ -171,33 +203,29 @@ export class ParserState {
     if (this.inError) {
       return;
     }
+
+    // Handle custom string messages (or default error when no message)
     if (!message || typeof message === "string") {
-      // We have a simple string message (or none at all)
       const token = (tokenOrArgs || this.token || this.last) as
         | t.Token
         | undefined;
       const severity = (tokenOrSeverity || Severity.S) as Severity;
       const msg =
         message ??
-        // Generate our own simple message
         (this.eof
           ? "Unexpected end of file."
           : `Unexpected token '${generateTokenErrorName(token)}'.`);
       this.diagnostics.push(diagnostic(severity, msg, token));
     } else if (isParametricPLICode(message)) {
-      // Cast the args and token parameters to fit with the parametric code signature
-      const args = tokenOrArgs as Parameters<ParametricPLICode["message"]>;
-      const token = (tokenOrSeverity || this.token || this.last) as
-        | t.Token
-        | undefined;
-      this.diagnostics.push(diagnosticFromCode(message, token, ...args));
-    } else if (isSimplePLICode(message)) {
-      // Cast the token parameter to fit with the simple code signature
-      const token = (tokenOrArgs || this.token || this.last) as
-        | t.Token
-        | undefined;
-      this.diagnostics.push(diagnosticFromCode(message, token));
+      this.diagnostic(
+        message,
+        tokenOrArgs as Parameters<ParametricPLICode["message"]>,
+        tokenOrSeverity as t.Token | undefined,
+      );
+    } else {
+      this.diagnostic(message, tokenOrArgs as t.Token | undefined);
     }
+
     this.inError = true;
   }
 

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -79,7 +79,7 @@ const packageRule = rule(
     }
     state.consume(element, CstNodeKind.Package_Semicolon, tokens.Semicolon);
     const { inc } = state.createLoopContext("Package");
-    while (!state.eof && !performEndStatementLookahead(state).hasEnd) {
+    while (!state.eof && !performEndStatementLookahead(state)) {
       inc();
       const stmt = statement.rule(state);
       stmt && element.statements.push(stmt);
@@ -502,7 +502,7 @@ const procedureStatement = rule(
     );
 
     const { inc: inc3 } = state.createLoopContext("ProcedureStatement 3");
-    while (!state.eof && !performEndStatementLookahead(state).hasEnd) {
+    while (!state.eof && !performEndStatementLookahead(state)) {
       inc3();
       const stmt = statement.rule(state);
       stmt && element.statements.push(stmt);
@@ -1184,7 +1184,7 @@ const beginStatement = rule(
       tokens.Semicolon,
     );
     const { inc } = state.createLoopContext("BeginStatement");
-    while (!state.eof && !performEndStatementLookahead(state).hasEnd) {
+    while (!state.eof && !performEndStatementLookahead(state)) {
       inc();
       const stmt = statement.rule(state);
       stmt && element.statements.push(stmt);
@@ -1253,7 +1253,7 @@ function parseMulticloseEnd(
 
   if (alwaysOptional) {
     // PACKAGE: END is truly optional (can be omitted entirely)
-    if (!endInfo.hasEnd) {
+    if (endInfo === false) {
       return null;
     }
     // END present for PACKAGE - always consume it
@@ -1262,13 +1262,13 @@ function parseMulticloseEnd(
 
   if (state.isEndOptional()) {
     // MULTICLOSE mode: END can skip levels via labels, but must exist somewhere
-    if (!endInfo.hasEnd) {
+    if (endInfo === false) {
       // No END found (at EOF) - ERROR even with MULTICLOSE
       return endStatement.rule(state); // Will generate parser error
     }
 
     // END found - check if label matches this statement
-    if (state.endLabelMatches(endInfo.label)) {
+    if (state.endLabelMatches(endInfo)) {
       // Label matches (or unlabeled END for innermost) - consume it
       return endStatement.rule(state);
     } else {
@@ -2225,7 +2225,7 @@ const doStatement = rule(
 
     // Parse statements until END
     const { inc } = state.createLoopContext("DoStatement");
-    while (!state.eof && !performEndStatementLookahead(state).hasEnd) {
+    while (!state.eof && !performEndStatementLookahead(state)) {
       inc();
       const stmt = statement.rule(state);
       stmt && element.statements.push(stmt);
@@ -3940,7 +3940,7 @@ const qualifyStatement = rule(
     );
 
     const { inc } = state.createLoopContext("QualifyStatement");
-    while (!state.eof && !performEndStatementLookahead(state).hasEnd) {
+    while (!state.eof && !performEndStatementLookahead(state)) {
       inc();
       const stmt = statement.rule(state);
       stmt && element.statements.push(stmt);

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -33,12 +33,16 @@ import {
   performEndStatementLookahead,
 } from "./parser-lookahead";
 import { Token } from "./tokens";
+import { CompilerOptions } from "../preprocessor/compiler-options/options-pli";
 
-export function parsePli(input: tokens.Token[]): {
+export function parsePli(
+  input: tokens.Token[],
+  compilerOptions?: CompilerOptions,
+): {
   tree: ast.Program;
   diagnostics: Diagnostic[];
 } {
-  const state = new ParserState(input);
+  const state = new ParserState(input, compilerOptions);
   const program = pliProgram.rule(state);
   const tree = program ?? ast.createProgram();
   return { tree, diagnostics: state.diagnostics };
@@ -75,15 +79,13 @@ const packageRule = rule(
     }
     state.consume(element, CstNodeKind.Package_Semicolon, tokens.Semicolon);
     const { inc } = state.createLoopContext("Package");
-    while (!state.eof && !performEndStatementLookahead(state)) {
+    while (!state.eof && !performEndStatementLookahead(state).hasEnd) {
       inc();
       const stmt = statement.rule(state);
       stmt && element.statements.push(stmt);
     }
-    // END statement for PACKAGE is optional
-    if (performEndStatementLookahead(state)) {
-      element.end = endStatement.rule(state);
-    }
+    // END statement for PACKAGE is always optional
+    element.end = parseMulticloseEnd(state, true);
     return element;
   },
 );
@@ -500,12 +502,12 @@ const procedureStatement = rule(
     );
 
     const { inc: inc3 } = state.createLoopContext("ProcedureStatement 3");
-    while (!state.eof && !performEndStatementLookahead(state)) {
+    while (!state.eof && !performEndStatementLookahead(state).hasEnd) {
       inc3();
       const stmt = statement.rule(state);
       stmt && element.statements.push(stmt);
     }
-    element.end = endStatement.rule(state);
+    element.end = parseMulticloseEnd(state);
     return element;
   },
 );
@@ -663,11 +665,18 @@ const statement = rule(
       label && element.labels.push(label);
     }
 
+    // Store labels in state so compound statements can access them
+    const previousLabels = state.currentStatementLabels;
+    state.currentStatementLabels = element.labels;
+
     if (performAssignmentLookahead(state)) {
       element.value = assignmentStatement.rule(state);
     } else {
       element.value = unit.rule(state);
     }
+
+    // Restore previous labels
+    state.currentStatementLabels = previousLabels;
 
     element.endToken = state.last ?? null;
 
@@ -1175,13 +1184,13 @@ const beginStatement = rule(
       tokens.Semicolon,
     );
     const { inc } = state.createLoopContext("BeginStatement");
-    while (!state.eof && !performEndStatementLookahead(state)) {
+    while (!state.eof && !performEndStatementLookahead(state).hasEnd) {
       inc();
       const stmt = statement.rule(state);
       stmt && element.statements.push(stmt);
     }
 
-    element.end = endStatement.rule(state);
+    element.end = parseMulticloseEnd(state);
 
     return element;
   },
@@ -1220,6 +1229,57 @@ const endStatement = rule(
     return element;
   },
 );
+
+/**
+ * Parses an END statement with RULES(MULTICLOSE) and label-matching logic.
+ *
+ * With RULES(MULTICLOSE) (or alwaysOptional=true):
+ * - Unlabeled END: Consumed by first (innermost) compound statement that sees it
+ * - Labeled END: Only consumed if label matches one of the current statement's labels
+ * - If END exists but doesn't match, it's left for outer scope
+ *
+ * With RULES(NOMULTICLOSE) (and alwaysOptional=false):
+ * - END is required - parsing error reported if missing
+ *
+ * @param state Parser state
+ * @param alwaysOptional If true, END is always optional regardless of MULTICLOSE setting (for PACKAGE)
+ * @returns EndStatement if END is present/required, null if optional and not present/matching
+ */
+function parseMulticloseEnd(
+  state: ParserState,
+  alwaysOptional: boolean = false,
+): ast.EndStatement | null {
+  const endInfo = performEndStatementLookahead(state);
+
+  if (alwaysOptional) {
+    // PACKAGE: END is truly optional (can be omitted entirely)
+    if (!endInfo.hasEnd) {
+      return null;
+    }
+    // END present for PACKAGE - always consume it
+    return endStatement.rule(state);
+  }
+
+  if (state.isEndOptional()) {
+    // MULTICLOSE mode: END can skip levels via labels, but must exist somewhere
+    if (!endInfo.hasEnd) {
+      // No END found (at EOF) - ERROR even with MULTICLOSE
+      return endStatement.rule(state); // Will generate parser error
+    }
+
+    // END found - check if label matches this statement
+    if (state.endLabelMatches(endInfo.label)) {
+      // Label matches (or unlabeled END for innermost) - consume it
+      return endStatement.rule(state);
+    } else {
+      // Label doesn't match - leave END for outer scope to consume
+      return null;
+    }
+  } else {
+    // NOMULTICLOSE: END is required for each compound
+    return endStatement.rule(state);
+  }
+}
 
 const callStatement = rule(
   sequence(tokens.CALL),
@@ -2165,13 +2225,13 @@ const doStatement = rule(
 
     // Parse statements until END
     const { inc } = state.createLoopContext("DoStatement");
-    while (!state.eof && !performEndStatementLookahead(state)) {
+    while (!state.eof && !performEndStatementLookahead(state).hasEnd) {
       inc();
       const stmt = statement.rule(state);
       stmt && element.statements.push(stmt);
     }
 
-    element.end = endStatement.rule(state);
+    element.end = parseMulticloseEnd(state);
 
     return element;
   },
@@ -3880,13 +3940,13 @@ const qualifyStatement = rule(
     );
 
     const { inc } = state.createLoopContext("QualifyStatement");
-    while (!state.eof && !performEndStatementLookahead(state)) {
+    while (!state.eof && !performEndStatementLookahead(state).hasEnd) {
       inc();
       const stmt = statement.rule(state);
       stmt && element.statements.push(stmt);
     }
 
-    element.end = endStatement.rule(state);
+    element.end = parseMulticloseEnd(state);
 
     return element;
   },
@@ -4252,7 +4312,7 @@ const selectStatement = rule(
       }
     }
 
-    element.end = endStatement.rule(state);
+    element.end = parseMulticloseEnd(state);
 
     return element;
   },

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -26,9 +26,10 @@ import {
   constructBinaryExpression,
   IntermediateBinaryExpression,
 } from "./binary-expressions";
-import { Severe } from "../validation/pli-codes";
+import { Severe, Warning } from "../validation/pli-codes";
 import { Diagnostic, Severity } from "../language-server/types";
 import {
+  hasEndStatementLookahead,
   performAssignmentLookahead,
   performEndStatementLookahead,
 } from "./parser-lookahead";
@@ -79,7 +80,7 @@ const packageRule = rule(
     }
     state.consume(element, CstNodeKind.Package_Semicolon, tokens.Semicolon);
     const { inc } = state.createLoopContext("Package");
-    while (!state.eof && !performEndStatementLookahead(state)) {
+    while (!state.eof && !hasEndStatementLookahead(state)) {
       inc();
       const stmt = statement.rule(state);
       stmt && element.statements.push(stmt);
@@ -502,7 +503,7 @@ const procedureStatement = rule(
     );
 
     const { inc: inc3 } = state.createLoopContext("ProcedureStatement 3");
-    while (!state.eof && !performEndStatementLookahead(state)) {
+    while (!state.eof && !hasEndStatementLookahead(state)) {
       inc3();
       const stmt = statement.rule(state);
       stmt && element.statements.push(stmt);
@@ -1184,7 +1185,7 @@ const beginStatement = rule(
       tokens.Semicolon,
     );
     const { inc } = state.createLoopContext("BeginStatement");
-    while (!state.eof && !performEndStatementLookahead(state)) {
+    while (!state.eof && !hasEndStatementLookahead(state)) {
       inc();
       const stmt = statement.rule(state);
       stmt && element.statements.push(stmt);
@@ -1253,7 +1254,7 @@ function parseMulticloseEnd(
 
   if (alwaysOptional) {
     // PACKAGE: END is truly optional (can be omitted entirely)
-    if (endInfo === false) {
+    if (endInfo.endStatement === false) {
       return null;
     }
     // END present for PACKAGE - always consume it
@@ -1262,17 +1263,24 @@ function parseMulticloseEnd(
 
   if (state.isEndOptional()) {
     // MULTICLOSE mode: END can skip levels via labels, but must exist somewhere
-    if (endInfo === false) {
+    if (endInfo.endStatement === false) {
       // No END found (at EOF) - ERROR even with MULTICLOSE
       return endStatement.rule(state); // Will generate parser error
     }
 
     // END found - check if label matches this statement
-    if (state.endLabelMatches(endInfo)) {
+    if (state.endLabelMatches(endInfo.endStatement)) {
       // Label matches (or unlabeled END for innermost) - consume it
       return endStatement.rule(state);
     } else {
       // Label doesn't match - leave END for outer scope to consume
+      // This is a multiclose - emit warning on the END token
+      if (endInfo.endTokenIndex !== undefined) {
+        const endToken = state.peek(endInfo.endTokenIndex);
+        if (endToken) {
+          state.diagnostic(Warning.IBM1120I, endToken);
+        }
+      }
       return null;
     }
   } else {
@@ -2225,7 +2233,7 @@ const doStatement = rule(
 
     // Parse statements until END
     const { inc } = state.createLoopContext("DoStatement");
-    while (!state.eof && !performEndStatementLookahead(state)) {
+    while (!state.eof && !hasEndStatementLookahead(state)) {
       inc();
       const stmt = statement.rule(state);
       stmt && element.statements.push(stmt);
@@ -3940,7 +3948,7 @@ const qualifyStatement = rule(
     );
 
     const { inc } = state.createLoopContext("QualifyStatement");
-    while (!state.eof && !performEndStatementLookahead(state)) {
+    while (!state.eof && !hasEndStatementLookahead(state)) {
       inc();
       const stmt = statement.rule(state);
       stmt && element.statements.push(stmt);

--- a/packages/language/src/workspace/lifecycle.ts
+++ b/packages/language/src/workspace/lifecycle.ts
@@ -70,7 +70,10 @@ export async function tokenize(
 }
 
 export function parse(compilationUnit: CompilationUnit): Program {
-  const { tree, diagnostics } = parsePli(compilationUnit.tokens);
+  const { tree, diagnostics } = parsePli(
+    compilationUnit.tokens,
+    compilationUnit.compilerOptions,
+  );
   compilationUnit.ast = tree;
   compilationUnit.diagnostics.addAll(DiagnosticCategory.Parser, diagnostics);
 

--- a/packages/language/test/fourslash-harness/harness-interface.ts
+++ b/packages/language/test/fourslash-harness/harness-interface.ts
@@ -10,7 +10,7 @@
  */
 
 import { CompletionKeywords } from "../../src/language-server/completion/keywords";
-import { Diagnostic, type Severity } from "../../src/language-server/types";
+import { type Severity } from "../../src/language-server/types";
 import { CompilerOptionsCodes } from "../../src/preprocessor/compiler-options/codes";
 import { CompilerOptions as PliCompilerOptions } from "../../src/preprocessor/compiler-options/options-pli";
 import { CompilerOptions as MacroCompilerOptions } from "../../src/preprocessor/compiler-options/options-macro";
@@ -48,7 +48,12 @@ import {
 } from "../../src/validation/internal-codes";
 import { LspCodes } from "../../src/validation/lsp-codes";
 import { PLICode, PLICodes } from "../../src/validation/pli-codes";
-import { ExpectedCompletion, Label, TestBuilder } from "../test-builder";
+import {
+  ExpectedCompletion,
+  Label,
+  TestBuilder,
+  DiagnosticExpectation,
+} from "../test-builder";
 import {
   SemanticTokenModifiers,
   SemanticTokenTypes,
@@ -162,29 +167,18 @@ export interface HarnessTesterInterface {
     /**
      * Expect that the given label has _only_ the given diagnostics.
      * @param label The label to expect the diagnostics at.
-     * @param diagnostics The only diagnostics to expect.
+     * @param diagnostics The only diagnostics to expect. Message field can be a string or RegExp for flexible matching.
      */
     expectExclusiveDiagnosticsAt(
       label: Label,
-      diagnostics:
-        | Partial<Diagnostic>
-        | Partial<Diagnostic>[]
-        | PLICode
-        | PLICode[],
+      diagnostics: DiagnosticExpectation,
     ): void;
     /**
      * Expect that the given label has the given diagnostics.
      * @param label The label to expect the diagnostics at.
-     * @param diagnostics The diagnostics to expect.
+     * @param diagnostics The diagnostics to expect. Message field can be a string or RegExp for flexible matching.
      */
-    expectDiagnosticsAt(
-      label: Label,
-      diagnostics:
-        | Partial<Diagnostic>
-        | Partial<Diagnostic>[]
-        | PLICode
-        | PLICode[],
-    ): void;
+    expectDiagnosticsAt(label: Label, diagnostics: DiagnosticExpectation): void;
     /**
      * Expect that there are no code actions at the given label.
      * @param label The label to expect no code actions at.

--- a/packages/language/test/fourslash-harness/harness-interface.ts
+++ b/packages/language/test/fourslash-harness/harness-interface.ts
@@ -206,6 +206,12 @@ export interface HarnessTesterInterface {
     noParserDiagnostics(): void;
 
     /**
+     * Expect that the compilation unit has no parser errors.
+     * Warnings and info diagnostics are allowed.
+     */
+    noParserErrors(): void;
+
+    /**
      * Expect that the compilation unit has no linking diagnostics.
      */
     noLinkingDiagnostics(): void;

--- a/packages/language/test/fourslash-harness/harness.test.ts
+++ b/packages/language/test/fourslash-harness/harness.test.ts
@@ -65,6 +65,7 @@ async function createTestingHarnessImplementation(
       noDiagnosticsExcept: listen("verify.noDiagnosticsExcept"),
       noDiagnosticsExceptAt: listen("verify.noDiagnosticsExceptAt"),
       noParserDiagnostics: listen("verify.noParserDiagnostics"),
+      noParserErrors: listen("verify.noParserErrors"),
       noLinkingDiagnostics: listen("verify.noLinkingDiagnostics"),
       expectToThrow: listen("verify.expectToThrow"),
       expectCompilerOptions: listen("verify.expectCompilerOptions"),

--- a/packages/language/test/fourslash-harness/implementation/test-builder.ts
+++ b/packages/language/test/fourslash-harness/implementation/test-builder.ts
@@ -24,6 +24,7 @@ import { PLICode } from "../../../src/validation/pli-codes";
 import { HarnessTypeAttributes } from "./type-attributes";
 import { SyntaxKind } from "../../../src/syntax-tree/ast";
 import { DiagnosticCategory } from "../../../src/validation/diagnostics-store";
+import { Severity } from "../../../src/language-server/types";
 
 /**
  * Create a harness implementation that can be used to run the harness test.
@@ -62,6 +63,11 @@ export function createTestBuilderHarnessImplementation(
         testBuilder.noDiagnosticsExcept(regex, label),
       noParserDiagnostics: () =>
         testBuilder.expectNoCategoryDiagnostics(DiagnosticCategory.Parser),
+      noParserErrors: () =>
+        testBuilder.expectNoCategoryDiagnostics(
+          DiagnosticCategory.Parser,
+          (d) => d.severity === Severity.E || d.severity === Severity.S,
+        ),
       noLinkingDiagnostics: () =>
         testBuilder.expectNoCategoryDiagnostics(DiagnosticCategory.Linking),
       expectToThrow: (fn, messageToThrow) =>

--- a/packages/language/test/fourslash/parser/multiclose/multiclose-end-label-no-match.ts
+++ b/packages/language/test/fourslash/parser/multiclose/multiclose-end-label-no-match.ts
@@ -1,0 +1,22 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS RULES(MULTICLOSE);
+//// P: PROC OPTIONS(MAIN);
+////    DO;
+////       PUT SKIP LIST('HELLO');
+//// <|END|> NONEXISTENT;
+
+verify.expectDiagnosticsAt("END", {
+  message: /Expected any of .+, but found "END"/,
+});

--- a/packages/language/test/fourslash/parser/multiclose/multiclose-eof-fails.ts
+++ b/packages/language/test/fourslash/parser/multiclose/multiclose-eof-fails.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS RULES(MULTICLOSE);
+//// P: PROCEDURE OPTIONS(MAIN);
+////    DO;
+////       PUT SKIP LIST('HELLO');
+//// <|EOF|>
+
+// With MULTICLOSE, END can skip levels but must exist - EOF never closes compounds
+verify.expectDiagnosticsAt("EOF", {
+  message: 'Expected token "END", but received end of file instead.',
+});

--- a/packages/language/test/fourslash/parser/multiclose/multiclose-labeled-end-skips-levels.ts
+++ b/packages/language/test/fourslash/parser/multiclose/multiclose-labeled-end-skips-levels.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS RULES(MULTICLOSE);
+//// P: PROC OPTIONS(MAIN);
+////    DO;
+////       PUT SKIP LIST('HELLO');
+//// END P;
+
+verify.noParserDiagnostics();

--- a/packages/language/test/fourslash/parser/multiclose/multiclose-multiple-labels-any-matches.ts
+++ b/packages/language/test/fourslash/parser/multiclose/multiclose-multiple-labels-any-matches.ts
@@ -15,6 +15,7 @@
 //// L1: L2: L3: PROC OPTIONS(MAIN);
 ////    DO;
 ////       PUT SKIP LIST('HELLO');
-//// END L2;
+//// <|END|> L2;
 
-verify.noParserDiagnostics();
+verify.noParserErrors();
+verify.expectDiagnosticsAt("END", code.Warning.IBM1120I);

--- a/packages/language/test/fourslash/parser/multiclose/multiclose-multiple-labels-any-matches.ts
+++ b/packages/language/test/fourslash/parser/multiclose/multiclose-multiple-labels-any-matches.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS RULES(MULTICLOSE);
+//// L1: L2: L3: PROC OPTIONS(MAIN);
+////    DO;
+////       PUT SKIP LIST('HELLO');
+//// END L2;
+
+verify.noParserDiagnostics();

--- a/packages/language/test/fourslash/parser/multiclose/multiclose-package-closes-all-levels.ts
+++ b/packages/language/test/fourslash/parser/multiclose/multiclose-package-closes-all-levels.ts
@@ -18,6 +18,7 @@
 ////       DO I = 1 TO 10;
 ////          BEGIN;
 ////             PUT SKIP LIST('NESTED');
-//// END PKG;
+//// <|END|> PKG;
 
-verify.noParserDiagnostics();
+verify.noParserErrors();
+verify.expectDiagnosticsAt("END", code.Warning.IBM1120I);

--- a/packages/language/test/fourslash/parser/multiclose/multiclose-package-closes-all-levels.ts
+++ b/packages/language/test/fourslash/parser/multiclose/multiclose-package-closes-all-levels.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS RULES(MULTICLOSE);
+//// PKG: PACKAGE;
+////    PROC1: PROCEDURE OPTIONS(MAIN);
+////       DCL I FIXED BIN(31);
+////       DO I = 1 TO 10;
+////          BEGIN;
+////             PUT SKIP LIST('NESTED');
+//// END PKG;
+
+verify.noParserDiagnostics();

--- a/packages/language/test/fourslash/parser/multiclose/multiclose-package-end-closes-nested.ts
+++ b/packages/language/test/fourslash/parser/multiclose/multiclose-package-end-closes-nested.ts
@@ -1,0 +1,22 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS RULES(MULTICLOSE);
+////*PROCESS RULES(LAXIF);
+//// MY_PKG: PACKAGE;
+////    P: PROC OPTIONS(MAIN);
+////       IF 0 THEN DO;
+////          PUT SKIP LIST('IF BODY STATEMENT 1');
+//// END MY_PKG;
+
+verify.noParserDiagnostics();

--- a/packages/language/test/fourslash/parser/multiclose/multiclose-package-end-closes-nested.ts
+++ b/packages/language/test/fourslash/parser/multiclose/multiclose-package-end-closes-nested.ts
@@ -17,6 +17,7 @@
 ////    P: PROC OPTIONS(MAIN);
 ////       IF 0 THEN DO;
 ////          PUT SKIP LIST('IF BODY STATEMENT 1');
-//// END MY_PKG;
+//// <|END|> MY_PKG;
 
-verify.noParserDiagnostics();
+verify.noParserErrors();
+verify.expectDiagnosticsAt("END", code.Warning.IBM1120I);

--- a/packages/language/test/fourslash/parser/multiclose/multiclose-package-end-optional.ts
+++ b/packages/language/test/fourslash/parser/multiclose/multiclose-package-end-optional.ts
@@ -1,0 +1,22 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS RULES(MULTICLOSE);
+//// PKG: PACKAGE;
+////    PROC1: PROCEDURE OPTIONS(MAIN);
+////       DCL X FIXED BIN(31);
+////       X = 1;
+////    END PROC1;
+//// // No END PKG - valid (PACKAGE END is always optional)
+
+verify.noParserDiagnostics();

--- a/packages/language/test/fourslash/parser/multiclose/multiclose-package-multiple-labeled-ends.ts
+++ b/packages/language/test/fourslash/parser/multiclose/multiclose-package-multiple-labeled-ends.ts
@@ -1,0 +1,26 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS RULES(MULTICLOSE);
+////*PROCESS RULES(LAXIF);
+//// MY_PKG: PACKAGE;
+////    P: PROC OPTIONS(MAIN);
+////       IF 0 THEN IFG0: DO;
+////          PUT SKIP LIST('IF BODY STATEMENT 1');
+////          IF 0 THEN DO;
+////             PUT SKIP LIST('IF BODY STATEMENT 2');
+////       END IFG0;
+////    END P;
+//// END MY_PKG;
+
+verify.noParserDiagnostics();

--- a/packages/language/test/fourslash/parser/multiclose/multiclose-package-multiple-labeled-ends.ts
+++ b/packages/language/test/fourslash/parser/multiclose/multiclose-package-multiple-labeled-ends.ts
@@ -19,8 +19,9 @@
 ////          PUT SKIP LIST('IF BODY STATEMENT 1');
 ////          IF 0 THEN DO;
 ////             PUT SKIP LIST('IF BODY STATEMENT 2');
-////       END IFG0;
+////       <|END|> IFG0;
 ////    END P;
 //// END MY_PKG;
 
-verify.noParserDiagnostics();
+verify.noParserErrors();
+verify.expectDiagnosticsAt("END", code.Warning.IBM1120I);

--- a/packages/language/test/fourslash/parser/multiclose/multiclose-package-procedure-eof-fails.ts
+++ b/packages/language/test/fourslash/parser/multiclose/multiclose-package-procedure-eof-fails.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS RULES(MULTICLOSE);
+//// PKG: PACKAGE;
+////    PROC1: PROCEDURE OPTIONS(MAIN);
+////       DCL X FIXED BIN(31);
+////       X = 1;
+//// <|EOF|>
+
+verify.expectDiagnosticsAt("EOF", {
+  message: 'Expected token "END", but received end of file instead.',
+});

--- a/packages/language/test/fourslash/parser/multiclose/multiclose-package-with-end.ts
+++ b/packages/language/test/fourslash/parser/multiclose/multiclose-package-with-end.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS RULES(MULTICLOSE);
+//// PKG2: PACKAGE;
+////    PROC2: PROCEDURE OPTIONS(MAIN);
+////       DCL Y FIXED BIN(31);
+////    END PROC2;
+//// END PKG2;
+
+verify.noParserDiagnostics();

--- a/packages/language/test/fourslash/parser/multiclose/multiclose-unlabeled-end-closes-innermost.ts
+++ b/packages/language/test/fourslash/parser/multiclose/multiclose-unlabeled-end-closes-innermost.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS RULES(MULTICLOSE);
+//// P: PROC OPTIONS(MAIN);
+////    DO;
+////       PUT SKIP LIST('HELLO');
+////    END;
+//// END P;
+
+verify.noParserDiagnostics();

--- a/packages/language/test/fourslash/parser/multiclose/multiclose-variable-named-end.ts
+++ b/packages/language/test/fourslash/parser/multiclose/multiclose-variable-named-end.ts
@@ -11,11 +11,22 @@
 
 /// <reference path="../../framework.ts" />
 
+/**
+ * Test that a variable named END can be used in multiclose scenarios.
+ * The parser should correctly distinguish between "END = ..." (variable assignment)
+ * and "END LABEL;" (END statement for multiclose).
+ */
+
 ////*PROCESS RULES(MULTICLOSE);
-//// P: PROC OPTIONS(MAIN);
-////    DO;
-////       PUT SKIP LIST('HELLO');
-//// <|END|> P;
+//// TEST: PROC OPTIONS(MAIN);
+////    DCL END CHAR(20);
+////    OUTER: DO;
+////       INNER: DO;
+////          END = 'HELLO_WORLD';
+////          PUT SKIP LIST(END);
+//// <|END|> OUTER;
+////    PUT SKIP LIST('AFTER');
+//// END TEST;
 
 verify.noParserErrors();
 verify.expectDiagnosticsAt("END", code.Warning.IBM1120I);

--- a/packages/language/test/fourslash/parser/multiclose/nomulticlose-default-eof-fails.ts
+++ b/packages/language/test/fourslash/parser/multiclose/nomulticlose-default-eof-fails.ts
@@ -1,0 +1,22 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// P: PROCEDURE OPTIONS(MAIN);
+////    DO;
+////       PUT SKIP LIST('HELLO');
+//// <|EOF|>
+
+// Verify that the parser reports specific error message for missing END token at EOF (default is NOMULTICLOSE)
+verify.expectDiagnosticsAt("EOF", {
+  message: 'Expected token "END", but received end of file instead.',
+});

--- a/packages/language/test/fourslash/parser/multiclose/nomulticlose-inner-has-end-outer-fails.ts
+++ b/packages/language/test/fourslash/parser/multiclose/nomulticlose-inner-has-end-outer-fails.ts
@@ -1,0 +1,25 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS RULES(NOMULTICLOSE);
+//// P: PROCEDURE OPTIONS(MAIN);
+////    DCL I FIXED BIN(31);
+////    DO I = 1 TO 10;
+////       PUT SKIP LIST('HELLO');
+////    END;
+//// <|EOF|>
+
+// DO has its END, but PROCEDURE is missing END - still fails at EOF
+verify.expectDiagnosticsAt("EOF", {
+  message: 'Expected token "END", but received end of file instead.',
+});

--- a/packages/language/test/fourslash/parser/multiclose/nomulticlose-package-all-need-end.ts
+++ b/packages/language/test/fourslash/parser/multiclose/nomulticlose-package-all-need-end.ts
@@ -1,0 +1,26 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS RULES(NOMULTICLOSE);
+//// PKG: PACKAGE;
+////    PROC1: PROCEDURE OPTIONS(MAIN);
+////       DCL I FIXED BIN(31);
+////       DO I = 1 TO 10;
+////          BEGIN;
+////             PUT SKIP LIST('NESTED');
+////          END;  // BEGIN
+////       END;     // DO
+////    END PROC1;  // PROCEDURE
+//// END PKG;       // PACKAGE (optional but included)
+
+verify.noParserDiagnostics();

--- a/packages/language/test/fourslash/parser/multiclose/nomulticlose-package-end-optional.ts
+++ b/packages/language/test/fourslash/parser/multiclose/nomulticlose-package-end-optional.ts
@@ -1,0 +1,22 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS RULES(NOMULTICLOSE);
+//// PKG: PACKAGE;
+////    PROC1: PROCEDURE OPTIONS(MAIN);
+////       DCL X FIXED BIN(31);
+////       X = 1;
+////    END PROC1;
+//// // No END PKG - valid (PACKAGE END is always optional)
+
+verify.noParserDiagnostics();

--- a/packages/language/test/fourslash/parser/multiclose/nomulticlose-package-with-end.ts
+++ b/packages/language/test/fourslash/parser/multiclose/nomulticlose-package-with-end.ts
@@ -1,0 +1,22 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS RULES(NOMULTICLOSE);
+//// PKG: PACKAGE;
+////    PROC1: PROCEDURE OPTIONS(MAIN);
+////       DCL X FIXED BIN(31);
+////       X = 1;
+////    END PROC1;
+//// END PKG;
+
+verify.noParserDiagnostics();

--- a/packages/language/test/fourslash/parser/multiclose/nomulticlose-requires-end.ts
+++ b/packages/language/test/fourslash/parser/multiclose/nomulticlose-requires-end.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS RULES(NOMULTICLOSE);
+//// PROC1: PROCEDURE OPTIONS(MAIN);
+////    DCL X FIXED BIN(31);
+////    X = 1;
+//// END PROC1;
+
+verify.noParserDiagnostics();

--- a/packages/language/test/fourslash/parser/multiclose/variable-named-end.ts
+++ b/packages/language/test/fourslash/parser/multiclose/variable-named-end.ts
@@ -1,0 +1,25 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+/**
+ * Test that a variable named END can be used without being confused with END statement.
+ * The parser should not treat "END = ..." as an END statement.
+ */
+
+//// TEST: PROC OPTIONS(MAIN);
+////    DCL END CHAR(20);
+////    END = 'HELLO_WORLD';
+////    PUT SKIP LIST(END);
+//// END TEST;
+
+verify.noParserDiagnostics();

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -1010,10 +1010,15 @@ Available code actions for label "${label}" and URI "${uri}": ${codeActions.map(
     return this;
   }
 
-  expectNoCategoryDiagnostics(category: DiagnosticCategory): TestBuilder {
+  expectNoCategoryDiagnostics(
+    category: DiagnosticCategory,
+    filter?: (d: Diagnostic) => boolean,
+  ): TestBuilder {
     const diagnostics = this.unit.diagnostics.get(category);
-    if (diagnostics.length > 0) {
-      const message = diagnostics
+    const filtered = filter ? diagnostics.filter(filter) : diagnostics;
+
+    if (filtered.length > 0) {
+      const message = filtered
         .map((diagnostic) => this.createDiagnosticMessage(diagnostic))
         .join("\n- ");
       fail(`Expected no diagnostics but received:\n- ${message}`);

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -58,6 +58,24 @@ export type Label = string | number | string[] | number[];
 
 export const DEFAULT_FILE_URI = "file:///main.pli";
 
+/**
+ * Extended Diagnostic type that allows RegExp for message field in tests.
+ * This enables more flexible message matching that is less brittle to, e.g., parser changes.
+ */
+export type TestDiagnostic = Omit<Partial<Diagnostic>, "message"> & {
+  message?: string | RegExp;
+};
+
+/**
+ * Type for diagnostic expectations in tests.
+ * Accepts TestDiagnostic (with optional RegExp message), PLICode, or arrays of either.
+ */
+export type DiagnosticExpectation =
+  | TestDiagnostic
+  | TestDiagnostic[]
+  | PLICode
+  | PLICode[];
+
 type Path = string;
 export type LocationOverride = {
   uri: Path;
@@ -745,44 +763,110 @@ Available code actions for label "${label}" and URI "${uri}": ${codeActions.map(
     };
   }
 
+  /**
+   * Check if a diagnostic matches an expected diagnostic specification.
+   * Supports RegExp patterns for string fields (e.g., message).
+   */
+  private diagnosticMatchesExpectation(
+    actual: Diagnostic,
+    expected: TestDiagnostic | PLICode,
+  ): boolean {
+    if (isPLICode(expected)) {
+      return actual.code === fullCode(expected);
+    }
+
+    for (const key of Object.keys(expected)) {
+      const expectedValue = (expected as any)[key];
+      const actualValue = (actual as any)[key];
+
+      if (typeof expectedValue === "object" && expectedValue !== null) {
+        // Check if it is a RegExp. We cannot use instance of here,
+        // because the RegExp might come from a different context.
+        if (typeof expectedValue.test === "function") {
+          if (
+            typeof actualValue !== "string" ||
+            !expectedValue.test(actualValue)
+          ) {
+            return false;
+          }
+        } else {
+          // It is a plain object: check deep equality
+          if (JSON.stringify(actualValue) !== JSON.stringify(expectedValue)) {
+            return false;
+          }
+        }
+      } else {
+        // Check primitive
+        if (actualValue !== expectedValue) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Format an expected diagnostic for display in error messages.
+   * Properly handles RegExp objects by converting them to strings.
+   */
+  private formatExpectedDiagnostic(expected: TestDiagnostic | PLICode): string {
+    if (isPLICode(expected)) {
+      return `code: ${fullCode(expected)}`;
+    }
+
+    const parts: string[] = [];
+    for (const key of Object.keys(expected)) {
+      const value = (expected as any)[key];
+
+      if (typeof value === "object" && value !== null) {
+        if (typeof value.test === "function") {
+          parts.push(`${key}: ${value.toString()}`);
+        } else {
+          parts.push(`${key}: ${JSON.stringify(value)}`);
+        }
+      } else {
+        parts.push(`${key}: ${JSON.stringify(value)}`);
+      }
+    }
+    return `{ ${parts.join(", ")} }`;
+  }
+
   expectExclusiveDiagnosticsAt(
     label: string,
-    diagnostics:
-      | Partial<Diagnostic>
-      | Partial<Diagnostic>[]
-      | PLICode
-      | PLICode[],
+    diagnostics: DiagnosticExpectation,
   ): TestBuilder {
     const diagnosticsArray = Array.isArray(diagnostics)
       ? diagnostics
       : [diagnostics];
-    const expectedDiagnostics = diagnosticsArray.map((diag) => {
-      if (isPLICode(diag)) {
-        return { code: fullCode(diag) };
-      }
-      return diag;
-    });
 
     const { exactMatches, containingMatches } =
       this.getMatchingDiagnostics(label);
     const rangeMessage = this.createLabelRangeMessage(label);
 
+    const expectedDesc = diagnosticsArray.map((d) =>
+      this.formatExpectedDiagnostic(d),
+    );
+
     const message = [
       `At label "${label}" (${rangeMessage})`,
       `Got errors:\n\n${JSON.stringify(exactMatches, null, 2)}`,
-      `Expected errors:\n\n${JSON.stringify(expectedDiagnostics, null, 2)}`,
+      `Expected errors:\n\n${expectedDesc.join("\n")}`,
       containingMatches.length > 0
         ? `Note! This label also contains other diagnostics: ${JSON.stringify(containingMatches, null, 2)}\n\n`
         : "",
     ].join("\n\n");
 
-    expect(exactMatches, message).toHaveLength(expectedDiagnostics.length);
+    expect(exactMatches, message).toHaveLength(diagnosticsArray.length);
 
-    for (const diagnostic of expectedDiagnostics) {
-      const message = `At label "${label}" (${rangeMessage})`;
-      expect(exactMatches, message).toContainEqual(
-        expect.objectContaining(diagnostic),
+    for (const expected of diagnosticsArray) {
+      const found = exactMatches.some((actual) =>
+        this.diagnosticMatchesExpectation(actual, expected),
       );
+      if (!found) {
+        fail(
+          `${message}\n\nExpected diagnostic not found:\n${this.formatExpectedDiagnostic(expected)}`,
+        );
+      }
     }
 
     return this;
@@ -790,11 +874,7 @@ Available code actions for label "${label}" and URI "${uri}": ${codeActions.map(
 
   expectDiagnosticsAt(
     label: Label,
-    diagnostics:
-      | Partial<Diagnostic>
-      | Partial<Diagnostic>[]
-      | PLICode
-      | PLICode[],
+    diagnostics: DiagnosticExpectation,
   ): TestBuilder {
     if (Array.isArray(label)) {
       for (const l of label) {
@@ -809,12 +889,6 @@ Available code actions for label "${label}" and URI "${uri}": ${codeActions.map(
     const diagnosticsArray = Array.isArray(diagnostics)
       ? diagnostics
       : [diagnostics];
-    const expectedDiagnostics = diagnosticsArray.map((diag) => {
-      if (isPLICode(diag)) {
-        return { code: fullCode(diag) };
-      }
-      return diag;
-    });
 
     const { exactMatches, containingMatches } =
       this.getMatchingDiagnostics(label);
@@ -827,10 +901,19 @@ Available code actions for label "${label}" and URI "${uri}": ${codeActions.map(
       }
     };
 
-    for (const diagnostic of expectedDiagnostics) {
-      expect(exactMatches, getMessage()).toContainEqual(
-        expect.objectContaining(diagnostic),
+    // Check both exactMatches and containingMatches since the diagnostic range
+    // might not exactly match the label range (especially for parser errors)
+    for (const expected of diagnosticsArray) {
+      const allMatches = [...exactMatches, ...containingMatches];
+      const found = allMatches.some((actual) =>
+        this.diagnosticMatchesExpectation(actual, expected),
       );
+
+      if (!found) {
+        fail(
+          `${getMessage()}\n\nExpected diagnostic not found:\n${this.formatExpectedDiagnostic(expected)}\n\nActual diagnostics:\n${JSON.stringify(allMatches, null, 2)}`,
+        );
+      }
     }
 
     return this;


### PR DESCRIPTION
Fixes https://github.com/zowe/zowe-pli-language-support/issues/559
Closes https://github.com/zowe/zowe-pli-language-support/issues/673
and part of https://github.com/zowe/zowe-pli-language-support/issues/382

Implements the RULES(MULTICLOSE) feature. Basically, the logic is:
- With RULES(MULTICLOSE) (or alwaysOptional=true):
  - Unlabeled END: Consumed by first (innermost) compound statement that sees it
  - Labeled END: Only consumed if label matches one of the current statement's labels
  - If END exists but doesn't match, it's left for outer scope
  - However, at least one matching END is required
- With RULES(NOMULTICLOSE) (and alwaysOptional=false):
  - END is required - parsing error reported if missing
- END at `package` is always optional

Also extends the `test-builder` to accept regexes at diagnostic messages and refactored the code a bit to remove duplicated code.

Two additional observations: 
1. The mainframe compiler actually reports a warning `IBM1120I` when a multiclose is applied. This is not part of this PR, but will be implemented in a followup.
2. The `test-builder` grew quite a lot over the past year. Maybe we should put some refactoring work in it to improve long-term maintainability.