### PR TITLE
Add builtins LP int types

### DIFF
--- a/packages/language/src/workspace/builtins.ts
+++ b/packages/language/src/workspace/builtins.ts
@@ -12,6 +12,7 @@
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { UriUtils } from "../utils/uri";
 import { BuiltinsUriSchema } from "./builtins-constants";
+import { CompilerOptions } from "../preprocessor/compiler-options/options-pli";
 
 export const KNOWN_BUILTINS = "/* Known Builtins */";
 export { BuiltinsUriSchema };
@@ -13946,9 +13947,6 @@ export const Builtins =
  END;
 
  ${KNOWN_BUILTINS}
-
- define alias __SIGNED_INT signed fixed bin(31,0);
- define alias __UNSIGNED_INT unsigned fixed bin(32,0);
  ` +
   BuiltinsBoolean +
   BuiltinsFiles +
@@ -14586,4 +14584,34 @@ export const BuiltinsMacroTextDocument = TextDocument.create(
   "pli",
   0,
   BuiltinsMacro,
+);
+
+function getIntTypeAliasesForLP(lp: CompilerOptions.LP): string {
+  const p1 = lp === CompilerOptions.LP.LP64 ? 63 : 31;
+  const p2 = lp === CompilerOptions.LP.LP64 ? 64 : 32;
+
+  return `
+ define alias __SIGNED_INT signed fixed bin(${p1},0);
+ define alias __UNSIGNED_INT unsigned fixed bin(${p2},0);
+`;
+}
+
+export const BuiltinsIntTypeAliasesLP32File =
+  "builtins-int-type-aliases-lp32.pli";
+export const BuiltinsIntTypeAliasesLP32Uri = `${BuiltinsUriSchema}:/${BuiltinsIntTypeAliasesLP32File}`;
+export const BuiltinsIntTypeAliasesLP64File =
+  "builtins-int-type-aliases-lp64.pli";
+export const BuiltinsIntTypeAliasesLP64Uri = `${BuiltinsUriSchema}:/${BuiltinsIntTypeAliasesLP64File}`;
+
+export const BuiltinsIntTypeAliasesLP32TextDocument = TextDocument.create(
+  BuiltinsIntTypeAliasesLP32Uri,
+  "pli",
+  0,
+  getIntTypeAliasesForLP(CompilerOptions.LP.LP32),
+);
+export const BuiltinsIntTypeAliasesLP64TextDocument = TextDocument.create(
+  BuiltinsIntTypeAliasesLP64Uri,
+  "pli",
+  0,
+  getIntTypeAliasesForLP(CompilerOptions.LP.LP64),
 );

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -33,6 +33,8 @@ import {
 import {
   BuiltinsMacroTextDocument,
   BuiltinsTextDocument,
+  BuiltinsIntTypeAliasesLP32TextDocument,
+  BuiltinsIntTypeAliasesLP64TextDocument,
   BuiltinsUriSchema,
 } from "./builtins.js";
 import { GroupRecord, ProgramRecord } from "./plugin-configuration-provider.js";
@@ -49,6 +51,7 @@ import {
   CompilerOptions,
   getDefaultCompilerOptions,
 } from "../preprocessor/compiler-options/options.js";
+import { CompilerOptions as PliCompilerOptions } from "../preprocessor/compiler-options/options-pli.js";
 import { DiagnosticsStore } from "../validation/diagnostics-store.js";
 import { LRUCache } from "lru-cache";
 
@@ -104,8 +107,6 @@ export interface CompilationServices {
   workspace: WorkspaceContext;
 }
 
-const BuiltinFileStart = `${BuiltinsUriSchema}:/`;
-const isBuiltinFile = (uri: URI) => uri.toString().startsWith(BuiltinFileStart);
 const FIVE_MINUTES = 1000 * 60 * 5;
 
 /**
@@ -117,59 +118,13 @@ function isPluginConfigurationUri(uri: URI): boolean {
   return path.includes("/.pliplugin/") && /\.json$/i.test(path);
 }
 
-function createBuiltinUnitGetter(
-  builtinDocument: TextDocument,
-): (workspace: WorkspaceContext) => Promise<CompilationUnit> {
-  let builtinUnit: CompilationUnit | undefined = undefined;
-  return async (workspace) => {
-    if (!builtinUnit) {
-      const fileUri = URI.parse(builtinDocument.uri);
-      builtinUnit = await createCompilationUnit(fileUri, workspace);
-      await tokenize(builtinUnit, builtinDocument);
-      parse(builtinUnit);
-      generateSymbolTable(builtinUnit);
-      link(builtinUnit);
-    }
-    return builtinUnit;
-  };
-}
-
-function createBuiltinScopeGetter(
-  unitGetter: (workspace: WorkspaceContext) => Promise<CompilationUnit>,
-) {
-  let builtinFileScope: Scope | undefined;
-  return async (uri: URI, workspace: WorkspaceContext): Promise<Scope> => {
-    if (isBuiltinFile(uri)) {
-      return Scope.createRoot();
-    }
-    if (!builtinFileScope) {
-      const unit = await unitGetter(workspace);
-      builtinFileScope =
-        unit.scopeCaches.regular.get(unit.ast) ?? Scope.createRoot();
-    }
-    return builtinFileScope;
-  };
-}
-
-const getBuiltinUnit = createBuiltinUnitGetter(BuiltinsTextDocument);
-const getBuiltinMacroUnit = createBuiltinUnitGetter(BuiltinsMacroTextDocument);
-
-const getBuiltinScope = createBuiltinScopeGetter(getBuiltinUnit);
-const getRootPreprocessorScope = createBuiltinScopeGetter(getBuiltinMacroUnit);
-
 export async function createCompilationUnit(
   uri: URI,
   workspace: WorkspaceContext,
 ): Promise<CompilationUnit> {
   const compilerOptions = getDefaultCompilerOptions();
-  const baseFiles: CompilationUnit[] = [];
-  if (uri.scheme !== BuiltinsUriSchema) {
-    const unit = await getBuiltinUnit(workspace);
-    const macroUnit = await getBuiltinMacroUnit(workspace);
-    baseFiles.push(unit, macroUnit);
-  }
   const services: CompilationServices = {
-    files: new FileStore(baseFiles),
+    files: new FileStore([]),
     typeCache: new DefaultTypeCache(),
     includeCache: new LRUCache({
       max: 500,
@@ -212,8 +167,8 @@ export async function createCompilationUnit(
       .onRevalidate("skippedCodeRanges", ({ connection, unit }) => {
         skippedCode(connection, unit);
       }),
-    rootScope: await getBuiltinScope(uri, workspace),
-    rootPreprocessorScope: await getRootPreprocessorScope(uri, workspace),
+    rootScope: Scope.createRoot(),
+    rootPreprocessorScope: Scope.createRoot(),
     get programConfig() {
       if (cachedProgramConfig !== null) {
         return cachedProgramConfig;
@@ -247,6 +202,78 @@ export async function createCompilationUnit(
     },
   };
   return unit;
+}
+
+const BuiltinFileStart = `${BuiltinsUriSchema}:/`;
+const isBuiltinFile = (uri: URI) => uri.toString().startsWith(BuiltinFileStart);
+
+function createBuiltinUnitGetter(
+  builtinDocument: TextDocument,
+  parentUnitGetter?: (workspace: WorkspaceContext) => Promise<CompilationUnit>,
+): (workspace: WorkspaceContext) => Promise<CompilationUnit> {
+  let builtinUnit: CompilationUnit | undefined = undefined;
+  return async (workspace) => {
+    if (!builtinUnit) {
+      const fileUri = URI.parse(builtinDocument.uri);
+      builtinUnit = await createCompilationUnit(fileUri, workspace);
+      await tokenize(builtinUnit, builtinDocument);
+      parse(builtinUnit);
+
+      if (parentUnitGetter) {
+        const parentUnit = await parentUnitGetter(workspace);
+        const parentScope = parentUnit.scopeCaches.regular.get(parentUnit.ast);
+        if (parentScope) {
+          builtinUnit.rootScope = parentScope;
+        }
+      }
+
+      await generateSymbolTable(builtinUnit);
+      link(builtinUnit);
+    }
+    return builtinUnit;
+  };
+}
+
+const getBuiltinUnit = createBuiltinUnitGetter(BuiltinsTextDocument);
+const getBuiltinMacroUnit = createBuiltinUnitGetter(BuiltinsMacroTextDocument);
+const getBuiltinIntTypeAliasesLP32Unit = createBuiltinUnitGetter(
+  BuiltinsIntTypeAliasesLP32TextDocument,
+  getBuiltinUnit,
+);
+const getBuiltinIntTypeAliasesLP64Unit = createBuiltinUnitGetter(
+  BuiltinsIntTypeAliasesLP64TextDocument,
+  getBuiltinUnit,
+);
+
+/**
+ * Add all builtin units and set up the root scope chain.
+ * Must be called after compiler options are extracted (during tokenization).
+ */
+export async function addBuiltinUnits(
+  unit: CompilationUnit,
+  workspace: WorkspaceContext,
+): Promise<void> {
+  if (isBuiltinFile(unit.uri)) {
+    return;
+  }
+
+  const builtinUnit = await getBuiltinUnit(workspace);
+  const macroUnit = await getBuiltinMacroUnit(workspace);
+  const intTypeAliasUnit =
+    unit.compilerOptions.LP === PliCompilerOptions.LP.LP64
+      ? await getBuiltinIntTypeAliasesLP64Unit(workspace)
+      : await getBuiltinIntTypeAliasesLP32Unit(workspace);
+
+  unit.services.files.addBaseFiles([builtinUnit, macroUnit, intTypeAliasUnit]);
+
+  const intTypeAliasScope =
+    intTypeAliasUnit.scopeCaches.regular.get(intTypeAliasUnit.ast) ??
+    Scope.createRoot();
+  const macroScope =
+    macroUnit.scopeCaches.regular.get(macroUnit.ast) ?? Scope.createRoot();
+
+  unit.rootScope = Scope.createChild(intTypeAliasScope);
+  unit.rootPreprocessorScope = Scope.createChild(macroScope);
 }
 
 export class CompilationUnitHandler {

--- a/packages/language/src/workspace/file-store.ts
+++ b/packages/language/src/workspace/file-store.ts
@@ -75,6 +75,15 @@ export class FileStore {
     }
   }
 
+  addBaseFiles(files: CompilationUnit[]): void {
+    for (const file of files) {
+      const uriString = file.uri.toString();
+      this.baseFiles.push(file);
+      this.baseFileUris.add(uriString);
+      this.map.set(uriString, file.services.files.get(file.uri)!);
+    }
+  }
+
   has(uri: URI | string): boolean {
     return this.map.has(uri.toString());
   }

--- a/packages/language/src/workspace/lifecycle.ts
+++ b/packages/language/src/workspace/lifecycle.ts
@@ -11,7 +11,7 @@
 
 import { ReferencesCache, resolveReferences } from "../linking/resolver";
 import { iterateSymbols } from "../linking/symbol-table";
-import { CompilationUnit } from "./compilation-unit";
+import { CompilationUnit, addBuiltinUnits } from "./compilation-unit";
 import { Program } from "../syntax-tree/ast";
 import {
   generatePliValidationDiagnostics,
@@ -38,7 +38,7 @@ export async function lifecycle(
   await interruptAndCheck(cancellation);
   parse(compilationUnit);
   await interruptAndCheck(cancellation);
-  generateSymbolTable(compilationUnit);
+  await generateSymbolTable(compilationUnit);
   await interruptAndCheck(cancellation);
   link(compilationUnit);
   await interruptAndCheck(cancellation);
@@ -84,7 +84,8 @@ export function parse(compilationUnit: CompilationUnit): Program {
   return tree;
 }
 
-export function generateSymbolTable(compilationUnit: CompilationUnit) {
+export async function generateSymbolTable(compilationUnit: CompilationUnit) {
+  await addBuiltinUnits(compilationUnit, compilationUnit.services.workspace);
   iterateSymbols(compilationUnit);
 }
 

--- a/packages/language/test/extracted-doc-cases.test.ts
+++ b/packages/language/test/extracted-doc-cases.test.ts
@@ -50,7 +50,7 @@ test("Block block-492.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-508.pli", async () => {
@@ -85,7 +85,7 @@ test("Block block-508.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-400.pli", async () => {
@@ -116,7 +116,7 @@ test("Block block-400.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-204.pli", async () => {
@@ -143,7 +143,7 @@ test("Block block-204.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-658.pli", async () => {
@@ -177,7 +177,7 @@ test("Block block-658.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-297.pli", async () => {
@@ -205,7 +205,7 @@ test("Block block-297.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-477.pli", async () => {
@@ -233,7 +233,7 @@ test("Block block-477.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-610.pli", async () => {
@@ -268,7 +268,7 @@ test("Block block-610.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-278.pli", async () => {
@@ -301,7 +301,7 @@ test("Block block-278.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-184.pli", async () => {
@@ -328,7 +328,7 @@ test("Block block-184.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-129.pli", async () => {
@@ -356,7 +356,7 @@ test("Block block-129.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-689.pli", async () => {
@@ -484,7 +484,7 @@ test("Block block-689.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-688.pli", async () => {
@@ -610,7 +610,7 @@ test("Block block-688.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-68.pli", async () => {
@@ -639,7 +639,7 @@ test("Block block-68.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-142.pli", async () => {
@@ -675,7 +675,7 @@ test("Block block-142.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-21.pli", async () => {
@@ -702,7 +702,7 @@ test("Block block-21.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-20.pli", async () => {
@@ -729,7 +729,7 @@ test("Block block-20.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-389.pli", async () => {
@@ -764,7 +764,7 @@ test("Block block-389.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-212.pli", async () => {
@@ -791,7 +791,7 @@ test("Block block-212.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-149.pli", async () => {
@@ -825,7 +825,7 @@ test("Block block-149.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-192.pli", async () => {
@@ -852,7 +852,7 @@ test("Block block-192.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-633.pli", async () => {
@@ -886,7 +886,7 @@ test("Block block-633.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-383.pli", async () => {
@@ -914,7 +914,7 @@ test("Block block-383.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-382.pli", async () => {
@@ -944,7 +944,7 @@ test("Block block-382.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-177.pli", async () => {
@@ -972,7 +972,7 @@ test("Block block-177.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-87.pli", async () => {
@@ -1001,7 +1001,7 @@ test("Block block-87.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-562.pli", async () => {
@@ -1034,7 +1034,7 @@ test("Block block-562.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-563.pli", async () => {
@@ -1071,7 +1071,7 @@ test("Block block-563.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-27.pli", async () => {
@@ -1099,7 +1099,7 @@ test("Block block-27.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-692.pli", async () => {
@@ -1165,7 +1165,7 @@ test("Block block-692.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-214.pli", async () => {
@@ -1203,7 +1203,7 @@ test("Block block-214.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-215.pli", async () => {
@@ -1235,7 +1235,7 @@ test("Block block-215.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-286.pli", async () => {
@@ -1263,7 +1263,7 @@ test("Block block-286.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-329.pli", async () => {
@@ -1294,7 +1294,7 @@ test("Block block-329.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-194.pli", async () => {
@@ -1330,7 +1330,7 @@ test("Block block-194.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-317.pli", async () => {
@@ -1357,7 +1357,7 @@ test("Block block-317.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-12.pli", async () => {
@@ -1384,7 +1384,7 @@ test("Block block-12.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-385.pli", async () => {
@@ -1418,7 +1418,7 @@ test("Block block-385.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-153.pli", async () => {
@@ -1449,7 +1449,7 @@ test("Block block-153.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-152.pli", async () => {
@@ -1478,7 +1478,7 @@ test("Block block-152.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-31.pli", async () => {
@@ -1512,7 +1512,7 @@ test("Block block-31.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-629.pli", async () => {
@@ -1559,7 +1559,7 @@ test("Block block-629.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-291.pli", async () => {
@@ -1591,7 +1591,7 @@ test("Block block-291.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-530.pli", async () => {
@@ -1629,7 +1629,7 @@ test("Block block-530.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-399.pli", async () => {
@@ -1658,7 +1658,7 @@ test("Block block-399.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-471.pli", async () => {
@@ -1687,7 +1687,7 @@ test("Block block-471.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-183.pli", async () => {
@@ -1714,7 +1714,7 @@ test("Block block-183.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-236.pli", async () => {
@@ -1752,7 +1752,7 @@ test("Block block-236.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-209.pli", async () => {
@@ -1790,7 +1790,7 @@ test("Block block-209.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-208.pli", async () => {
@@ -1822,7 +1822,7 @@ test("Block block-208.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-393.pli", async () => {
@@ -1849,7 +1849,7 @@ test("Block block-393.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-392.pli", async () => {
@@ -1876,7 +1876,7 @@ test("Block block-392.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-300.pli", async () => {
@@ -1904,7 +1904,7 @@ test("Block block-300.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-166.pli", async () => {
@@ -1931,7 +1931,7 @@ test("Block block-166.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-28.pli", async () => {
@@ -1958,7 +1958,7 @@ test("Block block-28.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-29.pli", async () => {
@@ -1989,7 +1989,7 @@ test("Block block-29.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-516.pli", async () => {
@@ -2018,7 +2018,7 @@ test("Block block-516.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-679.pli", async () => {
@@ -2046,7 +2046,7 @@ test("Block block-679.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-191.pli", async () => {
@@ -2073,7 +2073,7 @@ test("Block block-191.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-380.pli", async () => {
@@ -2101,7 +2101,7 @@ test("Block block-380.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-528.pli", async () => {
@@ -2130,7 +2130,7 @@ test("Block block-528.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-486.pli", async () => {
@@ -2161,7 +2161,7 @@ test("Block block-486.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-22.pli", async () => {
@@ -2188,7 +2188,7 @@ test("Block block-22.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-23.pli", async () => {
@@ -2215,7 +2215,7 @@ test("Block block-23.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-115.pli", async () => {
@@ -2242,7 +2242,7 @@ test("Block block-115.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-548.pli", async () => {
@@ -2272,7 +2272,7 @@ test("Block block-548.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-549.pli", async () => {
@@ -2320,7 +2320,7 @@ test("Block block-549.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-436.pli", async () => {
@@ -2352,7 +2352,7 @@ test("Block block-436.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-305.pli", async () => {
@@ -2380,7 +2380,7 @@ test("Block block-305.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-239.pli", async () => {
@@ -2418,7 +2418,7 @@ test("Block block-239.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-403.pli", async () => {
@@ -2451,7 +2451,7 @@ test("Block block-403.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-402.pli", async () => {
@@ -2479,7 +2479,7 @@ test("Block block-402.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-379.pli", async () => {
@@ -2507,7 +2507,7 @@ test("Block block-379.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-475.pli", async () => {
@@ -2535,7 +2535,7 @@ test("Block block-475.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-613.pli", async () => {
@@ -2566,7 +2566,7 @@ test("Block block-613.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-181.pli", async () => {
@@ -2595,7 +2595,7 @@ test("Block block-181.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-180.pli", async () => {
@@ -2628,7 +2628,7 @@ test("Block block-180.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-375.pli", async () => {
@@ -2656,7 +2656,7 @@ test("Block block-375.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-374.pli", async () => {
@@ -2684,7 +2684,7 @@ test("Block block-374.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-506.pli", async () => {
@@ -2711,7 +2711,7 @@ test("Block block-506.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-594.pli", async () => {
@@ -2745,7 +2745,7 @@ test("Block block-594.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-479.pli", async () => {
@@ -2772,7 +2772,7 @@ test("Block block-479.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-478.pli", async () => {
@@ -2799,7 +2799,7 @@ test("Block block-478.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-94.pli", async () => {
@@ -2830,7 +2830,7 @@ test("Block block-94.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-299.pli", async () => {
@@ -2857,7 +2857,7 @@ test("Block block-299.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-302.pli", async () => {
@@ -2885,7 +2885,7 @@ test("Block block-302.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-165.pli", async () => {
@@ -2920,7 +2920,7 @@ test("Block block-165.pli", async () => {
    end X;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-150.pli", async () => {
@@ -2948,7 +2948,7 @@ test("Block block-150.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-309.pli", async () => {
@@ -2980,7 +2980,7 @@ test("Block block-309.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-532.pli", async () => {
@@ -3018,7 +3018,7 @@ test("Block block-532.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-473.pli", async () => {
@@ -3048,7 +3048,7 @@ test("Block block-473.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-687.pli", async () => {
@@ -3154,7 +3154,7 @@ test("Block block-687.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-222.pli", async () => {
@@ -3236,7 +3236,7 @@ test("Block block-222.pli", async () => {
    end;          
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-450.pli", async () => {
@@ -3269,7 +3269,7 @@ test("Block block-450.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-637.pli", async () => {
@@ -3296,7 +3296,7 @@ test("Block block-637.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-196.pli", async () => {
@@ -3334,7 +3334,7 @@ test("Block block-196.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-67.pli", async () => {
@@ -3377,7 +3377,7 @@ test("Block block-67.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-315.pli", async () => {
@@ -3405,7 +3405,7 @@ test("Block block-315.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-172.pli", async () => {
@@ -3433,7 +3433,7 @@ test("Block block-172.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-387.pli", async () => {
@@ -3466,7 +3466,7 @@ test("Block block-387.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-25.pli", async () => {
@@ -3494,7 +3494,7 @@ test("Block block-25.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-480.pli", async () => {
@@ -3522,7 +3522,7 @@ test("Block block-480.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-24.pli", async () => {
@@ -3549,7 +3549,7 @@ test("Block block-24.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-589.pli", async () => {
@@ -3594,7 +3594,7 @@ test("Block block-589.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-147.pli", async () => {
@@ -3640,7 +3640,7 @@ test("Block block-147.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-321.pli", async () => {
@@ -3670,7 +3670,7 @@ test("Block block-321.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-146.pli", async () => {
@@ -3698,7 +3698,7 @@ test("Block block-146.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-52.pli", async () => {
@@ -3727,7 +3727,7 @@ test("Block block-52.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-690.pli", async () => {
@@ -3873,7 +3873,7 @@ test("Block block-690.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-691.pli", async () => {
@@ -4019,7 +4019,7 @@ test("Block block-691.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-216.pli", async () => {
@@ -4054,7 +4054,7 @@ test("Block block-216.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-179.pli", async () => {
@@ -4081,7 +4081,7 @@ test("Block block-179.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-178.pli", async () => {
@@ -4109,7 +4109,7 @@ test("Block block-178.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-271.pli", async () => {
@@ -4156,7 +4156,7 @@ test("Block block-271.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-169.pli", async () => {
@@ -4184,7 +4184,7 @@ test("Block block-169.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-48.pli", async () => {
@@ -4224,7 +4224,7 @@ test("Block block-48.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-187.pli", async () => {
@@ -4257,7 +4257,7 @@ test("Block block-187.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-2.pli", async () => {
@@ -4287,7 +4287,7 @@ test("Block block-2.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-267.pli", async () => {
@@ -4314,7 +4314,7 @@ test("Block block-267.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-283.pli", async () => {
@@ -4347,7 +4347,7 @@ test("Block block-283.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-137.pli", async () => {
@@ -4377,7 +4377,7 @@ test("Block block-137.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-102.pli", async () => {
@@ -4404,7 +4404,7 @@ test("Block block-102.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-8.pli", async () => {
@@ -4434,7 +4434,7 @@ test("Block block-8.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-289.pli", async () => {
@@ -4475,7 +4475,7 @@ test("Block block-289.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-55.pli", async () => {
@@ -4507,7 +4507,7 @@ test("Block block-55.pli", async () => {
     End FMAIN;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-285.pli", async () => {
@@ -4539,7 +4539,7 @@ test("Block block-285.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-284.pli", async () => {
@@ -4571,7 +4571,7 @@ test("Block block-284.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-131.pli", async () => {
@@ -4601,7 +4601,7 @@ test("Block block-131.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-11.pli", async () => {
@@ -4635,7 +4635,7 @@ test("Block block-11.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-276.pli", async () => {
@@ -4663,7 +4663,7 @@ test("Block block-276.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-249.pli", async () => {
@@ -4691,7 +4691,7 @@ test("Block block-249.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-94.pli", async () => {
@@ -4739,7 +4739,7 @@ test("Block block-94.pli", async () => {
   //GO.IN DD */
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-309.pli", async () => {
@@ -4783,7 +4783,7 @@ test("Block block-309.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-303.pli", async () => {
@@ -4819,7 +4819,7 @@ test("Block block-303.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-298.pli", async () => {
@@ -4853,7 +4853,7 @@ test("Block block-298.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-299.pli", async () => {
@@ -4909,7 +4909,7 @@ test("Block block-299.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-101.pli", async () => {
@@ -4947,7 +4947,7 @@ test("Block block-101.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-21.pli", async () => {
@@ -4977,7 +4977,7 @@ test("Block block-21.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-311.pli", async () => {
@@ -5043,7 +5043,7 @@ test("Block block-311.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-310.pli", async () => {
@@ -5082,7 +5082,7 @@ test("Block block-310.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-56.pli", async () => {
@@ -5118,7 +5118,7 @@ test("Block block-56.pli", async () => {
     End;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-143.pli", async () => {
@@ -5150,7 +5150,7 @@ test("Block block-143.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-281.pli", async () => {
@@ -5183,7 +5183,7 @@ test("Block block-281.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-280.pli", async () => {
@@ -5238,7 +5238,7 @@ test("Block block-280.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-135.pli", async () => {
@@ -5266,7 +5266,7 @@ test("Block block-135.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-307.pli", async () => {
@@ -5328,7 +5328,7 @@ test("Block block-307.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-128.pli", async () => {
@@ -5364,7 +5364,7 @@ test("Block block-128.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-273.pli", async () => {
@@ -5392,7 +5392,7 @@ test("Block block-273.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-272.pli", async () => {
@@ -5422,7 +5422,7 @@ test("Block block-272.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-74.pli", async () => {
@@ -5452,7 +5452,7 @@ test("Block block-74.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-91.pli", async () => {
@@ -5479,7 +5479,7 @@ test("Block block-91.pli", async () => {
  end;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-300.pli", async () => {
@@ -5513,7 +5513,7 @@ test("Block block-300.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-274.pli", async () => {
@@ -5541,7 +5541,7 @@ test("Block block-274.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-188.pli", async () => {
@@ -5575,7 +5575,7 @@ test("Block block-188.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-220.pli", async () => {
@@ -5605,7 +5605,7 @@ test("Block block-220.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-171.pli", async () => {
@@ -5639,7 +5639,7 @@ test("Block block-171.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-287.pli", async () => {
@@ -5686,7 +5686,7 @@ test("Block block-287.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-215.pli", async () => {
@@ -5713,7 +5713,7 @@ test("Block block-215.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });
 
 test("Block block-12.pli", async () => {
@@ -5747,5 +5747,5 @@ test("Block block-12.pli", async () => {
  END MAINTP;
 `);
   assertNoParseErrors(doc);
-  generateAndAssertValidSymbolTable(doc);
+  await generateAndAssertValidSymbolTable(doc);
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/lp32-int-types.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/lp32-int-types.ts
@@ -1,0 +1,32 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: main
+//// DCL <|x32|> type __SIGNED_INT;
+//// DCL <|y32|> type __UNSIGNED_INT;
+
+types.expectTypeAt("x32", {
+  type: types.dataTypes.Arithmetic,
+  scale: types.scales.Fixed,
+  base: types.bases.Binary,
+  sign: types.signs.Signed,
+  precision: { totalDigitsCount: 31 },
+});
+
+types.expectTypeAt("y32", {
+  type: types.dataTypes.Arithmetic,
+  scale: types.scales.Fixed,
+  base: types.bases.Binary,
+  sign: types.signs.Unsigned,
+  precision: { totalDigitsCount: 32 },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/lp64-int-types.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/lp64-int-types.ts
@@ -1,0 +1,35 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+////*PROCESS LP(64);
+////
+//// STARTPR: PROCEDURE OPTIONS (MAIN);
+////   DCL <|x64|> type __SIGNED_INT;
+////   DCL <|y64|> type __UNSIGNED_INT;
+//// END STARTPR;
+
+types.expectTypeAt("x64", {
+  type: types.dataTypes.Arithmetic,
+  scale: types.scales.Fixed,
+  base: types.bases.Binary,
+  sign: types.signs.Signed,
+  precision: { totalDigitsCount: 63 },
+});
+
+types.expectTypeAt("y64", {
+  type: types.dataTypes.Arithmetic,
+  scale: types.scales.Fixed,
+  base: types.bases.Binary,
+  sign: types.signs.Unsigned,
+  precision: { totalDigitsCount: 64 },
+});

--- a/packages/language/test/parsing.test.ts
+++ b/packages/language/test/parsing.test.ts
@@ -25,19 +25,19 @@ describe("PL/I Parsing tests", () => {
     // later for validation
     const doc = await parse("");
     assertNoParseErrors(doc);
-    generateAndAssertValidSymbolTable(doc);
+    await generateAndAssertValidSymbolTable(doc);
   });
 
   test("empty program w/ null statement", async () => {
     const doc = await parseStmts(` ;`);
     assertNoParseErrors(doc);
-    generateAndAssertValidSymbolTable(doc);
+    await generateAndAssertValidSymbolTable(doc);
   });
 
   test("empty program w/ null %statement", async () => {
     const doc = await parseStmts(` %;`);
     assertNoParseErrors(doc);
-    generateAndAssertValidSymbolTable(doc);
+    await generateAndAssertValidSymbolTable(doc);
   });
 
   test("Hello World Program", async () => {
@@ -48,7 +48,7 @@ describe("PL/I Parsing tests", () => {
    PUT LIST ('PROGRAM TO COMPUTE AVERAGE');
  END AVERAGE;`);
     assertNoParseErrors(doc);
-    generateAndAssertValidSymbolTable(doc);
+    await generateAndAssertValidSymbolTable(doc);
   });
 
   describe("Procedures", async () => {
@@ -57,7 +57,7 @@ describe("PL/I Parsing tests", () => {
     P1: procedure;
     end P1;`);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("Procedure w/ alternate entry point", async () => {
@@ -66,7 +66,7 @@ describe("PL/I Parsing tests", () => {
     B: entry; // secondary entry point into this procedure
     end P1;`);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("Procedure with call", async () => {
@@ -79,7 +79,7 @@ describe("PL/I Parsing tests", () => {
  put skip list(VAR1);
  end A;`);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("Simple recursive procedure w/ recursive stated before returns", async () => {
@@ -92,7 +92,7 @@ describe("PL/I Parsing tests", () => {
   return( Input*Fact(Input-1) );
  end Fact;`);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("Simple recursive procedure w/ recursive stated after returns", async () => {
@@ -105,7 +105,7 @@ describe("PL/I Parsing tests", () => {
   return( Input*Fact(Input-1) );
  end Fact;`);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("Procedures w/ Order & Reorder options", async () => {
@@ -117,7 +117,7 @@ describe("PL/I Parsing tests", () => {
  call P1;
  call P2;`);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("Procedure w/ Reorder option & Returns", async () => {
@@ -129,7 +129,7 @@ describe("PL/I Parsing tests", () => {
  declare X fixed bin(31);
  X = Double(5);`);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("Recursive - Returns - Options for a Procedure in various permutations", async () => {
@@ -180,7 +180,7 @@ describe("PL/I Parsing tests", () => {
  end F5;
  `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("Unassigned closing end is OK", async () => {
@@ -195,7 +195,7 @@ describe("PL/I Parsing tests", () => {
   END;
   `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("Options Separate by Commas & Spaces", async () => {
@@ -209,7 +209,7 @@ describe("PL/I Parsing tests", () => {
     P4: proc Options(Order, Reorder Recursive);
     end P4;`);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("Complex recursive procedure", async () => {
@@ -231,7 +231,7 @@ describe("PL/I Parsing tests", () => {
  end Start;
 `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
   });
 
@@ -240,13 +240,13 @@ describe("PL/I Parsing tests", () => {
     test("empty label, null statement", async () => {
       const doc = await parseStmts(` main:;`);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("Declared label", async () => {
       const doc = await parseStmts(` declare Label_x label;`);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("Label assignment", async () => {
@@ -257,7 +257,7 @@ describe("PL/I Parsing tests", () => {
  go to Label_x; // jump to label
 `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
   });
 
@@ -273,7 +273,7 @@ describe("PL/I Parsing tests", () => {
  dcl Z char(3) nonvarying init('abc');
 `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("char declaration w/ overflow assignment", async () => {
@@ -282,7 +282,7 @@ describe("PL/I Parsing tests", () => {
  Subject = 'Transformations'; // will truncate the last 5 chars, emitting a warning (but valid nonetheless)
 `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("arbitrary length char decl", async () => {
@@ -290,7 +290,7 @@ describe("PL/I Parsing tests", () => {
  dcl VAL char(*) value('Some text that runs on and on');
 `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("nested quotes char decl", async () => {
@@ -300,7 +300,7 @@ describe("PL/I Parsing tests", () => {
  declare User3 character (30) init('/* blah */');
 `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("Bit declarations", async () => {
@@ -311,7 +311,7 @@ describe("PL/I Parsing tests", () => {
  Code = '1100110000'B;
 `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("Format constants", async () => {
@@ -322,7 +322,7 @@ describe("PL/I Parsing tests", () => {
     ( column(20),A(10), column(35),A(10), column(50),A(10) );
 `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("Attribute declarations", async () => {
@@ -333,7 +333,7 @@ describe("PL/I Parsing tests", () => {
  File2 file; // file constant
 `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("Value List declaration", async () => {
@@ -343,7 +343,7 @@ describe("PL/I Parsing tests", () => {
                          'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec' );
 `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("value list from declaration", async () => {
@@ -355,7 +355,7 @@ describe("PL/I Parsing tests", () => {
  dcl x fixed bin valuelistfrom a;
 `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     // Handle as validation error
@@ -367,7 +367,7 @@ describe("PL/I Parsing tests", () => {
      dcl x fixed bin valuelistfrom a;
     `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test.fails(
@@ -378,7 +378,7 @@ describe("PL/I Parsing tests", () => {
  dcl x fixed bin valuelistfrom a;
 `);
         assertNoParseErrors(doc);
-        generateAndAssertValidSymbolTable(doc);
+        await generateAndAssertValidSymbolTable(doc);
       },
     );
 
@@ -391,7 +391,7 @@ describe("PL/I Parsing tests", () => {
                      'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec' );
 `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("multi-declaration", async () => {
@@ -402,7 +402,7 @@ describe("PL/I Parsing tests", () => {
         C character(2), D bit(4);
     `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
   });
 
@@ -414,7 +414,7 @@ describe("PL/I Parsing tests", () => {
  substr(A,6,5) = substr(B,20,5);
 `);
     assertNoParseErrors(doc);
-    generateAndAssertValidSymbolTable(doc);
+    await generateAndAssertValidSymbolTable(doc);
   });
 
   test("assignment from multi-declaration", async () => {
@@ -430,7 +430,7 @@ describe("PL/I Parsing tests", () => {
  Result = A + B < C & D;
 `);
     assertNoParseErrors(doc);
-    generateAndAssertValidSymbolTable(doc);
+    await generateAndAssertValidSymbolTable(doc);
   });
 
   describe("Expressions", async () => {
@@ -456,7 +456,7 @@ describe("PL/I Parsing tests", () => {
  dcl Identical_to_Ar( lbound(Ar):hbound(Ar) ) pointer;
 `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("Simple arithmetic expressions", async () => {
@@ -471,7 +471,7 @@ describe("PL/I Parsing tests", () => {
  C = A ** B;
 `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("Function invocation", async () => {
@@ -488,7 +488,7 @@ describe("PL/I Parsing tests", () => {
  end ADD;
 `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
   });
 
@@ -504,7 +504,7 @@ describe("PL/I Parsing tests", () => {
  Y:;
 `);
     assertNoParseErrors(doc);
-    generateAndAssertValidSymbolTable(doc);
+    await generateAndAssertValidSymbolTable(doc);
   });
 
   describe("Packages", async () => {
@@ -516,7 +516,7 @@ describe("PL/I Parsing tests", () => {
  end Package_Demo;
 `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
   });
 
@@ -524,7 +524,7 @@ describe("PL/I Parsing tests", () => {
     // output a string to the stdout
     const doc = await parseStmts(` put skip list('Hello ' || 'World');`);
     assertNoParseErrors(doc);
-    generateAndAssertValidSymbolTable(doc);
+    await generateAndAssertValidSymbolTable(doc);
   });
 
   test("simple GET", async () => {
@@ -534,7 +534,7 @@ describe("PL/I Parsing tests", () => {
  get list(var);
 `);
     assertNoParseErrors(doc);
-    generateAndAssertValidSymbolTable(doc);
+    await generateAndAssertValidSymbolTable(doc);
   });
 
   test("fetch", async () => {
@@ -550,7 +550,7 @@ describe("PL/I Parsing tests", () => {
  call ProgA;
  release ProgA;`);
     assertNoParseErrors(doc);
-    generateAndAssertValidSymbolTable(doc);
+    await generateAndAssertValidSymbolTable(doc);
   });
 
   test("BEGIN block", async () => {
@@ -559,7 +559,7 @@ describe("PL/I Parsing tests", () => {
  declare A fixed bin(15);
  end B;`);
     assertNoParseErrors(doc);
-    generateAndAssertValidSymbolTable(doc);
+    await generateAndAssertValidSymbolTable(doc);
   });
 
   test("Subscripted entry invocation", async () => {
@@ -574,7 +574,7 @@ describe("PL/I Parsing tests", () => {
   call F(I) (X,Y,Z); // each entry call gets args x,y,z
  end;`);
     assertNoParseErrors(doc);
-    generateAndAssertValidSymbolTable(doc);
+    await generateAndAssertValidSymbolTable(doc);
   });
 
   test("Optional args", async () => {
@@ -594,7 +594,7 @@ describe("PL/I Parsing tests", () => {
  call Vrtn(10, addr(x), 15.5);
 `);
     assertNoParseErrors(doc);
-    generateAndAssertValidSymbolTable(doc);
+    await generateAndAssertValidSymbolTable(doc);
   });
 
   test("Block 27", async () => {
@@ -603,7 +603,7 @@ describe("PL/I Parsing tests", () => {
     A = '/* This is a constant, not a comment */' ;
     `);
     assertNoParseErrors(doc);
-    generateAndAssertValidSymbolTable(doc);
+    await generateAndAssertValidSymbolTable(doc);
   });
 
   describe("Ordinal Tests", async () => {
@@ -628,7 +628,7 @@ describe("PL/I Parsing tests", () => {
       end get_day;
         `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("parses ordinals w/ multiple unsigned/signed attributes", async () => {
@@ -639,7 +639,7 @@ describe("PL/I Parsing tests", () => {
       ) prec(15) signed signed unsigned signed unsigned signed prec(15);
        `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     /**
@@ -662,7 +662,7 @@ describe("PL/I Parsing tests", () => {
       );
        `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("Can specify negative value on ordinal definition", async () => {
@@ -672,7 +672,7 @@ describe("PL/I Parsing tests", () => {
       );
        `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("Can use non-UNION attributes in DEFINE STRUCTURE statement", async () => {
@@ -693,7 +693,7 @@ describe("PL/I Parsing tests", () => {
        ;
       `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     /**
@@ -710,7 +710,7 @@ describe("PL/I Parsing tests", () => {
       ) prec(15);
        `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
   });
 
@@ -723,7 +723,7 @@ describe("PL/I Parsing tests", () => {
    end MAINPR;
       `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("xu binary fixed point constants", async () => {
@@ -734,7 +734,7 @@ describe("PL/I Parsing tests", () => {
    end MAINPR;
       `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("x character constants", async () => {
@@ -744,7 +744,7 @@ describe("PL/I Parsing tests", () => {
    end MAINPR;
       `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("a character constants", async () => {
@@ -754,7 +754,7 @@ describe("PL/I Parsing tests", () => {
    end MAINPR;
       `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("e character constants", async () => {
@@ -764,7 +764,7 @@ describe("PL/I Parsing tests", () => {
    end MAINPR;
       `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("b3 octal constants", async () => {
@@ -774,7 +774,7 @@ describe("PL/I Parsing tests", () => {
    end MAINPR;
       `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("b4 hex bit constants", async () => {
@@ -784,7 +784,7 @@ describe("PL/I Parsing tests", () => {
    end MAINPR;
       `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("bx hex bit constants", async () => {
@@ -794,7 +794,7 @@ describe("PL/I Parsing tests", () => {
    end MAINPR;
       `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("b bit constants", async () => {
@@ -804,7 +804,7 @@ describe("PL/I Parsing tests", () => {
    end MAINPR;
       `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("gx hex graphic constants", async () => {
@@ -814,7 +814,7 @@ describe("PL/I Parsing tests", () => {
    end MAINPR;
       `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("g graphic constants", async () => {
@@ -825,7 +825,7 @@ describe("PL/I Parsing tests", () => {
    end MAINPR;
       `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("ux hex uchar constants", async () => {
@@ -835,7 +835,7 @@ describe("PL/I Parsing tests", () => {
    end MAINPR;
       `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("wx hex widechar constants", async () => {
@@ -845,7 +845,7 @@ describe("PL/I Parsing tests", () => {
    end MAINPR;
       `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
 
     test("m mixed character constants", async () => {
@@ -855,7 +855,7 @@ describe("PL/I Parsing tests", () => {
    end MAINPR;
       `);
       assertNoParseErrors(doc);
-      generateAndAssertValidSymbolTable(doc);
+      await generateAndAssertValidSymbolTable(doc);
     });
   });
 
@@ -869,7 +869,7 @@ describe("PL/I Parsing tests", () => {
         options ( nodescriptor );
         `);
     assertNoParseErrors(doc);
-    generateAndAssertValidSymbolTable(doc);
+    await generateAndAssertValidSymbolTable(doc);
   });
 
   test("parses GET LIST w/ file", async () => {
@@ -880,7 +880,7 @@ describe("PL/I Parsing tests", () => {
     END H;
     `);
     assertNoParseErrors(doc);
-    generateAndAssertValidSymbolTable(doc);
+    await generateAndAssertValidSymbolTable(doc);
   });
 
   test("Procedures w/ aligned & unaligned attributes", async () => {
@@ -906,7 +906,7 @@ describe("PL/I Parsing tests", () => {
  end P6;
     `);
     assertNoParseErrors(doc);
-    generateAndAssertValidSymbolTable(doc);
+    await generateAndAssertValidSymbolTable(doc);
   });
 
   test("align in returns attributes is valid as well", async () => {
@@ -917,7 +917,7 @@ describe("PL/I Parsing tests", () => {
         );
         `);
     assertNoParseErrors(doc);
-    generateAndAssertValidSymbolTable(doc);
+    await generateAndAssertValidSymbolTable(doc);
   });
 
   test("Supports GENERIC attribute", async () => {
@@ -931,7 +931,7 @@ describe("PL/I Parsing tests", () => {
       );
     `);
     assertNoParseErrors(doc);
-    generateAndAssertValidSymbolTable(doc);
+    await generateAndAssertValidSymbolTable(doc);
   });
 
   test("Supports Member Call syntax on DoType3", async () => {
@@ -942,7 +942,7 @@ describe("PL/I Parsing tests", () => {
       END;
     `);
     assertNoParseErrors(doc);
-    generateAndAssertValidSymbolTable(doc);
+    await generateAndAssertValidSymbolTable(doc);
   });
 
   test("Expect error on EOF", async () => {

--- a/packages/language/test/utils.ts
+++ b/packages/language/test/utils.ts
@@ -178,7 +178,7 @@ function isIntermediateBinaryExpression(
   return node && "infix" in node && "items" in node && "operators" in node;
 }
 
-export function generateAndAssertValidSymbolTable(
+export async function generateAndAssertValidSymbolTable(
   compilationUnit: CompilationUnit,
 ) {
   // Retrieve a list of valid tokens with validated payloads.
@@ -232,7 +232,7 @@ export function generateAndAssertValidSymbolTable(
   forEachNode(compilationUnit.ast, (node) => verifyNodeReachability(node));
 
   // Generate the symbol table and verify the container structure.
-  lifecycle.generateSymbolTable(compilationUnit);
+  await lifecycle.generateSymbolTable(compilationUnit);
 
   forEachNode(compilationUnit.ast, (node) =>
     addProperty(node, "_afterSymbolTable"),
@@ -281,7 +281,7 @@ export async function parseAndLink(
 
   await lifecycle.tokenize(unit, document);
   lifecycle.parse(unit);
-  lifecycle.generateSymbolTable(unit);
+  await lifecycle.generateSymbolTable(unit);
   lifecycle.link(unit);
   if (options?.validate) {
     lifecycle.preprocessorValidate(unit);

--- a/packages/language/test/validating.test.ts
+++ b/packages/language/test/validating.test.ts
@@ -128,19 +128,35 @@ describe("Validating", () => {
     assertNoDiagnostics(doc);
   });
 
-  // TODO @montymxb Mar. 28th, 2025: Pending re-integration of the built-in library for testing
-  test.fails.skip(
-    "Reference to alias types __SIGNED_INT & __UNSIGNED_INT",
-    async () => {
-      const doc = await parseWithValidations(`
+  test("Reference to alias types __SIGNED_INT & __UNSIGNED_INT", async () => {
+    const doc = await parseWithValidations(`
+      mypackage: package;
+      DCL x type __SIGNED_INT;
+      DCL y type __UNSIGNED_INT;
+      end mypackage;
+      `);
+    assertNoDiagnostics(doc);
+  });
+
+  test("__SIGNED_INT and __UNSIGNED_INT with LP(32)", async () => {
+    const doc = await parseWithValidations(`*PROCESS LP(32);
         mypackage: package;
         DCL x type __SIGNED_INT;
         DCL y type __UNSIGNED_INT;
         end mypackage;
         `);
-      assertNoDiagnostics(doc);
-    },
-  );
+    assertNoDiagnostics(doc);
+  });
+
+  test("__SIGNED_INT and __UNSIGNED_INT with LP(64)", async () => {
+    const doc = await parseWithValidations(`*PROCESS LP(64);
+        mypackage: package;
+        DCL x type __SIGNED_INT;
+        DCL y type __UNSIGNED_INT;
+        end mypackage;
+        `);
+    assertNoDiagnostics(doc);
+  });
 
   describe("Call validations", () => {
     test("can call function declared by procedure", async () => {


### PR DESCRIPTION
Closes https://github.com/zowe/zowe-pli-language-support/issues/53

Add the builtin int type definitions according to the LP compiler option setting. 
Since the type definition can only be added after the compiler option extraction, I moved the whole builtin unit addition out of the initialization. (In theory it can happen directly after the tokenizing step,  but I thought closer to the symbol table is actually more appropriate. But we can change that if desired.)
Reuses the scope parent mechanism to load the correct builtins into the compilation unit.