### PR TITLE
Show proper preview URL

### DIFF
--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -54,6 +54,7 @@ jobs:
 
       - name: Deploy or remove PR preview
         uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 #v1.8.1
+        id: deployment
         with:
           source-dir: ./packages/playground/out
           preview-branch: previews


### PR DESCRIPTION
I noticed that the PR comment left by the bot currently contains a link to the PR and not its preview. This fixes this by attaching the correct ID to the deployment step, so that `steps.deployment.outputs.deployment-url` evaluates correctly.