### PR TITLE
Support member calls in call statement

### DIFF
--- a/packages/language/src/language-server/semantic-tokens.ts
+++ b/packages/language/src/language-server/semantic-tokens.ts
@@ -282,7 +282,6 @@ function isProcedureKind(container: SyntaxNode | null | undefined): boolean {
 
 function isProcedureType(token: Token): boolean {
   switch (token.kind) {
-    case CstNodeKind.ProcedureCall_ProcedureRef:
     case CstNodeKind.Exports_Procedure:
       return true;
     case CstNodeKind.LabelPrefix_Name:

--- a/packages/language/src/language-server/signature-help-request.ts
+++ b/packages/language/src/language-server/signature-help-request.ts
@@ -14,7 +14,6 @@ import type { SignatureHelp } from "vscode-languageserver";
 import { CompilationUnit } from "../workspace/compilation-unit";
 import { binaryTokenIndexRightMost } from "../utils/search";
 import {
-  CallStatement,
   getContainer,
   LabelPrefix,
   MemberCall,
@@ -26,7 +25,6 @@ import { extractDeclaration } from "../typesystem/stringify";
 import { getJSDocCommentBeforeLabelPrefix } from "./hover-request";
 import { retrieveProcedureFromLabelPrefix } from "../validation/utils";
 import { Token } from "../parser/tokens";
-import { assertType } from "../preprocessor/util";
 import { takeWhile } from "lodash-es";
 import { isJSDocParagraph } from "../documentation/jsdoc";
 import { TypeDescriptions } from "../typesystem/descriptions";
@@ -137,33 +135,10 @@ function tryGetCallInfo(
     return null;
   }
   const memberCall = getContainer(token.element, SyntaxKind.MemberCall);
-  const callStatement = getContainer(token.element, SyntaxKind.CallStatement);
-  if (!memberCall && !callStatement) {
+  if (!memberCall) {
     return null;
   }
-  if (memberCall && memberCall.element && !callStatement) {
-    return getCallInfoFromMemberCall(memberCall, offset, unit);
-  }
-  if (callStatement && callStatement.call && !memberCall) {
-    return getCallInfoFromReferenceItem(callStatement.call, offset, unit);
-  }
-  assertType<MemberCall>(memberCall);
-  assertType<CallStatement>(callStatement);
-  if (memberCall.element === null || callStatement.call === null) {
-    return null;
-  }
-  const callStatementOffset = callStatement.call?.ref?.token.startOffset;
-  const memberCallOffset = memberCall.element?.ref?.token.startOffset;
-  if (callStatementOffset === undefined || memberCallOffset === undefined) {
-    return null;
-  }
-  if (callStatementOffset < memberCallOffset) {
-    const help = getCallInfoFromMemberCall(memberCall, offset, unit);
-    return help && help.argumentIndex !== null
-      ? help
-      : getCallInfoFromReferenceItem(callStatement.call, offset, unit);
-  }
-  return null;
+  return getCallInfoFromMemberCall(memberCall, offset, unit);
 }
 
 function getCallInfoFromMemberCall(

--- a/packages/language/src/linking/tokens.ts
+++ b/packages/language/src/linking/tokens.ts
@@ -60,7 +60,6 @@ export function isReferenceToken(kind: CstNodeKind | undefined): boolean {
     case CstNodeKind.TypeAttribute_TypeId1:
     case CstNodeKind.HandleAttribute_TypeId0:
     case CstNodeKind.HandleAttribute_TypeId1:
-    case CstNodeKind.ProcedureCall_ProcedureRef:
     case CstNodeKind.LabelReference_LabelRef:
     case CstNodeKind.ReferenceItem_Ref:
     case CstNodeKind.Exports_Procedure:

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -1297,7 +1297,7 @@ const callStatement = rule(
   (state: ParserState): ast.CallStatement => {
     const element = ast.createCallStatement();
     state.consume(element, CstNodeKind.CallStatement_CALL, tokens.CALL);
-    element.call = referenceItem.rule(state);
+    element.call = locatorCall.rule(state);
     state.consume(
       element,
       CstNodeKind.CallStatement_Semicolon,

--- a/packages/language/src/parser/preprocessor-parser.ts
+++ b/packages/language/src/parser/preprocessor-parser.ts
@@ -349,22 +349,7 @@ function performRecovery(
 function callStatement(state: ParserState): ast.CallStatement {
   const statement = ast.createCallStatement();
   state.consume(statement, CstNodeKind.CallStatement_CALL, t.CALL);
-  const nameToken = state.consume(
-    statement,
-    CstNodeKind.ProcedureCall_ProcedureRef,
-    t.ID,
-  );
-  statement.call = ast.createReferenceItem();
-  if (nameToken) {
-    statement.call.ref = ast.createReference(
-      statement,
-      nameToken,
-      ast.ReferenceType.Variable,
-    );
-  }
-  while (state.canConsume(t.OpenParen)) {
-    statement.call.dimensions.push(dimensions(state));
-  }
+  statement.call = locatorCall(state, true);
   state.consume(statement, CstNodeKind.CallStatement_Semicolon, t.Semicolon);
   return statement;
 }

--- a/packages/language/src/preprocessor/instruction-generator.ts
+++ b/packages/language/src/preprocessor/instruction-generator.ts
@@ -244,13 +244,14 @@ function generateCallInstruction(
   node: ast.CallStatement,
   context: GenerateInstructionContext,
 ): inst.CallInstruction | undefined {
-  if (!node.call?.ref?.text) {
+  const referenceItem = node.call?.element?.element;
+  if (!referenceItem?.ref?.text) {
     return undefined; // No procedure to call
   }
-  if (node.call.dimensions.length !== 1) {
+  if (referenceItem.dimensions.length !== 1) {
     return undefined; // Only support one dimension for CALL statements
   }
-  const args = (node.call.dimensions[0].dimensions ?? []).map((arg) => {
+  const args = (referenceItem.dimensions[0].dimensions ?? []).map((arg) => {
     assertType<ast.Expression>(arg.upper?.expression);
     return (
       generateExpressionInstruction(arg.upper.expression) ??
@@ -259,7 +260,7 @@ function generateCallInstruction(
   });
   return {
     kind: inst.InstructionKind.Call,
-    procedureName: node.call.ref.text,
+    procedureName: referenceItem.ref.text,
     args,
     node,
   };

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -1469,7 +1469,7 @@ export function createBound(): Bound {
 }
 export interface CallStatement extends AstNode {
   kind: SyntaxKind.CallStatement;
-  call: ReferenceItem | null;
+  call: LocatorCall | null;
 }
 
 export function createCallStatement(): CallStatement {

--- a/packages/language/src/syntax-tree/cst.ts
+++ b/packages/language/src/syntax-tree/cst.ts
@@ -678,7 +678,6 @@ export enum CstNodeKind {
   MemberCall_Dot,
   LocatorCall_Pointer,
   LocatorCall_Handle,
-  ProcedureCall_ProcedureRef,
   ProcedureCallArgs_OpenParen,
   ProcedureCallArgs_Star0,
   ProcedureCallArgs_Comma,

--- a/packages/language/src/validation/compiler/IBM3970-IBM3971-call-procedure.ts
+++ b/packages/language/src/validation/compiler/IBM3970-IBM3971-call-procedure.ts
@@ -19,7 +19,8 @@ export function IBM3970IS_IBM3971IS_check_pp_call_procedure(
   acceptor: ValidationAcceptor,
 ): void {
   const procedure = resolveProcedureFromCall(node);
-  const callToken = node.call?.ref?.token;
+  const refItem = node.call?.element?.element;
+  const callToken = refItem?.ref?.token;
   if (!procedure || !callToken) {
     if (callToken) {
       acceptor(diagnosticFromCode(PLICodes.Severe.IBM3968I, callToken));

--- a/packages/language/src/validation/compiler/check-arguments.ts
+++ b/packages/language/src/validation/compiler/check-arguments.ts
@@ -34,12 +34,14 @@ export function CallStatement_checkArguments(
   if (!procedure) {
     return;
   }
-  const callToken = node.call!.ref!.token;
-  if (node.call?.dimensions.length !== 1) {
+  // We can assume that all of these are set if the procedure was resolved
+  const refItem = node.call!.element!.element!;
+  const callToken = refItem.ref!.token;
+  if (refItem.dimensions.length !== 1) {
     return;
   }
   const providedTypes =
-    node.call?.dimensions[0].dimensions.map((d) => {
+    refItem.dimensions[0].dimensions.map((d) => {
       return unit.services.inferer.inferType(d, unit);
     }) ?? [];
   checkArguments(

--- a/packages/language/src/validation/utils.ts
+++ b/packages/language/src/validation/utils.ts
@@ -31,14 +31,14 @@ export function compareIdentifiers<T extends string>(lhs: T, rhs: T) {
 export function resolveProcedureFromCall(
   node: CallStatement,
 ): ProcedureStatement | null {
-  if (!node.call?.ref?.node) {
+  const target = node.call?.element?.element?.ref?.node;
+  if (!target) {
     return null;
   }
-  const labelPrefix = node.call.ref.node;
-  if (!labelPrefix || labelPrefix.kind !== SyntaxKind.LabelPrefix) {
+  if (!target || target.kind !== SyntaxKind.LabelPrefix) {
     return null;
   }
-  return retrieveProcedureFromLabelPrefix(labelPrefix);
+  return retrieveProcedureFromLabelPrefix(target);
 }
 
 /**

--- a/packages/language/test/fourslash/parser/membercall-call-statement.ts
+++ b/packages/language/test/fourslash/parser/membercall-call-statement.ts
@@ -1,0 +1,31 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// DEFINE ALIAS llst_remover ENTRY(PTR INONLY) VARIABLE LIMITED;
+//// DEFINE STRUCTURE
+////   1 llst,
+////     3 head PTR ,
+////     3 remove_el TYPE llst_remover;
+//// DEFINE STRUCTURE
+////  1 llst_el,
+////    3 next PTR ,
+////    3 prev PTR ,
+////    3 el_data PTR;
+//// DCL (llst_p, el_p) PTR;
+//// DCL el TYPE llst_el BASED(el_p);
+//// DCL llst TYPE llst BASED (llst_p);
+//// CALL llst.remove_el(el.el_data);
+
+verify.noParserDiagnostics();
+verify.noLinkingDiagnostics();


### PR DESCRIPTION
Closes https://github.com/zowe/zowe-pli-language-support/issues/703

Simply changes the type of `CallStatement#call` to be `LocatorCall` instead of `ReferenceItem`. This also simplifies a lot of other code :)