### PR TITLE
Fix missing pp exec when plugin config is missing

### DIFF
--- a/packages/language/src/preprocessor/compiler-options/translate.ts
+++ b/packages/language/src/preprocessor/compiler-options/translate.ts
@@ -9,7 +9,11 @@
  *
  */
 
-import { CompilerOptionResult, CompilerOptionsPP } from "./options";
+import {
+  CompilerOptionResult,
+  CompilerOptionsPP,
+  getDefaultCompilerOptions,
+} from "./options";
 import {
   AbstractCompilerOptions,
   parseAbstractCompilerOptions,
@@ -42,11 +46,7 @@ export class CompilerOptionTranslator {
   protected translatorSQL = getTranslatorSQL();
 
   protected result: CompilerOptionResult = {
-    options: {
-      ...({} as CompilerOptionsPLI),
-      macroOptions: {} as CompilerOptionsMacro,
-      sqlOptions: {} as CompilerOptionsSQL,
-    },
+    options: getDefaultCompilerOptions(),
     tokens: [],
     comments: [],
     issues: [],
@@ -111,14 +111,9 @@ export class CompilerOptionTranslator {
     this.translatorMacro.clear();
     this.translatorSQL.clear();
     this.result = {
-      options: {
-        ...({} as CompilerOptionsPLI),
-        macroOptions: {} as CompilerOptionsMacro,
-        sqlOptions: {} as CompilerOptionsSQL,
-      },
+      options: getDefaultCompilerOptions(),
       tokens: [],
       comments: [],
-
       issues: [],
     };
   }

--- a/packages/language/test/fourslash-harness/execute.test.ts
+++ b/packages/language/test/fourslash-harness/execute.test.ts
@@ -190,6 +190,8 @@ function runSingleHarnessTest(filePath: string, timeout = 10_000) {
           // can be exercised by harness tests. The afterEach hook above resets
           // the workspace config between tests, so this can't leak across tests.
           preservePluginConfiguration: true,
+          // Skip default config creation if @noDefaultConfig directive is present
+          noDefaultConfig: testFile.tags["noDefaultConfig"] === "true",
         });
         implementation = createTestBuilderHarnessImplementation(testBuilder);
       }

--- a/packages/language/test/fourslash/preprocessor/pp-phases/exec-cics-without-config.ts
+++ b/packages/language/test/fourslash/preprocessor/pp-phases/exec-cics-without-config.ts
@@ -1,0 +1,26 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// Regression test: EXEC SQL should work without config files or *PROCESS directive.
+// The default PP(MACRO SQL CICS) should be applied automatically.
+
+// @noDefaultConfig
+//// HELLO: PROCEDURE OPTIONS (MAIN);
+////   DCL PROGNAME CHAR(100);
+////   EXEC CICS LINK PROGRAM(PROGNAME);
+//// END HELLO;
+
+// If EXEC CICS is NOT processed, the EXEC token remains and we get a parser error.
+// If it IS processed, EXEC is replaced with DO; END; and DFHEIBLK is declared.
+preprocessor.containsTokens(["DFHEIBLK", "DFHEIPTR"]);
+verify.noDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/pp-phases/exec-sql-without-config.ts
+++ b/packages/language/test/fourslash/preprocessor/pp-phases/exec-sql-without-config.ts
@@ -1,0 +1,46 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// Regression test: EXEC SQL should work without config files or *PROCESS directive.
+// The default PP(MACRO SQL CICS) should be applied automatically.
+
+// @noDefaultConfig
+//// SQLTEST: PROCEDURE OPTIONS (MAIN);
+////   EXEC SQL BEGIN DECLARE SECTION;
+////     DCL EMPNO CHAR(6);
+////   EXEC SQL END DECLARE SECTION;
+//// END SQLTEST;
+
+// If EXEC SQL is NOT processed, the parser fails with "Expected ... but found EXEC"
+// If it IS processed, the EXEC SQL statements are replaced with DO; END;
+preprocessor.containsTokens([
+  "SQLTEST",
+  ":",
+  "PROCEDURE",
+  "OPTIONS",
+  "(",
+  "MAIN",
+  ")",
+  ";",
+  "DCL",
+  "EMPNO",
+  "CHAR",
+  "DO",
+  ";",
+  "END",
+  ";",
+  "END",
+  "SQLTEST",
+  ";",
+]);
+verify.noDiagnostics();

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -103,6 +103,13 @@ export type TestBuilderOptions = {
    * preservePluginConfiguration can be used to disable this behavior for other test cases.
    */
   preservePluginConfiguration?: boolean;
+
+  /**
+   * Skip creating default plugin configuration files (pgm_conf.json, proc_grps.json).
+   * Used to test scenarios where no configuration exists.
+   * Corresponds to the fourslash directive: // @noDefaultConfig
+   */
+  noDefaultConfig?: boolean;
 };
 
 type LinkingRequest = {
@@ -273,7 +280,7 @@ export class TestBuilder extends AbstractTestBuilder {
   /**
    * Configures the plugin configuration provider based on the test files.
    * If a file for either the program or process group configuration is found, use it.
-   * If not, provide a default configuration.
+   * If not, provide a default configuration (unless noDefaultConfig is set).
    * Ensures we have a proper config after writing all files to the fs & before parsing,
    * so that we can build $computedLibs correctly
    */
@@ -293,6 +300,12 @@ export class TestBuilder extends AbstractTestBuilder {
     const workspaceUri = pgmConfUri
       ? UriUtils.dirname(UriUtils.dirname(UriUtils.toUri(pgmConfUri)))
       : config.getWorkspacePath();
+
+    // Skip default config creation if noDefaultConfig is set
+    if (this.options.noDefaultConfig) {
+      await defaultTestWorkspace().config.init(workspaceUri);
+      return;
+    }
 
     if (!pgmConfUri) {
       await defaultTestWorkspace().config.writeProgramConfigFile(


### PR DESCRIPTION
When no `.pliplugin` config files exist AND no `*PROCESS` directive is present, EXEC SQL/CICS statements fail with parser errors, because the PPs are not executed. 

`CompilerOptionTranslator` initializes with empty objects `{}` instead of the default compiler options. 
Any config (even an empty one) triggers `translateCompilerOptions()`, which copies defaults from `translator.options`. 
However, if no config is present, `translateCompilerOptions()` is never called and `result.options` stays empty, and hence, gives an empty `PP` option to the pipeline.

The fix initializes `result.options` with the correct defaults from the start.

I also added a `@noDefaultConfig` tag to the test framework, because the test builder always creates a default plugin configuration, which prevents a proper fourslash test. 