### PR TITLE
Fix comment highlighting above compiler directives

### DIFF
--- a/packages/language/src/preprocessor/compiler-options-processor.ts
+++ b/packages/language/src/preprocessor/compiler-options-processor.ts
@@ -114,7 +114,7 @@ export class CompilerOptionsProcessor {
         option,
         uri,
         ranges[index].start + PROCESS_TOKEN_LENGTH,
-        index,
+        ranges[index].token.startLine,
         PROCESS_TOKEN_LENGTH,
       );
 

--- a/packages/language/test/fourslash/semantic-tokens/comments-before-process.ts
+++ b/packages/language/test/fourslash/semantic-tokens/comments-before-process.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+//// <|comment1:/* a comment that mentions happens and with before the directive|>
+////<|comment2:    and a second line of that very same comment here */|>
+////*PROCESS <|modifier:MARGINS|>(<|number:2|>,72);
+//// MAIN: PROC OPTIONS(MAIN);
+//// END MAIN;
+
+semanticTokens.expectAt("comment1", "comment");
+semanticTokens.expectAt("comment2", "comment");
+semanticTokens.expectAt("modifier");
+semanticTokens.expectAt("number");


### PR DESCRIPTION
Fixes https://github.com/zowe/zowe-pli-language-support/issues/694

Our assumption is that compiler options are always located at the beginning of the file. This still holds semantically, but directives can be preceded by comments and the semantic token information should not overlap. 
The fix uses the actual `startLine` of the token range. Added a test for this.