### PR TITLE
Remove ambiguity on DECLARE...REFER

### DIFF
--- a/packages/language/src/linking/resolver.ts
+++ b/packages/language/src/linking/resolver.ts
@@ -12,6 +12,7 @@
 import { Location, tokenToRange } from "../language-server/types";
 import { Token } from "../parser/tokens";
 import {
+  DeclaredItem,
   getContainer,
   iterateReferenceNodes,
   MemberCall,
@@ -281,7 +282,7 @@ function getMatchingSymbols(
 
   const getFullName = () => qualifiedName.toReversed().join(".");
 
-  const explicitlyDeclaredSymbols = scope
+  let explicitlyDeclaredSymbols = scope
     .getExplicitSymbols(qualifiedName, {
       /**
        * If the symbol is a procedure parameter, it is only permitted to
@@ -290,6 +291,15 @@ function getMatchingSymbols(
       searchOnlyImmediateScope: isProcedureParameterReference(reference),
     })
     .filter((symbol) => !symbol.isRedeclared); // Don't resolve reference to redeclared symbols.
+
+  if (reference.owner) {
+    const rootComposite = tryExtractRootStructureIfBasedMember(reference.owner);
+    if (rootComposite) {
+      explicitlyDeclaredSymbols = explicitlyDeclaredSymbols.filter((symbol) =>
+        isMemberOfComposite(symbol.node, rootComposite),
+      );
+    }
+  }
 
   const isAmbiguous = checkRedeclaration(explicitlyDeclaredSymbols);
   if (isAmbiguous) {
@@ -524,4 +534,48 @@ export function getTokenAt(unit: CompilationUnit, uri: URI, offset: number) {
     }
   }
   return token;
+}
+
+function getRootCompositeNode(node: SyntaxNode): DeclaredItem | null {
+  let declaredItem = getContainer(node, SyntaxKind.DeclaredItem);
+  if (declaredItem && declaredItem.level !== 1) {
+    const parentDeclaration = getContainer(
+      declaredItem,
+      SyntaxKind.DeclareStatement,
+    )!;
+    let index = parentDeclaration.items.indexOf(declaredItem);
+    if (index === -1) {
+      return null;
+    }
+    let previousItem: DeclaredItem = declaredItem;
+    do {
+      index--;
+    } while (
+      index > -1 &&
+      (previousItem = parentDeclaration.items[index]) &&
+      typeof previousItem.level === "number" &&
+      previousItem.level > 1
+    );
+    if (typeof previousItem.level === "number" && previousItem.level === 1) {
+      declaredItem = previousItem;
+    }
+  }
+  if (declaredItem?.level !== 1) {
+    return null;
+  }
+  return declaredItem;
+}
+
+function tryExtractRootStructureIfBasedMember(
+  node: SyntaxNode,
+): DeclaredItem | null {
+  const referNode = getContainer(node, SyntaxKind.Bound);
+  if (referNode?.refer?.element?.element !== node) {
+    return null;
+  }
+  return getRootCompositeNode(referNode);
+}
+
+function isMemberOfComposite(node: SyntaxNode, rootComposite: DeclaredItem) {
+  return getRootCompositeNode(node) === rootComposite;
 }

--- a/packages/language/src/linking/resolver.ts
+++ b/packages/language/src/linking/resolver.ts
@@ -12,12 +12,15 @@
 import { Location, tokenToRange } from "../language-server/types";
 import { Token } from "../parser/tokens";
 import {
+  Bound,
   DeclaredItem,
   getContainer,
   iterateReferenceNodes,
+  LocatorCall,
   MemberCall,
   ProcedureParameter,
   Reference,
+  ReferenceItem,
   ReferenceType,
   SyntaxKind,
   SyntaxNode,
@@ -537,8 +540,10 @@ export function getTokenAt(unit: CompilationUnit, uri: URI, offset: number) {
 }
 
 function getRootCompositeNode(node: SyntaxNode): DeclaredItem | null {
+  //pick the first parent that is a declared item
   let declaredItem = getContainer(node, SyntaxKind.DeclaredItem);
   if (declaredItem && declaredItem.level !== 1) {
+    //if it is not a level 1 item, go up until we find the declare statement, and then pick the first level 1 item before it
     const parentDeclaration = getContainer(
       declaredItem,
       SyntaxKind.DeclareStatement,
@@ -547,6 +552,7 @@ function getRootCompositeNode(node: SyntaxNode): DeclaredItem | null {
     if (index === -1) {
       return null;
     }
+    // walk up the declaration items until we find a level 1 item, which should be the root composite item
     let previousItem: DeclaredItem = declaredItem;
     do {
       index--;
@@ -569,11 +575,41 @@ function getRootCompositeNode(node: SyntaxNode): DeclaredItem | null {
 function tryExtractRootStructureIfBasedMember(
   node: SyntaxNode,
 ): DeclaredItem | null {
-  const referNode = getContainer(node, SyntaxKind.Bound);
-  if (referNode?.refer?.element?.element !== node) {
+  if (node.kind !== SyntaxKind.ReferenceItem) {
     return null;
   }
-  return getRootCompositeNode(referNode);
+  const memberCall = traverseUpwardsExpect<ReferenceItem, MemberCall>(
+    node,
+    SyntaxKind.MemberCall,
+  );
+  if (!memberCall) {
+    return null;
+  }
+  const locatorCall = traverseUpwardsExpect<MemberCall, LocatorCall>(
+    memberCall,
+    SyntaxKind.LocatorCall,
+  );
+  if (!locatorCall) {
+    return null;
+  }
+  const bound = traverseUpwardsExpect<LocatorCall, Bound>(
+    locatorCall,
+    SyntaxKind.Bound,
+  );
+  if (!bound || !bound.refer || bound.refer !== locatorCall) {
+    return null;
+  }
+  return getRootCompositeNode(bound.refer);
+}
+
+function traverseUpwardsExpect<N extends SyntaxNode, M extends SyntaxNode>(
+  node: N,
+  kind: M["kind"],
+): M | null {
+  if (node.container && node.container.kind === kind) {
+    return node.container as M;
+  }
+  return null;
 }
 
 function isMemberOfComposite(node: SyntaxNode, rootComposite: DeclaredItem) {

--- a/packages/language/src/linking/resolver.ts
+++ b/packages/language/src/linking/resolver.ts
@@ -296,6 +296,7 @@ function getMatchingSymbols(
     .filter((symbol) => !symbol.isRedeclared); // Don't resolve reference to redeclared symbols.
 
   if (reference.owner) {
+    // edge case for type based on `C REFER(D)`
     const rootComposite = tryExtractRootStructureIfBasedMember(reference.owner);
     if (rootComposite) {
       explicitlyDeclaredSymbols = explicitlyDeclaredSymbols.filter((symbol) =>
@@ -572,6 +573,19 @@ function getRootCompositeNode(node: SyntaxNode): DeclaredItem | null {
   return declaredItem;
 }
 
+/**
+ * Tries to extract the root `AAA` if `node` in in the role of `D`
+ * at REFER sub node.
+ *
+ * ```pli
+ * DCL C FIXED;
+ * DCL 1 AAA,
+ *     2 BBB (C REFER(D)),
+ *     2 D FIXED;
+ * ```
+ * @param node
+ * @returns the root composite item if the node is in the role of `D` at REFER sub node, otherwise null
+ */
 function tryExtractRootStructureIfBasedMember(
   node: SyntaxNode,
 ): DeclaredItem | null {

--- a/packages/language/test/fourslash/linker/non-ambiguous-refer.ts
+++ b/packages/language/test/fourslash/linker/non-ambiguous-refer.ts
@@ -1,0 +1,24 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// DCL   a            FIXED BIN(31);
+//// DCL   p            POINTER;
+//// DCL 1 s,
+////       2 len        FIXED BIN(31);
+//// DCL 1 t            BASED(p),
+////       2 <|len|>    FIXED BIN(31),
+////       2 buff(a REFER(<|len>len));
+
+linker.expectLinks();
+verify.noDiagnostics("len");

--- a/packages/language/test/fourslash/quick-fixes/resolve-ambiguous-reference/different-declare-statement.ts
+++ b/packages/language/test/fourslash/quick-fixes/resolve-ambiguous-reference/different-declare-statement.ts
@@ -18,17 +18,5 @@
 ////       2 B FIXED,
 ////       2 C (S REFER(<|B|>));
 
-verify.expectDiagnosticsAt("B", code.Severe.IBM1881I);
-await verify.expectCodeActionCountAt("B", 1);
-await verify.expectCodeActionAt(
-  "B",
-  'Change to "AA.B"',
-  `
-  DCL S FIXED;
-  DCL 1 A,
-        2 B FIXED;
-  DCL 1 AA,
-        2 B FIXED,
-        2 C (S REFER(AA.B));
-`,
-);
+verify.noDiagnostics("B", code.Severe.IBM1881I);
+await verify.noCodeActions("B");

--- a/packages/language/test/fourslash/quick-fixes/resolve-ambiguous-reference/no-quickfixes-different-declare-statements.ts
+++ b/packages/language/test/fourslash/quick-fixes/resolve-ambiguous-reference/no-quickfixes-different-declare-statements.ts
@@ -20,5 +20,5 @@
 ////         3 Z FIXED,
 ////       2 Y3 (P REFER(<|Z|>));
 
-verify.expectDiagnosticsAt("Z", code.Severe.IBM1881I);
+verify.noDiagnostics("Z", code.Severe.IBM1881I);
 await verify.noCodeActions("Z");

--- a/packages/language/test/fourslash/quick-fixes/resolve-ambiguous-reference/same-declare-statement.ts
+++ b/packages/language/test/fourslash/quick-fixes/resolve-ambiguous-reference/same-declare-statement.ts
@@ -12,23 +12,25 @@
 /// <reference path="../../framework.ts" />
 
 //// DCL S FIXED;
-//// DCL 1 A,
-////       2 B FIXED,
-////     1 AA,
-////       2 B FIXED,
-////       2 C (S REFER(<|B|>));
+//// DCL 1 ZERO,
+////       2 A,
+////         3 B FIXED,
+////       2 AA,
+////         3 B FIXED,
+////         3 C (S REFER(<|B|>));
 
 verify.expectDiagnosticsAt("B", code.Severe.IBM1881I);
-await verify.expectCodeActionCountAt("B", 1);
+await verify.expectCodeActionCountAt("B", 2);
 await verify.expectCodeActionAt(
   "B",
   'Change to "AA.B"',
   `
   DCL S FIXED;
-  DCL 1 A,
-        2 B FIXED,
-      1 AA,
-        2 B FIXED,
-        2 C (S REFER(AA.B));
+  DCL 1 ZERO,
+        2 A,
+          3 B FIXED,
+        2 AA,
+          3 B FIXED,
+          3 C (S REFER(AA.B));
 `,
 );


### PR DESCRIPTION
The [documentation](https://www.ibm.com/docs/en/epfz/6.1.0?topic=attribute-refer-option-self-defining-data) says that the member expression is limited to the same STRUCTURE/UNION.

I added a special filter for this edge case.

Closes #696 