### PR TITLE
Colorize EXEC CICS/SQL keywords: using TextMate

### DIFF
--- a/packages/language/src/language-server/semantic-tokens.ts
+++ b/packages/language/src/language-server/semantic-tokens.ts
@@ -97,6 +97,12 @@ export function semanticTokens(
         );
       };
 
+      // Handle the CICS/SQL keyword at the start of the fragment
+      const prefixMatch = /^(\w+)\s*/i.exec(token.image);
+      if (prefixMatch) {
+        push(token, prefixMatch[1].length, SemanticTokenTypes.string);
+      }
+
       // Handle the remaining preprocessor tokens
       for (
         let index = 0;
@@ -229,8 +235,7 @@ function tokenType(token: Token): number | undefined {
   } else if (token.tokenTypeIdx === NUMBER.tokenTypeIdx) {
     return SemanticTokenTypes.number;
   } else if (token.tokenTypeIdx === EXEC.tokenTypeIdx) {
-    //because it is handled by the TextMate configuration
-    return undefined;
+    return SemanticTokenTypes.string;
   }
 
   // If the token has no semantic meaning based on the CST, check if it's a keyword

--- a/packages/language/src/language-server/semantic-tokens.ts
+++ b/packages/language/src/language-server/semantic-tokens.ts
@@ -24,6 +24,7 @@ import {
 import { CstNodeKind } from "../syntax-tree/cst";
 import {
   controlTokens,
+  EXEC,
   modifierTokens,
   NUMBER,
   STRING_TERM,
@@ -95,12 +96,6 @@ export function semanticTokens(
           modifier,
         );
       };
-
-      // Handle the CICS/SQL keyword at the start of the fragment
-      const prefixMatch = /^(\w+)\s*/i.exec(token.image);
-      if (prefixMatch) {
-        push(token, prefixMatch[1].length, SemanticTokenTypes.keyword);
-      }
 
       // Handle the remaining preprocessor tokens
       for (
@@ -233,6 +228,9 @@ function tokenType(token: Token): number | undefined {
     return SemanticTokenTypes.string;
   } else if (token.tokenTypeIdx === NUMBER.tokenTypeIdx) {
     return SemanticTokenTypes.number;
+  } else if (token.tokenTypeIdx === EXEC.tokenTypeIdx) {
+    //because it is handled by the TextMate configuration
+    return undefined;
   }
 
   // If the token has no semantic meaning based on the CST, check if it's a keyword

--- a/packages/language/test/fourslash/semantic-tokens/db2/exec-preprocessor-modifier.ts
+++ b/packages/language/test/fourslash/semantic-tokens/db2/exec-preprocessor-modifier.ts
@@ -12,13 +12,14 @@
 /// <reference path="../../framework.ts" />
 
 // @wrap: main
-//// <|EXEC|> <|CICS|> <|ABEND|> <|ABCODE|>(<|str:'$CAN'|>);
+//// <|EXEC|> <|SQL|> <|SELECT|> <|name|> <|FROM|> <|tbl|>;
 
 semanticTokens.expectModifierAt("EXEC", "preprocessor");
-semanticTokens.expectModifierAt("CICS", "preprocessor");
-semanticTokens.expectModifierAt("ABEND", "preprocessor");
-semanticTokens.expectModifierAt("ABCODE", "preprocessor");
-semanticTokens.expectModifierAt("str", "preprocessor");
+semanticTokens.expectModifierAt("SQL", "preprocessor");
+semanticTokens.expectModifierAt("SELECT", "preprocessor");
+semanticTokens.expectModifierAt("name", "preprocessor");
+semanticTokens.expectModifierAt("FROM", "preprocessor");
+semanticTokens.expectModifierAt("tbl", "preprocessor");
 
 semanticTokens.expectAt("EXEC", "string");
-semanticTokens.expectAt("CICS", "string");
+semanticTokens.expectAt("SQL", "string");

--- a/packages/vscode-extension/syntaxes/pli.manual.json
+++ b/packages/vscode-extension/syntaxes/pli.manual.json
@@ -4,6 +4,14 @@
   "fileTypes": [".pli"],
   "patterns": [
     {
+      "name": "string.quoted.sql.pli",
+      "match": "(?i:EXEC\\s+SQL)"
+    },
+    {
+      "name": "string.quoted.cics.pli",
+      "match": "(?i:EXEC\\s+CICS)"
+    },
+    {
       "name": "string.quoted.single.pli",
       "begin": "'",
       "end": "'",

--- a/scripts/generate-tmlanguage.mts
+++ b/scripts/generate-tmlanguage.mts
@@ -13,6 +13,8 @@
 import * as fs from "fs/promises";
 import * as tokens from "../packages/language/src/parser/tokens.js";
 
+const BLACKLISTED_KEYWORDS = new Set([tokens.EXEC, tokens.SQL, tokens.CICS]);
+
 const manual = JSON.parse(
   await fs.readFile(
     "./packages/vscode-extension/syntaxes/pli.manual.json",
@@ -25,6 +27,9 @@ const storageKeywords: string[] = [];
 
 for (const [text, type] of tokens.keywordMap.entries()) {
   const lowerText = text.toLowerCase();
+  if (BLACKLISTED_KEYWORDS.has(type)) {
+    continue;
+  }
   if (tokens.controlTokens.has(type)) {
     controlKeywords.push(lowerText);
   } else {


### PR DESCRIPTION
Closes #674 as well

An approach by using the TextMate configuration instead of semantic tokens.