### PR TITLE
Add warnings for dup/mutex suboptions in rules directive

### DIFF
--- a/packages/language/src/preprocessor/compiler-options/translator-pli.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator-pli.ts
@@ -3040,6 +3040,11 @@ translator.rule(
                 );
               }
             }
+            reportDuplicateSubOptions(value, acceptor);
+            reportMutexSubOptions(value, acceptor, [
+              ["ALL", "SOURCE"],
+              ["STRICT", "LOOSE"],
+            ]);
             break;
           case "NOLAXMARGINS":
             ensureOnlyOneSubOption();
@@ -3095,6 +3100,11 @@ translator.rule(
                 );
               }
             }
+            reportDuplicateSubOptions(value, acceptor);
+            reportMutexSubOptions(value, acceptor, [
+              ["ALL", "FORCE"],
+              ["STRICT", "LOOSE", "FULL"],
+            ]);
             break;
           case "NOLAXSCALE":
             options.rules.laxScale = {
@@ -3118,6 +3128,11 @@ translator.rule(
                 );
               }
             }
+            reportDuplicateSubOptions(value, acceptor);
+            reportMutexSubOptions(value, acceptor, [
+              ["ALL", "SOURCE"],
+              ["STRICT", "LOOSE"],
+            ]);
             break;
           case "NOLAXSTMT":
             ensureOnlyOneSubOption();
@@ -3173,6 +3188,11 @@ translator.rule(
                 );
               }
             }
+            reportDuplicateSubOptions(value, acceptor);
+            reportMutexSubOptions(value, acceptor, [
+              ["ALL", "SOURCE"],
+              ["STRICT", "LOOSE"],
+            ]);
             break;
           case "NOPROCENDONLY":
             ensureOnlyOneSubOption();

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules-pli/rules-laxinout.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules-pli/rules-laxinout.ts
@@ -17,18 +17,30 @@
 ////*PROCESS RULES(<|3:NOLAXINOUT|>);
 ////*PROCESS RULES(NOLAXINOUT(<|4:)|>);
 ////*PROCESS RULES(NOLAXINOUT(<|5:INVALID|>));
-////*PROCESS RULES(NOLAXINOUT(ALL LOOSE STRICT <|6:SOURCE|>));
+////*PROCESS RULES(NOLAXINOUT(ALL LOOSE <|6:STRICT|> <|7:SOURCE|> <|8:STRICT|> <|9:LOOSE|> <|10:STRICT|> <|11:ALL|> <|12:SOURCE|>));
 
 verify.expectDiagnosticsAt(1, {
   message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
 });
-verify.noDiagnostics([2, 3, 6]);
+verify.noDiagnostics([2, 3]);
 verify.expectDiagnosticsAt(4, {
   message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
 });
 verify.expectDiagnosticsAt(5, {
   message:
     code.CompilerOptions.Rules.InvalidLaxInOutParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt([6, 8, 10], {
+  message: code.CompilerOptions.MutexOptionIssue.message("NOLAXINOUT(STRICT)"),
+});
+verify.expectDiagnosticsAt([7, 12], {
+  message: code.CompilerOptions.MutexOptionIssue.message("NOLAXINOUT(SOURCE)"),
+});
+verify.expectDiagnosticsAt(9, {
+  message: code.CompilerOptions.DupeOptionIssue.message("NOLAXINOUT(LOOSE)"),
+});
+verify.expectDiagnosticsAt(11, {
+  message: code.CompilerOptions.DupeOptionIssue.message("NOLAXINOUT(ALL)"),
 });
 verify.expectCompilerOptions({
   rules: {

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules-pli/rules-laxqual.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules-pli/rules-laxqual.ts
@@ -17,18 +17,24 @@
 ////*PROCESS RULES(<|3:NOLAXQUAL|>);
 ////*PROCESS RULES(NOLAXQUAL(<|4:)|>);
 ////*PROCESS RULES(NOLAXQUAL(<|5:INVALID|>));
-////*PROCESS RULES(NOLAXQUAL(ALL LOOSE FULL STRICT <|6:FORCE|>));
+////*PROCESS RULES(NOLAXQUAL(ALL LOOSE FULL <|6:STRICT|> <|7:FORCE|>));
 
 verify.expectDiagnosticsAt(1, {
   message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
 });
-verify.noDiagnostics([2, 3, 6]);
+verify.noDiagnostics([2, 3]);
 verify.expectDiagnosticsAt(4, {
   message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
 });
 verify.expectDiagnosticsAt(5, {
   message:
     code.CompilerOptions.Rules.InvalidLaxQualParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt(6, {
+  message: code.CompilerOptions.MutexOptionIssue.message("NOLAXQUAL(STRICT)"),
+});
+verify.expectDiagnosticsAt(7, {
+  message: code.CompilerOptions.MutexOptionIssue.message("NOLAXQUAL(FORCE)"),
 });
 verify.expectCompilerOptions({
   rules: {

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules-pli/rules-laxscale.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules-pli/rules-laxscale.ts
@@ -17,18 +17,24 @@
 ////*PROCESS RULES(<|3:NOLAXSCALE|>);
 ////*PROCESS RULES(NOLAXSCALE(<|4:)|>);
 ////*PROCESS RULES(NOLAXSCALE(<|5:INVALID|>));
-////*PROCESS RULES(NOLAXSCALE(ALL LOOSE STRICT <|6:SOURCE|>));
+////*PROCESS RULES(NOLAXSCALE(ALL LOOSE <|6:STRICT|> <|7:SOURCE|>));
 
 verify.expectDiagnosticsAt(1, {
   message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
 });
-verify.noDiagnostics([2, 3, 6]);
+verify.noDiagnostics([2, 3]);
 verify.expectDiagnosticsAt(4, {
   message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
 });
 verify.expectDiagnosticsAt(5, {
   message:
     code.CompilerOptions.Rules.InvalidLaxScaleParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt(6, {
+  message: code.CompilerOptions.MutexOptionIssue.message("NOLAXSCALE(STRICT)"),
+});
+verify.expectDiagnosticsAt(7, {
+  message: code.CompilerOptions.MutexOptionIssue.message("NOLAXSCALE(SOURCE)"),
 });
 verify.expectCompilerOptions({
   rules: {

--- a/packages/language/test/fourslash/preprocessor/compiler-options/rules-pli/rules-padding.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/rules-pli/rules-padding.ts
@@ -17,18 +17,24 @@
 ////*PROCESS RULES(<|3:NOPADDING|>);
 ////*PROCESS RULES(NOPADDING(<|4:)|>);
 ////*PROCESS RULES(NOPADDING(<|5:INVALID|>));
-////*PROCESS RULES(NOPADDING(ALL LOOSE STRICT <|6:SOURCE|>));
+////*PROCESS RULES(NOPADDING(ALL LOOSE <|6:STRICT|> <|7:SOURCE|>));
 
 verify.expectDiagnosticsAt(1, {
   message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
 });
-verify.noDiagnostics([2, 3, 6]);
+verify.noDiagnostics([2, 3]);
 verify.expectDiagnosticsAt(4, {
   message: code.CompilerOptions.ExpectedPlainNotEmpty.message(),
 });
 verify.expectDiagnosticsAt(5, {
   message:
     code.CompilerOptions.Rules.InvalidPaddingParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt(6, {
+  message: code.CompilerOptions.MutexOptionIssue.message("NOPADDING(STRICT)"),
+});
+verify.expectDiagnosticsAt(7, {
+  message: code.CompilerOptions.MutexOptionIssue.message("NOPADDING(SOURCE)"),
 });
 verify.expectCompilerOptions({
   rules: {


### PR DESCRIPTION
Addition to https://github.com/zowe/zowe-pli-language-support/issues/734

Adds duplication and mutex warnings to suboptions of the RULES directive. 