### PR TITLE
Fix extension CI upload

### DIFF
--- a/.github/workflows/extension.yml
+++ b/.github/workflows/extension.yml
@@ -38,4 +38,4 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: extension
-        path: packages/vscode-extension/pli-language-support-*.vsix
+        path: packages/vscode-extension/pli-language-support.vsix


### PR DESCRIPTION
Fixes an issue in the current CI. #742 Changed the name of the generated `.vsix` file to be stable.