### PR TITLE
Safeguard macro interpreter

### DIFF
--- a/packages/language/src/config/loader.ts
+++ b/packages/language/src/config/loader.ts
@@ -27,7 +27,7 @@ import {
 } from "../utils/jsonc";
 import { URI } from "../utils/uri";
 import { LspCodes } from "../validation/lsp-codes";
-import { MAX_INSTRUCTION_COUNTER } from "../preprocessor/instruction-interpreter";
+import { DEFAULT_INSTRUCTION_LIMIT } from "../preprocessor/instruction-interpreter";
 import {
   JsonItem,
   JsonItemMeta,
@@ -207,7 +207,7 @@ function readProcessGroup(
       "instruction-counter-limit",
       [...lspOptionsPath, "instruction-counter-limit"],
       uri,
-    ) ?? plainItem(MAX_INSTRUCTION_COUNTER);
+    ) ?? plainItem(DEFAULT_INSTRUCTION_LIMIT);
   const caseUpperValidation =
     readBooleanField(
       lspOptionsNode,

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -365,7 +365,7 @@ export interface InterpreterOptions {
   marginsProcessor: MarginsProcessor;
 }
 
-export const MAX_INSTRUCTION_COUNTER = 5000;
+export const DEFAULT_INSTRUCTION_LIMIT = 5000;
 export const MAX_INSTRUCTION_LIMIT = 50000;
 
 export async function runInstructions(
@@ -379,7 +379,7 @@ export async function runInstructions(
   const instructionLimit = Math.min(
     Math.max(
       unit.processGroup?.lspOptions.instructionCounterLimit.value ??
-        MAX_INSTRUCTION_COUNTER,
+        DEFAULT_INSTRUCTION_LIMIT,
       1,
     ),
     MAX_INSTRUCTION_LIMIT,
@@ -476,7 +476,7 @@ function doRunInstructionsSync(
   while (currentNode) {
     const value = context.counter.get(currentNode) || 0;
     // Prevent infinite loops by limiting the number of iterations
-    if (value > MAX_INSTRUCTION_COUNTER) {
+    if (value > context.instructionCounterLimit) {
       console.log("Long running preprocessor code detected. Stopping.");
       return;
     }
@@ -2540,6 +2540,8 @@ builtinImplementations.set("COMPILEDDATE", () => stringToValue(compiledDate));
 const compileTime = " 1.JAN.70 00.00.00";
 builtinImplementations.set("COMPILETIME", () => stringToValue(compileTime));
 
+const MAX_COPY_SIZE = 100_000;
+
 function copy(
   value: Value | undefined,
   repetitions: Value | undefined,
@@ -2554,7 +2556,7 @@ function copy(
     repeatCount <= 0 ||
     // Safeguard against large outputs
     // Could cause long processing times
-    value.value.length * repeatCount > 100_000
+    value.value.length * repeatCount > MAX_COPY_SIZE
   ) {
     return defaultEmptyValue;
   }

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -366,6 +366,7 @@ export interface InterpreterOptions {
 }
 
 export const MAX_INSTRUCTION_COUNTER = 5000;
+export const MAX_INSTRUCTION_LIMIT = 50000;
 
 export async function runInstructions(
   unit: CompilationUnit,
@@ -373,6 +374,16 @@ export async function runInstructions(
   instruction: InstructionGeneratorResult,
   options: InterpreterOptions,
 ): Promise<InstructionInterpreterResult> {
+  // Safeguard against unlimited instruction execution (like unlimited loops, infinite recursion, etc.)
+  // Can be configured via LSP options, but has a hard limit as well to prevent excessive processing times
+  const instructionLimit = Math.min(
+    Math.max(
+      unit.processGroup?.lspOptions.instructionCounterLimit.value ??
+        MAX_INSTRUCTION_COUNTER,
+      1,
+    ),
+    MAX_INSTRUCTION_LIMIT,
+  );
   const global = {
     variables: new Map(),
     doType3: new Map(),
@@ -404,9 +415,7 @@ export async function runInstructions(
       entries: new Map(),
     },
     macname: "",
-    instructionCounterLimit:
-      unit.processGroup?.lspOptions.instructionCounterLimit.value ??
-      MAX_INSTRUCTION_COUNTER,
+    instructionCounterLimit: instructionLimit,
   };
   for (const [key, value] of instruction.procedures.entries()) {
     context.procedures.set(key, value);
@@ -2536,11 +2545,17 @@ function copy(
   repetitions: Value | undefined,
   plus: number,
 ): Value {
-  if (!value || !isScalarValue(value) || !repetitions) {
+  if (!value || !isScalarValue(value) || !value.value || !repetitions) {
     return defaultEmptyValue;
   }
   const repeatCount = valueToNumber(repetitions, 0) + plus;
-  if (repeatCount === 0) {
+  if (
+    // Invalid repeat count, emit empty
+    repeatCount <= 0 ||
+    // Safeguard against large outputs
+    // Could cause long processing times
+    value.value.length * repeatCount > 100_000
+  ) {
     return defaultEmptyValue;
   }
   const repeatedText = value.value.repeat(repeatCount);

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -36,7 +36,7 @@ import {
 import { isBoolean, isNumber, isStringArray } from "../utils/types";
 import { URI, UriUtils } from "../utils/uri";
 import { FileSystemProvider } from "./file-system-provider";
-import { MAX_INSTRUCTION_COUNTER } from "../preprocessor/instruction-interpreter";
+import { DEFAULT_INSTRUCTION_LIMIT } from "../preprocessor/instruction-interpreter";
 import { PluginConfiguration } from "../language-server/constants";
 import { type JSONPath } from "../utils/jsonc";
 import { LspCodes } from "../validation/lsp-codes";
@@ -120,7 +120,7 @@ export function deserializeProcessGroup(
       instructionCounterLimit: plainItem(
         isNumber(instructionCounterLimit)
           ? instructionCounterLimit
-          : MAX_INSTRUCTION_COUNTER,
+          : DEFAULT_INSTRUCTION_LIMIT,
       ),
       caseUpperValidation: plainItem(
         isBoolean(lspOptions["case-upper-validation"])

--- a/packages/language/test/config-fixtures.ts
+++ b/packages/language/test/config-fixtures.ts
@@ -9,7 +9,7 @@
  *
  */
 
-import { MAX_INSTRUCTION_COUNTER } from "../src/preprocessor/instruction-interpreter";
+import { DEFAULT_INSTRUCTION_LIMIT } from "../src/preprocessor/instruction-interpreter";
 import {
   plainItem,
   ProcessGroup,
@@ -57,7 +57,7 @@ export function makeProcessGroup(input: {
     lspOptions: {
       checkMargins: plainItem(input.checkMargins ?? false),
       instructionCounterLimit: plainItem(
-        input.instructionCounterLimit ?? MAX_INSTRUCTION_COUNTER,
+        input.instructionCounterLimit ?? DEFAULT_INSTRUCTION_LIMIT,
       ),
       caseUpperValidation: plainItem(input.caseUpperValidation ?? true),
     },


### PR DESCRIPTION
Improves our macro interpreter by safeguarding against unreasonable user-inputs:
1. Hard caps the amount of times an instruction can run at 50,000.
2. Prevents out-of-memory issues by using a huge `COPY` call by limiting output size to 100_000 characters.