### PR TITLE
Remove a code duplication

### DIFF
--- a/packages/language/src/syntax-tree/ast-iterator.ts
+++ b/packages/language/src/syntax-tree/ast-iterator.ts
@@ -959,11 +959,6 @@ export function forEachNode(
         action(node.value);
       }
       break;
-    case SyntaxKind.CicsExecStatement:
-      if (node.content) {
-        action(node.content);
-      }
-      break;
     case SyntaxKind.CicsResponseStatement:
       break;
     case SyntaxKind.CicsExecStatement:


### PR DESCRIPTION
Remove a duplicated switch case.

This code will be gone after the CICS isolation. I fixed it for the quality statistics.