### PR TITLE
Remove dead command code

### DIFF
--- a/packages/language/src/language-server/commands.ts
+++ b/packages/language/src/language-server/commands.ts
@@ -11,7 +11,6 @@
 
 import { ExecuteCommandParams } from "vscode-languageserver";
 import { updateOrCreateConfig } from "../utils/config";
-import { UriUtils } from "../utils/uri";
 import { WorkspaceContext } from "../workspace/workspace-context";
 
 export async function commandCreateConfig(
@@ -26,19 +25,4 @@ export async function commandCreateConfig(
     return;
   }
   await updateOrCreateConfig(programPath, workspace);
-}
-
-export async function commandRemoveUnresolvedLib(
-  params: ExecuteCommandParams,
-  workspace: WorkspaceContext,
-) {
-  const [uri, content] = params.arguments as string[];
-  if (!uri || content === undefined) {
-    return;
-  }
-  try {
-    await workspace.fs.writeFile(UriUtils.toUri(uri), content);
-  } catch (err) {
-    console.error(`Failed to write file at URI: ${uri}`, err);
-  }
 }


### PR DESCRIPTION
This is a follow up on https://github.com/zowe/zowe-pli-language-support/pull/765. Removes some dead code that was no longer called anywhere.