### PR TITLE
Parse multiple attributes in allocate statement

### DIFF
--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -793,21 +793,24 @@ const allocatedVariable = rule(
   (state: ParserState): ast.AllocatedVariable => {
     const element = ast.createAllocatedVariable();
 
-    if (
-      state.tryConsume(
-        element,
-        CstNodeKind.AllocatedVariable_LevelNumber,
-        tokens.NUMBER,
-      )
-    ) {
-      const levelToken = state.last;
-      element.level = levelToken!.image;
+    const levelToken = state.tryConsume(
+      element,
+      CstNodeKind.AllocatedVariable_LevelNumber,
+      tokens.NUMBER,
+    );
+    if (levelToken) {
+      element.level = levelToken.image;
     }
 
     element.var = referenceItem.rule(state, ast.ReferenceType.Variable);
 
-    if (state.canConsumeFirst(allocateAttribute.first())) {
-      element.attribute = allocateAttribute.rule(state);
+    const { inc } = state.createLoopContext("AllocatedVariable");
+    while (state.canConsumeFirst(allocateAttribute.first())) {
+      inc();
+      const attribute = allocateAttribute.rule(state);
+      if (attribute) {
+        element.attributes.push(attribute);
+      }
     }
 
     return element;

--- a/packages/language/src/syntax-tree/ast-iterator.ts
+++ b/packages/language/src/syntax-tree/ast-iterator.ts
@@ -80,8 +80,8 @@ export function forEachNode(
       if (node.var) {
         action(node.var);
       }
-      if (node.attribute) {
-        action(node.attribute);
+      for (const attribute of node.attributes) {
+        action(attribute);
       }
       break;
     case SyntaxKind.AllocateLocationReferenceIn:

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -1320,7 +1320,7 @@ export interface AllocatedVariable extends AstNode {
   kind: SyntaxKind.AllocatedVariable;
   level: string | null;
   var: ReferenceItem | null;
-  attribute: AllocateAttribute | null;
+  attributes: AllocateAttribute[];
 }
 
 export function createAllocatedVariable(): AllocatedVariable {
@@ -1329,7 +1329,7 @@ export function createAllocatedVariable(): AllocatedVariable {
     container: null,
     level: null,
     var: null,
-    attribute: null,
+    attributes: [],
   };
 }
 export interface AllocateLocationReferenceIn extends AstNode {

--- a/packages/language/test/fourslash/parser/allocate-multiple-attributes.ts
+++ b/packages/language/test/fourslash/parser/allocate-multiple-attributes.ts
@@ -1,0 +1,17 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// ALLOCATE TEST CHAR(10) INIT("VALUE");
+
+verify.noParserDiagnostics();

--- a/packages/language/test/fourslash/parser/allocate-with-level.ts
+++ b/packages/language/test/fourslash/parser/allocate-with-level.ts
@@ -1,0 +1,17 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// ALLOCATE 01 TEST CHAR(10) INIT("VALUE");
+
+verify.noParserDiagnostics();


### PR DESCRIPTION
Part of an effort to resolve https://github.com/zowe/zowe-pli-language-support/issues/717.

Our `ALLOCATE` statement parser didn't allow for multiple attributes - only one at most. This change simply changes this to a loop and stores the results in an array.