### PR TITLE
Add exec statements in macro preprocessor

### DIFF
--- a/packages/language/src/parser/parser-entry.ts
+++ b/packages/language/src/parser/parser-entry.ts
@@ -14,12 +14,13 @@ import * as ast from "../syntax-tree/ast";
 import * as t from "./tokens";
 import { recursivelySetContainer } from "../linking/symbol-table";
 import { Diagnostic } from "../language-server/types";
+import { TextDocument } from "vscode-languageserver-textdocument";
 import {
   consumeTokenStatement,
   includeAltStatement,
+  parseExecStatement,
   statement,
 } from "./preprocessor-parser";
-import { execStatement } from "./exec-parser";
 import {
   isSqlAttributeStatement,
   sqlAttributeStatement,
@@ -29,7 +30,6 @@ import {
   isCicsResponseStatement,
 } from "./cics-response-parser";
 import { CompilerOptions } from "../preprocessor/compiler-options/options";
-import { TextDocument } from "vscode-languageserver-textdocument";
 
 export type PreprocessorParserResult = {
   statements: ast.Statement[];
@@ -45,19 +45,22 @@ export type PreprocessorParserResult = {
  */
 type StatementParser = (
   state: ParserState,
-  textDocument: TextDocument,
 ) => Promise<ast.Statement | null | undefined>;
 
-function createPreprocessorHandler(): StatementParser {
+function createPreprocessorHandler(
+  textDocument: TextDocument,
+): StatementParser {
   return async (state) => {
     if (state.token?.tokenTypeIdx !== t.Percent.tokenTypeIdx) {
       return undefined; // Not a preprocessor statement
     }
-    return statement(state);
+    return await statement(state, textDocument);
   };
 }
 
-function createIncOnlyPreprocessorHandler(): StatementParser {
+function createIncOnlyPreprocessorHandler(
+  textDocument: TextDocument,
+): StatementParser {
   return async (state) => {
     // If it is not a preprocessor statement and also not an include alternate,
     // return undefined to let other handlers process it.
@@ -75,7 +78,7 @@ function createIncOnlyPreprocessorHandler(): StatementParser {
         nextToken.tokenTypeIdx === t.INSCAN.tokenTypeIdx);
     if (isInclude) {
       // Only process include statements.
-      return statement(state);
+      return await statement(state, textDocument);
     }
 
     return undefined;
@@ -124,8 +127,8 @@ function createCicsResponseHandler(): StatementParser {
   };
 }
 
-function createExecHandler(): StatementParser {
-  return async (state, textDocument) => {
+function createExecHandler(textDocument: TextDocument): StatementParser {
+  return async (state) => {
     if (state.token?.tokenTypeIdx !== t.EXEC.tokenTypeIdx) {
       return undefined;
     }
@@ -133,47 +136,28 @@ function createExecHandler(): StatementParser {
   };
 }
 
-async function parseExecStatement(
-  state: ParserState,
-  textDocument: TextDocument,
-): Promise<ast.Statement | undefined> {
-  const statement = ast.createStatement();
-  if (state.canConsume(t.EXEC, t.ExecFragment)) {
-    const nextToken = state.peek(2);
-    if (/^(\w+)\b/i.test(nextToken?.image || "")) {
-      statement.value = await execStatement(state, textDocument);
-    } else {
-      // Unrecognized EXEC statement, treat as token statement
-      return undefined;
-    }
-  } else {
-    // Failure; fall back to token statement
-    return undefined;
-  }
-  return statement;
-}
-
 function generateStatementParser(
   compilerOptions: CompilerOptions | undefined,
+  textDocument: TextDocument,
 ): StatementParser {
   const handlers: StatementParser[] = [];
 
   const incOnly = compilerOptions?.macroOptions?.incOnly;
 
   if (incOnly) {
-    handlers.push(createIncOnlyPreprocessorHandler());
+    handlers.push(createIncOnlyPreprocessorHandler(textDocument));
   } else {
-    handlers.push(createPreprocessorHandler());
+    handlers.push(createPreprocessorHandler(textDocument));
   }
 
   handlers.push(createIncludeAltHandler());
   handlers.push(createSqlAttributeHandler());
   handlers.push(createCicsResponseHandler());
-  handlers.push(createExecHandler());
+  handlers.push(createExecHandler(textDocument));
 
-  return async (state, textDocument) => {
+  return async (state) => {
     for (const handler of handlers) {
-      const result = await handler(state, textDocument);
+      const result = await handler(state);
       if (result !== undefined) {
         return result;
       }
@@ -185,18 +169,20 @@ function generateStatementParser(
 export async function preprocessorParse(
   state: ParserState,
   textDocument: TextDocument,
-  compilerOptions?: CompilerOptions,
 ): Promise<PreprocessorParserResult> {
   const statements: ast.Statement[] = [];
 
-  const statementParser = generateStatementParser(compilerOptions);
+  const statementParser = generateStatementParser(
+    state.compilerOptions,
+    textDocument,
+  );
 
   let index = state.index;
   let token = state.token;
   while (token) {
     let stmt: ast.Statement | null = null;
 
-    const result = await statementParser(state, textDocument);
+    const result = await statementParser(state);
     if (result !== undefined) {
       stmt = result;
     } else {

--- a/packages/language/src/parser/parser-state.ts
+++ b/packages/language/src/parser/parser-state.ts
@@ -29,8 +29,7 @@ import {
 } from "../validation/pli-codes";
 import { tokenIdxToClass } from "./token-type-factory";
 import * as environment from "../workspace/environment";
-
-import { CompilerOptions } from "../preprocessor/compiler-options/options-pli";
+import { CompilerOptions } from "../preprocessor/compiler-options/options";
 
 export enum RecoveryResult {
   /**

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -35,7 +35,7 @@ import {
   performEndStatementLookahead,
 } from "./parser-lookahead";
 import { Token } from "./tokens";
-import { CompilerOptions } from "../preprocessor/compiler-options/options-pli";
+import { CompilerOptions } from "../preprocessor/compiler-options/options";
 
 export function parsePli(
   input: tokens.Token[],

--- a/packages/language/src/parser/preprocessor-parser.ts
+++ b/packages/language/src/parser/preprocessor-parser.ts
@@ -32,6 +32,8 @@ import {
 import { PLICodes } from "../validation/pli-codes";
 import { performAssignmentLookahead } from "./parser-lookahead";
 import { ExpressionParameter } from "./parser-types";
+import { execStatement } from "./exec-parser";
+import { TextDocument } from "vscode-languageserver-textdocument";
 
 const tokenEndSet = new Set(t.PPSignifier.map((tok) => tok.tokenTypeIdx!));
 
@@ -56,33 +58,45 @@ export function consumeTokenStatement(state: ParserState): ast.Statement {
   return statement;
 }
 
-export function statement(state: ParserState): ast.Statement | null;
 export function statement(
   state: ParserState,
+  textDocument: TextDocument,
+): Promise<ast.Statement | null>;
+export function statement(
+  state: ParserState,
+  textDocument: TextDocument,
   withEnd: true,
   endPercent: boolean,
-): ast.Statement | ast.EndStatement | null;
-export function statement(
+): Promise<ast.Statement | ast.EndStatement | null>;
+export async function statement(
   state: ParserState,
+  textDocument: TextDocument,
   withEnd?: true,
   endPercent?: boolean,
-): ast.Statement | ast.EndStatement | null {
+): Promise<ast.Statement | ast.EndStatement | null> {
   let end = withEnd ?? false;
   let endP = endPercent ?? false;
   if (!state.isInProcedure()) {
     if (state.tryConsume(undefined, CstNodeKind.Percentage, t.Percent)) {
-      return commonStatement(state, {
+      return await commonStatement(state, textDocument, {
         withEnd: end,
         endPercent: endP,
         startPercent: false, // Percent token already consumed
         labels: true,
       });
     } else {
+      // Try to parse EXEC CICS/SQL statement
+      if (state.token?.tokenTypeIdx === t.EXEC.tokenTypeIdx) {
+        const execStmt = await parseExecStatement(state, textDocument);
+        if (execStmt) {
+          return execStmt;
+        }
+      }
       return consumeTokenStatement(state);
     }
   } else {
     //state.isInProcedure()
-    return commonStatement(state, {
+    return await commonStatement(state, textDocument, {
       withEnd: end,
       endPercent: endP,
       startPercent: false, // Inside of a procedure, percent not required
@@ -125,16 +139,19 @@ interface StatementParseOptions {
 
 export function commonStatement(
   state: ParserState,
+  textDocument: TextDocument,
   options: StatementParseOptions & { withEnd: false },
-): ast.Statement | null;
+): Promise<ast.Statement | null>;
 export function commonStatement(
   state: ParserState,
+  textDocument: TextDocument,
   options: StatementParseOptions,
-): ast.Statement | ast.EndStatement | null;
-export function commonStatement(
+): Promise<ast.Statement | ast.EndStatement | null>;
+export async function commonStatement(
   state: ParserState,
+  textDocument: TextDocument,
   options: StatementParseOptions,
-): ast.Statement | ast.EndStatement | null {
+): Promise<ast.Statement | ast.EndStatement | null> {
   const statement = ast.createStatement();
   statement.startToken = state.token ?? null;
 
@@ -175,11 +192,19 @@ export function commonStatement(
         unit = declareStatement(state);
         break;
       case t.DO.tokenTypeIdx:
-        unit = doStatement(state);
+        unit = await doStatement(state, textDocument);
         break;
       case t.END.tokenTypeIdx:
         if (options.withEnd) {
           endStmt = endStatement(state, stmtLabels);
+        }
+        break;
+      case t.EXEC.tokenTypeIdx:
+        if (
+          state.canConsume(t.EXEC, t.ExecFragment) &&
+          hasNextWordToken(state)
+        ) {
+          unit = await execStatement(state, textDocument);
         }
         break;
       case t.GO.tokenTypeIdx:
@@ -187,7 +212,7 @@ export function commonStatement(
         unit = goToStatement(state);
         break;
       case t.IF.tokenTypeIdx:
-        unit = ifStatement(state);
+        unit = await ifStatement(state, textDocument);
         break;
       case t.ITERATE.tokenTypeIdx:
         unit = iterateStatement(state);
@@ -202,7 +227,7 @@ export function commonStatement(
         unit = returnStatement(state);
         break;
       case t.SELECT.tokenTypeIdx:
-        unit = selectStatement(state);
+        unit = await selectStatement(state, textDocument);
         break;
       case t.Semicolon.tokenTypeIdx:
         unit = nullStatement(state);
@@ -240,7 +265,7 @@ export function commonStatement(
         unit = noprintDirective(state);
         break;
       case t.DO.tokenTypeIdx:
-        unit = doStatement(state);
+        unit = await doStatement(state, textDocument);
         break;
       case t.GOTO.tokenTypeIdx:
       case t.GO.tokenTypeIdx:
@@ -250,7 +275,7 @@ export function commonStatement(
         unit = leaveStatement(state);
         break;
       case t.IF.tokenTypeIdx:
-        unit = ifStatement(state);
+        unit = await ifStatement(state, textDocument);
         break;
       case t.INCLUDE.tokenTypeIdx:
         unit = includeStatement(state);
@@ -267,7 +292,7 @@ export function commonStatement(
       case t.PROCEDURE.tokenTypeIdx:
         try {
           state.enterProcedure();
-          unit = procedureStatement(state);
+          unit = await procedureStatement(state, textDocument);
         } finally {
           state.leaveProcedure();
         }
@@ -279,7 +304,7 @@ export function commonStatement(
         unit = replaceStatement(state);
         break;
       case t.SELECT.tokenTypeIdx:
-        unit = selectStatement(state);
+        unit = await selectStatement(state, textDocument);
         break;
       case t.Semicolon.tokenTypeIdx:
         unit = nullStatement(state);
@@ -346,6 +371,29 @@ function performRecovery(
   return RecoveryResult.Continue;
 }
 
+export async function parseExecStatement(
+  state: ParserState,
+  textDocument: TextDocument,
+): Promise<ast.Statement | undefined> {
+  const statement = ast.createStatement();
+  if (!state.canConsume(t.EXEC, t.ExecFragment)) {
+    return undefined;
+  }
+
+  if (!hasNextWordToken(state)) {
+    // Not a valid EXEC statement
+    return undefined;
+  }
+
+  statement.value = await execStatement(state, textDocument);
+  return statement;
+}
+
+function hasNextWordToken(state: ParserState): boolean {
+  const nextToken = state.peek(2);
+  return !!nextToken && /^(\w+)\b/i.test(nextToken.image);
+}
+
 function callStatement(state: ParserState): ast.CallStatement {
   const statement = ast.createCallStatement();
   state.consume(statement, CstNodeKind.CallStatement_CALL, t.CALL);
@@ -354,7 +402,10 @@ function callStatement(state: ParserState): ast.CallStatement {
   return statement;
 }
 
-function procedureStatement(state: ParserState): ast.ProcedureStatement {
+async function procedureStatement(
+  state: ParserState,
+  textDocument: TextDocument,
+): Promise<ast.ProcedureStatement> {
   const statement = ast.createProcedureStatement();
   state.consume(
     statement,
@@ -454,7 +505,7 @@ function procedureStatement(state: ParserState): ast.ProcedureStatement {
     CstNodeKind.ProcedureStatement_Semicolon,
     t.Semicolon,
   );
-  const body = statements(state, true);
+  const body = await statements(state, textDocument, true);
   statement.statements = body.statements;
   statement.end = body.end;
   return statement;
@@ -849,7 +900,10 @@ function endStatement(
   return statement;
 }
 
-function doStatement(state: ParserState): ast.DoStatement {
+async function doStatement(
+  state: ParserState,
+  textDocument: TextDocument,
+): Promise<ast.DoStatement> {
   const statement = ast.createDoStatement();
   state.consume(statement, CstNodeKind.DoStatement_DO, t.DO);
 
@@ -858,14 +912,14 @@ function doStatement(state: ParserState): ast.DoStatement {
     state.consume(statement, CstNodeKind.DoStatement_SKIP, t.SKIP);
     state.consume(statement, CstNodeKind.DoStatement_Semicolon, t.Semicolon);
     statement.skip = true;
-    const body = statements(state);
+    const body = await statements(state, textDocument);
     statement.end = body.end;
     return statement;
   } else if (state.canConsume(t.WHILE)) {
     //type-2-do-while-first
     const type2 = doWhile(state);
     state.consume(statement, CstNodeKind.DoStatement_Semicolon, t.Semicolon);
-    const body = statements(state);
+    const body = await statements(state, textDocument);
     statement.doType2 = type2;
     statement.statements = body.statements;
     statement.end = body.end;
@@ -873,7 +927,7 @@ function doStatement(state: ParserState): ast.DoStatement {
     //type-2-do-until-first
     const type2 = doUntil(state);
     state.consume(statement, CstNodeKind.DoStatement_Semicolon, t.Semicolon);
-    const body = statements(state);
+    const body = await statements(state, textDocument);
     statement.doType2 = type2;
     statement.statements = body.statements;
     statement.end = body.end;
@@ -883,14 +937,14 @@ function doStatement(state: ParserState): ast.DoStatement {
     //type-4 loops
     statement.doType4 = true;
     state.consume(statement, CstNodeKind.DoStatement_Semicolon, t.Semicolon);
-    const body = statements(state);
+    const body = await statements(state, textDocument);
     statement.statements = body.statements;
     statement.end = body.end;
   } else if (state.canConsume(t.ID)) {
     // type-3-do
     const type3 = doType3(state);
     state.consume(statement, CstNodeKind.DoStatement_Semicolon, t.Semicolon);
-    const body = statements(state);
+    const body = await statements(state, textDocument);
     statement.doType3 = type3;
     statement.statements = body.statements;
     statement.end = body.end;
@@ -898,7 +952,7 @@ function doStatement(state: ParserState): ast.DoStatement {
     state.tryConsume(statement, CstNodeKind.DoStatement_Semicolon, t.Semicolon)
   ) {
     //type-1-do
-    const body = statements(state);
+    const body = await statements(state, textDocument);
     statement.statements = body.statements;
     statement.end = body.end;
   } else {
@@ -1016,12 +1070,16 @@ interface StatementList {
   end: ast.EndStatement | null;
 }
 
-function statements(state: ParserState, endWithPercent = false): StatementList {
+async function statements(
+  state: ParserState,
+  textDocument: TextDocument,
+  endWithPercent = false,
+): Promise<StatementList> {
   const statements: ast.Statement[] = [];
   let end: ast.EndStatement | null = null;
   while (!state.eof) {
     const startIndex = state.index;
-    const stmt = statement(state, true, endWithPercent);
+    const stmt = await statement(state, textDocument, true, endWithPercent);
     if (stmt) {
       if (stmt.kind === ast.SyntaxKind.EndStatement) {
         end = stmt;
@@ -1041,7 +1099,10 @@ function statements(state: ParserState, endWithPercent = false): StatementList {
   };
 }
 
-function selectStatement(state: ParserState): ast.SelectStatement {
+async function selectStatement(
+  state: ParserState,
+  textDocument: TextDocument,
+): Promise<ast.SelectStatement> {
   const statement = ast.createSelectStatement();
   statement.selectToken = state.consume(
     statement,
@@ -1064,10 +1125,10 @@ function selectStatement(state: ParserState): ast.SelectStatement {
   }
   state.consume(statement, CstNodeKind.SelectStatement_Semicolon, t.Semicolon);
   while (state.canPercentConsume(t.WHEN)) {
-    statement.cases.push(whenStatement(state));
+    statement.cases.push(await whenStatement(state, textDocument));
   }
   if (state.canPercentConsume(t.OTHERWISE)) {
-    statement.cases.push(otherwiseStatement(state));
+    statement.cases.push(await otherwiseStatement(state, textDocument));
   }
   if (!state.isInProcedure()) {
     // END statement is preceded by a percent
@@ -1077,7 +1138,10 @@ function selectStatement(state: ParserState): ast.SelectStatement {
   return statement;
 }
 
-function whenStatement(state: ParserState): ast.WhenStatement {
+async function whenStatement(
+  state: ParserState,
+  textDocument: TextDocument,
+): Promise<ast.WhenStatement> {
   const when = ast.createWhenStatement();
   state.percentConsume(when, CstNodeKind.WhenStatement_WHEN, t.WHEN);
   state.consume(when, CstNodeKind.WhenStatement_OpenParen, t.OpenParen);
@@ -1093,7 +1157,7 @@ function whenStatement(state: ParserState): ast.WhenStatement {
   }
   state.consume(when, CstNodeKind.WhenStatement_CloseParen, t.CloseParen);
   const rangeStart = state.token?.startOffset;
-  when.unit = statementAfterCase(state);
+  when.unit = await statementAfterCase(state, textDocument);
   if (rangeStart != undefined && state.last) {
     when.range = {
       start: rangeStart,
@@ -1103,7 +1167,10 @@ function whenStatement(state: ParserState): ast.WhenStatement {
   return when;
 }
 
-function otherwiseStatement(state: ParserState): ast.OtherwiseStatement {
+async function otherwiseStatement(
+  state: ParserState,
+  textDocument: TextDocument,
+): Promise<ast.OtherwiseStatement> {
   const otherwise = ast.createOtherwiseStatement();
   state.percentConsume(
     otherwise,
@@ -1111,7 +1178,7 @@ function otherwiseStatement(state: ParserState): ast.OtherwiseStatement {
     t.OTHERWISE,
   );
   const rangeStart = state.token?.startOffset;
-  otherwise.unit = statementAfterCase(state);
+  otherwise.unit = await statementAfterCase(state, textDocument);
   if (rangeStart != undefined && state.last) {
     otherwise.range = {
       start: rangeStart,
@@ -1127,7 +1194,10 @@ function nullStatement(state: ParserState): ast.NullStatement {
   return statement;
 }
 
-function ifStatement(state: ParserState): ast.IfStatement {
+async function ifStatement(
+  state: ParserState,
+  textDocument: TextDocument,
+): Promise<ast.IfStatement> {
   const ifStatement = ast.createIfStatement();
   state.consume(ifStatement, CstNodeKind.IfStatement_IF, t.IF);
   ifStatement.expression = expression(state);
@@ -1141,7 +1211,7 @@ function ifStatement(state: ParserState): ast.IfStatement {
     state.consume(ifStatement, CstNodeKind.IfStatement_THEN, t.THEN);
   }
   const unitRangeStart = state.token?.startOffset;
-  ifStatement.unit = statementAfterCase(state);
+  ifStatement.unit = await statementAfterCase(state, textDocument);
   if (unitRangeStart != undefined && state.last) {
     ifStatement.unitRange = {
       start: unitRangeStart,
@@ -1151,7 +1221,7 @@ function ifStatement(state: ParserState): ast.IfStatement {
   if (state.canPercentConsume(t.ELSE)) {
     state.percentConsume(ifStatement, CstNodeKind.IfStatement_ELSE, t.ELSE);
     const elseRangeStart = state.token?.startOffset;
-    ifStatement.else = statementAfterCase(state);
+    ifStatement.else = await statementAfterCase(state, textDocument);
     if (elseRangeStart != undefined && state.last) {
       ifStatement.elseRange = {
         start: elseRangeStart,
@@ -1164,8 +1234,11 @@ function ifStatement(state: ParserState): ast.IfStatement {
 
 // Statement used after IF, WHEN and OTHERWISE clauses
 // Has special semantics that uses an optional starting percent and prohibits labels
-function statementAfterCase(state: ParserState): ast.Statement | null {
-  return commonStatement(state, {
+async function statementAfterCase(
+  state: ParserState,
+  textDocument: TextDocument,
+): Promise<ast.Statement | null> {
+  return await commonStatement(state, textDocument, {
     withEnd: false,
     endPercent: false,
     startPercent: true, // Can optionally start with a percent

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2452,12 +2452,11 @@ async function runInclude(
             context.unit.services.workspace,
           );
         const tokenizeResult = tokenize(processedContent, uri);
-        const subState = new ParserState(tokenizeResult.tokens);
-        const subProgram = await preprocessorParse(
-          subState,
-          document,
+        const subState = new ParserState(
+          tokenizeResult.tokens,
           context.options.compilerOptions?.options,
         );
+        const subProgram = await preprocessorParse(subState, document);
         subProgram.diagnostics.push(...tokenizeResult.diagnostics);
         const result = generateInstructions(subProgram.statements);
         return {

--- a/packages/language/src/preprocessor/pli-lexer.ts
+++ b/packages/language/src/preprocessor/pli-lexer.ts
@@ -80,12 +80,11 @@ export class PliLexer {
           unit.services.workspace,
         );
         const tokenizeResult = tokenize(textWithoutMargins, uri);
-        const state = new ParserState(tokenizeResult.tokens);
+        const state = new ParserState(tokenizeResult.tokens, opts);
         // Do a full parsing of the input text to extract all *local* statements
         const { statements, diagnostics } = await preprocessorParse(
           state,
           document,
-          opts,
         );
         const result = generateInstructions(statements);
         diagnostics.push(...tokenizeResult.diagnostics);

--- a/packages/language/test/fourslash/preprocessor/cics/exec-in-macro-do.ts
+++ b/packages/language/test/fourslash/preprocessor/cics/exec-in-macro-do.ts
@@ -1,0 +1,73 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// TEST: PROC;
+////   %DO;
+////     EXEC CICS ABEND ABCODE('$CAN');
+////   %END;
+//// END;
+
+// EXEC CICS inside a %DO block should be recognized and processed,
+// generating CICS declarations and replacing the statement with DO; END;
+preprocessor.expectTokens(`
+TEST: PROC;
+    DCL 
+      1 DFHCNSTS STATIC,
+        2 DFHLDVER CHAR(22) INIT('LD TABLE DFHEITAB 730.'),
+        2 DFHEIB0 FIXED BIN(15) INIT(0),
+        2 DFHEID0 FIXED DEC(7) INIT(0),
+        2 DFHEICB CHAR(8) INIT('        ');
+    DCL DFHEPI ENTRY, DFHEIPTR PTR;
+    DCL 
+      1 DFHEIBLK BASED (DFHEIPTR),
+        2 EIBTIME  FIXED DEC(7),
+        2 EIBDATE  FIXED DEC(7),
+        2 EIBTRNID CHAR(4),
+        2 EIBTASKN FIXED DEC(7),
+        2 EIBTRMID CHAR(4),
+        2 EIBFIL01 FIXED BIN(15),
+        2 EIBCPOSN FIXED BIN(15),
+        2 EIBCALEN FIXED BIN(15),
+        2 EIBAID   CHAR(1),
+        2 EIBFN    CHAR(2),
+        2 EIBRCODE CHAR(6),
+        2 EIBDS    CHAR(8),
+        2 EIBREQID CHAR(8),
+        2 EIBRSRCE CHAR(8),
+        2 EIBSYNC  CHAR(1),
+        2 EIBFREE  CHAR(1),
+        2 EIBRECV  CHAR(1),
+        2 EIBFIL02 CHAR(1),
+        2 EIBATT   CHAR(1),
+        2 EIBEOC   CHAR(1),
+        2 EIBFMH   CHAR(1),
+        2 EIBCOMPL CHAR(1),
+        2 EIBSIG   CHAR(1),
+        2 EIBCONF  CHAR(1),
+        2 EIBERR   CHAR(1),
+        2 EIBERRCD CHAR(4),
+        2 EIBSYNRB CHAR(1),
+        2 EIBNODAT CHAR(1),
+        2 EIBRESP  FIXED BIN(31),
+        2 EIBRESP2 FIXED BIN(31),
+        2 EIBRLDBK CHAR(1);
+    DCL 
+      1 DFHCNTBS  STATIC,
+        2  DFHLDTBS CHAR(22) INIT('LD TABLE DFHEITBS 730.');
+    DCL DFHDUMMY STATIC FIXED BIN(15) INIT(0);
+    DCL DFHEI0 ENTRY VARIABLE INIT(DFHEI01) AUTO OPTIONS(INTER ASSEMBLER);
+    DCL DFHEI01 ENTRY OPTIONS(INTER ASSEMBLER);
+
+    DO; END;
+END;
+`);

--- a/packages/language/test/fourslash/preprocessor/cics/exec-in-macro-if-do.ts
+++ b/packages/language/test/fourslash/preprocessor/cics/exec-in-macro-if-do.ts
@@ -1,0 +1,46 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// TEST: PROC;
+////   %DECLARE SYSTEM CHARACTER;
+////   %SYSTEM = 'CICS';
+////   %IF TRIM(SYSTEM) ^= 'CICS'
+////   %THEN %DO;
+////     <|1:EXEC|> CICS ABEND ABCODE('$CAN');
+////   %END;
+////   %ELSE %DO;
+////     /* This branch is taken */
+////     DCL VAR1 FIXED BIN(31);
+////   %END;
+//// END;
+
+// EXEC CICS inside a %IF/%THEN/%DO block should be recognized and processed.
+// Since SYSTEM = 'CICS', the condition is false, so the ELSE branch is taken.
+// The CICS declarations should still be generated (for the %THEN branch even though not executed)
+preprocessor.containsTokens([
+  "TEST",
+  ":",
+  "PROC",
+  ";",
+  "DCL",
+  "VAR1",
+  "FIXED",
+  "BIN",
+  "(",
+  "31",
+  ")",
+  ";",
+  "END",
+  ";",
+]);
+verify.noDiagnostics(1);


### PR DESCRIPTION
Fixes https://github.com/zowe/zowe-pli-language-support/issues/716 second part and allows the preprocessors to be run inside the macro preprocessor.

The change basically moves `parseExecStatement` into the preprocessor-parser and makes the required functions async. 