### PR TITLE
Add ppinclude option effect

### DIFF
--- a/packages/language/src/language-server/hover-request.ts
+++ b/packages/language/src/language-server/hover-request.ts
@@ -36,6 +36,7 @@ import {
 import { URI } from "../utils/uri";
 import { retrieveProcedureFromLabelPrefix } from "../validation/utils";
 import { CompilationUnit } from "../workspace/compilation-unit";
+import { getEffectiveIncludeAlt } from "../preprocessor/compiler-options/options-pli";
 import { HoverResponse, tokenToRange } from "./types";
 import { getFileContentPreview } from "./cache/include-cache";
 import {
@@ -300,7 +301,7 @@ function getNodeRepresentation(
 
 function computeIncludeType(unit: CompilationUnit, node: SyntaxNode): string {
   let type = "%INCLUDE";
-  const ppInclude = unit.compilerOptions?.pp?.ppInclude?.value;
+  const ppInclude = getEffectiveIncludeAlt(unit.compilerOptions);
   if (node.container?.kind === SyntaxKind.IncludeAltDirective && ppInclude) {
     type = ppInclude;
   }

--- a/packages/language/src/parser/tokenizer/pli-tokenizer.ts
+++ b/packages/language/src/parser/tokenizer/pli-tokenizer.ts
@@ -11,6 +11,7 @@
 
 import * as tokens from "../tokens";
 import { CompilerOptions } from "../../preprocessor/compiler-options/options";
+import { getEffectiveIncludeAlt } from "../../preprocessor/compiler-options/options-pli";
 import {
   generateDoubleCharFunc,
   generateKeywords,
@@ -126,7 +127,7 @@ export function updatePliTokenizer(compilerOptions: CompilerOptions): void {
   }
   orSymbols = compilerOptions.or ?? defaultOr;
   notSymbols = compilerOptions.not ?? defaultNot;
-  includeAlt = compilerOptions.pp?.ppInclude?.value;
+  includeAlt = getEffectiveIncludeAlt(compilerOptions);
   pliFuncs = new Array(256);
   pliFuncs["/".charCodeAt(0)] = tokenizeSlashWithComment;
   pliFuncs['"'.charCodeAt(0)] = tokenizeString;

--- a/packages/language/src/preprocessor/compiler-options/codes.ts
+++ b/packages/language/src/preprocessor/compiler-options/codes.ts
@@ -1135,6 +1135,15 @@ export const CompilerOptionsCodes = {
     },
   },
 
+  PPInclude: {
+    InvalidParameterLength: {
+      code: "COPPInclude01",
+      severity: Severity.E,
+      message: (value: string) =>
+        `Expected a string up to 1000 characters long, but received length ${value.length}.`,
+    },
+  },
+
   PPMacro: {
     Case: {
       InvalidParameter: {

--- a/packages/language/src/preprocessor/compiler-options/options-pli.ts
+++ b/packages/language/src/preprocessor/compiler-options/options-pli.ts
@@ -1634,3 +1634,35 @@ export function getDefaultCompilerOptions(): CompilerOptions {
     },
   };
 }
+
+/**
+ * Computes the effective INCLUDE-preprocessor alt-keyword, merging the
+ * PPINCLUDE base value with any PP(INCLUDE(...)) override.
+ * PPINCLUDE has no effect unless PP(INCLUDE) is also present.
+ */
+export function getEffectiveIncludeAlt(
+  options: CompilerOptions,
+): string | undefined {
+  const pp = options.pp;
+  if (!pp) {
+    return undefined;
+  }
+  if (pp.ppInclude?.value) {
+    // Explicit PP(INCLUDE('ID(...)')) override wins.
+    return pp.ppInclude.value;
+  }
+  const includeActive = pp.items.some(
+    (item) => item.name === CompilerOptions.PPItemName.INCLUDE,
+  );
+  if (!includeActive) {
+    return undefined;
+  }
+  if (typeof options.ppInclude === "string") {
+    // Fall back to the PPINCLUDE base value (bare PP(INCLUDE), no args).
+    const match = options.ppInclude.match(/ID\(([^)]+)\)\s*$/);
+    if (match) {
+      return match[0].slice(3, -1).toUpperCase();
+    }
+  }
+  return undefined;
+}

--- a/packages/language/src/preprocessor/compiler-options/translator-pli.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator-pli.ts
@@ -2346,12 +2346,25 @@ translator.rule(
     ensureArguments(option, 1, 1);
     const value = option.values[0];
     ensureType(value, "string");
+    if (value.value.length > 1000) {
+      throw diagnosticFromCode(
+        CompilerOptionsCodes.PPInclude.InvalidParameterLength,
+        value.token,
+        value.value,
+      );
+    }
     options.ppInclude = value.value;
   },
   ["NOPPINCLUDE"],
   (option, options) => {
-    options.ppInclude = false;
     ensureArguments(option, 0, 0);
+
+    // Clear both the base value and any override previously set via
+    // PP(INCLUDE('ID(...)')).
+    options.ppInclude = false;
+    if (options.pp) {
+      options.pp.ppInclude = undefined;
+    }
   },
   { recompile: true },
 );

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/noppinclude.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/noppinclude.ts
@@ -1,0 +1,24 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:PPINCLUDE|>('ID(-inc)');
+////*PROCESS <|2:NOPPINCLUDE|>;
+
+verify.noDiagnostics(1);
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.MutexOptionIssue.message("NOPPINCLUDE"),
+});
+verify.expectCompilerOptions({
+  ppInclude: false,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/ppinclude-length-exceeded.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/ppinclude-length-exceeded.ts
@@ -1,0 +1,22 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+//// // PPINCLUDE configuration must not exceed 1000 characters in length.
+////*PROCESS PPINCLUDE(<|1:'\$1k'|>);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.PPInclude.InvalidParameterLength.message(
+    "x".repeat(1024),
+  ),
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/ppinclude.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/ppinclude.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:PPINCLUDE|>('ID(-inc)');
+
+verify.noDiagnostics(1);
+verify.expectCompilerOptions({
+  ppInclude: "ID(-inc)",
+});

--- a/packages/language/test/fourslash/preprocessor/include/noppinclude-clears-with-pp-include.ts
+++ b/packages/language/test/fourslash/preprocessor/include/noppinclude-clears-with-pp-include.ts
@@ -1,0 +1,24 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: cpy/lib.pli
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: main.pli
+////*PROCESS PPINCLUDE('ID(-inc)') PP(INCLUDE) NOPPINCLUDE;
+//// // NOPPINCLUDE clears the base value even though PP(INCLUDE) remains present
+//// -inc lib
+
+preprocessor.expectTokens(`
+  -inc lib
+`);

--- a/packages/language/test/fourslash/preprocessor/include/ppinclude-activated-by-pp-include.ts
+++ b/packages/language/test/fourslash/preprocessor/include/ppinclude-activated-by-pp-include.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: cpy/lib.pli
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: main.pli
+////*PROCESS PPINCLUDE('ID(-inc)') PP(INCLUDE);
+//// -inc lib
+
+preprocessor.expectTokens(`
+  DECLARE LIB_VAR FIXED;
+`);

--- a/packages/language/test/fourslash/preprocessor/include/ppinclude-alone-no-effect.ts
+++ b/packages/language/test/fourslash/preprocessor/include/ppinclude-alone-no-effect.ts
@@ -1,0 +1,24 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: cpy/lib.pli
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: main.pli
+////*PROCESS PPINCLUDE('ID(-inc)');
+//// // PPINCLUDE alone has no effect without PP(INCLUDE)
+//// -inc lib
+
+preprocessor.expectTokens(`
+  -inc lib
+`);

--- a/packages/language/test/fourslash/preprocessor/include/ppinclude-order-independence.ts
+++ b/packages/language/test/fourslash/preprocessor/include/ppinclude-order-independence.ts
@@ -1,0 +1,24 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: cpy/lib.pli
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: main.pli
+////*PROCESS PP(INCLUDE) PPINCLUDE('ID(-inc)');
+//// // PP(INCLUDE) declared before PPINCLUDE - order must not matter
+//// -inc lib
+
+preprocessor.expectTokens(`
+  DECLARE LIB_VAR FIXED;
+`);

--- a/packages/language/test/fourslash/preprocessor/include/ppinclude-overridden-by-pp-include.ts
+++ b/packages/language/test/fourslash/preprocessor/include/ppinclude-overridden-by-pp-include.ts
@@ -1,0 +1,26 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: cpy/lib.pli
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: main.pli
+////*PROCESS PPINCLUDE('ID(-inc)') PP(INCLUDE('ID(++inc)'));
+//// // Explicit PP(INCLUDE('ID(...)')) overrides the PPINCLUDE base value
+//// -inc lib
+//// ++inc lib
+
+preprocessor.expectTokens(`
+  -inc lib
+  DECLARE LIB_VAR FIXED;
+`);


### PR DESCRIPTION
Closes https://github.com/zowe/zowe-pli-language-support/issues/300

Adds the logic for the `PPINCLUDE` (also see https://github.com/zowe/zowe-pli-language-support/issues/300) and provides a helper function `getEffectiveIncludeAlt` that can be used to retrieve the final active configuration.
Added several tests to cover the different cases.