### PR TITLE
Proposal: Split pp calls into individual phases

### DIFF
--- a/packages/language/src/parser/exec-parser.ts
+++ b/packages/language/src/parser/exec-parser.ts
@@ -45,7 +45,6 @@ export async function execStatement(
   if (fragmentToken) {
     const { preprocessor, statementText, startOffset } = handleExecFragment(
       fragmentToken,
-      textDocument,
       execStatement,
     );
     if (preprocessor) {
@@ -184,16 +183,12 @@ function handleDiagnostics(
 
 function handleExecFragment(
   fragmentToken: t.Token,
-  textDocument: TextDocument,
   execStatement: ast.ExecStatement,
 ) {
   const prefixMatch = /^(\w+)\s*/i.exec(fragmentToken.image);
   const prefixLength = prefixMatch?.[0].length || 0;
   const startOffset = fragmentToken.startOffset + prefixLength;
-  const endOffset = fragmentToken.endOffset + 1;
-  const statementText = textDocument
-    .getText()
-    .substring(startOffset, endOffset);
+  const statementText = fragmentToken.image.substring(prefixLength);
   let preprocessor: Preprocessor | undefined;
   switch (prefixMatch?.[1].toUpperCase()) {
     case "CICS":

--- a/packages/language/src/parser/parser-entry.ts
+++ b/packages/language/src/parser/parser-entry.ts
@@ -11,25 +11,9 @@
 
 import { ParserState } from "./parser-state";
 import * as ast from "../syntax-tree/ast";
-import * as t from "./tokens";
 import { recursivelySetContainer } from "../linking/symbol-table";
 import { Diagnostic } from "../language-server/types";
-import { TextDocument } from "vscode-languageserver-textdocument";
-import {
-  consumeTokenStatement,
-  includeAltStatement,
-  parseExecStatement,
-  statement,
-} from "./preprocessor-parser";
-import {
-  isSqlAttributeStatement,
-  sqlAttributeStatement,
-} from "./sql-attribute-parser";
-import {
-  cicsResponseStatement,
-  isCicsResponseStatement,
-} from "./cics-response-parser";
-import { CompilerOptions } from "../preprocessor/compiler-options/options";
+import { consumeTokenStatement } from "./preprocessor-parser";
 
 export type PreprocessorParserResult = {
   statements: ast.Statement[];
@@ -38,124 +22,35 @@ export type PreprocessorParserResult = {
 
 /**
  * Statement parser handler function type.
+ *
+ * Each preprocessor phase composes its own ordered list of these and hands it to
+ * {@link preprocessorParse}, so this module only owns the generic parse loop while the
+ * phases own the building blocks they recognize.
+ *
  * Returns:
  * - ast.Statement: Successfully parsed a statement
  * - null: Failed to parse (error condition)
  * - undefined: This handler doesn't recognize this token (pass to next handler)
  */
-type StatementParser = (
+export type StatementParser = (
   state: ParserState,
 ) => Promise<ast.Statement | null | undefined>;
 
-function createPreprocessorHandler(
-  textDocument: TextDocument,
-): StatementParser {
-  return async (state) => {
-    if (state.token?.tokenTypeIdx !== t.Percent.tokenTypeIdx) {
-      return undefined; // Not a preprocessor statement
-    }
-    return await statement(state, textDocument);
-  };
-}
+/**
+ * Parse a token stream into preprocessor statements using an explicit, ordered list
+ * of statement handlers.
+ *
+ * Each preprocessor phase composes its own handler list.
+ * Falls back to a plain token statement when none of them recognize the current token.
+ * Tokens that are not consumed by any handler simply pass through to the next phase.
+ */
+export async function preprocessorParse(
+  state: ParserState,
+  handlers: StatementParser[],
+): Promise<PreprocessorParserResult> {
+  const statements: ast.Statement[] = [];
 
-function createIncOnlyPreprocessorHandler(
-  textDocument: TextDocument,
-): StatementParser {
-  return async (state) => {
-    // If it is not a preprocessor statement and also not an include alternate,
-    // return undefined to let other handlers process it.
-    if (
-      state.token?.tokenTypeIdx !== t.Percent.tokenTypeIdx &&
-      state.token?.tokenTypeIdx !== t.INCLUDE_ALT.tokenTypeIdx
-    ) {
-      return undefined;
-    }
-
-    const nextToken = state.peek(2);
-    const isInclude =
-      nextToken &&
-      (nextToken.tokenTypeIdx === t.INCLUDE.tokenTypeIdx ||
-        nextToken.tokenTypeIdx === t.INSCAN.tokenTypeIdx);
-    if (isInclude) {
-      // Only process include statements.
-      return await statement(state, textDocument);
-    }
-
-    return undefined;
-  };
-}
-
-function createIncludeAltHandler(): StatementParser {
-  return async (state) => {
-    if (state.token?.tokenTypeIdx !== t.INCLUDE_ALT.tokenTypeIdx) {
-      return undefined;
-    }
-    const includeAlt = includeAltStatement(state);
-    const includeAltStmt = ast.createStatement();
-    includeAltStmt.value = includeAlt;
-    return includeAltStmt;
-  };
-}
-
-function createSqlAttributeHandler(): StatementParser {
-  return async (state) => {
-    if (state.token?.tokenTypeIdx !== t.SQL.tokenTypeIdx) {
-      return undefined;
-    }
-    if (!isSqlAttributeStatement(state)) {
-      return undefined;
-    }
-    const sqlAttrStmt = sqlAttributeStatement(state);
-    const sqlAttrStatement = ast.createStatement();
-    sqlAttrStatement.value = sqlAttrStmt;
-    return sqlAttrStatement;
-  };
-}
-
-function createCicsResponseHandler(): StatementParser {
-  return async (state) => {
-    if (state.token?.tokenTypeIdx !== t.DFHRESP.tokenTypeIdx) {
-      return undefined;
-    }
-    if (!isCicsResponseStatement(state)) {
-      return undefined;
-    }
-    const cicsRespStmt = cicsResponseStatement(state);
-    const cicsRespStatement = ast.createStatement();
-    cicsRespStatement.value = cicsRespStmt;
-    return cicsRespStatement;
-  };
-}
-
-function createExecHandler(textDocument: TextDocument): StatementParser {
-  return async (state) => {
-    if (state.token?.tokenTypeIdx !== t.EXEC.tokenTypeIdx) {
-      return undefined;
-    }
-    return await parseExecStatement(state, textDocument);
-  };
-}
-
-function generateStatementParser(
-  compilerOptions: CompilerOptions | undefined,
-  textDocument: TextDocument,
-): StatementParser {
-  const handlers: StatementParser[] = [];
-
-  const incOnly = compilerOptions?.macroOptions?.incOnly;
-
-  if (incOnly) {
-    handlers.push(createIncOnlyPreprocessorHandler(textDocument));
-  } else {
-    handlers.push(createPreprocessorHandler(textDocument));
-  }
-
-  handlers.push(createIncludeAltHandler());
-  handlers.push(createSqlAttributeHandler());
-  handlers.push(createCicsResponseHandler());
-  handlers.push(createExecHandler(textDocument));
-
-  return async (state) => {
+  const statementParser: StatementParser = async (state) => {
     for (const handler of handlers) {
       const result = await handler(state);
       if (result !== undefined) {
@@ -164,18 +59,6 @@ function generateStatementParser(
     }
     return undefined;
   };
-}
-
-export async function preprocessorParse(
-  state: ParserState,
-  textDocument: TextDocument,
-): Promise<PreprocessorParserResult> {
-  const statements: ast.Statement[] = [];
-
-  const statementParser = generateStatementParser(
-    state.compilerOptions,
-    textDocument,
-  );
 
   let index = state.index;
   let token = state.token;
@@ -200,7 +83,6 @@ export async function preprocessorParse(
       state.index++;
     }
 
-    // Always recover after each statement
     state.skipRecovery();
     token = state.token;
     index = state.index;

--- a/packages/language/src/preprocessor/compiler-options/options-pli.ts
+++ b/packages/language/src/preprocessor/compiler-options/options-pli.ts
@@ -1504,6 +1504,7 @@ export function getDefaultCompilerOptions(): CompilerOptions {
       items: [
         { name: CompilerOptions.PPItemName.MACRO },
         { name: CompilerOptions.PPItemName.SQL },
+        { name: CompilerOptions.PPItemName.CICS },
       ],
     },
     precType: CompilerOptions.PrecType.ANS,

--- a/packages/language/src/preprocessor/exec-phase.ts
+++ b/packages/language/src/preprocessor/exec-phase.ts
@@ -1,0 +1,165 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { preprocessorParse, StatementParser } from "../parser/parser-entry";
+import { ParserState } from "../parser/parser-state";
+import {
+  cicsResponseStatement,
+  isCicsResponseStatement,
+} from "../parser/cics-response-parser";
+import { parseExecStatement } from "../parser/preprocessor-parser";
+import {
+  isSqlAttributeStatement,
+  sqlAttributeStatement,
+} from "../parser/sql-attribute-parser";
+import * as t from "../parser/tokens";
+import * as ast from "../syntax-tree/ast";
+import { CompilerOptionResult } from "./compiler-options/options";
+import { generateInstructions } from "./instruction-generator";
+import { runInstructions } from "./instruction-interpreter";
+import { MarginsProcessor } from "./pli-margins-processor";
+import { PhaseInput, PhaseResult, PreprocessorPhase } from "./pp-phase";
+
+/**
+ * Recognizes `SQL TYPE IS ...` attribute declarations (handled by the SQL phase).
+ */
+function createSqlAttributeHandler(): StatementParser {
+  return async (state) => {
+    if (state.token?.tokenTypeIdx !== t.SQL.tokenTypeIdx) {
+      return undefined;
+    }
+    if (!isSqlAttributeStatement(state)) {
+      return undefined;
+    }
+    const sqlAttrStmt = sqlAttributeStatement(state);
+    const sqlAttrStatement = ast.createStatement();
+    sqlAttrStatement.value = sqlAttrStmt;
+    return sqlAttrStatement;
+  };
+}
+
+/**
+ * Recognizes `DFHRESP(...)` response code references (handled by the CICS phase).
+ */
+function createCicsResponseHandler(): StatementParser {
+  return async (state) => {
+    if (state.token?.tokenTypeIdx !== t.DFHRESP.tokenTypeIdx) {
+      return undefined;
+    }
+    if (!isCicsResponseStatement(state)) {
+      return undefined;
+    }
+    const cicsRespStmt = cicsResponseStatement(state);
+    const cicsRespStatement = ast.createStatement();
+    cicsRespStatement.value = cicsRespStmt;
+    return cicsRespStatement;
+  };
+}
+
+/**
+ * Recognizes `EXEC SQL`/`EXEC CICS` statements. When `execType` is given, the handler
+ * only claims EXEC statements whose prefix matches, so the SQL and CICS phases never
+ * process each other's statements.
+ */
+function createExecHandler(
+  textDocument: TextDocument,
+  execType: ast.PreprocessorType,
+): StatementParser {
+  return async (state) => {
+    if (state.token?.tokenTypeIdx !== t.EXEC.tokenTypeIdx) {
+      return undefined;
+    }
+
+    const nextToken = state.peek(2);
+    if (!nextToken) {
+      return undefined;
+    }
+
+    const prefix = nextToken.image.match(/^(\w+)/i)?.[1]?.toUpperCase();
+    const tokenType =
+      prefix === "SQL"
+        ? ast.PreprocessorType.SQL
+        : prefix === "CICS"
+          ? ast.PreprocessorType.CICS
+          : ast.PreprocessorType.UNKNOWN;
+
+    if (tokenType !== execType) {
+      return undefined;
+    }
+    return await parseExecStatement(state, textDocument);
+  };
+}
+
+/**
+ * Base class for the EXEC-based preprocessor phases (SQL and CICS).
+ *
+ * Both phases share the same shape: re-parse the potentially macro-expanded token stream
+ * with their own handlers, generate instructions, and run them. The only difference is which
+ * handlers they compose ({@link createHandlers}).
+ */
+abstract class ExecPreprocessorPhase implements PreprocessorPhase {
+  constructor(
+    protected readonly compilerOptionsResult: CompilerOptionResult | undefined,
+    protected readonly marginsProcessor: MarginsProcessor,
+  ) {}
+
+  protected abstract createHandlers(
+    textDocument: TextDocument,
+  ): StatementParser[];
+
+  async execute(input: PhaseInput): Promise<PhaseResult> {
+    const { tokens, unit, uri, textDocument } = input;
+    const opts = this.compilerOptionsResult?.options;
+
+    const state = new ParserState(tokens, opts);
+    const { statements, diagnostics } = await preprocessorParse(
+      state,
+      this.createHandlers(textDocument),
+    );
+
+    const instructionResult = generateInstructions(statements);
+
+    const output = await runInstructions(unit, uri, instructionResult, {
+      compilerOptions: this.compilerOptionsResult,
+      marginsProcessor: this.marginsProcessor,
+      // Nested EXEC ... INCLUDE files are re-parsed with this same phase's handlers,
+      // keeping the preprocessors independent of one another.
+      createParseHandlers: (includeDocument) =>
+        this.createHandlers(includeDocument),
+    });
+
+    return {
+      tokens: output.all,
+      statements: [...statements, ...output.statements],
+      diagnostics: [...diagnostics, ...output.errors],
+      references: output.references,
+    };
+  }
+}
+
+export class ExecSqlPreprocessorPhase extends ExecPreprocessorPhase {
+  protected createHandlers(textDocument: TextDocument): StatementParser[] {
+    return [
+      createSqlAttributeHandler(),
+      createExecHandler(textDocument, ast.PreprocessorType.SQL),
+    ];
+  }
+}
+
+export class ExecCicsPreprocessorPhase extends ExecPreprocessorPhase {
+  protected createHandlers(textDocument: TextDocument): StatementParser[] {
+    return [
+      createCicsResponseHandler(),
+      createExecHandler(textDocument, ast.PreprocessorType.CICS),
+    ];
+  }
+}

--- a/packages/language/src/preprocessor/instruction-cache.ts
+++ b/packages/language/src/preprocessor/instruction-cache.ts
@@ -11,25 +11,17 @@
 
 import { Diagnostic } from "../language-server/types";
 import { Token } from "../parser/tokens";
+import { TokenizationResult } from "../parser/tokenizer";
 import { Statement } from "../syntax-tree/ast";
 import { URI } from "../utils/uri";
 import { InstructionGeneratorResult } from "./instruction-generator";
 
-interface CachedInstructions {
-  text: string;
-  instructions: FileInstructionResult;
-}
-
-export interface FileInstructionResult {
-  tokens: Token[];
-  comments: Token[];
-  diagnostics: Diagnostic[];
-  statements: Statement[];
-  result: InstructionGeneratorResult;
-}
-
-export class InstructionCache {
-  private cache = new Map<string, CachedInstructions>();
+/**
+ * A per-file, text-keyed cache that is invalidated whenever the recompile fingerprint
+ * changes (i.e. a compiler option flagged as `recompile` changed).
+ */
+export class TextKeyedCache<T> {
+  private cache = new Map<string, { text: string; value: T }>();
 
   private previousRecompileFingerprint: string | undefined;
 
@@ -46,20 +38,33 @@ export class InstructionCache {
     this.previousRecompileFingerprint = fingerprint;
   }
 
-  async get(
-    uri: URI,
-    text: string,
-    getter: () => Promise<FileInstructionResult>,
-  ): Promise<FileInstructionResult> {
+  async get(uri: URI, text: string, getter: () => Promise<T> | T): Promise<T> {
     const key = uri.toString();
-    if (this.cache.has(key)) {
-      const cached = this.cache.get(key)!;
-      if (cached.text === text) {
-        return cached.instructions;
-      }
+    const cached = this.cache.get(key);
+    if (cached && cached.text === text) {
+      return cached.value;
     }
-    const instructions = await getter();
-    this.cache.set(key, { text, instructions });
-    return instructions;
+    const value = await getter();
+    this.cache.set(key, { text, value });
+    return value;
   }
 }
+
+export interface FileInstructionResult {
+  tokens: Token[];
+  comments: Token[];
+  diagnostics: Diagnostic[];
+  statements: Statement[];
+  result: InstructionGeneratorResult;
+}
+
+/**
+ * Caches the parse + instruction generation of a single file. Used by the macro
+ * preprocessor when resolving `%INCLUDE`d files.
+ */
+export class InstructionCache extends TextKeyedCache<FileInstructionResult> {}
+
+/**
+ * Caches the raw tokenization (margins + tokenize) of the main compilation unit's source.
+ */
+export class TokenizationCache extends TextKeyedCache<TokenizationResult> {}

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -10,14 +10,16 @@
  */
 
 import { tokenMatcher, TokenType } from "chevrotain";
+import { TextDocument } from "vscode-languageserver-textdocument";
 import { TextDocuments } from "../language-server/text-documents";
 import { Diagnostic, diagnosticFromCode } from "../language-server/types";
-import { preprocessorParse } from "../parser/parser-entry";
+import { preprocessorParse, StatementParser } from "../parser/parser-entry";
 import { ParserState } from "../parser/parser-state";
 import { tokenize } from "../parser/tokenizer";
 import {
   createTokenInstance,
   EXEC_VARIABLE_MARKER,
+  ExecFragment,
   Token,
 } from "../parser/tokens";
 import * as ast from "../syntax-tree/ast";
@@ -384,6 +386,11 @@ export type InstructionInterpreterResult = {
 export interface InterpreterOptions {
   compilerOptions: CompilerOptionResult | undefined;
   marginsProcessor: MarginsProcessor;
+  /**
+   * Each phase supplies its own handlers so that included files are processed by the same preprocessor
+   * that is currently running, keeping the preprocessors independent of one another.
+   */
+  createParseHandlers: (textDocument: TextDocument) => StatementParser[];
 }
 
 export const DEFAULT_INSTRUCTION_LIMIT = 5000;
@@ -1910,11 +1917,40 @@ function runTokenInstruction(
       mergePush(context.tokens, result.tokens, i === 0);
       i += result.advance;
     } else {
-      // If the scan found no active variable, push the original token
-      mergePush(context.tokens, [tokens[i]], i === 0);
+      const token = tokens[i];
+      // For ExecFragment tokens, expand macro variables embedded in the image.
+      if (token.tokenTypeIdx === ExecFragment.tokenTypeIdx) {
+        const expandedImage = expandVariablesInText(token.image, context);
+        if (expandedImage !== token.image) {
+          const newToken: Token = { ...token, image: expandedImage };
+          mergePush(context.tokens, [newToken], i === 0);
+        } else {
+          mergePush(context.tokens, [token], i === 0);
+        }
+      } else {
+        // If the scan found no active variable, push the original token
+        mergePush(context.tokens, [token], i === 0);
+      }
       i++;
     }
   }
+}
+
+/**
+ * Expand macro variables in a text string by replacing identifiers that match
+ * active macro variable names with their current values.
+ */
+function expandVariablesInText(
+  text: string,
+  context: InterpreterContext,
+): string {
+  return text.replace(/\b([A-Z_$@#]\w*)\b/gi, (match) => {
+    const variable = getVariable(context, match.toUpperCase());
+    if (variable && variable.active && isScalarValue(variable.value)) {
+      return variable.value.value;
+    }
+    return match;
+  });
 }
 
 function mergePush(target: Token[], source: Token[], firstSource: boolean) {
@@ -2493,7 +2529,10 @@ async function runInclude(
           tokenizeResult.tokens,
           context.options.compilerOptions?.options,
         );
-        const subProgram = await preprocessorParse(subState, document);
+        const subProgram = await preprocessorParse(
+          subState,
+          context.options.createParseHandlers(document),
+        );
         subProgram.diagnostics.push(...tokenizeResult.diagnostics);
         const result = generateInstructions(subProgram.statements);
         return {

--- a/packages/language/src/preprocessor/macro-phase.ts
+++ b/packages/language/src/preprocessor/macro-phase.ts
@@ -1,0 +1,171 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { preprocessorParse, StatementParser } from "../parser/parser-entry";
+import { ParserState } from "../parser/parser-state";
+import { includeAltStatement, statement } from "../parser/preprocessor-parser";
+import * as t from "../parser/tokens";
+import * as ast from "../syntax-tree/ast";
+import { CstNodeKind } from "../syntax-tree/cst";
+import {
+  CompilerOptionResult,
+  CompilerOptions as PliCompilerOptions,
+} from "./compiler-options/options";
+import { CompilerOptions } from "./compiler-options/options-pli";
+import { generateInstructions } from "./instruction-generator";
+import { runInstructions } from "./instruction-interpreter";
+import { createIncludeInstruction, InstructionNode } from "./instructions";
+import { MarginsProcessor } from "./pli-margins-processor";
+import { PhaseInput, PhaseResult, PreprocessorPhase } from "./pp-phase";
+
+/**
+ * Recognizes `%` preprocessor statements.
+ */
+function createPreprocessorHandler(
+  textDocument: TextDocument,
+): StatementParser {
+  return async (state) => {
+    if (state.token?.tokenTypeIdx !== t.Percent.tokenTypeIdx) {
+      return undefined; // Not a preprocessor statement
+    }
+    return await statement(state, textDocument);
+  };
+}
+
+/**
+ * Under the macro `INCONLY` option, only
+ * processes `%INCLUDE`/`%INSCAN` statements and lets everything else pass through.
+ */
+function createIncOnlyPreprocessorHandler(
+  textDocument: TextDocument,
+): StatementParser {
+  return async (state) => {
+    // If it is not a preprocessor statement and also not an include alternate,
+    // return undefined to let other handlers process it.
+    if (
+      state.token?.tokenTypeIdx !== t.Percent.tokenTypeIdx &&
+      state.token?.tokenTypeIdx !== t.INCLUDE_ALT.tokenTypeIdx
+    ) {
+      return undefined;
+    }
+
+    const nextToken = state.peek(2);
+    const isInclude =
+      nextToken &&
+      (nextToken.tokenTypeIdx === t.INCLUDE.tokenTypeIdx ||
+        nextToken.tokenTypeIdx === t.INSCAN.tokenTypeIdx);
+    if (isInclude) {
+      // Only process include statements.
+      return await statement(state, textDocument);
+    }
+
+    return undefined;
+  };
+}
+
+/**
+ * Recognizes `++INCLUDE` alternative include statements.
+ */
+function createIncludeAltHandler(): StatementParser {
+  return async (state: ParserState) => {
+    if (state.token?.tokenTypeIdx !== t.INCLUDE_ALT.tokenTypeIdx) {
+      return undefined;
+    }
+    const includeAlt = includeAltStatement(state);
+    const includeAltStmt = ast.createStatement();
+    includeAltStmt.value = includeAlt;
+    return includeAltStmt;
+  };
+}
+
+export function createMacroHandlers(
+  compilerOptions: PliCompilerOptions | undefined,
+  textDocument: TextDocument,
+): StatementParser[] {
+  const preprocessorHandler = compilerOptions?.macroOptions?.incOnly
+    ? createIncOnlyPreprocessorHandler(textDocument)
+    : createPreprocessorHandler(textDocument);
+  return [preprocessorHandler, createIncludeAltHandler()];
+}
+
+/**
+ * Macro preprocessor phase. A `Token[] -> Token[]` transformation that parses `%`
+ * statements and includes from its input tokens, runs the macro instructions (variable
+ * expansion, `%IF`/`%DO`, `%INCLUDE`, `REPLACE`, ...) and passes EXEC SQL/CICS tokens
+ * through with macro variables expanded.
+ */
+export class MacroPreprocessorPhase implements PreprocessorPhase {
+  constructor(
+    private readonly compilerOptionsResult: CompilerOptionResult | undefined,
+    private readonly marginsProcessor: MarginsProcessor,
+  ) {}
+
+  async execute(input: PhaseInput): Promise<PhaseResult> {
+    const { tokens, unit, uri, textDocument } = input;
+    const opts = this.compilerOptionsResult?.options;
+
+    // Parse the incoming tokens for macro statements and build the instruction set.
+    const state = new ParserState(tokens, opts);
+    const { statements, diagnostics } = await preprocessorParse(
+      state,
+      createMacroHandlers(opts, textDocument),
+    );
+    const instructionResult = generateInstructions(statements);
+
+    // Handle the incAfter option - prepend an include instruction.
+    const incAfter = opts?.incAfter;
+    if (incAfter?.process) {
+      instructionResult.entryNode = generateIncAfterInstruction(
+        instructionResult.entryNode,
+        incAfter,
+      );
+    }
+
+    const output = await runInstructions(unit, uri, instructionResult, {
+      compilerOptions: this.compilerOptionsResult,
+      marginsProcessor: this.marginsProcessor,
+      createParseHandlers: (includeDocument) =>
+        createMacroHandlers(opts, includeDocument),
+    });
+
+    return {
+      tokens: output.all,
+      statements: [...statements, ...output.statements],
+      diagnostics: [...diagnostics, ...output.errors],
+      references: output.references,
+      evaluationResults: output.evaluationResults,
+    };
+  }
+}
+
+function generateIncAfterInstruction(
+  existingNode: InstructionNode,
+  incAfter: CompilerOptions.IncAfter | undefined,
+): InstructionNode {
+  if (!incAfter || !incAfter.process) {
+    return existingNode;
+  }
+  const includeItem = ast.createIncludeItemFile();
+  includeItem.fileName = incAfter.process;
+  includeItem.token = incAfter.token || null;
+  if (incAfter.token) {
+    includeItem.token = incAfter.token;
+    incAfter.token.element = includeItem;
+    incAfter.token.kind = CstNodeKind.IncludeItem_FileID;
+  }
+  const instruction: InstructionNode = {
+    labels: [],
+    instruction: createIncludeInstruction([includeItem], false),
+    next: existingNode,
+  };
+  return instruction;
+}

--- a/packages/language/src/preprocessor/pli-lexer.ts
+++ b/packages/language/src/preprocessor/pli-lexer.ts
@@ -10,8 +10,6 @@
  */
 
 import { MarginsProcessor, PliMarginsProcessor } from "./pli-margins-processor";
-import { preprocessorParse } from "../parser/parser-entry";
-import * as ast from "../syntax-tree/ast";
 import { URI } from "../utils/uri";
 import {
   CompilerOptionsProcessor,
@@ -20,17 +18,24 @@ import {
 import { CompilationUnit } from "../workspace/compilation-unit";
 import { Reference, Statement } from "../syntax-tree/ast";
 import { Token } from "../parser/tokens";
-import { generateInstructions } from "./instruction-generator";
-import { EvaluationResults, runInstructions } from "./instruction-interpreter";
-import { createIncludeInstruction, InstructionNode } from "./instructions";
-import { CstNodeKind } from "../syntax-tree/cst";
-import { tokenize } from "../parser/tokenizer";
-import { ParserState } from "../parser/parser-state";
+import { EvaluationResults } from "./instruction-interpreter";
+import { tokenize, TokenizationResult } from "../parser/tokenizer";
 import { TextDocument } from "vscode-languageserver-textdocument";
-import { getDefaultCompilerOptions } from "./compiler-options/options";
-import { CompilerOptions } from "./compiler-options/options-pli";
+import {
+  CompilerOptionResult,
+  CompilerOptions,
+  getDefaultCompilerOptions,
+} from "./compiler-options/options";
+import { CompilerOptions as PliCompilerOptions } from "./compiler-options/options-pli";
 import { DiagnosticCategory } from "../validation/diagnostics-store";
 import { updatePliTokenizer } from "../parser/tokenizer/pli-tokenizer";
+import { PipelineResult, runPipeline } from "./pp-pipeline";
+import { PreprocessorPhase } from "./pp-phase";
+import { MacroPreprocessorPhase } from "./macro-phase";
+import {
+  ExecCicsPreprocessorPhase,
+  ExecSqlPreprocessorPhase,
+} from "./exec-phase";
 
 export interface LexerResult {
   all: Token[];
@@ -59,6 +64,8 @@ export class PliLexer {
     uri: URI,
   ): Promise<LexerResult> {
     const inputText = document.getText();
+
+    // Compiler options
     const compilerOptionsResult =
       this.compilerOptionsPreprocessor.extractCompilerOptions(
         inputText,
@@ -70,105 +77,180 @@ export class PliLexer {
     unit.compilerOptions = opts;
     updatePliTokenizer(opts);
     unit.instructionCache.update(compilerOptionsResult.recompileFingerprint);
-    const instruction = await unit.instructionCache.get(
-      uri,
-      inputText,
-      async () => {
-        const textWithoutMargins = this.marginsProcessor.processMargins(
-          compilerOptionsResult,
-          uri,
-          unit.services.workspace,
-        );
-        const tokenizeResult = tokenize(textWithoutMargins, uri);
-        const state = new ParserState(tokenizeResult.tokens, opts);
-        // Do a full parsing of the input text to extract all *local* statements
-        const { statements, diagnostics } = await preprocessorParse(
-          state,
-          document,
-        );
-        const result = generateInstructions(statements);
-        diagnostics.push(...tokenizeResult.diagnostics);
-        return {
-          tokens: tokenizeResult.tokens,
-          comments: tokenizeResult.comments,
-          diagnostics: diagnostics,
-          statements: statements,
-          result,
-        };
-      },
-    );
-    unit.diagnostics.addAll(DiagnosticCategory.Lexer, instruction.diagnostics);
-    unit.diagnostics.addAll(
-      DiagnosticCategory.Lexer,
-      this.marginsProcessor.issues,
+    unit.tokenizationCache.update(compilerOptionsResult.recompileFingerprint);
+
+    // Produce the first Token[] (margins + tokenize).
+    const tokenization = await unit.tokenizationCache.get(uri, inputText, () =>
+      this.tokenizeSource(unit, uri, compilerOptionsResult),
     );
 
-    const incAfter = compilerOptionsResult.result?.options.incAfter;
-    if (incAfter?.process) {
-      instruction.result = {
-        entryNode: generateIncAfterInstruction(
-          instruction.result.entryNode,
-          incAfter,
-        ),
-        procedures: instruction.result.procedures,
-      };
-    }
-    const output = await runInstructions(unit, uri, instruction.result, {
-      compilerOptions: compilerOptionsResult.result,
-      marginsProcessor: this.marginsProcessor,
-    });
-    unit.services.files.set({
-      textDocument: document,
-      tokens: instruction.tokens,
-      comments: instruction.comments,
+    // Run the preprocessor pipeline (MACRO, SQL, CICS according to PP()).
+    // Each phase parses the tokens it receives, so the stages compose as
+    // Token[] -> MACRO -> Token[] -> SQL -> ... -> final Token[].
+    const phases = buildPhases(
+      opts,
+      compilerOptionsResult.result,
+      this.marginsProcessor,
+    );
+    const pipeline = await runPipeline(phases, {
+      tokens: tokenization.tokens,
+      unit,
       uri,
+      textDocument: document,
     });
-    if (compilerOptionsResult.result) {
-      instruction.tokens.unshift(...compilerOptionsResult.result.tokens);
-      instruction.comments.unshift(...compilerOptionsResult.result.comments);
-    }
+
+    // Publish diagnostics, register the file's tokens, and assemble the result.
+    this.reportDiagnostics(
+      unit,
+      uri,
+      compilerOptionsResult,
+      tokenization,
+      pipeline,
+    );
+    this.registerFileTokens(
+      unit,
+      document,
+      uri,
+      compilerOptionsResult,
+      tokenization,
+    );
+
+    return {
+      all: pipeline.tokens,
+      compilerOptions: compilerOptionsResult,
+      statements: pipeline.statements,
+      evaluationResults: pipeline.evaluationResults,
+      tokenReferences: pipeline.references,
+    };
+  }
+
+  /**
+   * Process margins and tokenize the source
+   * into the first `Token[]`. Margin diagnostics are folded into the result so they stay
+   * correct on cache hits (the pipeline reuses the same margins processor for %INCLUDE
+   * files and would otherwise overwrite `marginsProcessor.issues`).
+   */
+  private tokenizeSource(
+    unit: CompilationUnit,
+    uri: URI,
+    compilerOptionsResult: CompilerOptionsProcessorResult,
+  ): TokenizationResult {
+    const textWithoutMargins = this.marginsProcessor.processMargins(
+      compilerOptionsResult,
+      uri,
+      unit.services.workspace,
+    );
+    const marginIssues = [...this.marginsProcessor.issues];
+    const tokenizeResult = tokenize(textWithoutMargins, uri);
+    return {
+      tokens: tokenizeResult.tokens,
+      comments: tokenizeResult.comments,
+      diagnostics: [...tokenizeResult.diagnostics, ...marginIssues],
+    };
+  }
+
+  /**
+   * Publish the diagnostics collected across all stages.
+   */
+  private reportDiagnostics(
+    unit: CompilationUnit,
+    uri: URI,
+    compilerOptionsResult: CompilerOptionsProcessorResult,
+    tokenization: TokenizationResult,
+    pipeline: PipelineResult,
+  ): void {
+    unit.diagnostics.addAll(DiagnosticCategory.Lexer, tokenization.diagnostics);
+    unit.diagnostics.addAll(DiagnosticCategory.Lexer, pipeline.diagnostics);
     const uriString = uri.toString();
-    unit.diagnostics.addAll(DiagnosticCategory.Lexer, output.errors);
     unit.diagnostics.addAll(
       DiagnosticCategory.CompilerOptions,
       (compilerOptionsResult.result?.issues ?? []).filter(
         (e) => e.uri === uriString,
       ),
     );
+  }
 
-    return {
-      all: output.all,
-      compilerOptions: compilerOptionsResult,
-      statements: [...instruction.statements, ...output.statements],
-      evaluationResults: output.evaluationResults,
-      tokenReferences: output.references,
-    };
+  /**
+   * Register the file's tokens with the file store.
+   */
+  private registerFileTokens(
+    unit: CompilationUnit,
+    document: TextDocument,
+    uri: URI,
+    compilerOptionsResult: CompilerOptionsProcessorResult,
+    tokenization: TokenizationResult,
+  ): void {
+    const optionTokens = compilerOptionsResult.result?.tokens ?? [];
+    const optionComments = compilerOptionsResult.result?.comments ?? [];
+    unit.services.files.set({
+      textDocument: document,
+      tokens: [...optionTokens, ...tokenization.tokens],
+      comments: [...optionComments, ...tokenization.comments],
+      uri,
+    });
   }
 }
 
-function generateIncAfterInstruction(
-  existingNode: InstructionNode,
-  incAfter: CompilerOptions.IncAfter | undefined,
-): InstructionNode {
-  if (!incAfter || !incAfter.process) {
-    return existingNode;
+/**
+ * Build the preprocessor phase list from the PP() compiler option.
+ * The PP option contains an ordered list of preprocessor items
+ * (MACRO, SQL, CICS, INCLUDE), and each maps to a PreprocessorPhase.
+ * The phases run sequentially: Token[] -> Phase1 -> Token[] -> Phase2 -> ...
+ */
+function buildPhases(
+  opts: CompilerOptions,
+  compilerOptionsResult: CompilerOptionResult | undefined,
+  marginsProcessor: MarginsProcessor,
+): PreprocessorPhase[] {
+  const phases: PreprocessorPhase[] = [];
+  const pp = opts.pp;
+
+  if (!pp || !pp.items) {
+    // No PP option - default to just macro phase
+    phases.push(
+      new MacroPreprocessorPhase(compilerOptionsResult, marginsProcessor),
+    );
+    return phases;
   }
-  // Generate a synthetic include item here
-  // This allows us to perform LSP operations to jump to the included file
-  const includeItem = ast.createIncludeItemFile();
-  includeItem.fileName = incAfter.process;
-  includeItem.token = incAfter.token || null;
-  if (incAfter.token) {
-    includeItem.token = incAfter.token;
-    incAfter.token.element = includeItem;
-    incAfter.token.kind = CstNodeKind.IncludeItem_FileID;
+
+  let hasMacroPhase = false;
+
+  for (const item of pp.items) {
+    switch (item.name) {
+      case PliCompilerOptions.PPItemName.MACRO:
+        // Each explicit MACRO item is its own pass, so e.g. PP(MACRO MACRO) runs the
+        // macro preprocessor twice. A second pass can expand macro code that the first
+        // pass generated.
+        hasMacroPhase = true;
+        phases.push(
+          new MacroPreprocessorPhase(compilerOptionsResult, marginsProcessor),
+        );
+        break;
+      case PliCompilerOptions.PPItemName.INCLUDE:
+        // INCLUDE is handled by the macro phase (the instruction interpreter processes
+        // %INCLUDE/++INCLUDE). Only add a macro phase for it if none exists yet.
+        if (!hasMacroPhase) {
+          hasMacroPhase = true;
+          phases.push(
+            new MacroPreprocessorPhase(compilerOptionsResult, marginsProcessor),
+          );
+        }
+        break;
+      case PliCompilerOptions.PPItemName.SQL:
+        phases.push(
+          new ExecSqlPreprocessorPhase(compilerOptionsResult, marginsProcessor),
+        );
+        break;
+      case PliCompilerOptions.PPItemName.CICS:
+        phases.push(
+          new ExecCicsPreprocessorPhase(
+            compilerOptionsResult,
+            marginsProcessor,
+          ),
+        );
+        break;
+    }
   }
-  // IncAfter runs as the very first instruction in the preprocessor.
-  // It allows to include ONE SINGLE file. Afterwards the preprocessor runs as normal.
-  const instruction: InstructionNode = {
-    labels: [],
-    instruction: createIncludeInstruction([includeItem], false),
-    next: existingNode,
-  };
-  return instruction;
+
+  return phases;
 }

--- a/packages/language/src/preprocessor/pp-phase.ts
+++ b/packages/language/src/preprocessor/pp-phase.ts
@@ -1,0 +1,37 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { Token } from "../parser/tokens";
+import { CompilationUnit } from "../workspace/compilation-unit";
+import { URI } from "../utils/uri";
+import { Reference, Statement } from "../syntax-tree/ast";
+import { Diagnostic } from "../language-server/types";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { EvaluationResults } from "./instruction-interpreter";
+
+export interface PhaseInput {
+  tokens: Token[];
+  unit: CompilationUnit;
+  uri: URI;
+  textDocument: TextDocument;
+}
+
+export interface PhaseResult {
+  tokens: Token[];
+  statements: Statement[];
+  diagnostics: Diagnostic[];
+  references: Reference[];
+  evaluationResults?: EvaluationResults;
+}
+
+export interface PreprocessorPhase {
+  execute(input: PhaseInput): Promise<PhaseResult>;
+}

--- a/packages/language/src/preprocessor/pp-pipeline.ts
+++ b/packages/language/src/preprocessor/pp-pipeline.ts
@@ -1,0 +1,58 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { Token } from "../parser/tokens";
+import { Reference, Statement } from "../syntax-tree/ast";
+import { Diagnostic } from "../language-server/types";
+import { EvaluationResults } from "./instruction-interpreter";
+import { PhaseInput, PhaseResult, PreprocessorPhase } from "./pp-phase";
+
+export interface PipelineResult {
+  tokens: Token[];
+  statements: Statement[];
+  diagnostics: Diagnostic[];
+  references: Reference[];
+  evaluationResults: EvaluationResults;
+}
+
+export async function runPipeline(
+  phases: PreprocessorPhase[],
+  input: PhaseInput,
+): Promise<PipelineResult> {
+  let tokens = input.tokens;
+  const allStatements: Statement[] = [];
+  const allDiagnostics: Diagnostic[] = [];
+  const allReferences: Reference[] = [];
+  let evaluationResults: EvaluationResults = {
+    branchExecutions: new Map(),
+  };
+
+  for (const phase of phases) {
+    const result: PhaseResult = await phase.execute({ ...input, tokens });
+    tokens = result.tokens;
+    allStatements.push(...result.statements);
+    allDiagnostics.push(...result.diagnostics);
+    allReferences.push(...result.references);
+    if (result.evaluationResults) {
+      for (const [key, value] of result.evaluationResults.branchExecutions) {
+        evaluationResults.branchExecutions.set(key, value);
+      }
+    }
+  }
+
+  return {
+    tokens,
+    statements: allStatements,
+    diagnostics: allDiagnostics,
+    references: allReferences,
+    evaluationResults,
+  };
+}

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -42,7 +42,10 @@ import { WorkspaceContext } from "./workspace-context.js";
 import { EvaluationResults } from "../preprocessor/instruction-interpreter.js";
 import { createMutex, Mutex } from "./mutex.js";
 import { Deferred, isOperationCancelled } from "../utils/promises.js";
-import { InstructionCache } from "../preprocessor/instruction-cache.js";
+import {
+  InstructionCache,
+  TokenizationCache,
+} from "../preprocessor/instruction-cache.js";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { FileStore } from "./file-store.js";
 import { DefaultTypeInferer, TypeInferer } from "../typesystem/infer.js";
@@ -81,6 +84,7 @@ export interface CompilationUnit {
   scopeCaches: ScopeCacheGroups;
   requestCaches: LSRequestCache;
   instructionCache: InstructionCache;
+  tokenizationCache: TokenizationCache;
   rootScope: Scope;
   rootPreprocessorScope: Scope;
   /**
@@ -169,6 +173,7 @@ export async function createCompilationUnit(
     statementOrderCache: new StatementOrderCache(),
     scopeCaches: new ScopeCacheGroups(),
     instructionCache: new InstructionCache(),
+    tokenizationCache: new TokenizationCache(),
     diagnostics: new DiagnosticsStore(),
     requestCaches: createLSRequestCaches()
       .onRevalidate("margins", ({ connection, unit }) => {

--- a/packages/language/test/fourslash/preprocessor/pp-phases/exec-cics-in-macro-conditional.ts
+++ b/packages/language/test/fourslash/preprocessor/pp-phases/exec-cics-in-macro-conditional.ts
@@ -1,0 +1,42 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// EXEC CICS embedded inside a macro %IF/%THEN/%DO conditional must be handled by the
+// CICS phase after the MACRO phase decides which branch survives. Here SYSTEM = 'CICS',
+// so the condition is false and the %ELSE branch is taken, leaving only the SIGNAL ERROR
+// statement. The CICS phase still runs cleanly over the macro output.
+
+//// TEST: PROC;
+////   %DECLARE SYSTEM CHARACTER;
+////   %SYSTEM = 'CICS';
+////   %IF TRIM(SYSTEM) ^= 'CICS'
+////   %THEN %DO;
+////     EXEC CICS ABEND ABCODE('$CAN');
+////   %END;
+////   %ELSE %DO;
+////     SIGNAL ERROR;
+////   %END;
+//// END;
+
+preprocessor.containsTokens([
+  "TEST",
+  ":",
+  "PROC",
+  ";",
+  "SIGNAL",
+  "ERROR",
+  ";",
+  "END",
+  ";",
+]);
+verify.noDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/pp-phases/exec-cics-outside-macro.ts
+++ b/packages/language/test/fourslash/preprocessor/pp-phases/exec-cics-outside-macro.ts
@@ -1,0 +1,40 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// A plain EXEC CICS statement (not embedded in any macro construct) must still be
+// processed by the CICS phase: it generates the DFHEIBLK declarations once and the
+// statement itself is replaced by `DO; END;`.
+
+//// TEST: PROC;
+////   EXEC CICS ABEND ABCODE('$CAN');
+//// END;
+
+preprocessor.containsTokens([
+  "TEST",
+  ":",
+  "PROC",
+  ";",
+  "DCL",
+  "DFHEIBLK",
+  "BASED",
+  "(",
+  "DFHEIPTR",
+  ")",
+  "DO",
+  ";",
+  "END",
+  ";",
+  "END",
+  ";",
+]);
+verify.noDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/pp-phases/macro-expanded-exec-sql.ts
+++ b/packages/language/test/fourslash/preprocessor/pp-phases/macro-expanded-exec-sql.ts
@@ -1,0 +1,30 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// A macro variable holding the body of an EXEC SQL statement must be expanded by the
+// MACRO phase *before* the SQL phase processes it. The mainframe runs MACRO then SQL, so
+// `EXEC SQL SOME_SQL_CODE;` becomes `EXEC SQL INCLUDE SQLCA;`, which the SQL phase then
+// resolves to the included copybook content.
+
+// @filename: cpy/sqlca.pli
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: main.pli
+////*PROCESS PP(MACRO SQL);
+//// %DCL SOME_SQL_CODE CHAR;
+//// %SOME_SQL_CODE = 'INCLUDE SQLCA';
+//// EXEC SQL SOME_SQL_CODE;
+
+preprocessor.expectTokens(`
+  DECLARE LIB_VAR FIXED;
+`);

--- a/packages/language/test/fourslash/preprocessor/pp-phases/macro-generates-macro-once.ts
+++ b/packages/language/test/fourslash/preprocessor/pp-phases/macro-generates-macro-once.ts
@@ -1,0 +1,36 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// PP(MACRO) runs the macro preprocessor once, with the output tokens of the invocation becomes
+// the result (Token[] -> MACRO -> Token[]).
+
+////*PROCESS PP(MACRO);
+//// %TEST: PROC RETURNS (CHAR);
+////   RETURN ('%DCL Y FIXED; %Y = 7; Y');
+//// %END;
+//// %ACTIVATE TEST;
+//// TEST
+
+preprocessor.expectTokens([
+  "%",
+  "DCL",
+  "Y",
+  "FIXED",
+  ";",
+  "%",
+  "Y",
+  "=",
+  "7",
+  ";",
+  "Y",
+]);

--- a/packages/language/test/fourslash/preprocessor/pp-phases/macro-generates-macro-thrice.ts
+++ b/packages/language/test/fourslash/preprocessor/pp-phases/macro-generates-macro-thrice.ts
@@ -1,0 +1,28 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// PP(MACRO MACRO MACRO) runs the macro preprocessor three times, with the output tokens of the first
+// pass becoming the input tokens of the second (Token[] -> MACRO -> Token[] -> MACRO -> Token[] -> MACRO -> ...).
+//
+// First pass:  TEST  ->  % DCL Y FIXED ; % Y = 7 ; Y   (generated macro code, not yet run)
+// Second pass: the generated macro code runs  ->  7
+// Third pass: the result of the second pass (7) is processed again, but since it's just a literal token with no macros to expand, it remains 7.
+
+////*PROCESS PP(MACRO MACRO MACRO);
+//// %TEST: PROC RETURNS (CHAR);
+////   RETURN ('%DCL Y FIXED; %Y = 7; Y');
+//// %END;
+//// %ACTIVATE TEST;
+//// TEST
+
+preprocessor.expectTokens("7");

--- a/packages/language/test/fourslash/preprocessor/pp-phases/macro-generates-macro-twice.ts
+++ b/packages/language/test/fourslash/preprocessor/pp-phases/macro-generates-macro-twice.ts
@@ -1,0 +1,27 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// PP(MACRO MACRO) runs the macro preprocessor twice, with the output tokens of the first
+// pass becoming the input tokens of the second (Token[] -> MACRO -> Token[] -> MACRO -> ...).
+//
+// First pass:  TEST  ->  % DCL Y FIXED ; % Y = 7 ; Y
+// Second pass: the generated macro code runs  ->  7
+
+////*PROCESS PP(MACRO MACRO);
+//// %TEST: PROC RETURNS (CHAR);
+////   RETURN ('%DCL Y FIXED; %Y = 7; Y');
+//// %END;
+//// %ACTIVATE TEST;
+//// TEST
+
+preprocessor.expectTokens("7");

--- a/packages/language/test/fourslash/preprocessor/pp-phases/multiple-exec-types.ts
+++ b/packages/language/test/fourslash/preprocessor/pp-phases/multiple-exec-types.ts
@@ -1,0 +1,46 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// With PP(MACRO SQL CICS) all three phases run in order. The SQL phase resolves
+// `EXEC SQL INCLUDE SQLCA;` to the included copybook content, and the CICS phase replaces
+// `EXEC CICS ABEND ABCODE('$CAN');` with `DO; END;` plus the generated DFHEIBLK declarations.
+
+// @filename: cpy/sqlca.pli
+//// DECLARE SQL_VAR FIXED;
+
+// @filename: main.pli
+////*PROCESS PP(MACRO SQL CICS);
+//// TEST: PROC;
+////   EXEC SQL INCLUDE SQLCA;
+////   EXEC CICS ABEND ABCODE('$CAN');
+//// END;
+
+preprocessor.containsTokens([
+  "TEST",
+  ":",
+  "PROC",
+  ";",
+  "DECLARE",
+  "SQL_VAR",
+  "FIXED",
+  ";",
+  "DCL",
+  "DFHEIBLK",
+  "DO",
+  ";",
+  "END",
+  ";",
+  "END",
+  ";",
+]);
+verify.noDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/pp-phases/pp-order-matters.ts
+++ b/packages/language/test/fourslash/preprocessor/pp-phases/pp-order-matters.ts
@@ -1,0 +1,41 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// The PP() order is significant, and each phase transforms the tokens produced by the
+// previous one (Token[] -> phase -> Token[]).
+//
+// The companion test `macro-expanded-exec-sql.ts` uses PP(MACRO SQL): the MACRO phase
+// runs first and expands SOME_SQL_CODE to `INCLUDE SQLCA`, so the SQL phase then resolves
+// `EXEC SQL INCLUDE SQLCA;` to the included copybook content (`DECLARE LIB_VAR FIXED;`).
+//
+// Here, with PP(SQL MACRO), the SQL phase runs *first* before the macro variable exists.
+// It sees the literal `EXEC SQL SOME_SQL_CODE;`, which is not a recognized SQL statement,
+// so it replaces it with the empty `DO; END;` placeholder. The MACRO phase then runs on
+// the SQL phase's output: it consumes the `%DCL`/assignment statements (which emit no
+// tokens) and leaves the `DO; END;` behind. The include is therefore never resolved,
+// proving the SQL phase truly ran before the macro substitution.
+//
+// TODO: What is the correct error handling behavior here?
+// Should the SQL phase emit an error for unrecognized SQL syntax, or is it acceptable to just produce no tokens
+// and let the downstream compiler phases report errors for missing tokens?
+
+// @filename: cpy/sqlca.pli
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: main.pli
+////*PROCESS PP(SQL MACRO);
+//// %DCL SOME_SQL_CODE CHAR;
+//// %SOME_SQL_CODE = 'INCLUDE SQLCA';
+//// EXEC SQL SOME_SQL_CODE;
+
+preprocessor.expectTokens(["DO", ";", "END", ";"]);


### PR DESCRIPTION
This PR is a follow-up to https://github.com/zowe/zowe-pli-language-support/pull/745 and proposes to split the pp calls into individual phases. 

The PR mainly alters the way `pli-lexer` invokes the pps so that PP directives such as `*PROCESS PP(MACRO MACRO);` become possible. A pp phase strictly becomes a `Token[]` to `Token[]` transformation.
The pp phases still all use the same interpreter code, which currently seems to be more maintainable. 

This is probably not the last call here, but I'd appreciate it if we could talk about the direction. 