### PR TITLE
Improve skipped code eval

### DIFF
--- a/packages/language/src/language-server/skipped-code.ts
+++ b/packages/language/src/language-server/skipped-code.ts
@@ -77,27 +77,22 @@ export function skippedCodeRanges(
         compilationUnit.preprocessorEvaluationResults.branchExecutions.get(
           element,
         );
-      if (
-        // If the code block hasn't been evaluated, it likely was included in another un-evaluated block
-        // This will automatically skip the block already, so we don't have to do anything
-        evaluationResult !== undefined
-      ) {
-        const { elseRange, unitRange } = element;
-        const executedThen = evaluationResult.has(0);
-        const executedElse = evaluationResult.has(1);
-        if (elseRange && executedThen && !executedElse) {
-          // If the "then" branch has been exclusively evaluated, it means we need to skip the "else" branch
-          result.push({
-            start: textDocument.positionAt(elseRange.start),
-            end: textDocument.positionAt(elseRange.end),
-          });
-        } else if (unitRange && !executedThen && executedElse) {
-          // If the "else" branch has been exclusively evaluated, it means we need to skip the "then" branch
-          result.push({
-            start: textDocument.positionAt(unitRange.start),
-            end: textDocument.positionAt(unitRange.end),
-          });
-        }
+      if (evaluationResult === undefined) {
+        continue;
+      }
+      const { elseRange, unitRange } = element;
+      const executedThen = evaluationResult.has(0);
+      const executedElse = evaluationResult.has(1);
+      if (unitRange && !executedThen) {
+        result.push({
+          start: textDocument.positionAt(unitRange.start),
+          end: textDocument.positionAt(unitRange.end),
+        });
+      } else if (elseRange && !executedElse) {
+        result.push({
+          start: textDocument.positionAt(elseRange.start),
+          end: textDocument.positionAt(elseRange.end),
+        });
       }
     } else if (
       token.kind === CstNodeKind.SelectStatement_SELECT &&
@@ -108,17 +103,18 @@ export function skippedCodeRanges(
         compilationUnit.preprocessorEvaluationResults.branchExecutions.get(
           element,
         );
-      if (evaluationResult !== undefined) {
-        for (let i = 0; i < element.cases.length; i++) {
-          const caseElement = element.cases[i];
-          const caseRange = caseElement.range;
-          // If the case hasn't been executed, we display it as skipped
-          if (caseRange && !evaluationResult.has(i)) {
-            result.push({
-              start: textDocument.positionAt(caseRange.start),
-              end: textDocument.positionAt(caseRange.end),
-            });
-          }
+      if (evaluationResult === undefined) {
+        continue;
+      }
+      for (let i = 0; i < element.cases.length; i++) {
+        const caseElement = element.cases[i];
+        const caseRange = caseElement.range;
+        // If the case hasn't been executed, we display it as skipped
+        if (caseRange && !evaluationResult.has(i)) {
+          result.push({
+            start: textDocument.positionAt(caseRange.start),
+            end: textDocument.positionAt(caseRange.end),
+          });
         }
       }
     } else if (

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -254,7 +254,12 @@ function generateVariableValue(
 }
 
 export interface EvaluationResults {
-  branchExecutions: Map<ast.SyntaxNode, Set<number>>;
+  // If the map is undefined, the condition could not be evaluated.
+  // Undefined values inside the map indicate the same for specific cases.
+  branchExecutions: Map<
+    ast.SyntaxNode,
+    Map<number, true | undefined> | undefined
+  >;
 }
 
 interface SymbolTable {
@@ -1292,28 +1297,29 @@ function runSelectInstruction(
     condition = evaluateExpression(instruction.compare, context);
   }
   if (!isScalarValue(condition)) {
-    // Condition cannot be evaluated, simply skip the whole if instruction
+    context.evaluations.branchExecutions.set(instruction.element, undefined);
     return undefined;
   }
-  const set =
-    context.evaluations.branchExecutions.get(instruction.element) ?? new Set();
-  context.evaluations.branchExecutions.set(instruction.element, set);
+  const map =
+    context.evaluations.branchExecutions.get(instruction.element) ?? new Map();
+  context.evaluations.branchExecutions.set(instruction.element, map);
   for (let i = 0; i < instruction.cases.length; i++) {
     const selectCase = instruction.cases[i];
     // No conditions indicates that this is the OTHERWISE/false branch
     // If we have arrived here, we can safely return the branch
     if (selectCase.conditions.length === 0) {
-      set.add(i);
+      map.set(i, true);
       return selectCase.body;
     }
     for (const caseCondition of selectCase.conditions) {
       const caseValue = evaluateExpression(caseCondition, context);
       if (!isScalarValue(caseValue)) {
-        // Condition cannot be evaluated, skip this case
+        // Condition cannot be evaluated
+        map.set(i, undefined);
         continue;
       }
       if (condition.value === caseValue.value) {
-        set.add(i);
+        map.set(i, true);
         return selectCase.body;
       }
     }

--- a/packages/language/test/fourslash/preprocessor/skipped-code-if-loop-both-branches.ts
+++ b/packages/language/test/fourslash/preprocessor/skipped-code-if-loop-both-branches.ts
@@ -1,0 +1,26 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// %DECLARE I fixed;
+//// %DO I = 1 TO 2;
+////   %IF I = 1 %THEN <|notSkipped1:%DO;
+////     WHAT = 123;
+////   %END;|>
+////   %ELSE <|notSkipped2:%DO;
+////     WHAT = 456;
+////   %END;|>
+//// %END;
+
+preprocessor.not.expectSkippedCodeAt("notSkipped1");
+preprocessor.not.expectSkippedCodeAt("notSkipped2");

--- a/packages/language/test/fourslash/preprocessor/skipped-code-if-no-else-false.ts
+++ b/packages/language/test/fourslash/preprocessor/skipped-code-if-no-else-false.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// %DECLARE C fixed;
+//// %C = 0;
+//// %IF C %THEN <|skipped:%DO;
+////   WHAT = 123;
+//// %END;|>
+
+preprocessor.expectSkippedCodeAt("skipped");

--- a/packages/language/test/fourslash/preprocessor/skipped-code-if-no-else-true.ts
+++ b/packages/language/test/fourslash/preprocessor/skipped-code-if-no-else-true.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// %DECLARE C fixed;
+//// %C = 1;
+//// %IF C %THEN <|notSkipped:%DO;
+////   WHAT = 123;
+//// %END;|>
+
+preprocessor.not.expectSkippedCodeAt("notSkipped");

--- a/packages/language/test/fourslash/preprocessor/skipped-code-if-no-else-unknown.ts
+++ b/packages/language/test/fourslash/preprocessor/skipped-code-if-no-else-unknown.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// %DECLARE ARR(5) CHARACTER;
+//// %IF ARR %THEN <|notSkipped:%DO;
+////   WHAT = 123;
+//// %END;|>
+
+preprocessor.not.expectSkippedCodeAt("notSkipped");


### PR DESCRIPTION
Related to https://github.com/zowe/zowe-pli-language-support/issues/716

Currently, the skipped code indicator only works at `IF` if there is an else branch.
If the branch is missing and the (true) branch is missing from the evaluation results, it is not clear, if the condition could not be evaluated or if the result was false (which is displayed differently w.r.t. the skipped code indicator). 

To fix this, this PR also stores `undefined` in the evaluation results to indicate when the condition (resp. case values) couldn't be evaluation and in which case it should not be treated as skipped code.