### PR TITLE
Experimental: Fourslash LS integration

### DIFF
--- a/packages/language/test/fourslash-harness/execute.test.ts
+++ b/packages/language/test/fourslash-harness/execute.test.ts
@@ -199,7 +199,14 @@ function runSingleHarnessTest(filePath: string, timeout = 10_000) {
       const implementation =
         createTestBuilderHarnessImplementation(testBuilder);
 
-      await runHarnessTest(testFile, implementation);
+      try {
+        await runHarnessTest(testFile, implementation);
+      } finally {
+        // Cleanup LSP server resources if they were used
+        if (implementation.server.cleanup) {
+          await implementation.server.cleanup();
+        }
+      }
     },
   );
 }

--- a/packages/language/test/fourslash-harness/harness-interface.ts
+++ b/packages/language/test/fourslash-harness/harness-interface.ts
@@ -9,6 +9,7 @@
  *
  */
 
+import { CodeAction, Command } from "vscode-languageserver-types";
 import { CompletionKeywords } from "../../src/language-server/completion/keywords";
 import { type Severity } from "../../src/language-server/types";
 import { CompilerOptionsCodes } from "../../src/preprocessor/compiler-options/codes";
@@ -430,6 +431,85 @@ export interface HarnessTesterInterface {
     CompilerOptions: typeof PliCompilerOptions & {
       Macro: typeof MacroCompilerOptions;
       SQL: typeof SQLCompilerOptions;
+    };
+  };
+
+  /**
+   * Server mode testing: Routes requests through a running LSP server.
+   * Tests the full LSP protocol stack including connection-handler.ts,
+   * message serialization, and protocol compliance.
+   *
+   * All methods are async since they communicate via LSP.
+   */
+  server: {
+    cleanup?: () => Promise<void>;
+    verify: {
+      expectErrorCodesAt(
+        label: Label,
+        codes: string[] | string | PLICode | PLICode[],
+      ): Promise<void>;
+      expectDiagnosticsAt(
+        label: Label,
+        diagnostics: DiagnosticExpectation,
+      ): Promise<void>;
+      noDiagnostics(label?: Label, ...errorCodes: PLICode[]): Promise<void>;
+    };
+
+    hover: {
+      expectMarkdownAt(label: Label, markdown: string): Promise<void>;
+      expectTextAt(label: Label, text: string): Promise<void>;
+    };
+
+    completion: {
+      expectAt(label: Label, expected: ExpectedCompletion): Promise<void>;
+    };
+
+    linker: {
+      expectLinks(): Promise<void>;
+      expectNoLinksAt(label: Label): Promise<void>;
+    };
+
+    semanticTokens: {
+      expectAt(
+        label: Label,
+        tokenType: SemanticTokenTypesValues,
+        ...tokenModifiers: SemanticTokenModifiersValues[]
+      ): Promise<void>;
+    };
+
+    signatureHelp: {
+      expectMarkdownSignatureAt(label: Label, markdown: string): Promise<void>;
+    };
+
+    references: {
+      expectAt(label: Label, expectedCount?: number): Promise<void>;
+    };
+
+    documentHighlight: {
+      expectAt(label: Label, expectedCount?: number): Promise<void>;
+    };
+
+    rename: {
+      expectAt(label: Label, newName: string): Promise<void>;
+    };
+
+    documentSymbols: {
+      expectSymbols(expectedSymbols: string[]): Promise<void>;
+      expectSymbols(filename: string, expectedSymbols: string[]): Promise<void>;
+    };
+
+    workspaceSymbols: {
+      expectSymbols(query: string, expectedSymbols: string[]): Promise<void>;
+    };
+
+    codeActions: {
+      expectAt(
+        label: Label,
+        kind?: string,
+        expectedCount?: number,
+      ): Promise<(CodeAction | Command)[]>;
+      getAt(label: Label, kind?: string): Promise<any[]>;
+      apply(action: any): Promise<void>;
     };
   };
 }

--- a/packages/language/test/fourslash-harness/harness.test.ts
+++ b/packages/language/test/fourslash-harness/harness.test.ts
@@ -114,6 +114,58 @@ async function createTestingHarnessImplementation(
     },
     code: HarnessCodes,
     constants: HarnessConstants,
+    server: {
+      verify: {
+        expectErrorCodesAt: listen("server.verify.expectErrorCodesAt"),
+        expectDiagnosticsAt: listen("server.verify.expectDiagnosticsAt"),
+        noDiagnostics: listen("server.verify.noDiagnostics"),
+      },
+      hover: {
+        expectMarkdownAt: listen("server.hover.expectMarkdownAt"),
+        expectTextAt: listen("server.hover.expectTextAt"),
+      },
+      completion: {
+        expectAt: listen("server.completion.expectAt"),
+      },
+      linker: {
+        expectLinks: listen("server.linker.expectLinks"),
+        expectNoLinksAt: listen("server.linker.expectNoLinksAt"),
+      },
+      semanticTokens: {
+        expectAt: listen("server.semanticTokens.expectAt"),
+      },
+      signatureHelp: {
+        expectMarkdownSignatureAt: listen(
+          "server.signatureHelp.expectMarkdownSignatureAt",
+        ),
+      },
+      references: {
+        expectAt: listen("server.references.expectAt"),
+      },
+      documentHighlight: {
+        expectAt: listen("server.documentHighlight.expectAt"),
+      },
+      rename: {
+        expectAt: listen("server.rename.expectAt"),
+      },
+      documentSymbols: {
+        expectSymbols: listen("server.documentSymbols.expectSymbols"),
+      },
+      workspaceSymbols: {
+        expectSymbols: listen("server.workspaceSymbols.expectSymbols"),
+      },
+      codeActions: {
+        expectAt: async (...args: any[]) => {
+          await listen("server.codeActions.expectAt")(...args);
+          return [];
+        },
+        getAt: async (...args: any[]) => {
+          await listen("server.codeActions.getAt")(...args);
+          return [];
+        },
+        apply: listen("server.codeActions.apply"),
+      },
+    },
   };
 }
 

--- a/packages/language/test/fourslash-harness/implementation/test-builder.ts
+++ b/packages/language/test/fourslash-harness/implementation/test-builder.ts
@@ -25,6 +25,9 @@ import { HarnessTypeAttributes } from "./type-attributes";
 import { SyntaxKind } from "../../../src/syntax-tree/ast";
 import { DiagnosticCategory } from "../../../src/validation/diagnostics-store";
 import { Severity } from "../../../src/language-server/types";
+import { LspServerAdapter } from "../../test-builder/lsp-server-adapter";
+import { TestLspClient } from "../../test-builder/lsp-client";
+import { VirtualFileSystemProvider } from "../../../src/workspace/file-system-provider";
 
 /**
  * Create a harness implementation that can be used to run the harness test.
@@ -35,6 +38,40 @@ import { Severity } from "../../../src/language-server/types";
 export function createTestBuilderHarnessImplementation(
   testBuilder: TestBuilder,
 ): HarnessTesterInterface {
+  let lspClient: TestLspClient | undefined;
+  let serverAdapter: LspServerAdapter | undefined;
+
+  function getServerAdapter(): LspServerAdapter {
+    if (!serverAdapter) {
+      // Get test files from TestBuilder
+      const files = testBuilder.getFiles();
+      const fileInfoMap = new Map(
+        Array.from(files.entries()).map(([uri, file]) => [
+          uri,
+          {
+            uri,
+            content: file.output,
+            languageId: "pli",
+          },
+        ]),
+      );
+
+      const fs = new VirtualFileSystemProvider();
+      lspClient = new TestLspClient(fileInfoMap, fs);
+
+      serverAdapter = new LspServerAdapter(testBuilder, lspClient);
+    }
+    return serverAdapter;
+  }
+
+  async function cleanup() {
+    if (lspClient) {
+      await lspClient.shutdown();
+      lspClient = undefined;
+      serverAdapter = undefined;
+    }
+  }
+
   return {
     Syntax: SyntaxKind,
     testAPI: {
@@ -151,5 +188,94 @@ export function createTestBuilderHarnessImplementation(
     },
     code: HarnessCodes,
     constants: HarnessConstants,
+
+    // Server mode: Routes requests through a running LSP server
+    server: {
+      cleanup: cleanup,
+      verify: {
+        expectErrorCodesAt: async (label, codes) =>
+          getServerAdapter().expectErrorCodesAt(label.toString(), codes),
+        expectDiagnosticsAt: async (label, diagnostics) =>
+          getServerAdapter().expectDiagnosticsAt(label.toString(), diagnostics),
+        noDiagnostics: async (label, ...errorCodes: PLICode[]) =>
+          getServerAdapter().noDiagnostics(label?.toString(), ...errorCodes),
+      },
+      hover: {
+        expectMarkdownAt: async (label, markdown) =>
+          getServerAdapter().expectHover(label.toString(), {
+            kind: MarkupKind.Markdown,
+            value: markdown,
+          }),
+        expectTextAt: async (label, text) =>
+          getServerAdapter().expectHover(label.toString(), {
+            kind: MarkupKind.PlainText,
+            value: text,
+          }),
+      },
+      completion: {
+        expectAt: async (label, expected) =>
+          getServerAdapter().expectCompletionAt(label.toString(), expected),
+      },
+      linker: {
+        expectLinks: async () => getServerAdapter().expectLinks(),
+        expectNoLinksAt: async (label) =>
+          getServerAdapter().expectNoLinksAt(label.toString()),
+      },
+      semanticTokens: {
+        expectAt: async (label, tokenType, ...tokenModifiers) =>
+          getServerAdapter().expectSemanticTokenTypeAt(
+            label.toString(),
+            tokenType,
+            ...tokenModifiers,
+          ),
+      },
+      signatureHelp: {
+        expectMarkdownSignatureAt: async (label, markdown) =>
+          getServerAdapter().expectMarkdownSignatureAt(
+            label.toString(),
+            markdown,
+          ),
+      },
+      references: {
+        expectAt: async (label, expectedCount) =>
+          getServerAdapter().expectReferences(label.toString(), expectedCount),
+      },
+      documentHighlight: {
+        expectAt: async (label, expectedCount) =>
+          getServerAdapter().expectDocumentHighlight(
+            label.toString(),
+            expectedCount,
+          ),
+      },
+      rename: {
+        expectAt: async (label, newName) =>
+          getServerAdapter().expectRename(label.toString(), newName),
+      },
+      documentSymbols: {
+        expectSymbols: async (
+          filenameOrSymbols: string | string[],
+          expectedSymbols?: string[],
+        ) =>
+          getServerAdapter().expectDocumentSymbols(
+            filenameOrSymbols,
+            expectedSymbols,
+          ),
+      },
+      workspaceSymbols: {
+        expectSymbols: async (query, expectedSymbols) =>
+          getServerAdapter().expectWorkspaceSymbols(query, expectedSymbols),
+      },
+      codeActions: {
+        expectAt: async (label, kind, expectedCount) =>
+          getServerAdapter().expectCodeActions(
+            label.toString(),
+            kind,
+            expectedCount,
+          ),
+        getAt: async (label, kind) =>
+          getServerAdapter().getCodeActionsAt(label.toString(), kind),
+        apply: async (action) => getServerAdapter().applyCodeAction(action),
+      },
+    },
   };
 }

--- a/packages/language/test/fourslash/framework.ts
+++ b/packages/language/test/fourslash/framework.ts
@@ -24,4 +24,5 @@ declare global {
   var preprocessor: HarnessTesterInterface["preprocessor"];
   var code: HarnessTesterInterface["code"];
   var constants: HarnessTesterInterface["constants"];
+  var server: HarnessTesterInterface["server"];
 }

--- a/packages/language/test/fourslash/server/lsp-code-actions-ambiguous.ts
+++ b/packages/language/test/fourslash/server/lsp-code-actions-ambiguous.ts
@@ -1,0 +1,46 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+//// TEST: PROC OPTIONS(MAIN);
+////   DCL P BIN FIXED;
+////   DCL 1 X,
+////         2 Y1,
+////           3 <|decl1:Z|> FIXED,
+////         2 Y2,
+////           3 <|decl2:Z|> FIXED,
+////         2 Y3 (P REFER(<|ambiguous:Z|>));
+//// END TEST;
+
+// Test 1: Verify that ambiguous reference diagnostic is present (TestBuilder state)
+verify.expectDiagnosticsAt("ambiguous", code.Severe.IBM1881I);
+
+// Test 2: No diagnostics at the declaration sites (TestBuilder state)
+verify.noDiagnostics("decl1", code.Severe.IBM1881I);
+verify.noDiagnostics("decl2", code.Severe.IBM1881I);
+
+// Test 3: Verify code actions are available for ambiguous reference via LSP
+// The IBM1881I diagnostic (ambiguous reference) should provide 2 quickfix actions
+const actions = await server.codeActions.expectAt("ambiguous", "quickfix", 2);
+
+if (actions.length > 0) {
+  // Apply the first suggested fix (e.g., "Change to Y1.Z")
+  await server.codeActions.apply(actions[0]);
+
+  // Verify the ambiguous reference diagnostic is now gone via LSP server
+  // This uses server.verify which checks the LSP server state after the code action
+  await server.verify.noDiagnostics("ambiguous", code.Severe.IBM1881I);
+} else {
+  throw new Error(
+    "Expected code actions for ambiguous reference, but none were found.",
+  );
+}

--- a/packages/language/test/fourslash/server/lsp-code-actions-cross-file.ts
+++ b/packages/language/test/fourslash/server/lsp-code-actions-cross-file.ts
@@ -1,0 +1,55 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @filename: helper.pli
+//// HELPER: PROC;
+////   DCL RESULT FIXED BIN(31);
+////   RESULT = 42;
+////   RETURN;
+//// END HELPER;
+
+// @filename: main.pli
+//// %INCLUDE HELPER;
+////
+//// MAIN: PROC OPTIONS(MAIN);
+////   DCL P BIN FIXED;
+////   DCL 1 X,
+////         2 Y1,
+////           3 <|z_decl1:Z|> FIXED,
+////         2 Y2,
+////           3 <|z_decl2:Z|> FIXED,
+////         2 Y3 (P REFER(<|ambiguous:Z|>));
+////
+////   CALL HELPER;
+//// END MAIN;
+
+// Test 1: Verify ambiguous reference diagnostic in main.pli
+verify.expectDiagnosticsAt("ambiguous", code.Severe.IBM1881I);
+
+// Test 2: No diagnostics at declaration sites
+verify.noDiagnostics("z_decl1", code.Severe.IBM1881I);
+verify.noDiagnostics("z_decl2", code.Severe.IBM1881I);
+
+// Test 3: Verify linker works across files
+linker.expectLinks();
+
+// Test 4: Code actions work in multi-file context
+// Even though helper.pli is loaded, code actions in main.pli should work correctly
+const actions = await server.codeActions.getAt("ambiguous", "quickfix");
+if (actions.length > 0) {
+  // Apply the code action to fix the ambiguous reference in main.pli
+  await server.codeActions.apply(actions[0]);
+
+  // Verify the diagnostic is removed in main.pli via LSP server
+  await server.verify.noDiagnostics("ambiguous", code.Severe.IBM1881I);
+}

--- a/packages/language/test/fourslash/server/lsp-code-actions.ts
+++ b/packages/language/test/fourslash/server/lsp-code-actions.ts
@@ -1,0 +1,30 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+//// MAIN: PROC OPTIONS(MAIN);
+////   DCL <|VAR1|> FIXED;
+////   DCL <|VAR2|> FIXED;
+////   VAR1 = 100;
+////   VAR2 = 200;
+////   PUT SKIP LIST(VAR1, VAR2);
+//// END MAIN;
+
+// Test 1: Code action endpoint responds to requests
+// The endpoint should respond successfully even if no code actions are available
+await server.codeActions.expectAt("VAR1");
+await server.codeActions.expectAt("VAR2");
+
+// Test 2: Code action endpoint responds to source action requests
+// This exercises the source action branch in connection-handler.ts.
+await server.codeActions.expectAt("VAR1", "source.fixAll", 0);
+await server.codeActions.expectAt("VAR2", "source.fixAll", 0);

--- a/packages/language/test/fourslash/server/lsp-features-extended.ts
+++ b/packages/language/test/fourslash/server/lsp-features-extended.ts
@@ -1,0 +1,38 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+//// TESTPROG: PROC OPTIONS(MAIN);
+////   DCL <|X>X FIXED BIN(31);
+////   DCL Y FIXED BIN(31);
+////
+////   X = 10;
+////   <|Y>Y = X + 5;
+////   PUT SKIP LIST(X, Y);
+////
+////   CALL <|SUB>SUB_PROC(X);
+//// END TESTPROG;
+////
+//// SUB_PROC: PROC(PARAM);
+////   DCL PARAM FIXED BIN(31);
+////   PUT SKIP LIST('Parameter:', PARAM);
+//// END SUB_PROC;
+
+// Test 1: References via textDocument/references
+// Find all references to variable X
+await server.references.expectAt("X", 5); // DCL (2 tokens), assignment, expression, PUT LIST
+
+// Test 2: Document Highlight via textDocument/documentHighlight
+await server.documentHighlight.expectAt("Y", 3); // DCL, assignment, PUT LIST
+
+// Test 3: Rename via textDocument/rename
+await server.rename.expectAt("SUB", "MY_SUBROUTINE");

--- a/packages/language/test/fourslash/server/lsp-integration.ts
+++ b/packages/language/test/fourslash/server/lsp-integration.ts
@@ -1,0 +1,67 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+//// TESTPROC: PROC (A, B) OPTIONS(MAIN);
+////   DCL <|1:X|> FIXED BIN(31);
+////   DCL <|2:Y|> CHAR(10);
+////   DCL <|3>A FIXED BIN(31);
+////   DCL B CHAR(20);
+////
+////   /* Hover test: X should show declaration */
+////   PUT(<|hover>X);
+////
+////   /* Completion test: should complete variable names */
+////   PUT(<|complete>);
+////
+////   /* Definition test: link from X to its declaration */
+////   <|defLink>X = 42;
+////
+////   /* Signature help test */
+////   CALL SUBSTR(<|sig>);
+////
+//// END TESTPROC;
+
+// Test 1: Diagnostics via textDocument/publishDiagnostics
+await server.verify.noDiagnostics();
+
+// Test 2: Hover via textDocument/hover
+const expectedHoverMarkdown = hover.codeBlock(
+  "DCL X FIXED BINARY PRECISION(31);",
+);
+await server.hover.expectMarkdownAt("hover", expectedHoverMarkdown);
+
+// Test 3: Completion via textDocument/completion
+await server.completion.expectAt("complete", {
+  includes: ["X", "Y", "A", "B"],
+});
+
+// Test 4: Definition links via textDocument/definition
+await server.linker.expectLinks();
+
+// Test 5: Semantic tokens via textDocument/semanticTokens/full
+await server.semanticTokens.expectAt("1", "variable");
+
+// Test 6: Signature help via textDocument/signatureHelp
+const expectedSignatureDoc = `SUBSTR returns a substring, specified by \`y\` and \`z\`, of
+\`x\`.
+
+The STRINGRANGE condition is raised if \`z\` is negative or if
+the values of \`y\` and \`z\` are such that the substring does
+not lie entirely within the current length of \`x\`. It is not
+raised when \`y\` = LENGTH(\`x\`)+1 and \`z\` = 0. For an
+example of the SUBSTR built-in function, see SEARCH.
+`;
+await server.signatureHelp.expectMarkdownSignatureAt(
+  "sig",
+  expectedSignatureDoc,
+);

--- a/packages/language/test/fourslash/server/lsp-symbols-multifile.ts
+++ b/packages/language/test/fourslash/server/lsp-symbols-multifile.ts
@@ -1,0 +1,64 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @filename: file1.pli
+//// FILE1_MAIN: PROC OPTIONS(MAIN);
+////   DCL FILE1_VAR FIXED BIN(31);
+////   FILE1_VAR = 100;
+////   CALL FILE1_HELPER;
+//// END FILE1_MAIN;
+////
+//// FILE1_HELPER: PROC;
+////   PUT SKIP LIST('Helper from file1');
+//// END FILE1_HELPER;
+
+// @filename: file2.pli
+//// FILE2_MAIN: PROC OPTIONS(MAIN);
+////   DCL FILE2_VAR FIXED BIN(31);
+////   FILE2_VAR = 200;
+////   CALL FILE2_HELPER;
+//// END FILE2_MAIN;
+////
+//// FILE2_HELPER: PROC;
+////   PUT SKIP LIST('Helper from file2');
+//// END FILE2_HELPER;
+
+// Test 1: Document symbols from file1.pli should only return symbols from that file
+await server.documentSymbols.expectSymbols("file1.pli", [
+  "FILE1_MAIN",
+  "FILE1_HELPER",
+]);
+
+// Test 2: Document symbols from file2.pli should only return symbols from that file
+await server.documentSymbols.expectSymbols("file2.pli", [
+  "FILE2_MAIN",
+  "FILE2_HELPER",
+]);
+
+// Test 3: Workspace symbols searches across ALL files
+await server.workspaceSymbols.expectSymbols("HELPER", [
+  "FILE1_HELPER",
+  "FILE2_HELPER",
+]);
+
+// Test 4: Workspace symbols can find file-specific procedures
+await server.workspaceSymbols.expectSymbols("FILE1", [
+  "FILE1_MAIN",
+  "FILE1_HELPER",
+]);
+
+// Test 5: Workspace symbols can find file-specific procedures
+await server.workspaceSymbols.expectSymbols("FILE2", [
+  "FILE2_MAIN",
+  "FILE2_HELPER",
+]);

--- a/packages/language/test/fourslash/server/lsp-symbols.ts
+++ b/packages/language/test/fourslash/server/lsp-symbols.ts
@@ -1,0 +1,64 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+//// MAINPROG: PROC OPTIONS(MAIN);
+////   DCL GLOBAL_VAR FIXED BIN(31);
+////   DCL LOCAL_STRING CHAR(50);
+////
+////   GLOBAL_VAR = 100;
+////   LOCAL_STRING = 'Test Program';
+////
+////   CALL HELPER_PROC(GLOBAL_VAR);
+////
+////   PUT SKIP LIST('Done:', GLOBAL_VAR);
+//// END MAINPROG;
+////
+//// HELPER_PROC: PROC(INPUT_PARAM);
+////   DCL INPUT_PARAM FIXED BIN(31);
+////   DCL HELPER_LOCAL FIXED BIN(31);
+////
+////   HELPER_LOCAL = INPUT_PARAM * 2;
+////   PUT SKIP LIST('Helper:', HELPER_LOCAL);
+//// END HELPER_PROC;
+////
+//// UTILITY_FUNC: PROC(X, Y) RETURNS(FIXED BIN(31));
+////   DCL X FIXED BIN(31);
+////   DCL Y FIXED BIN(31);
+////   DCL RESULT FIXED BIN(31);
+////
+////   RESULT = X + Y;
+////   RETURN(RESULT);
+//// END UTILITY_FUNC;
+
+// Test 1: Document Symbols - get all symbols in the current document
+await server.documentSymbols.expectSymbols([
+  "MAINPROG",
+  "HELPER_PROC",
+  "UTILITY_FUNC",
+]);
+
+// Test 2: Document Symbols - explicitly query for a specific file
+await server.documentSymbols.expectSymbols("main.pli", [
+  "MAINPROG",
+  "HELPER_PROC",
+  "UTILITY_FUNC",
+]);
+
+// Test 3: Workspace Symbols - search for procedure names
+await server.workspaceSymbols.expectSymbols("PROC", ["HELPER_PROC"]);
+
+// Test 4: Workspace Symbols - search for specific variable
+await server.workspaceSymbols.expectSymbols("GLOBAL_VAR", ["GLOBAL_VAR"]);
+
+// Test 5: Workspace Symbols - search for function names
+await server.workspaceSymbols.expectSymbols("FUNC", ["UTILITY_FUNC"]);

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -306,6 +306,10 @@ export class TestBuilder {
     }
   }
 
+  public getFiles(): Map<string, TestFile> {
+    return this.files;
+  }
+
   /**
    * Create a test builder that does not validate the PL/I text after linking.
    *
@@ -722,7 +726,7 @@ Available code actions for label "${label}" and URI "${uri}": ${codeActions.map(
     );
   }
 
-  private getMatchingDiagnostics(label: string): MatchingDiagnosticsResult {
+  public getMatchingDiagnostics(label: string): MatchingDiagnosticsResult {
     const ranges = this.ranges[label];
     if (!ranges || ranges.length === 0) {
       throw new Error(`Label "${label}" not found`);
@@ -1086,11 +1090,11 @@ Available code actions for label "${label}" and URI "${uri}": ${codeActions.map(
 
   /**
    * Get the positions of a label
-   * @param label - The label to get the positions for
+   * @param label - The label to get the positions of
    * @returns The positions of the label
    * @throws If the label is not found
    */
-  private getLabelPositions(label: string): TestIndex[] {
+  public getLabelPositions(label: string): TestIndex[] {
     const indices = this.indices[label];
     if (!indices) {
       throw new Error(`Label "${label}" not found`);
@@ -1578,12 +1582,12 @@ Available code actions for label "${label}" and URI "${uri}": ${codeActions.map(
     }
   }
 
-  private createLabelPositionMessage(label: string): string {
+  public createLabelPositionMessage(label: string): string {
     const { uri, offset } = this.getLabelPosition(label);
     return this.createPositionMessage(offset, uri);
   }
 
-  private getLabelRanges(label: string): TestRange[] {
+  public getLabelRanges(label: string): TestRange[] {
     const ranges = this.ranges[label];
     if (!ranges || ranges.length === 0) {
       throw new Error(`Label "${label}" not found`);

--- a/packages/language/test/test-builder/lsp-client.ts
+++ b/packages/language/test/test-builder/lsp-client.ts
@@ -1,0 +1,483 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import {
+  Connection,
+  CompletionParams,
+  DefinitionParams,
+  HoverParams,
+  InitializeParams,
+  PublishDiagnosticsParams,
+  ReferenceParams,
+  SemanticTokensParams,
+  SignatureHelpParams,
+  DocumentHighlightParams,
+  RenameParams,
+  DocumentSymbolParams,
+  WorkspaceSymbolParams,
+  CodeActionParams,
+  ExecuteCommandParams,
+} from "vscode-languageserver/node";
+import {
+  CompletionItem,
+  Diagnostic,
+  Hover,
+  Location,
+  LocationLink,
+  Position,
+  SemanticTokens,
+  SignatureHelp,
+  TextDocumentItem,
+  DocumentHighlight,
+  WorkspaceEdit,
+  DocumentSymbol,
+  SymbolInformation,
+  CodeAction,
+  Command,
+} from "vscode-languageserver-types";
+import { createTestConnection } from "./lsp-connection";
+import { startLanguageServer } from "../../src/language-server/connection-handler";
+import { FileSystemProvider } from "../../src/workspace/file-system-provider";
+
+export interface TestFileInfo {
+  uri: string;
+  content: string;
+  languageId?: string;
+}
+
+export class TestLspClient {
+  private connection: Connection;
+  private serverConnection: Connection;
+  private dispose: () => void;
+  private diagnosticsByUri = new Map<string, Diagnostic[]>();
+  private initializePromise: Promise<void>;
+
+  constructor(files: Map<string, TestFileInfo>, fs: FileSystemProvider) {
+    const { clientConnection, serverConnection, dispose } =
+      createTestConnection();
+    this.connection = clientConnection;
+    this.serverConnection = serverConnection;
+    this.dispose = dispose;
+
+    this.connection.onNotification(
+      "textDocument/publishDiagnostics",
+      (params: PublishDiagnosticsParams) => {
+        this.diagnosticsByUri.set(params.uri, params.diagnostics);
+      },
+    );
+
+    startLanguageServer(this.serverConnection, fs);
+
+    this.connection.listen();
+
+    this.initializePromise = this.initialize(files);
+  }
+
+  private async initialize(files: Map<string, TestFileInfo>): Promise<void> {
+    const initParams: InitializeParams = {
+      processId: process.pid,
+      rootUri: null,
+      capabilities: {
+        textDocument: {
+          hover: {
+            contentFormat: ["markdown", "plaintext"],
+          },
+          completion: {
+            completionItem: {
+              snippetSupport: false,
+            },
+          },
+          signatureHelp: {
+            signatureInformation: {
+              documentationFormat: ["markdown", "plaintext"],
+            },
+          },
+          semanticTokens: {
+            requests: {
+              full: true,
+            },
+            tokenTypes: [],
+            tokenModifiers: [],
+            formats: ["relative"],
+          },
+        },
+      },
+      workspaceFolders: null,
+    };
+
+    await this.connection.sendRequest("initialize", initParams);
+
+    await this.connection.sendNotification("initialized", {});
+
+    for (const [uri, fileInfo] of files) {
+      await this.didOpen(uri, fileInfo.content, fileInfo.languageId);
+    }
+  }
+
+  async ensureInitialized(): Promise<void> {
+    await this.initializePromise;
+  }
+
+  async didOpen(
+    uri: string,
+    content: string,
+    languageId: string = "pli",
+  ): Promise<void> {
+    const textDocument: TextDocumentItem = {
+      uri,
+      languageId,
+      version: 1,
+      text: content,
+    };
+
+    await this.connection.sendNotification("textDocument/didOpen", {
+      textDocument,
+    });
+
+    // Wait for diagnostics to be published
+    await this.waitForDiagnostics(uri);
+  }
+
+  /**
+   * Waits for diagnostics to be published and stable for a URI.
+   * Waits until diagnostics are published, then waits a bit more to ensure they're stable.
+   */
+  private async waitForDiagnostics(
+    uri: string,
+    timeoutMs: number = 1000,
+  ): Promise<void> {
+    const startTime = Date.now();
+    let delay = 5; // Start with 5ms
+    let lastChangeTime: number | undefined;
+    let lastDiagnosticCount = -1;
+    let hasSeenDiagnostics = false;
+
+    while (Date.now() - startTime < timeoutMs) {
+      const currentDiagnostics = this.diagnosticsByUri.get(uri);
+      const currentCount = currentDiagnostics?.length ?? -1;
+
+      // Track if we've seen any diagnostics publication
+      if (!hasSeenDiagnostics && this.diagnosticsByUri.has(uri)) {
+        hasSeenDiagnostics = true;
+      }
+
+      // Check if diagnostics have changed
+      if (currentCount !== lastDiagnosticCount) {
+        lastDiagnosticCount = currentCount;
+        lastChangeTime = Date.now();
+      }
+
+      // If we've seen diagnostics and they've been stable for 50ms, consider them final
+      if (
+        hasSeenDiagnostics &&
+        lastChangeTime &&
+        Date.now() - lastChangeTime >= 50
+      ) {
+        return;
+      }
+
+      // Wait with exponential backoff
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      delay = Math.min(delay * 2, 50); // Cap at 50ms
+    }
+
+    // Timeout reached - diagnostics may legitimately be empty or still changing
+  }
+
+  async didChange(uri: string, content: string): Promise<void> {
+    await this.connection.sendNotification("textDocument/didChange", {
+      textDocument: {
+        uri,
+        version: 1,
+      },
+      contentChanges: [{ text: content }],
+    });
+
+    // Wait for updated diagnostics to be published
+    await this.waitForDiagnostics(uri);
+  }
+
+  async didClose(uri: string): Promise<void> {
+    await this.connection.sendNotification("textDocument/didClose", {
+      textDocument: { uri },
+    });
+  }
+
+  async hover(uri: string, position: Position): Promise<Hover | null> {
+    await this.ensureInitialized();
+
+    const params: HoverParams = {
+      textDocument: { uri },
+      position,
+    };
+
+    return this.connection.sendRequest("textDocument/hover", params);
+  }
+
+  async completion(uri: string, position: Position): Promise<CompletionItem[]> {
+    await this.ensureInitialized();
+
+    const params: CompletionParams = {
+      textDocument: { uri },
+      position,
+    };
+
+    const result = await this.connection.sendRequest(
+      "textDocument/completion",
+      params,
+    );
+
+    // Handle both CompletionItem[] and CompletionList responses
+    if (Array.isArray(result)) {
+      return result as CompletionItem[];
+    } else if (result && typeof result === "object" && "items" in result) {
+      return (result as { items: CompletionItem[] }).items;
+    }
+    return [];
+  }
+
+  async definition(
+    uri: string,
+    position: Position,
+  ): Promise<(Location | LocationLink)[]> {
+    await this.ensureInitialized();
+
+    const params: DefinitionParams = {
+      textDocument: { uri },
+      position,
+    };
+
+    const result = await this.connection.sendRequest(
+      "textDocument/definition",
+      params,
+    );
+
+    if (!result) {
+      return [];
+    }
+
+    return Array.isArray(result)
+      ? (result as (Location | LocationLink)[])
+      : [result as Location | LocationLink];
+  }
+
+  async references(
+    uri: string,
+    position: Position,
+    includeDeclaration: boolean = true,
+  ): Promise<Location[]> {
+    await this.ensureInitialized();
+
+    const params: ReferenceParams = {
+      textDocument: { uri },
+      position,
+      context: { includeDeclaration },
+    };
+
+    const result = await this.connection.sendRequest(
+      "textDocument/references",
+      params,
+    );
+
+    return (result as Location[] | null) ?? [];
+  }
+
+  async semanticTokens(uri: string): Promise<SemanticTokens | null> {
+    await this.ensureInitialized();
+
+    const params: SemanticTokensParams = {
+      textDocument: { uri },
+    };
+
+    return this.connection.sendRequest(
+      "textDocument/semanticTokens/full",
+      params,
+    );
+  }
+
+  async signatureHelp(
+    uri: string,
+    position: Position,
+  ): Promise<SignatureHelp | null> {
+    await this.ensureInitialized();
+
+    const params: SignatureHelpParams = {
+      textDocument: { uri },
+      position,
+    };
+
+    return this.connection.sendRequest("textDocument/signatureHelp", params);
+  }
+
+  async documentHighlight(
+    uri: string,
+    position: Position,
+  ): Promise<DocumentHighlight[]> {
+    await this.ensureInitialized();
+
+    const params: DocumentHighlightParams = {
+      textDocument: { uri },
+      position,
+    };
+
+    const result = await this.connection.sendRequest(
+      "textDocument/documentHighlight",
+      params,
+    );
+
+    return (result as DocumentHighlight[] | null) ?? [];
+  }
+
+  async rename(
+    uri: string,
+    position: Position,
+    newName: string,
+  ): Promise<WorkspaceEdit | null> {
+    await this.ensureInitialized();
+
+    const params: RenameParams = {
+      textDocument: { uri },
+      position,
+      newName,
+    };
+
+    return this.connection.sendRequest("textDocument/rename", params);
+  }
+
+  async documentSymbol(
+    uri: string,
+  ): Promise<(DocumentSymbol | SymbolInformation)[]> {
+    await this.ensureInitialized();
+
+    const params: DocumentSymbolParams = {
+      textDocument: { uri },
+    };
+
+    const result = await this.connection.sendRequest(
+      "textDocument/documentSymbol",
+      params,
+    );
+
+    return (result as (DocumentSymbol | SymbolInformation)[] | null) ?? [];
+  }
+
+  async workspaceSymbol(query: string): Promise<SymbolInformation[]> {
+    await this.ensureInitialized();
+
+    const params: WorkspaceSymbolParams = {
+      query,
+    };
+
+    const result = await this.connection.sendRequest(
+      "workspace/symbol",
+      params,
+    );
+
+    return (result as SymbolInformation[] | null) ?? [];
+  }
+
+  async codeAction(
+    uri: string,
+    range: { start: Position; end: Position },
+    diagnostics: Diagnostic[] = [],
+    only?: string[],
+  ): Promise<(CodeAction | Command)[]> {
+    await this.ensureInitialized();
+
+    const params: CodeActionParams = {
+      textDocument: { uri },
+      range,
+      context: {
+        diagnostics,
+        only,
+      },
+    };
+
+    const result = await this.connection.sendRequest(
+      "textDocument/codeAction",
+      params,
+    );
+
+    return (result as (CodeAction | Command)[] | null) ?? [];
+  }
+
+  async executeCommand(command: string, args?: any[]): Promise<any> {
+    await this.ensureInitialized();
+
+    const params: ExecuteCommandParams = {
+      command,
+      arguments: args,
+    };
+
+    return this.connection.sendRequest("workspace/executeCommand", params);
+  }
+
+  async applyCodeAction(action: CodeAction | Command): Promise<void> {
+    await this.ensureInitialized();
+
+    // Check if it's a Command (has 'command' as string property)
+    if (
+      typeof (action as Command).command === "string" &&
+      !(action as CodeAction).edit
+    ) {
+      const command = action as Command;
+      await this.executeCommand(command.command, command.arguments);
+      return;
+    }
+
+    // Otherwise, it's a CodeAction with an edit
+    const codeAction = action as CodeAction;
+    if (codeAction.edit?.changes) {
+      const affectedUris: string[] = [];
+
+      // Apply the workspace edit by sending didChange notifications
+      for (const [uri, edits] of Object.entries(codeAction.edit.changes)) {
+        affectedUris.push(uri);
+
+        // Send didChange notification with the edits
+        await this.connection.sendNotification("textDocument/didChange", {
+          textDocument: {
+            uri,
+            version: 1,
+          },
+          contentChanges: edits.map((edit) => ({
+            range: edit.range,
+            text: edit.newText,
+          })),
+        });
+      }
+
+      // Wait for diagnostics to be republished for all affected files
+      for (const uri of affectedUris) {
+        await this.waitForDiagnostics(uri);
+      }
+    }
+  }
+
+  getDiagnostics(uri: string): Diagnostic[] {
+    return this.diagnosticsByUri.get(uri) ?? [];
+  }
+
+  getAllDiagnostics(): Map<string, Diagnostic[]> {
+    return new Map(this.diagnosticsByUri);
+  }
+
+  async shutdown(): Promise<void> {
+    try {
+      await this.connection.sendRequest("shutdown");
+      await this.connection.sendNotification("exit");
+    } catch (error) {
+      // Ignore errors during shutdown
+    } finally {
+      this.dispose();
+    }
+  }
+}

--- a/packages/language/test/test-builder/lsp-connection.ts
+++ b/packages/language/test/test-builder/lsp-connection.ts
@@ -1,0 +1,53 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { PassThrough } from "stream";
+import {
+  createConnection,
+  Connection,
+  StreamMessageReader,
+  StreamMessageWriter,
+} from "vscode-languageserver/node";
+
+export interface TestConnectionPair {
+  serverConnection: Connection;
+  clientConnection: Connection;
+  dispose: () => void;
+}
+
+export function createTestConnection(): TestConnectionPair {
+  const clientToServer = new PassThrough();
+  const serverToClient = new PassThrough();
+
+  const serverConnection = createConnection(
+    new StreamMessageReader(clientToServer),
+    new StreamMessageWriter(serverToClient),
+  );
+
+  const clientConnection = createConnection(
+    new StreamMessageReader(serverToClient),
+    new StreamMessageWriter(clientToServer),
+  );
+
+  const dispose = () => {
+    serverConnection.dispose();
+    clientConnection.dispose();
+
+    clientToServer.end();
+    serverToClient.end();
+  };
+
+  return {
+    serverConnection,
+    clientConnection,
+    dispose,
+  };
+}

--- a/packages/language/test/test-builder/lsp-server-adapter.ts
+++ b/packages/language/test/test-builder/lsp-server-adapter.ts
@@ -1,0 +1,676 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import {
+  TestBuilder,
+  DiagnosticExpectation,
+  ExpectedCompletion,
+} from "../test-builder";
+import { TestLspClient } from "./lsp-client";
+import { MarkupContent, Position } from "vscode-languageserver";
+import { expect } from "vitest";
+import { isPLICode, PLICode } from "../../src/validation/pli-codes";
+import { fullCode } from "../../src/language-server/types";
+import { Diagnostic, CodeAction, Command } from "vscode-languageserver-types";
+import { SemanticTokenDecoder } from "../../src/language-server/semantic-token-decoder";
+import {
+  SemanticTokenModifiersValues,
+  SemanticTokenTypesValues,
+} from "../fourslash-harness/harness-interface";
+import { TestRange } from "../test-builder";
+
+/**
+ * LSP Server Adapter for testing language server via LSP protocol.
+ * Delegates to TestBuilder for fourslash parsing and label/position resolution,
+ * but calls the LSP client for all language server operations instead of
+ * calling functions directly.
+ *
+ * This enables testing the full LSP stack including connection-handler.ts
+ * and message serialization/deserialization.
+ */
+export class LspServerAdapter {
+  constructor(
+    private testBuilder: TestBuilder,
+    private lspClient: TestLspClient,
+  ) {}
+
+  private offsetToPosition(uri: string, offset: number): Position {
+    const file = this.testBuilder.getFiles().get(uri);
+    if (!file) {
+      throw new Error(`File not found: ${uri}`);
+    }
+    return file.textDocument.positionAt(offset);
+  }
+
+  private positionToOffset(uri: string, position: Position): number {
+    const file = this.testBuilder.getFiles().get(uri);
+    if (!file) {
+      throw new Error(`File not found: ${uri}`);
+    }
+    return file.textDocument.offsetAt(position);
+  }
+
+  private lspRangeToOffsetRange(
+    uri: string,
+    lspRange: { start: Position; end: Position },
+  ): TestRange {
+    const start = this.positionToOffset(uri, lspRange.start);
+    const end = this.positionToOffset(uri, lspRange.end);
+    return { uri, start, end };
+  }
+
+  /**
+   * Expects hover content at the given label positions.
+   * Sends textDocument/hover requests to the LSP server.
+   *
+   * @param label Label to check hover at
+   * @param content Expected hover content
+   */
+  async expectHover(label: string, content: MarkupContent): Promise<void> {
+    // Reuse TestBuilder's label resolution
+    const indices = this.testBuilder.getLabelPositions(label);
+
+    for (const { uri, offset } of indices) {
+      // Reuse TestBuilder's position conversion
+      const position = this.offsetToPosition(uri, offset);
+
+      // Call LSP instead of direct function
+      const hoverResult = await this.lspClient.hover(uri, position);
+
+      // Same verification as TestBuilder
+      const message = `Expected hover for label "${label}" (${this.testBuilder.createLabelPositionMessage(label)})`;
+      expect(hoverResult, message).toBeDefined();
+      expect(hoverResult?.contents, message).toEqual(content);
+    }
+  }
+
+  /**
+   * Expects diagnostics at the given label.
+   * Uses diagnostics received via textDocument/publishDiagnostics notifications.
+   *
+   * @param label Label to check diagnostics at
+   * @param expected Expected diagnostics (can be codes, or full diagnostic objects)
+   */
+  async expectDiagnosticsAt(
+    label: string,
+    expected: DiagnosticExpectation,
+  ): Promise<void> {
+    const ranges = this.testBuilder.getLabelRanges(label);
+
+    // Normalize expected to array of test diagnostics
+    const expectedDiagnostics = this.normalizeDiagnosticExpectation(expected);
+
+    for (const range of ranges) {
+      const { uri, start, end } = range;
+
+      // Get diagnostics from LSP client (received via notifications)
+      const allDiagnostics = this.lspClient.getDiagnostics(uri);
+
+      // Convert LSP diagnostics to offset-based ranges for matching
+      const lspDiagnosticsWithOffsets = allDiagnostics.map((d) => ({
+        ...d,
+        offsetRange: this.lspRangeToOffsetRange(uri, d.range),
+      }));
+
+      // Find exact matches: diagnostics that exactly match the label range
+      const exactMatches = lspDiagnosticsWithOffsets.filter(
+        (d) => d.offsetRange.start === start && d.offsetRange.end === end,
+      );
+
+      // Match diagnostics against expectations
+      this.matchDiagnostics(exactMatches, expectedDiagnostics, label);
+    }
+  }
+
+  /**
+   * Expects error codes at the given label.
+   *
+   * @param label Label to check error codes at
+   * @param codes Expected error codes
+   */
+  async expectErrorCodesAt(
+    label: string,
+    codes: string | string[] | PLICode | PLICode[],
+  ): Promise<void> {
+    const codesArray = Array.isArray(codes) ? codes : [codes];
+    const diagnostics = codesArray.map((code) => ({
+      code: typeof code === "string" ? code : fullCode(code),
+    }));
+    await this.expectDiagnosticsAt(label, diagnostics);
+  }
+
+  /**
+   * Expects no diagnostics at the given label, optionally excluding specific error codes.
+   *
+   * @param label Label to check (if undefined, checks entire file)
+   * @param errorCodes Error codes to exclude from the check
+   */
+  async noDiagnostics(label?: string, ...errorCodes: PLICode[]): Promise<void> {
+    if (label) {
+      const ranges = this.testBuilder.getLabelRanges(label);
+      for (const range of ranges) {
+        const { uri, start, end } = range;
+        const allDiagnostics = this.lspClient.getDiagnostics(uri);
+
+        // Convert and filter diagnostics
+        const matchingDiagnostics = allDiagnostics
+          .map((d) => ({
+            ...d,
+            offsetRange: this.lspRangeToOffsetRange(uri, d.range),
+          }))
+          .filter(
+            (d) => d.offsetRange.start === start && d.offsetRange.end === end,
+          )
+          .filter((d) => {
+            // Filter to only the specified error codes (if any provided)
+            if (errorCodes.length === 0) return true;
+            const code = d.code?.toString() ?? "";
+            return errorCodes.some((ec) => code === fullCode(ec));
+          });
+
+        const message = `Expected no diagnostics at label "${label}"`;
+        expect(matchingDiagnostics, message).toEqual([]);
+      }
+    } else {
+      // Check all diagnostics across all files
+      const allDiagnostics = this.lspClient.getAllDiagnostics();
+      for (const [uri, diagnostics] of allDiagnostics) {
+        const filtered = diagnostics.filter((d) => {
+          if (errorCodes.length === 0) return true;
+          const code = d.code?.toString() ?? "";
+          return errorCodes.some((ec) => code === fullCode(ec));
+        });
+        expect(filtered, `Expected no diagnostics in ${uri}`).toEqual([]);
+      }
+    }
+  }
+
+  /**
+   * Expects completion items at the given label.
+   *
+   * @param label Label to check completion at
+   * @param expected Expected completion configuration
+   */
+  async expectCompletionAt(
+    label: string,
+    expected: ExpectedCompletion,
+  ): Promise<void> {
+    const indices = this.testBuilder.getLabelPositions(label);
+
+    for (const { uri, offset } of indices) {
+      const position = this.offsetToPosition(uri, offset);
+      const completionItems = await this.lspClient.completion(uri, position);
+
+      const labels = completionItems.map((item) => item.label);
+      const message = `Expected completion at label "${label}"`;
+
+      if (expected.includes) {
+        for (const include of expected.includes) {
+          expect(labels, message).toContain(include);
+        }
+      }
+
+      if (expected.excludes) {
+        for (const exclude of expected.excludes) {
+          expect(labels, message).not.toContain(exclude);
+        }
+      }
+    }
+  }
+
+  /**
+   * Expects definition links from the label positions.
+   * Sends textDocument/definition requests to the LSP server.
+   */
+  async expectLinks(): Promise<void> {
+    const files = this.testBuilder.getFiles();
+
+    for (const [uri, file] of files) {
+      // Get all labeled indices for this file
+      for (const [_label, indices] of Object.entries(file.indices)) {
+        for (const { offset } of indices) {
+          const position = this.offsetToPosition(uri, offset);
+          const definitions = await this.lspClient.definition(uri, position);
+
+          // For links, we just verify that definitions were found
+          // (matching exact targets would require more complex test setup)
+          if (definitions.length > 0) {
+            // Link found - this is what we expect
+            continue;
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Expects no definition links at the given label.
+   *
+   * @param label Label to check for absence of links
+   */
+  async expectNoLinksAt(label: string): Promise<void> {
+    const indices = this.testBuilder.getLabelPositions(label);
+
+    for (const { uri, offset } of indices) {
+      const position = this.offsetToPosition(uri, offset);
+      const definitions = await this.lspClient.definition(uri, position);
+
+      const message = `Expected no links at label "${label}"`;
+      expect(definitions, message).toEqual([]);
+    }
+  }
+
+  /**
+   * Expects semantic tokens at the given label.
+   *
+   * @param label Label to check semantic tokens at
+   * @param tokenType Expected token type
+   * @param tokenModifiers Expected token modifiers
+   */
+  async expectSemanticTokenTypeAt(
+    label: string,
+    tokenType: SemanticTokenTypesValues,
+    ...tokenModifiers: SemanticTokenModifiersValues[]
+  ): Promise<void> {
+    const ranges = this.testBuilder.getLabelRanges(label);
+
+    for (const range of ranges) {
+      const { uri, start, end } = range;
+
+      // Get semantic tokens for the document
+      const semanticTokensResult = await this.lspClient.semanticTokens(uri);
+      expect(
+        semanticTokensResult,
+        `Expected semantic tokens for ${uri}`,
+      ).not.toBeNull();
+
+      if (!semanticTokensResult) continue;
+
+      // Decode semantic tokens
+      const file = this.testBuilder.getFiles().get(uri);
+      if (!file) continue;
+
+      const decodedTokens = SemanticTokenDecoder.decode(
+        semanticTokensResult.data,
+        file.textDocument,
+      );
+
+      // Find token that overlaps with the range
+      const matchingTokens = decodedTokens.filter((token) => {
+        return token.offsetStart >= start && token.offsetEnd <= end;
+      });
+
+      const message = `Expected semantic token at label "${label}"`;
+      expect(matchingTokens.length, message).toBeGreaterThan(0);
+
+      for (const token of matchingTokens) {
+        expect(token.semanticTokenType, message).toBe(tokenType);
+        if (tokenModifiers.length > 0) {
+          for (const modifier of tokenModifiers) {
+            expect(token.tokenModifiers, message).toContain(modifier);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Expects signature help at the given label.
+   *
+   * @param label Label to check signature help at
+   * @param markdown Expected markdown content
+   */
+  async expectMarkdownSignatureAt(
+    label: string,
+    markdown: string,
+  ): Promise<void> {
+    const indices = this.testBuilder.getLabelPositions(label);
+
+    for (const { uri, offset } of indices) {
+      const position = this.offsetToPosition(uri, offset);
+      const signatureHelp = await this.lspClient.signatureHelp(uri, position);
+
+      const message = `Expected signature help at label "${label}"`;
+      expect(signatureHelp, message).not.toBeNull();
+      expect(signatureHelp!.signatures.length, message).toBeGreaterThan(0);
+
+      const activeSignature =
+        signatureHelp!.signatures[signatureHelp!.activeSignature ?? 0];
+      expect(activeSignature.documentation, message).toBeDefined();
+
+      const doc = activeSignature.documentation as MarkupContent;
+      expect(doc.kind, message).toBe("markdown");
+      expect(doc.value, message).toBe(markdown);
+    }
+  }
+
+  /**
+   * Normalizes diagnostic expectations to a consistent format.
+   */
+  private normalizeDiagnosticExpectation(
+    expected: DiagnosticExpectation,
+  ): Array<Partial<Diagnostic> & { message?: string | RegExp }> {
+    const expectedArray = Array.isArray(expected) ? expected : [expected];
+
+    return expectedArray.map((exp) => {
+      if (isPLICode(exp)) {
+        return { code: fullCode(exp) };
+      }
+      return exp as Partial<Diagnostic> & { message?: string | RegExp };
+    });
+  }
+
+  /**
+   * Matches actual diagnostics against expected diagnostics.
+   */
+  private matchDiagnostics(
+    actual: Diagnostic[],
+    expected: Array<Partial<Diagnostic> & { message?: string | RegExp }>,
+    label: string,
+  ): void {
+    const message = `Expected diagnostics at label "${label}"`;
+
+    expect(actual.length, message).toBe(expected.length);
+
+    for (let i = 0; i < expected.length; i++) {
+      const exp = expected[i];
+      const act = actual[i];
+
+      if (exp.code !== undefined) {
+        expect(act.code, message).toBe(exp.code);
+      }
+
+      if (exp.message !== undefined) {
+        if (typeof exp.message === "object" && "test" in exp.message) {
+          // It's a RegExp
+          expect(act.message, message).toMatch(exp.message as RegExp);
+        } else {
+          expect(act.message, message).toBe(exp.message);
+        }
+      }
+
+      if (exp.severity !== undefined) {
+        expect(act.severity, message).toBe(exp.severity);
+      }
+
+      if (exp.source !== undefined) {
+        expect(act.source, message).toBe(exp.source);
+      }
+    }
+  }
+
+  /**
+   * Expects references at the given label.
+   *
+   * @param label Label to check references at
+   * @param expectedCount Expected number of references (or undefined for any)
+   */
+  async expectReferences(label: string, expectedCount?: number): Promise<void> {
+    const indices = this.testBuilder.getLabelPositions(label);
+
+    for (const { uri, offset } of indices) {
+      const position = this.offsetToPosition(uri, offset);
+      const references = await this.lspClient.references(uri, position, true);
+
+      const message = `Expected references at label "${label}"`;
+      if (expectedCount !== undefined) {
+        expect(references.length, message).toBe(expectedCount);
+      } else {
+        expect(references.length, message).toBeGreaterThan(0);
+      }
+    }
+  }
+
+  /**
+   * Expects document highlights at the given label.
+   *
+   * @param label Label to check highlights at
+   * @param expectedCount Expected number of highlights (or undefined for any)
+   */
+  async expectDocumentHighlight(
+    label: string,
+    expectedCount?: number,
+  ): Promise<void> {
+    const indices = this.testBuilder.getLabelPositions(label);
+
+    for (const { uri, offset } of indices) {
+      const position = this.offsetToPosition(uri, offset);
+      const highlights = await this.lspClient.documentHighlight(uri, position);
+
+      const message = `Expected document highlights at label "${label}"`;
+      if (expectedCount !== undefined) {
+        expect(highlights.length, message).toBe(expectedCount);
+      } else {
+        expect(highlights.length, message).toBeGreaterThan(0);
+      }
+    }
+  }
+
+  /**
+   * Expects rename to work at the given label.
+   *
+   * @param label Label to check rename at
+   * @param newName New name for the symbol
+   */
+  async expectRename(label: string, newName: string): Promise<void> {
+    const indices = this.testBuilder.getLabelPositions(label);
+
+    for (const { uri, offset } of indices) {
+      const position = this.offsetToPosition(uri, offset);
+      const workspaceEdit = await this.lspClient.rename(uri, position, newName);
+
+      const message = `Expected rename at label "${label}"`;
+      expect(workspaceEdit, message).not.toBeNull();
+      expect(workspaceEdit?.changes, message).toBeDefined();
+
+      // Verify that at least one change was generated
+      const changeCount = Object.values(workspaceEdit?.changes ?? {}).reduce(
+        (sum, edits) => sum + edits.length,
+        0,
+      );
+      expect(changeCount, message).toBeGreaterThan(0);
+    }
+  }
+
+  /**
+   * Expects document symbols in a specific file.
+   *
+   * @param filename Optional filename (e.g., "main.pli"). If not provided, uses the first file.
+   * @param expectedSymbols Expected symbol names (partial match)
+   */
+  async expectDocumentSymbols(
+    filenameOrSymbols: string | string[],
+    expectedSymbols?: string[],
+  ): Promise<void> {
+    const files = this.testBuilder.getFiles();
+
+    let targetUri: string;
+    let symbols: string[];
+
+    if (Array.isArray(filenameOrSymbols)) {
+      // First overload: just expectedSymbols, use first file
+      const firstUri = Array.from(files.keys())[0];
+      if (!firstUri) {
+        throw new Error("No files found in test builder");
+      }
+      targetUri = firstUri;
+      symbols = filenameOrSymbols;
+    } else {
+      // Second overload: (filename, expectedSymbols)
+      if (!expectedSymbols) {
+        throw new Error(
+          "expectedSymbols is required when filename is provided",
+        );
+      }
+      const filename = filenameOrSymbols;
+
+      // Find URI that matches the filename
+      const matchingUri = Array.from(files.keys()).find(
+        (uri) => uri.endsWith(filename) || uri.endsWith(`/${filename}`),
+      );
+
+      if (!matchingUri) {
+        const availableFiles = Array.from(files.keys()).join(", ");
+        throw new Error(
+          `File "${filename}" not found in test. Available files: ${availableFiles}`,
+        );
+      }
+
+      targetUri = matchingUri;
+      symbols = expectedSymbols;
+    }
+
+    const documentSymbols = await this.lspClient.documentSymbol(targetUri);
+
+    // Both DocumentSymbol and SymbolInformation have a 'name' property
+    const symbolNames = documentSymbols.map((s) => s.name);
+
+    const message = `Expected document symbols in ${targetUri}, got: ${symbolNames.join(", ")}`;
+    for (const expectedSymbol of symbols) {
+      expect(symbolNames, message).toContain(expectedSymbol);
+    }
+  }
+
+  /**
+   * Expects workspace symbols.
+   *
+   * @param query Search query
+   * @param expectedSymbols Expected symbol names (partial match)
+   */
+  async expectWorkspaceSymbols(
+    query: string,
+    expectedSymbols: string[],
+  ): Promise<void> {
+    const symbols = await this.lspClient.workspaceSymbol(query);
+
+    const symbolNames = symbols.map((s) => s.name);
+
+    const message = `Expected workspace symbols for query "${query}"`;
+    for (const expectedSymbol of expectedSymbols) {
+      expect(symbolNames, message).toContain(expectedSymbol);
+    }
+  }
+
+  /**
+   * Expects code actions at the given label.
+   *
+   * @param label Label to check code actions at
+   * @param kind Kind of code actions to request (e.g., "quickfix", "source")
+   * @param expectedCount Expected number of code actions (or undefined for any)
+   */
+  async expectCodeActions(
+    label: string,
+    kind?: string,
+    expectedCount?: number,
+  ): Promise<(CodeAction | Command)[]> {
+    // Ensure LSP client is fully initialized before expecting code actions
+    await this.lspClient.ensureInitialized();
+
+    const ranges = this.testBuilder.getLabelRanges(label);
+
+    if (ranges.length === 0) {
+      return [];
+    }
+
+    // Process first range and return its actions
+    const range = ranges[0];
+    const { uri, start, end } = range;
+    const startPos = this.offsetToPosition(uri, start);
+    const endPos = this.offsetToPosition(uri, end);
+
+    // Get diagnostics at this range if requesting quickfix
+    const diagnostics =
+      kind === "quickfix"
+        ? this.lspClient.getDiagnostics(uri).filter((d) => {
+            const diagRange = this.lspRangeToOffsetRange(uri, d.range);
+            return diagRange.start === start && diagRange.end === end;
+          })
+        : [];
+
+    const only = kind ? [kind] : undefined;
+    const codeActions = await this.lspClient.codeAction(
+      uri,
+      { start: startPos, end: endPos },
+      diagnostics,
+      only,
+    );
+
+    const message = `Expected code actions at label "${label}"`;
+    if (expectedCount !== undefined) {
+      expect(codeActions.length, message).toBe(expectedCount);
+    } else if (kind) {
+      // If requesting specific kind, expect at least one
+      expect(codeActions.length, message).toBeGreaterThan(0);
+    }
+
+    return codeActions;
+  }
+
+  /**
+   * Gets code actions at a label position.
+   * Returns the code actions for the first matching range.
+   *
+   * @param label Label to get code actions at
+   * @param kind Optional kind filter (e.g., "quickfix", "source.fixAll")
+   * @returns Code actions at the label
+   */
+  async getCodeActionsAt(
+    label: string,
+    kind?: string,
+  ): Promise<(CodeAction | Command)[]> {
+    // Ensure LSP client is fully initialized before getting code actions
+    await this.lspClient.ensureInitialized();
+
+    const ranges = this.testBuilder.getLabelRanges(label);
+    if (ranges.length === 0) {
+      return [];
+    }
+
+    const range = ranges[0]; // Get first range
+    const { uri, start, end } = range;
+    const startPos = this.offsetToPosition(uri, start);
+    const endPos = this.offsetToPosition(uri, end);
+
+    // Get diagnostics at this range if requesting quickfix
+    const allDiags = this.lspClient.getDiagnostics(uri);
+    const diagnostics =
+      kind === "quickfix"
+        ? allDiags.filter((d) => {
+            const diagRange = this.lspRangeToOffsetRange(uri, d.range);
+            return diagRange.start === start && diagRange.end === end;
+          })
+        : [];
+
+    const only = kind ? [kind] : undefined;
+    return await this.lspClient.codeAction(
+      uri,
+      { start: startPos, end: endPos },
+      diagnostics,
+      only,
+    );
+  }
+
+  /**
+   * Applies a code action.
+   *
+   * @param action Code action to apply
+   */
+  async applyCodeAction(action: CodeAction | Command): Promise<void> {
+    await this.lspClient.applyCodeAction(action);
+  }
+
+  /**
+   * Shuts down the LSP client and cleans up resources.
+   */
+  async dispose(): Promise<void> {
+    await this.lspClient.shutdown();
+  }
+}


### PR DESCRIPTION
This is the branch where I experimented with integrating the LS into the fourslash framework some time ago, mainly to address coverage concerns as mentioned in https://github.com/zowe/zowe-pli-language-support/pull/720. 
Following the recent changes to the test framework, the implementation would need some additional polishing.
For now, I am sharing it so that we can discuss the approach internally and decide whether it is worth pursuing further.

The core idea is probably best illustrated by [`packages/language/test/fourslash/server/lsp-code-actions-ambiguous.ts`](https://github.com/zowe/zowe-pli-language-support/pull/737/changes#diff-c018d4a883b069b5122b3805c63eea95d3368f80639cff5cc2e8d9be079c9fd1).
Essentially, the fourslash interface gains a new `server` category whose commands are routed through the LS, while keeping the changes to the `test-builder` relatively small.
On the branch, I experimented with a broad range of requests, but for an initial adoption we could focus on specific use cases, such as code actions. 

Feel free to ping me if you'd like to discuss it further.