### PR TITLE
Fix LAXDCL in linking

### DIFF
--- a/packages/language/src/linking/error.ts
+++ b/packages/language/src/linking/error.ts
@@ -253,7 +253,7 @@ export class LinkerErrorReporter {
    */
   reportImplicitDeclaration(node: QualifiedSyntaxNode) {
     // This should only emit a warning during the 'NOLAXDCL' compiler flag.
-    if (this.unit.compilerOptions.rules?.laxDef) {
+    if (this.unit.compilerOptions.rules?.laxDcl) {
       return;
     }
 

--- a/packages/language/test/fourslash/linker/implicit-declaration-laxdcl.ts
+++ b/packages/language/test/fourslash/linker/implicit-declaration-laxdcl.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: process
+////*PROCESS RULES(LAXDCL);
+//// A: PROCEDURE() OPTIONS (MAIN);
+////     <|1:J|> = 72;
+//// END A;
+
+verify.noDiagnostics(1, code.Error.IBM1373I);


### PR DESCRIPTION
Fixes https://github.com/zowe/zowe-pli-language-support/issues/702

Small bug, was testing `laxDef` instead of `laxDcl`. Added a test.