### PR TITLE
Prevent includes outside of library directories

### DIFF
--- a/packages/language/src/config/path-resolver.ts
+++ b/packages/language/src/config/path-resolver.ts
@@ -48,7 +48,16 @@ export function resolveLibFileUri(
   fileName: string | undefined,
   workspace: URI,
   scheme?: string,
-): URI {
+): URI | undefined {
   const base = resolveLibUri(lib, workspace, scheme);
-  return fileName ? UriUtils.joinPath(base, fileName) : base;
+  if (fileName) {
+    const joined = UriUtils.joinPath(base, fileName);
+    if (!UriUtils.contains(base, joined)) {
+      // The resolved path is outside of the lib.
+      // Don't return it, because it allows to read outside of the defined library
+      return undefined;
+    }
+    return joined;
+  }
+  return base;
 }

--- a/packages/language/src/preprocessor/include-resolver.ts
+++ b/packages/language/src/preprocessor/include-resolver.ts
@@ -240,8 +240,11 @@ function buildDatasetMemberUri(
   memberFileName: string,
   workspace: URI,
   scheme: string,
-): URI {
+): URI | undefined {
   const datasetUri = resolveLibFileUri(libPath, undefined, workspace, scheme);
+  if (!datasetUri) {
+    return undefined;
+  }
   const parentUri = UriUtils.dirname(datasetUri);
   return UriUtils.joinPath(parentUri, memberFileName);
 }
@@ -287,6 +290,9 @@ async function tryResolveFileInDir(
     return resolveLibFileUri(lib.path, matchedFileName, workspace, scheme);
   }
   const libFileUri = resolveLibFileUri(lib.path, query, workspace, scheme);
+  if (!libFileUri) {
+    return undefined;
+  }
   return tryLiveFile(unit, libFileUri, extensions);
 }
 

--- a/packages/language/src/utils/uri.ts
+++ b/packages/language/src/utils/uri.ts
@@ -169,6 +169,16 @@ export namespace UriUtils {
     return path.split("/").filter((e) => e.length > 0);
   }
 
+  export function contains(parent: URI | string, child: URI | string): boolean {
+    const parentKey = toNormalizedKey(parent);
+    const childKey = toNormalizedKey(child);
+    return (
+      childKey === parentKey ||
+      (childKey.startsWith(parentKey) &&
+        (childKey[parentKey.length] === "/" || parentKey.endsWith("/")))
+    );
+  }
+
   export function relative(from: URI | string, to: URI | string): string {
     const fromFull = toFilePath(from);
     const toFull = toFilePath(to);

--- a/packages/language/test/fourslash/preprocessor/include/outside-lib.ts
+++ b/packages/language/test/fourslash/preprocessor/include/outside-lib.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: some/lib.pli
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: main.pli
+//// %INCLUDE <|path:"../some/lib.pli"|>;
+
+// No tokens, the include is outside of the library (cpy/inc)
+preprocessor.expectTokens("");
+// Expect an unresolved include diagnostic
+verify.expectDiagnosticsAt("path", code.Severe.IBM1848I);


### PR DESCRIPTION
Does as the title says. On current `development` the test in the PR fails, because the include resolution is able to "escape" the lib folder it was using to resolve the path. This change simply ensures that we never escape the lib that we've used to compute the directory.