### PR TITLE
Improve compiler option handling

### DIFF
--- a/packages/language/src/preprocessor/compiler-options/codes.ts
+++ b/packages/language/src/preprocessor/compiler-options/codes.ts
@@ -138,7 +138,7 @@ export const CompilerOptionsCodes = {
       code: "COAG01",
       severity: Severity.E,
       message: (value: string) =>
-        `Expected "DECIMAL" or "BINARY", but received '${value}'.`,
+        `Expected "DECIMAL" or "HEXADEC", but received '${value}'.`,
     },
   },
 
@@ -866,50 +866,56 @@ export const CompilerOptionsCodes = {
       message: (value: string) =>
         `Received unknown RULES parameter: '${value}'.`,
     },
-    ExpectAllSourceParameter: {
+    InvalidSubParameter: {
       code: "CORU02",
+      severity: Severity.E,
+      message: (value: string) =>
+        `The sub-option does not expect multiple values and will ignore '${value}'.`,
+    },
+    ExpectAllSourceParameter: {
+      code: "CORU03",
       severity: Severity.E,
       message: (value: string) =>
         `Expected "ALL" or "SOURCE", but received '${value}'.`,
     },
     InvalidGotoParameter: {
-      code: "CORU03",
+      code: "CORU04",
       severity: Severity.E,
       message: (value: string) =>
         `Expected "STRICT", "LOOSE" or "LOOSEFORWARD", but received '${value}'.`,
     },
     InvalidLaxEntryParameter: {
-      code: "CORU04",
+      code: "CORU05",
       severity: Severity.E,
       message: (value: string) =>
         `Expected "STRICT" or "LOOSE", but received '${value}'.`,
     },
     InvalidLaxInOutParameter: {
-      code: "CORU05",
+      code: "CORU06",
       severity: Severity.E,
       message: (value: string) =>
         `Expected "ALL", "SOURCE", "STRICT" or "LOOSE", but received '${value}'.`,
     },
     InvalidLaxMarginsParameter: {
-      code: "CORU06",
+      code: "CORU07",
       severity: Severity.E,
       message: (value: string) =>
         `Expected "STRICT" or "XNUMERIC", but received '${value}'.`,
     },
     InvalidLaxQualParameter: {
-      code: "CORU07",
+      code: "CORU08",
       severity: Severity.E,
       message: (value: string) =>
         `Expected "ALL", "FORCE", "STRICT", "LOOSE" or "FULL", but received '${value}'.`,
     },
     InvalidLaxScaleParameter: {
-      code: "CORU08",
+      code: "CORU09",
       severity: Severity.E,
       message: (value: string) =>
         `Expected "ALL", "SOURCE", "STRICT" or "LOOSE", but received '${value}'.`,
     },
     InvalidPaddingParameter: {
-      code: "CORU08",
+      code: "CORU10",
       severity: Severity.E,
       message: (value: string) =>
         `Expected "ALL", "SOURCE", "STRICT" or "LOOSE", but received '${value}'.`,

--- a/packages/language/src/preprocessor/compiler-options/options-pli.ts
+++ b/packages/language/src/preprocessor/compiler-options/options-pli.ts
@@ -1233,10 +1233,10 @@ export namespace CompilerOptions {
     unrefCtl?: RulesSource | true;
     unrefDefined?: RulesSource | true;
     unrefEntry?: RulesSource | true;
-    unrefFile?: RulesSource | true;
+    unrefDefFile?: RulesSource | true;
     unrefStatic?: RulesSource | true;
     unrefValue?: RulesSource | true;
-    unset?: boolean;
+    unset?: RulesSource | true;
     yy?: boolean;
   };
   export type Semantic = {
@@ -1580,7 +1580,7 @@ export function getDefaultCompilerOptions(): CompilerOptions {
       unrefCtl: true,
       unrefDefined: true,
       unrefEntry: true,
-      unrefFile: true,
+      unrefDefFile: true,
       unrefStatic: true,
       unrefValue: true,
       unset: true,

--- a/packages/language/src/preprocessor/compiler-options/translator-pli.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator-pli.ts
@@ -67,6 +67,7 @@ translator.rule(
   },
   ["NOAGGREGATE", "NAG"],
   (_, options) => {
+    ensureArguments(_, 0, 0);
     options.aggregate = false;
   },
 );
@@ -293,7 +294,10 @@ translator.rule(["CHECK"], (option, options, acceptor) => {
         );
     }
   }
-  reportDuplicateSubOptions(option, acceptor);
+  reportDuplicateSubOptions(option, acceptor, {
+    STG: "STORAGE",
+    NSTG: "NOSTORAGE",
+  });
   reportMutexSubOptions(option, acceptor, [
     ["STORAGE", "NOSTORAGE"],
     ["STG", "NSTG"],
@@ -327,14 +331,19 @@ translator.rule(
     ensureArguments(option, 1, 1);
     ensureType(option.values[0], "plainNotEmpty");
 
-    if (!Options.PLI_CODEPAGE_SET.has(option.values[0].value)) {
+    // The leading zero is not mandatory, but if the codepage is present without it, it should be stored with the leading zero.
+    const value = option.values[0].value.startsWith("0")
+      ? option.values[0].value
+      : `0${option.values[0].value}`;
+
+    if (!Options.PLI_CODEPAGE_SET.has(value)) {
       throw diagnosticFromCode(
         CompilerOptionsCodes.CodePage.InvalidParameter,
         option.values[0].token,
         option.values[0].value,
       );
     }
-    options.codepage = option.values[0].value;
+    options.codepage = value;
   },
   undefined,
   undefined,
@@ -610,9 +619,11 @@ translator.rule(
               CompilerOptions.DefaultEncoding,
             );
             break;
+          case "ASGN":
           case "ASSIGNABLE":
+          case "NONASGN":
           case "NONASSIGNABLE":
-            def.assignable = val === "ASSIGNABLE";
+            def.assignable = val === "ASSIGNABLE" || val === "ASGN";
             break;
           case "BIN1ARG":
           case "NOBIN1ARG":
@@ -626,9 +637,11 @@ translator.rule(
               CompilerOptions.DefaultAllocator,
             );
             break;
+          case "CONN":
           case "CONNECTED":
+          case "NONCONN":
           case "NONCONNECTED":
-            def.connected = val === "CONNECTED";
+            def.connected = val === "CONNECTED" || val === "CONN";
             break;
           case "DESCLIST":
           case "DESCLOCATOR":
@@ -663,9 +676,11 @@ translator.rule(
             // Initfill is actually valid without a parameter and falls back to 00 in that case.
             def.initfill = val === "INITFILL" ? "00" : false;
             break;
+          case "INL":
           case "INLINE":
+          case "NOINL":
           case "NOINLINE":
-            def.inline = val === "INLINE";
+            def.inline = val === "INLINE" || val === "INL";
             break;
           case "LAXQUAL":
           case "NOLAXQUAL":
@@ -720,7 +735,7 @@ translator.rule(
             def.pseudodummy = val === "PSEUDODUMMY";
             break;
           case "RECURSIVE":
-          case "NORECURSIVE":
+          case "NONRECURSIVE":
             def.recursive = val === "RECURSIVE";
             break;
           case "RETCODE":
@@ -881,20 +896,36 @@ translator.rule(
         );
       }
     }
-    reportDuplicateSubOptions(option, acceptor);
+    reportDuplicateSubOptions(option, acceptor, {
+      ASGN: "ASSIGNABLE",
+      NONASGN: "NONASSIGNABLE",
+      CONN: "CONNECTED",
+      NONCONN: "NONCONNECTED",
+      INL: "INLINE",
+      NOINL: "NOINLINE",
+    });
     reportMutexSubOptions(option, acceptor, [
       ["ALIGNED", "UNALIGNED"],
       ["IBM", "ANS"],
       ["EBCDIC", "ASCII"],
       ["ASSIGNABLE", "NONASSIGNABLE"],
+      ["ASSIGNABLE", "NONASGN"],
+      ["ASGN", "NONASSIGNABLE"],
+      ["ASGN", "NONASGN"],
       ["BIN1ARG", "NOBIN1ARG"],
       ["BYADDR", "BYVALUE"],
       ["CONNECTED", "NONCONNECTED"],
+      ["CONNECTED", "NONCONN"],
+      ["CONN", "NONCONNECTED"],
+      ["CONN", "NONCONN"],
       ["DESCLIST", "DESCLOCATOR"],
       ["DESCRIPTOR", "NODESCRIPTOR"],
       ["EVENDEC", "NOEVENDEC"],
       ["HEXADEC", "IEEE"],
       ["INLINE", "NOINLINE"],
+      ["INLINE", "NOINL"],
+      ["INL", "NOINLINE"],
+      ["INL", "NOINL"],
       ["LAXQUAL", "NOLAXQUAL"],
       ["LOWERINC", "UPPERINC"],
       ["NATIVE", "NONNATIVE"],
@@ -2893,11 +2924,11 @@ translator.rule(
           case "NOUNREFENTRY":
             options.rules.unrefEntry = CompilerOptions.RulesSource.ALL;
             break;
-          case "UNREFFILE":
-            options.rules.unrefFile = true;
+          case "UNREFDEFFILE":
+            options.rules.unrefDefFile = true;
             break;
-          case "NOUNREFFILE":
-            options.rules.unrefFile = CompilerOptions.RulesSource.ALL;
+          case "NOUNREFDEFFILE":
+            options.rules.unrefDefFile = CompilerOptions.RulesSource.ALL;
             break;
           case "UNREFSTATIC":
             options.rules.unrefStatic = true;
@@ -2915,7 +2946,7 @@ translator.rule(
             options.rules.unset = true;
             break;
           case "NOUNSET":
-            options.rules.unset = false;
+            options.rules.unset = CompilerOptions.RulesSource.ALL;
             break;
           case "YY":
             options.rules.yy = true;
@@ -2932,10 +2963,23 @@ translator.rule(
         }
       } else if (value.kind === SyntaxKind.CompilerOption) {
         const subOption = value.values[0];
+
+        const ensureOnlyOneSubOption = () => {
+          for (let i = 1; i < value.values.length; i++) {
+            const invalidOption = value.values[i];
+            throw diagnosticFromCode(
+              CompilerOptionsCodes.Rules.InvalidSubParameter,
+              invalidOption.token,
+              invalidOption.token.image,
+            );
+          }
+        };
+
         ensureType(subOption, "plainNotEmpty");
         const name = value.name.toUpperCase();
         switch (name) {
           case "NOCOMPLEX":
+            ensureOnlyOneSubOption();
             options.rules.complex = ensureEnum(
               subOption,
               CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
@@ -2943,6 +2987,7 @@ translator.rule(
             );
             break;
           case "NOGLOBAL":
+            ensureOnlyOneSubOption();
             options.rules.global = ensureEnum(
               subOption,
               CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
@@ -2950,6 +2995,7 @@ translator.rule(
             );
             break;
           case "NOGOTO":
+            ensureOnlyOneSubOption();
             options.rules.goto = ensureEnum(
               subOption,
               CompilerOptionsCodes.Rules.InvalidGotoParameter,
@@ -2957,6 +3003,7 @@ translator.rule(
             );
             break;
           case "NOLAXCONV":
+            ensureOnlyOneSubOption();
             options.rules.laxConv = ensureEnum(
               subOption,
               CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
@@ -2964,6 +3011,7 @@ translator.rule(
             );
             break;
           case "NOLAXENTRY":
+            ensureOnlyOneSubOption();
             options.rules.laxEntry = ensureEnum(
               subOption,
               CompilerOptionsCodes.Rules.InvalidLaxEntryParameter,
@@ -2994,6 +3042,7 @@ translator.rule(
             }
             break;
           case "NOLAXMARGINS":
+            ensureOnlyOneSubOption();
             options.rules.laxMargins = ensureEnum(
               subOption,
               CompilerOptionsCodes.Rules.InvalidLaxMarginsParameter,
@@ -3001,6 +3050,7 @@ translator.rule(
             );
             break;
           case "NOLAXNESTED":
+            ensureOnlyOneSubOption();
             options.rules.laxNested = ensureEnum(
               subOption,
               CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
@@ -3008,6 +3058,7 @@ translator.rule(
             );
             break;
           case "NOLAXOPTIONAL":
+            ensureOnlyOneSubOption();
             options.rules.laxOptional = ensureEnum(
               subOption,
               CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
@@ -3015,6 +3066,7 @@ translator.rule(
             );
             break;
           case "NOLAXPARMS":
+            ensureOnlyOneSubOption();
             options.rules.laxParms = ensureEnum(
               subOption,
               CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
@@ -3068,6 +3120,7 @@ translator.rule(
             }
             break;
           case "NOLAXSTMT":
+            ensureOnlyOneSubOption();
             options.rules.laxStmt = ensureEnum(
               subOption,
               CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
@@ -3075,6 +3128,7 @@ translator.rule(
             );
             break;
           case "NOMULTIENTRY":
+            ensureOnlyOneSubOption();
             options.rules.multiEntry = ensureEnum(
               subOption,
               CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
@@ -3082,6 +3136,7 @@ translator.rule(
             );
             break;
           case "NOMULTIEXIT":
+            ensureOnlyOneSubOption();
             options.rules.multiExit = ensureEnum(
               subOption,
               CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
@@ -3089,6 +3144,7 @@ translator.rule(
             );
             break;
           case "NOMULTISEMI":
+            ensureOnlyOneSubOption();
             options.rules.multiSemi = ensureEnum(
               subOption,
               CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
@@ -3119,6 +3175,7 @@ translator.rule(
             }
             break;
           case "NOPROCENDONLY":
+            ensureOnlyOneSubOption();
             options.rules.procEndOnly = ensureEnum(
               subOption,
               CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
@@ -3126,6 +3183,7 @@ translator.rule(
             );
             break;
           case "NOUNREF":
+            ensureOnlyOneSubOption();
             options.rules.unref = ensureEnum(
               subOption,
               CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
@@ -3133,6 +3191,7 @@ translator.rule(
             );
             break;
           case "NOUNREFBASED":
+            ensureOnlyOneSubOption();
             options.rules.unrefBased = ensureEnum(
               subOption,
               CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
@@ -3140,6 +3199,7 @@ translator.rule(
             );
             break;
           case "NOUNREFCTL":
+            ensureOnlyOneSubOption();
             options.rules.unrefCtl = ensureEnum(
               subOption,
               CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
@@ -3147,6 +3207,7 @@ translator.rule(
             );
             break;
           case "NOUNREFDEFINED":
+            ensureOnlyOneSubOption();
             options.rules.unrefDefined = ensureEnum(
               subOption,
               CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
@@ -3154,20 +3215,23 @@ translator.rule(
             );
             break;
           case "NOUNREFENTRY":
+            ensureOnlyOneSubOption();
             options.rules.unrefEntry = ensureEnum(
               subOption,
               CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
               CompilerOptions.RulesSource,
             );
             break;
-          case "NOUNREFFILE":
-            options.rules.unrefFile = ensureEnum(
+          case "NOUNREFDEFFILE":
+            ensureOnlyOneSubOption();
+            options.rules.unrefDefFile = ensureEnum(
               subOption,
               CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
               CompilerOptions.RulesSource,
             );
             break;
           case "NOUNREFSTATIC":
+            ensureOnlyOneSubOption();
             options.rules.unrefStatic = ensureEnum(
               subOption,
               CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
@@ -3175,7 +3239,16 @@ translator.rule(
             );
             break;
           case "NOUNREFVALUE":
+            ensureOnlyOneSubOption();
             options.rules.unrefValue = ensureEnum(
+              subOption,
+              CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
+              CompilerOptions.RulesSource,
+            );
+            break;
+          case "NOUNSET":
+            ensureOnlyOneSubOption();
+            options.rules.unset = ensureEnum(
               subOption,
               CompilerOptionsCodes.Rules.ExpectAllSourceParameter,
               CompilerOptions.RulesSource,
@@ -3194,6 +3267,7 @@ translator.rule(
     reportMutexSubOptions(option, acceptor, [
       ["IBM", "ANS"],
       ["BYNAME", "NOBYNAME"],
+      ["COMPLEX", "NOCOMPLEX"],
       ["CONTROLLED", "NOCONTROLLED"],
       ["DECSIZE", "NODECSIZE"],
       ["ELSEIF", "NOELSEIF"],

--- a/packages/language/src/preprocessor/compiler-options/translator.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator.ts
@@ -686,10 +686,14 @@ export function getCompilerOptionValueName(value: CompilerOptionValue): string {
 export function reportDuplicateSubOptions(
   parent: CompilerOption,
   acceptor: TranslationDiagnosticAcceptor,
+  abbreviations?: Record<string, string>,
 ) {
   const seen = new Set<string>();
   for (const value of parent.values) {
-    const name = getCompilerOptionValueName(value);
+    let name = getCompilerOptionValueName(value);
+    if (abbreviations && abbreviations[name]) {
+      name = abbreviations[name];
+    }
     if (seen.has(name)) {
       acceptor(
         diagnosticFromCode(

--- a/packages/language/test/fourslash/preprocessor/compiler-options/default-pli/default-abbreviations.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/default-pli/default-abbreviations.ts
@@ -1,0 +1,38 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS DEFAULT(<|1:ASGN|>, <|3:NONASGN|>);
+////*PROCESS <|4:DEFAULT|>(<|5:CONN|>, <|7:NONCONN|>);
+////*PROCESS <|8:DEFAULT|>(<|9:INL|>, <|11:NOINL|>);
+
+verify.expectDiagnosticsAt([4, 8], {
+  message: code.CompilerOptions.DupeOptionIssue.message("DEFAULT"),
+});
+verify.noDiagnostics([1, 5, 9]);
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.MutexOptionIssue.message("DEFAULT(NONASGN)"),
+});
+verify.expectDiagnosticsAt(7, {
+  message: code.CompilerOptions.MutexOptionIssue.message("DEFAULT(NONCONN)"),
+});
+verify.expectDiagnosticsAt(11, {
+  message: code.CompilerOptions.MutexOptionIssue.message("DEFAULT(NOINL)"),
+});
+verify.expectCompilerOptions({
+  default: {
+    assignable: false,
+    connected: false,
+    inline: false,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/default-pli/default.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/default-pli/default.ts
@@ -39,18 +39,19 @@
 ////*PROCESS <|d24:DEFAULT|>(PADDING);
 ////*PROCESS <|d25:DEFAULT|>(NOPSEUDODUMMY);
 ////*PROCESS <|d26:DEFAULT|>(RECURSIVE);
-////*PROCESS <|d27:DFT|>(RETCODE);
+////*PROCESS <|d27:DEFAULT|>(NONRECURSIVE);
+////*PROCESS <|d28:DFT|>(RETCODE);
 
 verify.expectDiagnosticsAt(0, {
   message: code.CompilerOptions.InvalidParameterCount.message(0, 1),
 });
 verify.expectDiagnosticsAt(
-  Array.from({ length: 25 }, (_, i) => `d${i + 1}`),
+  Array.from({ length: 26 }, (_, i) => `d${i + 1}`),
   {
     message: code.CompilerOptions.DupeOptionIssue.message("DEFAULT"),
   },
 );
-verify.expectDiagnosticsAt("d27", {
+verify.expectDiagnosticsAt("d28", {
   message: code.CompilerOptions.DupeOptionIssue.message("DFT"),
 });
 verify.noDiagnostics(1);
@@ -82,7 +83,7 @@ verify.expectCompilerOptions({
     overlap: true,
     padding: true,
     pseudodummy: false,
-    recursive: true,
+    recursive: false,
     retcode: true,
   },
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/aggregate.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/aggregate.ts
@@ -18,8 +18,9 @@
 ////*PROCESS <|4:AGGREGATE|>(<|5:)|>;
 ////*PROCESS <|6:AGGREGATE|>(<|7:INVALID|>);
 ////*PROCESS <|8:AG|>(HEXADEC);
+////*PROCESS <|10:NAG|>(DECIMAL);
 
-verify.expectDiagnosticsAt(1, {
+verify.expectDiagnosticsAt([1, 10], {
   message: code.CompilerOptions.DupeOptionIssue.message("NAG"),
 });
 verify.expectDiagnosticsAt([2, 4, 6], {
@@ -33,6 +34,9 @@ verify.expectDiagnosticsAt(5, {
 });
 verify.expectDiagnosticsAt(7, {
   message: code.CompilerOptions.Aggregate.InvalidParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt(10, {
+  message: code.CompilerOptions.InvalidParameterCount.message(1, 0, 0),
 });
 verify.expectCompilerOptions({
   aggregate: constants.CompilerOptions.Aggregate.HEXADEC,

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/check.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/check.ts
@@ -16,7 +16,7 @@
 ////*PROCESS <|2:CHECK|>(<|3:)|>;
 ////*PROCESS <|4:CHECK|>(<|5:INVALID|>);
 ////*PROCESS <|6:CHECK|>(STORAGE);
-////*PROCESS <|8:CHECK|>(STORAGE, STG);
+////*PROCESS <|8:CHECK|>(STORAGE, <|9:STG|>);
 ////*PROCESS <|10:CHECK|>(STORAGE NSTG);
 
 verify.expectDiagnosticsAt(1, {
@@ -28,6 +28,9 @@ verify.expectDiagnosticsAt([2, 4, 6, 8, 10], {
 verify.noDiagnostics(3);
 verify.expectDiagnosticsAt(5, {
   message: code.CompilerOptions.Check.InvalidParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt(9, {
+  message: code.CompilerOptions.DupeOptionIssue.message("CHECK(STG)"),
 });
 verify.expectCompilerOptions({
   check: { storage: constants.CompilerOptions.CheckStorage.NOSTORAGE },

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/codepage.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/codepage.ts
@@ -16,6 +16,7 @@
 ////*PROCESS <|4:CODEPAGE|>(<|5:)|>;
 ////*PROCESS <|6:CODEPAGE|>(<|7:INVALID|>);
 ////*PROCESS <|8:CP|>(00037);
+////*PROCESS <|10:CP|>(<|11:1140|>);
 
 verify.expectDiagnosticsAt(2, {
   message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
@@ -23,7 +24,7 @@ verify.expectDiagnosticsAt(2, {
 verify.expectDiagnosticsAt([4, 6], {
   message: code.CompilerOptions.DupeOptionIssue.message("CODEPAGE"),
 });
-verify.expectDiagnosticsAt(8, {
+verify.expectDiagnosticsAt([8, 10], {
   message: code.CompilerOptions.DupeOptionIssue.message("CP"),
 });
 verify.expectDiagnosticsAt(5, {
@@ -32,6 +33,7 @@ verify.expectDiagnosticsAt(5, {
 verify.expectDiagnosticsAt(7, {
   message: code.CompilerOptions.CodePage.InvalidParameter.message("INVALID"),
 });
+verify.noDiagnostics(11);
 verify.expectCompilerOptions({
-  codepage: "00037",
+  codepage: "01140",
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules-pli/rules-complex.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules-pli/rules-complex.ts
@@ -13,8 +13,7 @@
 
 // @wrap: process
 ////*PROCESS RULES(COMPLEX(<|1:)|>);
-////*PROCESS RULES(<|2:COMPLEX|>);
-////*PROCESS RULES(<|3:NOCOMPLEX|>);
+////*PROCESS RULES(<|2:COMPLEX|>, <|3:NOCOMPLEX|>);
 ////*PROCESS RULES(NOCOMPLEX(<|4:)|>);
 ////*PROCESS RULES(NOCOMPLEX(<|5:INVALID|>));
 ////*PROCESS RULES(NOCOMPLEX(<|6:SOURCE|>));
@@ -22,7 +21,10 @@
 verify.expectDiagnosticsAt(1, {
   message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
 });
-verify.noDiagnostics([2, 3, 6]);
+verify.noDiagnostics([2, 6]);
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.MutexOptionIssue.message("RULES(NOCOMPLEX)"),
+});
 verify.expectDiagnosticsAt(4, {
   message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules-pli/rules-unreffile.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules-pli/rules-unreffile.ts
@@ -13,11 +13,11 @@
 
 // @wrap: process
 ////*PROCESS RULES(UNREFFILE(<|1:)|>);
-////*PROCESS RULES(<|2:UNREFFILE|>);
-////*PROCESS RULES(<|3:NOUNREFFILE|>);
-////*PROCESS RULES(NOUNREFFILE(<|4:)|>);
-////*PROCESS RULES(NOUNREFFILE(<|5:INVALID|>));
-////*PROCESS RULES(NOUNREFFILE(<|6:SOURCE|>));
+////*PROCESS RULES(<|2:UNREFDEFFILE|>);
+////*PROCESS RULES(<|3:NOUNREFDEFFILE|>);
+////*PROCESS RULES(NOUNREFDEFFILE(<|4:)|>);
+////*PROCESS RULES(NOUNREFDEFFILE(<|5:INVALID|>));
+////*PROCESS RULES(NOUNREFDEFFILE(<|6:SOURCE|>));
 
 verify.expectDiagnosticsAt(1, {
   message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
@@ -32,6 +32,6 @@ verify.expectDiagnosticsAt(5, {
 });
 verify.expectCompilerOptions({
   rules: {
-    unrefFile: constants.CompilerOptions.RulesSource.SOURCE,
+    unrefDefFile: constants.CompilerOptions.RulesSource.SOURCE,
   },
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules-pli/rules.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules-pli/rules.ts
@@ -86,7 +86,7 @@ verify.expectCompilerOptions({
     multiClose: true,
     recursive: false,
     selfAssign: false,
-    unset: false,
+    unset: constants.CompilerOptions.RulesSource.ALL,
     yy: false,
   },
 });


### PR DESCRIPTION
Additions and fixes w.r.t. the compiler option tests mention in https://github.com/zowe/zowe-pli-language-support/issues/734.

Summary of the fixes/additions
- NOAGGREGATE should not accept parameters.
- "Binary" should be "Hexadec" in AGGREGATE.
- **CHECK** Added check for duplicated abbreviations.
- **CODEPAGE** leading zero is not mandatory, but note that is is still stored as `CODEPAGE( 01140 )` in the compiler.
- **DEFAULT**
  - "NORECURSIVE" should be "NONRECURSIVE".
  - Added abbreviations.
- **RULES**
  - Fixed mutex options `COMPLEX` vs `NOCOMPLEX`.
  - Single suboptions do only expect one parameter. (confirmed on mainframe.) Note that suboptions with lists, such as `NOLAXINOUT`, allow arbitrary many entries in their lists, so `*PROCESS RULES(NOLAXINOUT(ALL LOOSE STRICT SOURCE));` is valid here.
  - Fixed `NOUNSET`, but note that even sub-options have defaults and are valid without option on the mainframe. so `*PROCESS RULES(NOUNSET);` is valid and will  result in `NOUNSET( ALL )`. Note that `*PROCESS RULES(NOUNSET());` is NOT valid.
  - Fixed `UNREFFILE` should be `UNREFDEFFILE`.