### PR TITLE
Properly await node-fs readFile

### DIFF
--- a/packages/vscode-extension/src/language/main.ts
+++ b/packages/vscode-extension/src/language/main.ts
@@ -33,14 +33,14 @@ import { VSCodeFileSystemProvider } from "./file-system";
 //
 // For non-file URIs, it falls back to the VSCodeFileSystemProvider which sends requests to the client.
 class NodeFileSystemProvider extends VSCodeFileSystemProvider {
-  override readFile(uri: URI): Promise<string | undefined> {
+  override async readFile(uri: URI): Promise<string | undefined> {
     if (uri.scheme !== "file") {
       return super.readFile(uri);
     }
     try {
-      return fs.promises.readFile(uri.fsPath, "utf8");
+      return await fs.promises.readFile(uri.fsPath, "utf8");
     } catch {
-      return Promise.resolve(undefined);
+      return undefined;
     }
   }
 


### PR DESCRIPTION
Call the `await` within the try-catch, so that it can actually be caught.