### PR TITLE
Remove include extension restrictions in plugin config

### DIFF
--- a/packages/vscode-extension/schemas/proc_grps.schema.json
+++ b/packages/vscode-extension/schemas/proc_grps.schema.json
@@ -31,13 +31,7 @@
             "type": "array",
             "description": "List of file extensions to treat as include files.",
             "items": {
-              "type": "string",
-              "enum": [
-                ".pli",
-                ".pl1",
-                ".cpy",
-                ".inc"
-              ]
+              "type": "string"
             }
           },
           "member-name-validation": {


### PR DESCRIPTION
Fixed https://github.com/zowe/zowe-pli-language-support/issues/701
and removes the restriction on `include-extensions`. 
Also, double-checked the interpreter. Works well with other extensions.