### PR TITLE
Add support for multiple workspaces

### DIFF
--- a/packages/language/src/language-server/connection-handler.ts
+++ b/packages/language/src/language-server/connection-handler.ts
@@ -55,7 +55,12 @@ import { applySourceActions } from "./code-actions/apply-source-actions";
 import { commandCreateConfig } from "./commands";
 import { Commands } from "./constants";
 import { signatureHelpRequest } from "./signature-help-request";
-import { GlobalConfigLoader, Messages, NotificationType, RequestType } from "../utils/messages";
+import {
+  GlobalConfigLoader,
+  Messages,
+  NotificationType,
+  RequestType,
+} from "../utils/messages";
 import { configCompletionRequest } from "./completion/completion-plugin-configuration";
 import { JsonItemMeta } from "../config/schema";
 import { assertType } from "../preprocessor/util";
@@ -70,7 +75,11 @@ export function startLanguageServer(
   // Wire the on-demand file loader for include URIs to the workspace's fs
   // so the document store doesn't reach for any module-level singleton.
   resetDocumentProviders(fs);
-  const compilationUnitHandler = new CompilationUnitHandler(fs, globalConfigLoader, new LongRunningOperationImpl(connection));
+  const compilationUnitHandler = new CompilationUnitHandler(
+    fs,
+    globalConfigLoader,
+    new LongRunningOperationImpl(connection),
+  );
   compilationUnitHandler.listen(connection);
   let folders: WorkspaceFolder[] = [];
 
@@ -152,12 +161,14 @@ export function startLanguageServer(
         },
       ],
     });
-    const promises = folders.map(async (folder) =>
-      compilationUnitHandler.initializeWorkspaceFolder(folder.uri),
-    ).concat(
-      //add more default schemes here if needed
-      compilationUnitHandler.initializeFallbackFolderForScheme("file"),
-    );
+    const promises = folders
+      .map(async (folder) =>
+        compilationUnitHandler.initializeWorkspaceFolder(folder.uri),
+      )
+      .concat(
+        //add more default schemes here if needed
+        compilationUnitHandler.initializeFallbackFolder(),
+      );
     await Promise.all(promises);
     compilationUnitHandler.markReady();
   });

--- a/packages/language/src/language-server/connection-handler.ts
+++ b/packages/language/src/language-server/connection-handler.ts
@@ -152,6 +152,9 @@ export function startLanguageServer(
     });
     const promises = folders.map(async (folder) =>
       compilationUnitHandler.initializeWorkspaceFolder(folder.uri),
+    ).concat(
+      //add more default schemes here if needed
+      compilationUnitHandler.initializeFallbackFolderForScheme("file"),
     );
     await Promise.all(promises);
     compilationUnitHandler.markReady();

--- a/packages/language/src/language-server/connection-handler.ts
+++ b/packages/language/src/language-server/connection-handler.ts
@@ -55,20 +55,22 @@ import { applySourceActions } from "./code-actions/apply-source-actions";
 import { commandCreateConfig } from "./commands";
 import { Commands } from "./constants";
 import { signatureHelpRequest } from "./signature-help-request";
-import { Messages, NotificationType, RequestType } from "../utils/messages";
+import { GlobalConfigLoader, Messages, NotificationType, RequestType } from "../utils/messages";
 import { configCompletionRequest } from "./completion/completion-plugin-configuration";
 import { JsonItemMeta } from "../config/schema";
 import { assertType } from "../preprocessor/util";
+import { LongRunningOperationImpl } from "../utils/promises";
 export { PluginConfiguration, Commands } from "./constants";
 
 export function startLanguageServer(
   connection: Connection,
   fs: FileSystemProvider,
+  globalConfigLoader: GlobalConfigLoader,
 ): void {
   // Wire the on-demand file loader for include URIs to the workspace's fs
   // so the document store doesn't reach for any module-level singleton.
   resetDocumentProviders(fs);
-  const compilationUnitHandler = new CompilationUnitHandler(fs);
+  const compilationUnitHandler = new CompilationUnitHandler(fs, globalConfigLoader, new LongRunningOperationImpl(connection));
   compilationUnitHandler.listen(connection);
   let folders: WorkspaceFolder[] = [];
 

--- a/packages/language/src/language-server/connection-handler.ts
+++ b/packages/language/src/language-server/connection-handler.ts
@@ -12,15 +12,12 @@
 import {
   CompilationUnit,
   CompilationUnitHandler,
-  publishPluginConfigDiagnostics,
+  pluginConfigChanged,
 } from "../workspace/compilation-unit";
 import {
-  CancellationToken,
   Connection,
   DidChangeWatchedFilesNotification,
   DocumentHighlight,
-  FileChangeType,
-  FileEvent,
   TextDocumentSyncKind,
 } from "vscode-languageserver";
 import { URI, UriUtils } from "../utils/uri";
@@ -419,52 +416,6 @@ export function startLanguageServer(
     });
   });
 
-  async function pluginConfigChanged(
-    workspaceContext: WorkspaceContext,
-  ): Promise<void> {
-    // handle changes to the .pliplugin config folder's contents
-    const diagnosticsByUri =
-      await workspaceContext.config.reloadConfigurations();
-    publishPluginConfigDiagnostics(connection, diagnosticsByUri);
-
-    // reindex reachable compilation units
-    await compilationUnitHandler.reindex(connection, CancellationToken.None);
-
-    // refresh semantic tokens so syntax coloring updates immediately
-    connection.languages.semanticTokens.refresh();
-  }
-
-  // A structural change to a lib folder (a file/dir created or deleted
-  // inside a lib, or a directory removed that is or contains a lib)
-  // invalidates the computed lib index, so the libs must be re-expanded.
-  // Note: Simple file edits are not considered structural changes,
-  // so they don't trigger a reindex.
-  function changeAffectsLibs(
-    workspace: WorkspaceContext,
-    changes: readonly FileEvent[],
-  ): boolean {
-    const libDirs = workspace.config.getLibDirectoryUris();
-    if (libDirs.length === 0) {
-      return false;
-    }
-    for (const change of changes) {
-      if (change.type === FileChangeType.Changed) {
-        continue;
-      }
-      const changeUri = UriUtils.toUri(change.uri);
-      for (const libDir of libDirs) {
-        // Change inside a lib (create/delete of a member) OR the change
-        // is/contains the lib dir itself (whole lib folder gone).
-        if (
-          UriUtils.contains(libDir, changeUri) ||
-          UriUtils.contains(changeUri, libDir)
-        ) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
   onNotification(
     connection,
     Messages.OnDidChangePluginConfigSettingsNotification,
@@ -473,99 +424,13 @@ export function startLanguageServer(
       const promises = compilationUnitHandler
         .getAllWorkspaceFolders()
         .map(async (workspaceContext) => {
-          await pluginConfigChanged(workspaceContext);
+          await pluginConfigChanged(connection, compilationUnitHandler, workspaceContext);
         });
       await Promise.all(promises);
     },
   );
   connection.onDidChangeWatchedFiles(async (params) => {
-    // First thing: Figure out whether any of the changed files are plugin config files
-    // If they are, we need to reindex the workspace anyway - no need to check for other changes.
-    function isPluginConfigFile(uri: string): boolean {
-      return (
-        uri.endsWith("/.pliplugin") ||
-        uri.endsWith("/.pliplugin/pgm_conf.json") ||
-        uri.endsWith("/.pliplugin/proc_grps.json")
-      );
-    }
-
-    const fileEventsByWorkspace = new Map<WorkspaceContext, FileEvent[]>();
-    for (const change of params.changes) {
-      const workspace = compilationUnitHandler.getWorkspaceFolderOf(change.uri);
-      if (workspace) {
-        if (!fileEventsByWorkspace.has(workspace)) {
-          fileEventsByWorkspace.set(workspace, []);
-        }
-        fileEventsByWorkspace.get(workspace)!.push(change);
-      }
-    }
-
-    for (const [workspace, changes] of fileEventsByWorkspace.entries()) {
-      // Since we cannot know whether a created directory is a lib in advance
-      // We always have to reindex if a directory is created, since it may contain a lib.
-      let directoryCreated = false;
-      for (const change of changes) {
-        if (change.type === FileChangeType.Created) {
-          // Try to stat the changed file to see if it's a directory.
-          const uri = UriUtils.toUri(change.uri);
-          try {
-            const stats = await fs.stat(uri);
-            if (stats.isDirectory) {
-              directoryCreated = true;
-              break;
-            }
-          } catch {
-            // Ignore errors, assume it's not a directory.
-          }
-        }
-      }
-      const pluginConfigHasChanged = changes.some((change) =>
-        isPluginConfigFile(change.uri),
-      );
-      if (
-        directoryCreated ||
-        pluginConfigHasChanged ||
-        changeAffectsLibs(workspace, changes)
-      ) {
-        const promises = compilationUnitHandler
-          .getAllWorkspaceFolders()
-          .map(async (workspaceContext) => {
-            await pluginConfigChanged(workspaceContext);
-          });
-        await Promise.all(promises);
-      } else {
-        const compilationUnits = new Set<CompilationUnit>();
-        // Not a plugin config change, meaning that individual folders/files have changed.
-        for (const compilationUnit of compilationUnitHandler
-          .getAllWorkspaceFolders()
-          .flatMap((workspace) => workspace.getAllCompilationUnits())) {
-          if (compilationUnit.includeError) {
-            // If the compilation unit has an unresolved include, we need to re-run the lifecycle
-            // to see if the include can now be resolved.
-            compilationUnits.add(compilationUnit);
-            // No need to change the change contents for this
-            continue;
-          }
-          changeLoop: for (const change of changes) {
-            for (const file of compilationUnit.services.files.keys()) {
-              // Either equal (i.e. file has changed) or the changed dir is a parent of the file
-              if (UriUtils.contains(change.uri, file)) {
-                compilationUnits.add(compilationUnit);
-                break changeLoop;
-              }
-            }
-          }
-        }
-        // Finally, update the compilation units themselves that might be affected by the change
-        for (const compilationUnit of compilationUnits) {
-          await compilationUnitHandler.updateUri(compilationUnit.uri);
-        }
-        if (compilationUnits.size > 0) {
-          // refresh semantic tokens so syntax coloring updates immediately
-          connection.languages.semanticTokens.refresh();
-        }
-      }
-    }
+    await compilationUnitHandler.triggerOnFileChange(params, connection);
   });
   onRequest(connection, Messages.ExistingFile, (uriString: string): boolean => {
     const uri = UriUtils.toUri(uriString);

--- a/packages/language/src/language-server/connection-handler.ts
+++ b/packages/language/src/language-server/connection-handler.ts
@@ -155,9 +155,9 @@ export function startLanguageServer(
         },
       ],
     });
-    const promises = folders.map(async (folder) => compilationUnitHandler.initializeWorkspaceFolder(
-      folder.uri,
-    ));
+    const promises = folders.map(async (folder) =>
+      compilationUnitHandler.initializeWorkspaceFolder(folder.uri),
+    );
     await Promise.all(promises);
     compilationUnitHandler.markReady();
   });
@@ -412,14 +412,19 @@ export function startLanguageServer(
     return compilationUnitHandler.globalMutex.read(async () => {
       return workspaceSymbolRequest(
         params.query,
-        compilationUnitHandler.getAllWorkspaceFolders().flatMap((workspace) => workspace.getAllCompilationUnits()),
+        compilationUnitHandler
+          .getAllWorkspaceFolders()
+          .flatMap((workspace) => workspace.getAllCompilationUnits()),
       );
     });
   });
 
-  async function pluginConfigChanged(workspaceContext: WorkspaceContext): Promise<void> {
+  async function pluginConfigChanged(
+    workspaceContext: WorkspaceContext,
+  ): Promise<void> {
     // handle changes to the .pliplugin config folder's contents
-    const diagnosticsByUri = await workspaceContext.config.reloadConfigurations();
+    const diagnosticsByUri =
+      await workspaceContext.config.reloadConfigurations();
     publishPluginConfigDiagnostics(connection, diagnosticsByUri);
 
     // reindex reachable compilation units
@@ -434,7 +439,10 @@ export function startLanguageServer(
   // invalidates the computed lib index, so the libs must be re-expanded.
   // Note: Simple file edits are not considered structural changes,
   // so they don't trigger a reindex.
-  function changeAffectsLibs(workspace: WorkspaceContext, changes: readonly FileEvent[]): boolean {
+  function changeAffectsLibs(
+    workspace: WorkspaceContext,
+    changes: readonly FileEvent[],
+  ): boolean {
     const libDirs = workspace.config.getLibDirectoryUris();
     if (libDirs.length === 0) {
       return false;
@@ -462,9 +470,11 @@ export function startLanguageServer(
     Messages.OnDidChangePluginConfigSettingsNotification,
     async () => {
       // Handle changes to the pli.pgm_conf and pli.proc_grps settings in vscode
-      const promises = compilationUnitHandler.getAllWorkspaceFolders().map(async (workspaceContext) => {
-        await pluginConfigChanged(workspaceContext);
-      });
+      const promises = compilationUnitHandler
+        .getAllWorkspaceFolders()
+        .map(async (workspaceContext) => {
+          await pluginConfigChanged(workspaceContext);
+        });
       await Promise.all(promises);
     },
   );
@@ -517,14 +527,18 @@ export function startLanguageServer(
         pluginConfigHasChanged ||
         changeAffectsLibs(workspace, changes)
       ) {
-        const promises = compilationUnitHandler.getAllWorkspaceFolders().map(async (workspaceContext) => {
-          await pluginConfigChanged(workspaceContext);
-        });
+        const promises = compilationUnitHandler
+          .getAllWorkspaceFolders()
+          .map(async (workspaceContext) => {
+            await pluginConfigChanged(workspaceContext);
+          });
         await Promise.all(promises);
       } else {
         const compilationUnits = new Set<CompilationUnit>();
         // Not a plugin config change, meaning that individual folders/files have changed.
-        for (const compilationUnit of compilationUnitHandler.getAllWorkspaceFolders().flatMap((workspace) => workspace.getAllCompilationUnits())) {
+        for (const compilationUnit of compilationUnitHandler
+          .getAllWorkspaceFolders()
+          .flatMap((workspace) => workspace.getAllCompilationUnits())) {
           if (compilationUnit.includeError) {
             // If the compilation unit has an unresolved include, we need to re-run the lifecycle
             // to see if the include can now be resolved.
@@ -646,7 +660,9 @@ export function startLanguageServer(
     } else {
       const diagnostics = params.context.diagnostics as Diagnostic[];
       if (!diagnostics || !diagnostics.length) return [];
-      const workspaceContext = compilationUnitHandler.getWorkspaceFolderOf(params.textDocument.uri);
+      const workspaceContext = compilationUnitHandler.getWorkspaceFolderOf(
+        params.textDocument.uri,
+      );
       if (workspaceContext === undefined) {
         return [];
       }
@@ -663,7 +679,9 @@ export function startLanguageServer(
     switch (params.command) {
       case Commands.CREATE_CONFIG:
         assertType<string[]>(params.arguments);
-        const workspaceContext = compilationUnitHandler.getWorkspaceFolderOf(params.arguments[0]);
+        const workspaceContext = compilationUnitHandler.getWorkspaceFolderOf(
+          params.arguments[0],
+        );
         if (workspaceContext) {
           await commandCreateConfig(params, workspaceContext);
         }

--- a/packages/language/src/language-server/connection-handler.ts
+++ b/packages/language/src/language-server/connection-handler.ts
@@ -12,6 +12,7 @@
 import {
   CompilationUnit,
   CompilationUnitHandler,
+  publishPluginConfigDiagnostics,
 } from "../workspace/compilation-unit";
 import {
   CancellationToken,
@@ -76,17 +77,6 @@ export function startLanguageServer(
   compilationUnitHandler.listen(connection);
   let folders: WorkspaceFolder[] = [];
 
-  function publishPluginConfigDiagnostics(
-    diagnosticsByUri: MultiMap<string, Diagnostic>,
-  ): void {
-    for (const [uri, diagnostics] of diagnosticsByUri.entriesGroupedByKey()) {
-      connection.sendDiagnostics({
-        uri,
-        diagnostics,
-      });
-    }
-  }
-
   async function withReadMutex<T>(
     uri: string,
     cb: (uri: URI, unit?: CompilationUnit) => Promise<T>,
@@ -94,8 +84,8 @@ export function startLanguageServer(
     await compilationUnitHandler.ready;
     return compilationUnitHandler.globalMutex.read(() => {
       const parsedUri = UriUtils.toUri(uri);
-      const compilationUnit =
-        compilationUnitHandler.getCompilationUnit(parsedUri);
+      const context = compilationUnitHandler.getWorkspaceFolderOf(parsedUri);
+      const compilationUnit = context?.getCompilationUnit(parsedUri);
       if (!compilationUnit) {
         return cb(parsedUri, undefined);
       }
@@ -165,18 +155,11 @@ export function startLanguageServer(
         },
       ],
     });
-    const promises: Promise<void>[] = [];
-    for (const folder of folders) {
-      const workspace = new WorkspaceContext(fs, connection);
-      compilationUnitHandler.workspaceByWorkspaceFolder.addWorkspaceFolder(UriUtils.toUri(folder.uri), workspace);
-      promises.push(
-        workspace.config
-          .init(UriUtils.toUri(folder.uri))
-          .then((diagnosticsByUri) => {
-            publishPluginConfigDiagnostics(diagnosticsByUri);
-          }),
-      );
-    }
+    const promises = folders.map(async (folder) => compilationUnitHandler.initializeWorkspaceFolder(
+      folder.uri,
+      fs,
+      connection,
+    ));
     await Promise.all(promises);
     compilationUnitHandler.markReady();
   });
@@ -227,7 +210,7 @@ export function startLanguageServer(
     triggerChar: string | undefined,
     docUri: string,
   ): LANG_LIST | undefined {
-    const workspace = compilationUnitHandler.workspaceByWorkspaceFolder.getWorkspaceFolderOf(docUri);
+    const workspace = compilationUnitHandler.getWorkspaceFolderOf(docUri);
     if (!workspace) {
       return undefined;
     }
@@ -278,7 +261,7 @@ export function startLanguageServer(
         return [];
       }
       const offset = textDocument.offsetAt(position);
-      const workspace = compilationUnitHandler.workspaceByWorkspaceFolder.getWorkspaceFolderOf(docUri);
+      const workspace = compilationUnitHandler.getWorkspaceFolderOf(docUri);
       if (!workspace) {
         return [];
       }
@@ -431,7 +414,7 @@ export function startLanguageServer(
     return compilationUnitHandler.globalMutex.read(async () => {
       return workspaceSymbolRequest(
         params.query,
-        compilationUnitHandler.getAllCompilationUnits(),
+        compilationUnitHandler.getAllWorkspaceFolders().flatMap((workspace) => workspace.getAllCompilationUnits()),
       );
     });
   });
@@ -439,7 +422,7 @@ export function startLanguageServer(
   async function pluginConfigChanged(workspaceContext: WorkspaceContext): Promise<void> {
     // handle changes to the .pliplugin config folder's contents
     const diagnosticsByUri = await workspaceContext.config.reloadConfigurations();
-    publishPluginConfigDiagnostics(diagnosticsByUri);
+    publishPluginConfigDiagnostics(connection, diagnosticsByUri);
 
     // reindex reachable compilation units
     await compilationUnitHandler.reindex(connection, CancellationToken.None);
@@ -481,7 +464,7 @@ export function startLanguageServer(
     Messages.OnDidChangePluginConfigSettingsNotification,
     async () => {
       // Handle changes to the pli.pgm_conf and pli.proc_grps settings in vscode
-      const promises = compilationUnitHandler.workspaceByWorkspaceFolder.getAllWorkspaceFolders().map(async (workspaceContext) => {
+      const promises = compilationUnitHandler.getAllWorkspaceFolders().map(async (workspaceContext) => {
         await pluginConfigChanged(workspaceContext);
       });
       await Promise.all(promises);
@@ -500,7 +483,7 @@ export function startLanguageServer(
 
     const fileEventsByWorkspace = new Map<WorkspaceContext, FileEvent[]>();
     for (const change of params.changes) {
-      const workspace = compilationUnitHandler.workspaceByWorkspaceFolder.getWorkspaceFolderOf(change.uri);
+      const workspace = compilationUnitHandler.getWorkspaceFolderOf(change.uri);
       if (workspace) {
         if (!fileEventsByWorkspace.has(workspace)) {
           fileEventsByWorkspace.set(workspace, []);
@@ -536,14 +519,14 @@ export function startLanguageServer(
         pluginConfigHasChanged ||
         changeAffectsLibs(workspace, changes)
       ) {
-        const promises = compilationUnitHandler.workspaceByWorkspaceFolder.getAllWorkspaceFolders().map(async (workspaceContext) => {
+        const promises = compilationUnitHandler.getAllWorkspaceFolders().map(async (workspaceContext) => {
           await pluginConfigChanged(workspaceContext);
         });
         await Promise.all(promises);
       } else {
         const compilationUnits = new Set<CompilationUnit>();
         // Not a plugin config change, meaning that individual folders/files have changed.
-        for (const compilationUnit of compilationUnitHandler.getAllCompilationUnits()) {
+        for (const compilationUnit of compilationUnitHandler.getAllWorkspaceFolders().flatMap((workspace) => workspace.getAllCompilationUnits())) {
           if (compilationUnit.includeError) {
             // If the compilation unit has an unresolved include, we need to re-run the lifecycle
             // to see if the include can now be resolved.
@@ -574,7 +557,11 @@ export function startLanguageServer(
   });
   onRequest(connection, Messages.ExistingFile, (uriString: string): boolean => {
     const uri = UriUtils.toUri(uriString);
-    const compilationUnit = compilationUnitHandler.getCompilationUnit(uri);
+    const context = compilationUnitHandler.getWorkspaceFolderOf(uri);
+    if (!context) {
+      return false;
+    }
+    const compilationUnit = context.getCompilationUnit(uri);
     return compilationUnit !== undefined;
   });
 
@@ -661,7 +648,7 @@ export function startLanguageServer(
     } else {
       const diagnostics = params.context.diagnostics as Diagnostic[];
       if (!diagnostics || !diagnostics.length) return [];
-      const workspaceContext = compilationUnitHandler.workspaceByWorkspaceFolder.getWorkspaceFolderOf(params.textDocument.uri);
+      const workspaceContext = compilationUnitHandler.getWorkspaceFolderOf(params.textDocument.uri);
       if (workspaceContext === undefined) {
         return [];
       }
@@ -678,7 +665,7 @@ export function startLanguageServer(
     switch (params.command) {
       case Commands.CREATE_CONFIG:
         assertType<string[]>(params.arguments);
-        const workspaceContext = compilationUnitHandler.workspaceByWorkspaceFolder.getWorkspaceFolderOf(params.arguments[0]);
+        const workspaceContext = compilationUnitHandler.getWorkspaceFolderOf(params.arguments[0]);
         if (workspaceContext) {
           await commandCreateConfig(params, workspaceContext);
         }

--- a/packages/language/src/language-server/connection-handler.ts
+++ b/packages/language/src/language-server/connection-handler.ts
@@ -62,17 +62,17 @@ import { Messages, NotificationType, RequestType } from "../utils/messages";
 import { configCompletionRequest } from "./completion/completion-plugin-configuration";
 import { MultiMap } from "../utils/collections";
 import { JsonItemMeta } from "../config/schema";
+import { assertType } from "../preprocessor/util";
 export { PluginConfiguration, Commands } from "./constants";
 
 export function startLanguageServer(
   connection: Connection,
   fs: FileSystemProvider,
 ): void {
-  const workspace = new WorkspaceContext(fs, connection);
   // Wire the on-demand file loader for include URIs to the workspace's fs
   // so the document store doesn't reach for any module-level singleton.
   resetDocumentProviders(fs);
-  const compilationUnitHandler = new CompilationUnitHandler(workspace);
+  const compilationUnitHandler = new CompilationUnitHandler();
   compilationUnitHandler.listen(connection);
   let folders: WorkspaceFolder[] = [];
 
@@ -167,6 +167,8 @@ export function startLanguageServer(
     });
     const promises: Promise<void>[] = [];
     for (const folder of folders) {
+      const workspace = new WorkspaceContext(fs, connection);
+      compilationUnitHandler.workspaceByWorkspaceFolder.addWorkspaceFolder(UriUtils.toUri(folder.uri), workspace);
       promises.push(
         workspace.config
           .init(UriUtils.toUri(folder.uri))
@@ -225,6 +227,10 @@ export function startLanguageServer(
     triggerChar: string | undefined,
     docUri: string,
   ): LANG_LIST | undefined {
+    const workspace = compilationUnitHandler.workspaceByWorkspaceFolder.getWorkspaceFolderOf(docUri);
+    if (!workspace) {
+      return undefined;
+    }
     const isConfigDocument = workspace.config.isPluginConfigDocumentUri(docUri);
     const triggerLang = triggerChar
       ? TRIGGER_CHAR_LANG[triggerChar]
@@ -233,7 +239,7 @@ export function startLanguageServer(
       (triggerLang === "config" && !isConfigDocument) ||
       (triggerLang === "pli" && isConfigDocument)
     ) {
-      return;
+      return undefined;
     }
     if (isConfigDocument) {
       return "config";
@@ -272,6 +278,10 @@ export function startLanguageServer(
         return [];
       }
       const offset = textDocument.offsetAt(position);
+      const workspace = compilationUnitHandler.workspaceByWorkspaceFolder.getWorkspaceFolderOf(docUri);
+      if (!workspace) {
+        return [];
+      }
       return configCompletionRequest(
         workspace.config,
         textDocument.getText(),
@@ -426,9 +436,9 @@ export function startLanguageServer(
     });
   });
 
-  async function pluginConfigChanged() {
+  async function pluginConfigChanged(workspaceContext: WorkspaceContext): Promise<void> {
     // handle changes to the .pliplugin config folder's contents
-    const diagnosticsByUri = await workspace.config.reloadConfigurations();
+    const diagnosticsByUri = await workspaceContext.config.reloadConfigurations();
     publishPluginConfigDiagnostics(diagnosticsByUri);
 
     // reindex reachable compilation units
@@ -443,7 +453,7 @@ export function startLanguageServer(
   // invalidates the computed lib index, so the libs must be re-expanded.
   // Note: Simple file edits are not considered structural changes,
   // so they don't trigger a reindex.
-  function changeAffectsLibs(changes: readonly FileEvent[]): boolean {
+  function changeAffectsLibs(workspace: WorkspaceContext, changes: readonly FileEvent[]): boolean {
     const libDirs = workspace.config.getLibDirectoryUris();
     if (libDirs.length === 0) {
       return false;
@@ -471,7 +481,10 @@ export function startLanguageServer(
     Messages.OnDidChangePluginConfigSettingsNotification,
     async () => {
       // Handle changes to the pli.pgm_conf and pli.proc_grps settings in vscode
-      await pluginConfigChanged();
+      const promises = compilationUnitHandler.workspaceByWorkspaceFolder.getAllWorkspaceFolders().map(async (workspaceContext) => {
+        await pluginConfigChanged(workspaceContext);
+      });
+      await Promise.all(promises);
     },
   );
   connection.onDidChangeWatchedFiles(async (params) => {
@@ -484,61 +497,78 @@ export function startLanguageServer(
         uri.endsWith("/.pliplugin/proc_grps.json")
       );
     }
-    // Since we cannot know whether a created directory is a lib in advance
-    // We always have to reindex if a directory is created, since it may contain a lib.
-    let directoryCreated = false;
+
+    const fileEventsByWorkspace = new Map<WorkspaceContext, FileEvent[]>();
     for (const change of params.changes) {
-      if (change.type === FileChangeType.Created) {
-        // Try to stat the changed file to see if it's a directory.
-        const uri = UriUtils.toUri(change.uri);
-        try {
-          const stats = await workspace.fs.stat(uri);
-          if (stats.isDirectory) {
-            directoryCreated = true;
-            break;
-          }
-        } catch {
-          // Ignore errors, assume it's not a directory.
+      const workspace = compilationUnitHandler.workspaceByWorkspaceFolder.getWorkspaceFolderOf(change.uri);
+      if (workspace) {
+        if (!fileEventsByWorkspace.has(workspace)) {
+          fileEventsByWorkspace.set(workspace, []);
         }
+        fileEventsByWorkspace.get(workspace)!.push(change);
       }
     }
-    const pluginConfigHasChanged = params.changes.some((change) =>
-      isPluginConfigFile(change.uri),
-    );
-    if (
-      directoryCreated ||
-      pluginConfigHasChanged ||
-      changeAffectsLibs(params.changes)
-    ) {
-      await pluginConfigChanged();
-    } else {
-      const compilationUnits = new Set<CompilationUnit>();
-      // Not a plugin config change, meaning that individual folders/files have changed.
-      for (const compilationUnit of compilationUnitHandler.getAllCompilationUnits()) {
-        if (compilationUnit.includeError) {
-          // If the compilation unit has an unresolved include, we need to re-run the lifecycle
-          // to see if the include can now be resolved.
-          compilationUnits.add(compilationUnit);
-          // No need to change the change contents for this
-          continue;
+
+    for (const [workspace, changes] of fileEventsByWorkspace.entries()) {
+      // Since we cannot know whether a created directory is a lib in advance
+      // We always have to reindex if a directory is created, since it may contain a lib.
+      let directoryCreated = false;
+      for (const change of changes) {
+        if (change.type === FileChangeType.Created) {
+          // Try to stat the changed file to see if it's a directory.
+          const uri = UriUtils.toUri(change.uri);
+          try {
+            const stats = await fs.stat(uri);
+            if (stats.isDirectory) {
+              directoryCreated = true;
+              break;
+            }
+          } catch {
+            // Ignore errors, assume it's not a directory.
+          }
         }
-        changeLoop: for (const change of params.changes) {
-          for (const file of compilationUnit.services.files.keys()) {
-            // Either equal (i.e. file has changed) or the changed dir is a parent of the file
-            if (UriUtils.contains(change.uri, file)) {
-              compilationUnits.add(compilationUnit);
-              break changeLoop;
+      }
+      const pluginConfigHasChanged = changes.some((change) =>
+        isPluginConfigFile(change.uri),
+      );
+      if (
+        directoryCreated ||
+        pluginConfigHasChanged ||
+        changeAffectsLibs(workspace, changes)
+      ) {
+        const promises = compilationUnitHandler.workspaceByWorkspaceFolder.getAllWorkspaceFolders().map(async (workspaceContext) => {
+          await pluginConfigChanged(workspaceContext);
+        });
+        await Promise.all(promises);
+      } else {
+        const compilationUnits = new Set<CompilationUnit>();
+        // Not a plugin config change, meaning that individual folders/files have changed.
+        for (const compilationUnit of compilationUnitHandler.getAllCompilationUnits()) {
+          if (compilationUnit.includeError) {
+            // If the compilation unit has an unresolved include, we need to re-run the lifecycle
+            // to see if the include can now be resolved.
+            compilationUnits.add(compilationUnit);
+            // No need to change the change contents for this
+            continue;
+          }
+          changeLoop: for (const change of changes) {
+            for (const file of compilationUnit.services.files.keys()) {
+              // Either equal (i.e. file has changed) or the changed dir is a parent of the file
+              if (UriUtils.contains(change.uri, file)) {
+                compilationUnits.add(compilationUnit);
+                break changeLoop;
+              }
             }
           }
         }
-      }
-      // Finally, update the compilation units themselves that might be affected by the change
-      for (const compilationUnit of compilationUnits) {
-        await compilationUnitHandler.updateUri(compilationUnit.uri);
-      }
-      if (compilationUnits.size > 0) {
-        // refresh semantic tokens so syntax coloring updates immediately
-        connection.languages.semanticTokens.refresh();
+        // Finally, update the compilation units themselves that might be affected by the change
+        for (const compilationUnit of compilationUnits) {
+          await compilationUnitHandler.updateUri(compilationUnit.uri);
+        }
+        if (compilationUnits.size > 0) {
+          // refresh semantic tokens so syntax coloring updates immediately
+          connection.languages.semanticTokens.refresh();
+        }
       }
     }
   });
@@ -631,10 +661,13 @@ export function startLanguageServer(
     } else {
       const diagnostics = params.context.diagnostics as Diagnostic[];
       if (!diagnostics || !diagnostics.length) return [];
-
+      const workspaceContext = compilationUnitHandler.workspaceByWorkspaceFolder.getWorkspaceFolderOf(params.textDocument.uri);
+      if (workspaceContext === undefined) {
+        return [];
+      }
       const actions = await applyQuickFixes(
         diagnostics,
-        workspace,
+        workspaceContext,
         params.textDocument.uri,
       );
       return actions || [];
@@ -644,7 +677,11 @@ export function startLanguageServer(
   connection.onExecuteCommand(async (params) => {
     switch (params.command) {
       case Commands.CREATE_CONFIG:
-        await commandCreateConfig(params, workspace);
+        assertType<string[]>(params.arguments);
+        const workspaceContext = compilationUnitHandler.workspaceByWorkspaceFolder.getWorkspaceFolderOf(params.arguments[0]);
+        if (workspaceContext) {
+          await commandCreateConfig(params, workspaceContext);
+        }
         break;
     }
   });

--- a/packages/language/src/language-server/connection-handler.ts
+++ b/packages/language/src/language-server/connection-handler.ts
@@ -73,7 +73,7 @@ export function startLanguageServer(
   // Wire the on-demand file loader for include URIs to the workspace's fs
   // so the document store doesn't reach for any module-level singleton.
   resetDocumentProviders(fs);
-  const compilationUnitHandler = new CompilationUnitHandler();
+  const compilationUnitHandler = new CompilationUnitHandler(fs);
   compilationUnitHandler.listen(connection);
   let folders: WorkspaceFolder[] = [];
 
@@ -157,8 +157,6 @@ export function startLanguageServer(
     });
     const promises = folders.map(async (folder) => compilationUnitHandler.initializeWorkspaceFolder(
       folder.uri,
-      fs,
-      connection,
     ));
     await Promise.all(promises);
     compilationUnitHandler.markReady();

--- a/packages/language/src/language-server/connection-handler.ts
+++ b/packages/language/src/language-server/connection-handler.ts
@@ -424,7 +424,11 @@ export function startLanguageServer(
       const promises = compilationUnitHandler
         .getAllWorkspaceFolders()
         .map(async (workspaceContext) => {
-          await pluginConfigChanged(connection, compilationUnitHandler, workspaceContext);
+          await pluginConfigChanged(
+            connection,
+            compilationUnitHandler,
+            workspaceContext,
+          );
         });
       await Promise.all(promises);
     },

--- a/packages/language/src/language-server/connection-handler.ts
+++ b/packages/language/src/language-server/connection-handler.ts
@@ -43,7 +43,6 @@ import { getReferenceLocations } from "../linking/resolver";
 import { documentSymbolRequest } from "./document-symbol-request";
 import { workspaceSymbolRequest } from "./workspace-symbol-request";
 import { FileSystemProvider } from "../workspace/file-system-provider";
-import { WorkspaceContext } from "../workspace/workspace-context";
 import {
   EditorDocuments,
   resetDocumentProviders,
@@ -58,7 +57,6 @@ import { Commands } from "./constants";
 import { signatureHelpRequest } from "./signature-help-request";
 import { Messages, NotificationType, RequestType } from "../utils/messages";
 import { configCompletionRequest } from "./completion/completion-plugin-configuration";
-import { MultiMap } from "../utils/collections";
 import { JsonItemMeta } from "../config/schema";
 import { assertType } from "../preprocessor/util";
 export { PluginConfiguration, Commands } from "./constants";
@@ -483,7 +481,8 @@ export function startLanguageServer(
     if (compilationUnit) {
       return compilationUnit.programConfig;
     }
-    return workspace.config.getProgramConfig(uri);
+    const workspace = compilationUnitHandler.getWorkspaceFolderOf(uri);
+    return workspace?.config.getProgramConfig(uri);
   }
 
   onRequest(
@@ -506,8 +505,9 @@ export function startLanguageServer(
         const programConfig = resolveProgramConfig(uri, compilationUnit);
         if (!programConfig) return null;
 
+        const workspace = compilationUnitHandler.getWorkspaceFolderOf(uri);
         const pgroupName = programConfig.pgroup.value;
-        const groupConfig = workspace.config.getProcessGroupConfig(pgroupName);
+        const groupConfig = workspace?.config.getProcessGroupConfig(pgroupName);
         if (!groupConfig) return null;
 
         return resolveConfigEntryLocation(groupConfig.meta);

--- a/packages/language/src/utils/messages.ts
+++ b/packages/language/src/utils/messages.ts
@@ -37,8 +37,8 @@ export function createNotificationType<P>(method: string): NotificationType<P> {
 }
 
 export namespace Messages {
-  export const GetUserSettingsUriRequest = createRequestType<void, string>(
-    "pli/getUserSettingsUri",
+  export const GetGlobalConfig = createRequestType<string, Messages.GlobalConfig>(
+    "pli/getGlobalConfig",
   );
 
   /**

--- a/packages/language/src/utils/messages.ts
+++ b/packages/language/src/utils/messages.ts
@@ -9,6 +9,8 @@
  *
  */
 
+import { URI } from "./uri";
+
 export type RequestType<P, R> = {
   method: string;
 
@@ -35,6 +37,10 @@ export function createNotificationType<P>(method: string): NotificationType<P> {
 }
 
 export namespace Messages {
+  export const GetUserSettingsUriRequest = createRequestType<void, string>(
+    "pli/getUserSettingsUri",
+  );
+
   /**
    * Notification sent to the LS when the workspace's plugin configuration changes.
    */
@@ -75,14 +81,6 @@ export namespace Messages {
   }
 
   /**
-   * Request sent to the language client to get the global configuration.
-   * Only required if no plugin configuration file is present in the workspace.
-   */
-  export const GetGlobalConfig = createRequestType<string, GlobalConfig>(
-    "config/getGlobal",
-  );
-
-  /**
    * Location information for a plugin configuration entry (either a
    * program entry in pgm_conf.json or a process group entry in
    * proc_grps.json). Used by the "Go to Program Configuration" and
@@ -120,4 +118,15 @@ export namespace Messages {
     string,
     PluginConfigEntryLocation | null
   >("pli/getProcessGroupLocation");
+}
+
+export interface GlobalConfigLoader {
+  loadGlobalConfig(workspaceUri: URI): Promise<Messages.GlobalConfig>;
+}
+
+export class TestGlobalConfigLoader implements GlobalConfigLoader {
+  constructor(private readonly config: Messages.GlobalConfig) {}
+  loadGlobalConfig(_workspaceUri: URI): Promise<Messages.GlobalConfig> {
+    return Promise.resolve(this.config);
+  }
 }

--- a/packages/language/src/utils/messages.ts
+++ b/packages/language/src/utils/messages.ts
@@ -78,7 +78,7 @@ export namespace Messages {
    * Request sent to the language client to get the global configuration.
    * Only required if no plugin configuration file is present in the workspace.
    */
-  export const GetGlobalConfig = createRequestType<void, GlobalConfig>(
+  export const GetGlobalConfig = createRequestType<string, GlobalConfig>(
     "config/getGlobal",
   );
 

--- a/packages/language/src/utils/messages.ts
+++ b/packages/language/src/utils/messages.ts
@@ -37,9 +37,10 @@ export function createNotificationType<P>(method: string): NotificationType<P> {
 }
 
 export namespace Messages {
-  export const GetGlobalConfig = createRequestType<string, Messages.GlobalConfig>(
-    "pli/getGlobalConfig",
-  );
+  export const GetGlobalConfig = createRequestType<
+    string,
+    Messages.GlobalConfig
+  >("pli/getGlobalConfig");
 
   /**
    * Notification sent to the LS when the workspace's plugin configuration changes.

--- a/packages/language/src/utils/promises.ts
+++ b/packages/language/src/utils/promises.ts
@@ -139,9 +139,7 @@ export class LongRunningOperationImpl implements LongRunningOperation {
       return () => {};
     },
   };
-  constructor(
-    private readonly connection: Connection | undefined
-  ) {}
+  constructor(private readonly connection: Connection | undefined) {}
 
   start(title: string, timeout: number = 500): Cancellation {
     return startLongRunningOperation(this.connection, title, timeout);

--- a/packages/language/src/utils/promises.ts
+++ b/packages/language/src/utils/promises.ts
@@ -125,7 +125,30 @@ export class Deferred<T = void> {
 
 export type Cancellation = () => void;
 
-export function startLongRunningOperation(
+export interface LongRunningOperation {
+  /**
+   * Starts the long-running operation and returns a cancellation function.
+   * The cancellation function can be called to cancel the operation.
+   */
+  start(title: string, timeout?: number): Cancellation;
+}
+
+export class LongRunningOperationImpl implements LongRunningOperation {
+  static Dummy: LongRunningOperation = {
+    start(title, timeout) {
+      return () => {};
+    },
+  };
+  constructor(
+    private readonly connection: Connection | undefined
+  ) {}
+
+  start(title: string, timeout: number = 500): Cancellation {
+    return startLongRunningOperation(this.connection, title, timeout);
+  }
+}
+
+function startLongRunningOperation(
   connection: Connection | undefined,
   title: string,
   timeout = 500,

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -11,7 +11,7 @@
 
 import { Program, SyntaxKind } from "../syntax-tree/ast.js";
 import { isVirtualFile, URI, UriUtils } from "../utils/uri.js";
-import { CancellationToken, Connection } from "vscode-languageserver";
+import { CancellationToken, Connection, Diagnostic } from "vscode-languageserver";
 import { ReferencesCache, StatementOrderCache } from "../linking/resolver.js";
 import { diagnosticsToLSP } from "../language-server/types.js";
 import {
@@ -58,6 +58,8 @@ import { CompilerOptions as PliCompilerOptions } from "../preprocessor/compiler-
 import { DiagnosticsStore } from "../validation/diagnostics-store.js";
 import { LRUCache } from "lru-cache";
 import { WorkspaceFolderTree } from "./workspace-folder-tree.js";
+import { FileSystemProvider } from "./file-system-provider.js";
+import { MultiMap } from "../utils/collections.js";
 
 /**
  * A compilation unit is a representation of a PL/I program in the language server.
@@ -119,19 +121,6 @@ export interface CompilationServices {
 }
 
 const FIVE_MINUTES = 1000 * 60 * 5;
-
-/**
- * JSON under `.pliplugin/` is not PL/I source. The client attaches the LS there for code actions;
- * we skip compilation so only plugin-config diagnostics (e.g. COPC*) from the plugin loader show.
- */
-function isPluginConfigurationUri(uri: URI): boolean {
-  const baseName = UriUtils.basename(uri);
-  if (baseName === "settings.json") {
-    return true;
-  }
-  const path = uri.path;
-  return path.includes("/.pliplugin/") && /\.json$/i.test(path);
-}
 
 export async function createCompilationUnit(
   uri: URI,
@@ -294,8 +283,7 @@ export async function addBuiltinUnits(
   unit.rootPreprocessorScope = Scope.createChild(macroScope);
 }
 
-export class CompilationUnitHandler {
-  private compilationUnits: Map<string, CompilationUnit> = new Map();
+export class CompilationUnitHandler extends WorkspaceFolderTree<WorkspaceContext> {
   private connection!: Connection;
   private readyDeferred = new Deferred();
 
@@ -304,72 +292,14 @@ export class CompilationUnitHandler {
    */
   readonly globalMutex = createMutex();
 
-  /**
-   * Workspace context shared by every unit this handler creates. Provides
-   * the file-system provider and the plugin configuration.
-   */
-  readonly workspaceByWorkspaceFolder: WorkspaceFolderTree<WorkspaceContext>;
-
   constructor() {
-    this.workspaceByWorkspaceFolder = new WorkspaceFolderTree<WorkspaceContext>(false);
+    super(false);
   }
 
-  
+
 
   get ready(): Promise<void> {
     return this.readyDeferred.promise;
-  }
-
-  getCompilationUnit(uri: URI): CompilationUnit | undefined {
-    return this.compilationUnits.get(uri.toString());
-  }
-
-  /**
-   * Gets an existing or creates a new compilation unit for the given URI, except for standalone library files
-   *
-   * @returns Pre-existing or new compilation unit, or undefined if it's a standalone library file
-   */
-  async getOrCreateCompilationUnit(
-    uri: URI,
-  ): Promise<CompilationUnit | undefined> {
-    if (this.compilationUnits.has(uri.toString())) {
-      // existing compilation unit
-      return this.compilationUnits.get(uri.toString());
-    }
-    if (isPluginConfigurationUri(uri)) {
-      return undefined;
-    } else if (!this.workspaceByWorkspaceFolder.getWorkspaceFolderOf(uri)?.config.isLibFileCandidate(uri)) {
-      // non-library files should always generate a compilation unit
-      const unit = await this.createAndStoreCompilationUnit(uri);
-      return unit;
-    } else {
-      // do not generate compilation units for standalone library files
-      return undefined;
-    }
-  }
-
-  async createAndStoreCompilationUnit(uri: URI): Promise<CompilationUnit> {
-    const unit = await createCompilationUnit(uri, this.workspaceByWorkspaceFolder.getWorkspaceFolderOf(uri)!);
-    this.compilationUnits.set(uri.toString(), unit);
-    return unit;
-  }
-
-  deleteCompilationUnit(uri: URI): boolean {
-    const unit = this.compilationUnits.get(uri.toString());
-    if (!unit) {
-      return false;
-    }
-
-    for (const file of unit.services.files.keys()) {
-      this.compilationUnits.delete(file);
-    }
-    this.compilationUnits.delete(uri.toString());
-
-    return true;
-  }
-
-  getAllCompilationUnits(): CompilationUnit[] {
-    return Array.from(new Set(this.compilationUnits.values()));
   }
 
   /**
@@ -391,7 +321,11 @@ export class CompilationUnitHandler {
     textDocuments.onDidClose((event) => {
       const uri = UriUtils.toUri(event.document.uri);
       this.globalMutex.read(async () => {
-        const unit = this.compilationUnits.get(uri.toString());
+        const context = this.getWorkspaceFolderOf(uri);
+        if (!context) {
+          return;
+        }
+        const unit = context.getCompilationUnit(uri);
         if (unit && this.tryCloseCompilationUnit(uri)) {
           for (const file of unit.services.files.keys()) {
             // Clear diagnostics for all files in the closed compilation unit
@@ -406,8 +340,48 @@ export class CompilationUnitHandler {
     });
   }
 
+  async initializeWorkspaceFolder(uri: string, fs: FileSystemProvider, connection: Connection) {
+    const workspace = new WorkspaceContext(fs, connection);
+    this.addWorkspaceFolder(UriUtils.toUri(uri), workspace);
+    return workspace.config
+      .init(UriUtils.toUri(uri))
+      .then((diagnosticsByUri) => {
+        publishPluginConfigDiagnostics(connection, diagnosticsByUri);
+      });
+  }
+
+  getCompilationUnit(uri: URI): CompilationUnit | undefined {
+    const context = this.getWorkspaceFolderOf(uri);
+    if (!context) {
+      return undefined;
+    }
+    return context.getCompilationUnit(uri);
+  }
+
+  async getOrCreateCompilationUnit(
+    uri: URI,
+  ): Promise<CompilationUnit | undefined> {
+    const context = this.getWorkspaceFolderOf(uri);
+    if (!context) {
+      return undefined;
+    }
+    return context.getOrCreateCompilationUnit(uri);
+  }
+
+  deleteCompilationUnit(uri: URI): boolean {
+    const context = this.getWorkspaceFolderOf(uri);
+    if (!context) {
+      return false;
+    }
+    return context.deleteCompilationUnit(uri);
+  }
+
   private tryCloseCompilationUnit(uri: URI): boolean {
-    const unit = this.compilationUnits.get(uri.toString());
+    const context = this.getWorkspaceFolderOf(uri);
+    if (!context) {
+      return false;
+    }
+    const unit = context.getCompilationUnit(uri);
     if (!unit) {
       // Nothing to close
       return false;
@@ -418,13 +392,17 @@ export class CompilationUnitHandler {
         return false;
       }
     }
-    return this.deleteCompilationUnit(uri);
+    return context.deleteCompilationUnit(uri);
   }
 
   async updateUri(uri: URI): Promise<void> {
     await this.globalMutex.run(async () => {
       await this.ready;
-      const unit = await this.getOrCreateCompilationUnit(uri);
+      const context = this.getWorkspaceFolderOf(uri);
+      if (!context) {
+        return;
+      }
+      const unit = await context.getOrCreateCompilationUnit(uri);
       if (!unit) {
         // standalone library files do not synthesize new compilation units
         return;
@@ -462,7 +440,10 @@ export class CompilationUnitHandler {
     try {
       await lifecycle(unit, document, cancellationToken);
       for (const file of unit.services.files.keys()) {
-        this.compilationUnits.set(file, unit);
+        const context = this.getWorkspaceFolderOf(file);
+        if (context) {
+          context.setCompilationUnit(URI.parse(file), unit);
+        }
       }
       const allDiagnostics = diagnosticsToLSP(unit, unit.diagnostics.getAll());
       for (const file of unit.services.files.keys()) {
@@ -497,28 +478,42 @@ export class CompilationUnitHandler {
   ): Promise<void> {
     const promises: Promise<void>[] = [];
     this.globalMutex.run(async () => {
-      for (const unit of this.getAllCompilationUnits()) {
-        if (cancellationToken.isCancellationRequested) {
-          return;
+      for (const context of this.getAllWorkspaceFolders()) {
+        for (const unit of context.getAllCompilationUnits()) {
+          if (cancellationToken.isCancellationRequested) {
+            return;
+          }
+          promises.push(
+            unit.mutex.run(async (cancellationToken) => {
+              const textDocument = await TextDocuments.get(unit.uri.toString());
+              if (textDocument) {
+                await this.process(
+                  unit,
+                  textDocument,
+                  connection,
+                  cancellationToken,
+                );
+                // Revalidate request caches (margins, skipped code, etc.)
+                // This is necessary so that changes to the plugin configuration are reflected immediately.
+                unit.requestCaches.revalidateAll({ connection, unit });
+              }
+            }),
+          );
         }
-        promises.push(
-          unit.mutex.run(async (cancellationToken) => {
-            const textDocument = await TextDocuments.get(unit.uri.toString());
-            if (textDocument) {
-              await this.process(
-                unit,
-                textDocument,
-                connection,
-                cancellationToken,
-              );
-              // Revalidate request caches (margins, skipped code, etc.)
-              // This is necessary so that changes to the plugin configuration are reflected immediately.
-              unit.requestCaches.revalidateAll({ connection, unit });
-            }
-          }),
-        );
       }
     });
     return Promise.all(promises).then(() => undefined);
+  }
+}
+
+export function publishPluginConfigDiagnostics(
+  connection: Connection,
+  diagnosticsByUri: MultiMap<string, Diagnostic>,
+): void {
+  for (const [uri, diagnostics] of diagnosticsByUri.entriesGroupedByKey()) {
+    connection.sendDiagnostics({
+      uri,
+      diagnostics,
+    });
   }
 }

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -520,7 +520,10 @@ export class CompilationUnitHandler extends WorkspaceFolderTree<WorkspaceContext
     return Promise.all(promises).then(() => undefined);
   }
 
-  async triggerOnFileChange(params: { changes: FileEvent[] }, connection?: Connection): Promise<void> {
+  async triggerOnFileChange(
+    params: { changes: FileEvent[] },
+    connection?: Connection,
+  ): Promise<void> {
     // First thing: Figure out whether any of the changed files are plugin config files
     // If they are, we need to reindex the workspace anyway - no need to check for other changes.
     function isPluginConfigFile(uri: string): boolean {
@@ -570,19 +573,19 @@ export class CompilationUnitHandler extends WorkspaceFolderTree<WorkspaceContext
         changeAffectsLibs(workspace, changes)
       ) {
         if (connection) {
-          const promises = this
-            .getAllWorkspaceFolders()
-            .map(async (workspaceContext) => {
+          const promises = this.getAllWorkspaceFolders().map(
+            async (workspaceContext) => {
               await pluginConfigChanged(connection, this, workspaceContext);
-            });
+            },
+          );
           await Promise.all(promises);
         }
       } else {
         const compilationUnits = new Set<CompilationUnit>();
         // Not a plugin config change, meaning that individual folders/files have changed.
-        for (const compilationUnit of this
-          .getAllWorkspaceFolders()
-          .flatMap((workspace) => workspace.getAllCompilationUnits())) {
+        for (const compilationUnit of this.getAllWorkspaceFolders().flatMap(
+          (workspace) => workspace.getAllCompilationUnits(),
+        )) {
           if (compilationUnit.includeError) {
             // If the compilation unit has an unresolved include, we need to re-run the lifecycle
             // to see if the include can now be resolved.
@@ -631,8 +634,7 @@ export async function pluginConfigChanged(
   workspaceContext: WorkspaceContext,
 ): Promise<void> {
   // handle changes to the .pliplugin config folder's contents
-  const diagnosticsByUri =
-    await workspaceContext.config.reloadConfigurations();
+  const diagnosticsByUri = await workspaceContext.config.reloadConfigurations();
   publishPluginConfigDiagnostics(connection, diagnosticsByUri);
 
   // reindex reachable compilation units

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -370,11 +370,11 @@ export class CompilationUnitHandler extends WorkspaceFolderTree<WorkspaceContext
     return workspace;
   }
 
-  private fallbackWorkspace: WorkspaceContext = undefined!;
+  private fallbackWorkspace: WorkspaceContext | undefined = undefined;
 
   /** must be initialized at least once */
   async initializeFallbackFolder() {
-    const uri = UriUtils.toUri(`file:///`);
+    const uri = UriUtils.toUri(`${BuiltinsUriSchema}://`);
     const workspace = new WorkspaceContext(
       this.fs,
       this.configLoader,

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -357,16 +357,26 @@ export class CompilationUnitHandler extends WorkspaceFolderTree<WorkspaceContext
     return workspace;
   }
 
-  private fallbackWorkspace: WorkspaceContext | undefined = undefined;
+  //URI scheme -> WorkspaceContext
+  private fallbackWorkspaces: Record<string, WorkspaceContext> = {};
+
+  async initializeFallbackFolderForScheme(uriScheme: string) {
+    const uri = UriUtils.toUri(`${uriScheme}:///`);
+    const workspace = new WorkspaceContext(this.fs, this.connection);
+    this.fallbackWorkspaces[uriScheme] = workspace;
+    const diagnosticsByUri = await workspace.config.init(uri);
+    if (this.connection) {
+      publishPluginConfigDiagnostics(this.connection, diagnosticsByUri);
+    }
+    return workspace;
+  }
+
   override getWorkspaceFolderOf(
     uri: string | URI,
   ): WorkspaceContext | undefined {
     const workspace = super.getWorkspaceFolderOf(uri);
-    if (!workspace) {
-      if (!this.fallbackWorkspace) {
-        this.fallbackWorkspace = new WorkspaceContext(this.fs, this.connection);
-      }
-      return this.fallbackWorkspace;
+    if (!workspace && typeof uri !== "string" && uri.scheme) {
+      return this.fallbackWorkspaces[uri.scheme];
     }
     return workspace;
   }

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -376,6 +376,14 @@ export class CompilationUnitHandler extends WorkspaceFolderTree<WorkspaceContext
     return context.deleteCompilationUnit(uri);
   }
 
+  getAllCompilationUnits(): CompilationUnit[] {
+    const units: CompilationUnit[] = [];
+    for (const context of this.getAllWorkspaceFolders()) {
+      units.push(...context.getAllCompilationUnits());
+    }
+    return units;
+  }
+
   private tryCloseCompilationUnit(uri: URI): boolean {
     const context = this.getWorkspaceFolderOf(uri);
     if (!context) {

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -370,7 +370,6 @@ export class CompilationUnitHandler extends WorkspaceFolderTree<WorkspaceContext
     return workspace;
   }
 
-  //URI scheme -> WorkspaceContext
   private fallbackWorkspace: WorkspaceContext = undefined!;
 
   /** must be initialized at least once */
@@ -387,6 +386,14 @@ export class CompilationUnitHandler extends WorkspaceFolderTree<WorkspaceContext
       publishPluginConfigDiagnostics(this.connection, diagnosticsByUri);
     }
     return workspace;
+  }
+
+  override getAllWorkspaceFolders(): WorkspaceContext[] {
+    const folders = super.getAllWorkspaceFolders();
+    if (this.fallbackWorkspace) {
+      folders.push(this.fallbackWorkspace);
+    }
+    return folders;
   }
 
   override getWorkspaceFolderOf(

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -57,6 +57,7 @@ import {
 import { CompilerOptions as PliCompilerOptions } from "../preprocessor/compiler-options/options-pli.js";
 import { DiagnosticsStore } from "../validation/diagnostics-store.js";
 import { LRUCache } from "lru-cache";
+import { WorkspaceFolderTree } from "./workspace-folder-tree.js";
 
 /**
  * A compilation unit is a representation of a PL/I program in the language server.
@@ -307,11 +308,13 @@ export class CompilationUnitHandler {
    * Workspace context shared by every unit this handler creates. Provides
    * the file-system provider and the plugin configuration.
    */
-  readonly workspace: WorkspaceContext;
+  readonly workspaceByWorkspaceFolder: WorkspaceFolderTree<WorkspaceContext>;
 
-  constructor(workspace: WorkspaceContext) {
-    this.workspace = workspace;
+  constructor() {
+    this.workspaceByWorkspaceFolder = new WorkspaceFolderTree<WorkspaceContext>(false);
   }
+
+  
 
   get ready(): Promise<void> {
     return this.readyDeferred.promise;
@@ -335,7 +338,7 @@ export class CompilationUnitHandler {
     }
     if (isPluginConfigurationUri(uri)) {
       return undefined;
-    } else if (!this.workspace.config.isLibFileCandidate(uri)) {
+    } else if (!this.workspaceByWorkspaceFolder.getWorkspaceFolderOf(uri)?.config.isLibFileCandidate(uri)) {
       // non-library files should always generate a compilation unit
       const unit = await this.createAndStoreCompilationUnit(uri);
       return unit;
@@ -346,7 +349,7 @@ export class CompilationUnitHandler {
   }
 
   async createAndStoreCompilationUnit(uri: URI): Promise<CompilationUnit> {
-    const unit = await createCompilationUnit(uri, this.workspace);
+    const unit = await createCompilationUnit(uri, this.workspaceByWorkspaceFolder.getWorkspaceFolderOf(uri)!);
     this.compilationUnits.set(uri.toString(), unit);
     return unit;
   }

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -348,11 +348,23 @@ export class CompilationUnitHandler extends WorkspaceFolderTree<WorkspaceContext
 
   async initializeWorkspaceFolder(uriString: string | URI) {
     const uri = UriUtils.toUri(uriString);
-    const workspace = new WorkspaceContext(uri, this.fs, this.connection);
+    const workspace = new WorkspaceContext(this.fs, this.connection);
     this.addWorkspaceFolder(uri, workspace);
     const diagnosticsByUri = await workspace.config.init(uri);
     if (this.connection) {
       publishPluginConfigDiagnostics(this.connection, diagnosticsByUri);
+    }
+    return workspace;
+  }
+
+  private fallbackWorkspace: WorkspaceContext | undefined = undefined;
+  override getWorkspaceFolderOf(uri: string | URI): WorkspaceContext | undefined {
+    const workspace = super.getWorkspaceFolderOf(uri);
+    if (!workspace) {
+      if (this.fallbackWorkspace) {
+        this.fallbackWorkspace = new WorkspaceContext(this.fs, this.connection);
+      }
+      return this.fallbackWorkspace;
     }
     return workspace;
   }

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -11,7 +11,11 @@
 
 import { Program, SyntaxKind } from "../syntax-tree/ast.js";
 import { isVirtualFile, URI, UriUtils } from "../utils/uri.js";
-import { CancellationToken, Connection, Diagnostic } from "vscode-languageserver";
+import {
+  CancellationToken,
+  Connection,
+  Diagnostic,
+} from "vscode-languageserver";
 import { ReferencesCache, StatementOrderCache } from "../linking/resolver.js";
 import { diagnosticsToLSP } from "../language-server/types.js";
 import {
@@ -298,8 +302,6 @@ export class CompilationUnitHandler extends WorkspaceFolderTree<WorkspaceContext
     this.fs = fs;
   }
 
-
-
   get ready(): Promise<void> {
     return this.readyDeferred.promise;
   }
@@ -342,18 +344,16 @@ export class CompilationUnitHandler extends WorkspaceFolderTree<WorkspaceContext
     });
   }
 
-  async initializeWorkspaceFolder(uriString: string|URI) {
+  async initializeWorkspaceFolder(uriString: string | URI) {
     const uri = UriUtils.toUri(uriString);
     const workspace = new WorkspaceContext(uri, this.fs, this.connection);
     this.addWorkspaceFolder(uri, workspace);
-    return workspace.config
-      .init(uri)
-      .then((diagnosticsByUri) => {
-        if(this.connection) {
-          publishPluginConfigDiagnostics(this.connection, diagnosticsByUri);
-        }
-        return workspace;
-      });
+    return workspace.config.init(uri).then((diagnosticsByUri) => {
+      if (this.connection) {
+        publishPluginConfigDiagnostics(this.connection, diagnosticsByUri);
+      }
+      return workspace;
+    });
   }
 
   getCompilationUnit(uri: URI): CompilationUnit | undefined {

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -47,7 +47,7 @@ import { GroupRecord, ProgramRecord } from "./plugin-configuration-provider.js";
 import { WorkspaceContext } from "./workspace-context.js";
 import { EvaluationResults } from "../preprocessor/instruction-interpreter.js";
 import { createMutex, Mutex } from "./mutex.js";
-import { Deferred, isOperationCancelled } from "../utils/promises.js";
+import { Deferred, isOperationCancelled, LongRunningOperation } from "../utils/promises.js";
 import {
   InstructionCache,
   TokenizationCache,
@@ -66,6 +66,7 @@ import { LRUCache } from "lru-cache";
 import { WorkspaceFolderTree } from "./workspace-folder-tree.js";
 import { FileSystemProvider } from "./file-system-provider.js";
 import { MultiMap } from "../utils/collections.js";
+import { GlobalConfigLoader } from "../index.js";
 
 /**
  * A compilation unit is a representation of a PL/I program in the language server.
@@ -299,7 +300,7 @@ export class CompilationUnitHandler extends WorkspaceFolderTree<WorkspaceContext
    */
   readonly globalMutex = createMutex();
 
-  constructor(fs: FileSystemProvider) {
+  constructor(fs: FileSystemProvider, private readonly configLoader: GlobalConfigLoader, private readonly longRunningOperation: LongRunningOperation) {
     super(false);
     this.fs = fs;
   }
@@ -348,7 +349,7 @@ export class CompilationUnitHandler extends WorkspaceFolderTree<WorkspaceContext
 
   async initializeWorkspaceFolder(uriString: string | URI) {
     const uri = UriUtils.toUri(uriString);
-    const workspace = new WorkspaceContext(this.fs, this.connection);
+    const workspace = new WorkspaceContext(this.fs, this.configLoader, this.longRunningOperation);
     this.addWorkspaceFolder(uri, workspace);
     const diagnosticsByUri = await workspace.config.init(uri);
     if (this.connection) {
@@ -362,7 +363,7 @@ export class CompilationUnitHandler extends WorkspaceFolderTree<WorkspaceContext
 
   async initializeFallbackFolderForScheme(uriScheme: string) {
     const uri = UriUtils.toUri(`${uriScheme}:///`);
-    const workspace = new WorkspaceContext(this.fs, this.connection);
+    const workspace = new WorkspaceContext(this.fs, this.configLoader, this.longRunningOperation);
     this.fallbackWorkspaces[uriScheme] = workspace;
     const diagnosticsByUri = await workspace.config.init(uri);
     if (this.connection) {

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -15,6 +15,8 @@ import {
   CancellationToken,
   Connection,
   Diagnostic,
+  FileChangeType,
+  FileEvent,
 } from "vscode-languageserver";
 import { ReferencesCache, StatementOrderCache } from "../linking/resolver.js";
 import { diagnosticsToLSP } from "../language-server/types.js";
@@ -348,12 +350,11 @@ export class CompilationUnitHandler extends WorkspaceFolderTree<WorkspaceContext
     const uri = UriUtils.toUri(uriString);
     const workspace = new WorkspaceContext(uri, this.fs, this.connection);
     this.addWorkspaceFolder(uri, workspace);
-    return workspace.config.init(uri).then((diagnosticsByUri) => {
-      if (this.connection) {
-        publishPluginConfigDiagnostics(this.connection, diagnosticsByUri);
-      }
-      return workspace;
-    });
+    const diagnosticsByUri = await workspace.config.init(uri);
+    if (this.connection) {
+      publishPluginConfigDiagnostics(this.connection, diagnosticsByUri);
+    }
+    return workspace;
   }
 
   getCompilationUnit(uri: URI): CompilationUnit | undefined {
@@ -518,6 +519,98 @@ export class CompilationUnitHandler extends WorkspaceFolderTree<WorkspaceContext
     });
     return Promise.all(promises).then(() => undefined);
   }
+
+  async triggerOnFileChange(params: { changes: FileEvent[] }, connection?: Connection): Promise<void> {
+    // First thing: Figure out whether any of the changed files are plugin config files
+    // If they are, we need to reindex the workspace anyway - no need to check for other changes.
+    function isPluginConfigFile(uri: string): boolean {
+      return (
+        uri.endsWith("/.pliplugin") ||
+        uri.endsWith("/.pliplugin/pgm_conf.json") ||
+        uri.endsWith("/.pliplugin/proc_grps.json")
+      );
+    }
+
+    const fileEventsByWorkspace = new Map<WorkspaceContext, FileEvent[]>();
+    for (const change of params.changes) {
+      const workspace = this.getWorkspaceFolderOf(change.uri);
+      if (workspace) {
+        if (!fileEventsByWorkspace.has(workspace)) {
+          fileEventsByWorkspace.set(workspace, []);
+        }
+        fileEventsByWorkspace.get(workspace)!.push(change);
+      }
+    }
+
+    for (const [workspace, changes] of fileEventsByWorkspace.entries()) {
+      // Since we cannot know whether a created directory is a lib in advance
+      // We always have to reindex if a directory is created, since it may contain a lib.
+      let directoryCreated = false;
+      for (const change of changes) {
+        if (change.type === FileChangeType.Created) {
+          // Try to stat the changed file to see if it's a directory.
+          const uri = UriUtils.toUri(change.uri);
+          try {
+            const stats = await this.fs.stat(uri);
+            if (stats.isDirectory) {
+              directoryCreated = true;
+              break;
+            }
+          } catch {
+            // Ignore errors, assume it's not a directory.
+          }
+        }
+      }
+      const pluginConfigHasChanged = changes.some((change) =>
+        isPluginConfigFile(change.uri),
+      );
+      if (
+        directoryCreated ||
+        pluginConfigHasChanged ||
+        changeAffectsLibs(workspace, changes)
+      ) {
+        if (connection) {
+          const promises = this
+            .getAllWorkspaceFolders()
+            .map(async (workspaceContext) => {
+              await pluginConfigChanged(connection, this, workspaceContext);
+            });
+          await Promise.all(promises);
+        }
+      } else {
+        const compilationUnits = new Set<CompilationUnit>();
+        // Not a plugin config change, meaning that individual folders/files have changed.
+        for (const compilationUnit of this
+          .getAllWorkspaceFolders()
+          .flatMap((workspace) => workspace.getAllCompilationUnits())) {
+          if (compilationUnit.includeError) {
+            // If the compilation unit has an unresolved include, we need to re-run the lifecycle
+            // to see if the include can now be resolved.
+            compilationUnits.add(compilationUnit);
+            // No need to change the change contents for this
+            continue;
+          }
+          changeLoop: for (const change of changes) {
+            for (const file of compilationUnit.services.files.keys()) {
+              // Either equal (i.e. file has changed) or the changed dir is a parent of the file
+              if (UriUtils.contains(change.uri, file)) {
+                compilationUnits.add(compilationUnit);
+                break changeLoop;
+              }
+            }
+          }
+        }
+        // Finally, update the compilation units themselves that might be affected by the change
+        for (const compilationUnit of compilationUnits) {
+          await this.updateUri(compilationUnit.uri);
+        }
+        if (compilationUnits.size > 0) {
+          // refresh semantic tokens so syntax coloring updates immediately
+          connection?.languages.semanticTokens.refresh();
+        }
+      }
+    }
+  }
 }
 
 export function publishPluginConfigDiagnostics(
@@ -530,4 +623,53 @@ export function publishPluginConfigDiagnostics(
       diagnostics,
     });
   }
+}
+
+export async function pluginConfigChanged(
+  connection: Connection,
+  compilationUnitHandler: CompilationUnitHandler,
+  workspaceContext: WorkspaceContext,
+): Promise<void> {
+  // handle changes to the .pliplugin config folder's contents
+  const diagnosticsByUri =
+    await workspaceContext.config.reloadConfigurations();
+  publishPluginConfigDiagnostics(connection, diagnosticsByUri);
+
+  // reindex reachable compilation units
+  await compilationUnitHandler.reindex(connection, CancellationToken.None);
+
+  // refresh semantic tokens so syntax coloring updates immediately
+  connection.languages.semanticTokens.refresh();
+}
+
+// A structural change to a lib folder (a file/dir created or deleted
+// inside a lib, or a directory removed that is or contains a lib)
+// invalidates the computed lib index, so the libs must be re-expanded.
+// Note: Simple file edits are not considered structural changes,
+// so they don't trigger a reindex.
+function changeAffectsLibs(
+  workspace: WorkspaceContext,
+  changes: readonly FileEvent[],
+): boolean {
+  const libDirs = workspace.config.getLibDirectoryUris();
+  if (libDirs.length === 0) {
+    return false;
+  }
+  for (const change of changes) {
+    if (change.type === FileChangeType.Changed) {
+      continue;
+    }
+    const changeUri = UriUtils.toUri(change.uri);
+    for (const libDir of libDirs) {
+      // Change inside a lib (create/delete of a member) OR the change
+      // is/contains the lib dir itself (whole lib folder gone).
+      if (
+        UriUtils.contains(libDir, changeUri) ||
+        UriUtils.contains(changeUri, libDir)
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
 }

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -47,7 +47,11 @@ import { GroupRecord, ProgramRecord } from "./plugin-configuration-provider.js";
 import { WorkspaceContext } from "./workspace-context.js";
 import { EvaluationResults } from "../preprocessor/instruction-interpreter.js";
 import { createMutex, Mutex } from "./mutex.js";
-import { Deferred, isOperationCancelled, LongRunningOperation } from "../utils/promises.js";
+import {
+  Deferred,
+  isOperationCancelled,
+  LongRunningOperation,
+} from "../utils/promises.js";
 import {
   InstructionCache,
   TokenizationCache,
@@ -300,7 +304,11 @@ export class CompilationUnitHandler extends WorkspaceFolderTree<WorkspaceContext
    */
   readonly globalMutex = createMutex();
 
-  constructor(fs: FileSystemProvider, private readonly configLoader: GlobalConfigLoader, private readonly longRunningOperation: LongRunningOperation) {
+  constructor(
+    fs: FileSystemProvider,
+    private readonly configLoader: GlobalConfigLoader,
+    private readonly longRunningOperation: LongRunningOperation,
+  ) {
     super(false);
     this.fs = fs;
   }
@@ -349,7 +357,11 @@ export class CompilationUnitHandler extends WorkspaceFolderTree<WorkspaceContext
 
   async initializeWorkspaceFolder(uriString: string | URI) {
     const uri = UriUtils.toUri(uriString);
-    const workspace = new WorkspaceContext(this.fs, this.configLoader, this.longRunningOperation);
+    const workspace = new WorkspaceContext(
+      this.fs,
+      this.configLoader,
+      this.longRunningOperation,
+    );
     this.addWorkspaceFolder(uri, workspace);
     const diagnosticsByUri = await workspace.config.init(uri);
     if (this.connection) {
@@ -359,12 +371,17 @@ export class CompilationUnitHandler extends WorkspaceFolderTree<WorkspaceContext
   }
 
   //URI scheme -> WorkspaceContext
-  private fallbackWorkspaces: Record<string, WorkspaceContext> = {};
+  private fallbackWorkspace: WorkspaceContext = undefined!;
 
-  async initializeFallbackFolderForScheme(uriScheme: string) {
-    const uri = UriUtils.toUri(`${uriScheme}:///`);
-    const workspace = new WorkspaceContext(this.fs, this.configLoader, this.longRunningOperation);
-    this.fallbackWorkspaces[uriScheme] = workspace;
+  /** must be initialized at least once */
+  async initializeFallbackFolder() {
+    const uri = UriUtils.toUri(`file:///`);
+    const workspace = new WorkspaceContext(
+      this.fs,
+      this.configLoader,
+      this.longRunningOperation,
+    );
+    this.fallbackWorkspace = workspace;
     const diagnosticsByUri = await workspace.config.init(uri);
     if (this.connection) {
       publishPluginConfigDiagnostics(this.connection, diagnosticsByUri);
@@ -376,8 +393,8 @@ export class CompilationUnitHandler extends WorkspaceFolderTree<WorkspaceContext
     uri: string | URI,
   ): WorkspaceContext | undefined {
     const workspace = super.getWorkspaceFolderOf(uri);
-    if (!workspace && typeof uri !== "string" && uri.scheme) {
-      return this.fallbackWorkspaces[uri.scheme];
+    if (!workspace) {
+      return this.fallbackWorkspace;
     }
     return workspace;
   }

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -358,7 +358,9 @@ export class CompilationUnitHandler extends WorkspaceFolderTree<WorkspaceContext
   }
 
   private fallbackWorkspace: WorkspaceContext | undefined = undefined;
-  override getWorkspaceFolderOf(uri: string | URI): WorkspaceContext | undefined {
+  override getWorkspaceFolderOf(
+    uri: string | URI,
+  ): WorkspaceContext | undefined {
     const workspace = super.getWorkspaceFolderOf(uri);
     if (!workspace) {
       if (!this.fallbackWorkspace) {

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -294,7 +294,7 @@ export async function addBuiltinUnits(
   unit.rootPreprocessorScope = Scope.createChild(macroScope);
 }
 
-export class CompilationUnitHandler extends WorkspaceFolderTree<WorkspaceContext> {
+export class CompilationUnitHandler {
   private fs: FileSystemProvider;
   private connection!: Connection;
   private readyDeferred = new Deferred();
@@ -304,12 +304,13 @@ export class CompilationUnitHandler extends WorkspaceFolderTree<WorkspaceContext
    */
   readonly globalMutex = createMutex();
 
+  private workspaceFolderTree = new WorkspaceFolderTree<WorkspaceContext>();
+
   constructor(
     fs: FileSystemProvider,
     private readonly configLoader: GlobalConfigLoader,
     private readonly longRunningOperation: LongRunningOperation,
   ) {
-    super(false);
     this.fs = fs;
   }
 
@@ -388,18 +389,20 @@ export class CompilationUnitHandler extends WorkspaceFolderTree<WorkspaceContext
     return workspace;
   }
 
-  override getAllWorkspaceFolders(): WorkspaceContext[] {
-    const folders = super.getAllWorkspaceFolders();
+  addWorkspaceFolder(uri: string | URI, workspace: WorkspaceContext): void {
+    this.workspaceFolderTree.addWorkspaceFolder(uri, workspace);
+  }
+
+  getAllWorkspaceFolders(): WorkspaceContext[] {
+    const folders = this.workspaceFolderTree.getAllWorkspaceFolders();
     if (this.fallbackWorkspace) {
       folders.push(this.fallbackWorkspace);
     }
     return folders;
   }
 
-  override getWorkspaceFolderOf(
-    uri: string | URI,
-  ): WorkspaceContext | undefined {
-    const workspace = super.getWorkspaceFolderOf(uri);
+  getWorkspaceFolderOf(uri: string | URI): WorkspaceContext | undefined {
+    const workspace = this.workspaceFolderTree.getWorkspaceFolderOf(uri);
     if (!workspace) {
       return this.fallbackWorkspace;
     }

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -284,6 +284,7 @@ export async function addBuiltinUnits(
 }
 
 export class CompilationUnitHandler extends WorkspaceFolderTree<WorkspaceContext> {
+  private fs: FileSystemProvider;
   private connection!: Connection;
   private readyDeferred = new Deferred();
 
@@ -292,8 +293,9 @@ export class CompilationUnitHandler extends WorkspaceFolderTree<WorkspaceContext
    */
   readonly globalMutex = createMutex();
 
-  constructor() {
+  constructor(fs: FileSystemProvider) {
     super(false);
+    this.fs = fs;
   }
 
 
@@ -340,13 +342,17 @@ export class CompilationUnitHandler extends WorkspaceFolderTree<WorkspaceContext
     });
   }
 
-  async initializeWorkspaceFolder(uri: string, fs: FileSystemProvider, connection: Connection) {
-    const workspace = new WorkspaceContext(fs, connection);
-    this.addWorkspaceFolder(UriUtils.toUri(uri), workspace);
+  async initializeWorkspaceFolder(uriString: string|URI) {
+    const uri = UriUtils.toUri(uriString);
+    const workspace = new WorkspaceContext(uri, this.fs, this.connection);
+    this.addWorkspaceFolder(uri, workspace);
     return workspace.config
-      .init(UriUtils.toUri(uri))
+      .init(uri)
       .then((diagnosticsByUri) => {
-        publishPluginConfigDiagnostics(connection, diagnosticsByUri);
+        if(this.connection) {
+          publishPluginConfigDiagnostics(this.connection, diagnosticsByUri);
+        }
+        return workspace;
       });
   }
 

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -375,7 +375,7 @@ export class CompilationUnitHandler {
 
   /** must be initialized at least once */
   async initializeFallbackFolder() {
-    const uri = UriUtils.toUri(`${BuiltinsUriSchema}://`);
+    const uri = UriUtils.toUri(`file://`);
     const workspace = new WorkspaceContext(
       this.fs,
       this.configLoader,

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -361,7 +361,7 @@ export class CompilationUnitHandler extends WorkspaceFolderTree<WorkspaceContext
   override getWorkspaceFolderOf(uri: string | URI): WorkspaceContext | undefined {
     const workspace = super.getWorkspaceFolderOf(uri);
     if (!workspace) {
-      if (this.fallbackWorkspace) {
+      if (!this.fallbackWorkspace) {
         this.fallbackWorkspace = new WorkspaceContext(this.fs, this.connection);
       }
       return this.fallbackWorkspace;

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -190,7 +190,7 @@ interface ConfigSource {
 
 /**
  * Precedence of a program-config match against a file, **lowest value wins**.
- * Used by {@link PluginConfigurationProvider.getProgramConfig} to pick the
+ * Used by {@link PluginConfigurationProvider["getProgramConfig"]} to pick the
  * best match rather than the first hit, so a user-scope `settings.json` entry
  * can never shadow a project `.pliplugin/` entry that also matches:
  *

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -634,7 +634,7 @@ export class PluginConfigurationProvider {
       return await sendRequest(
         this.connection,
         Messages.GetGlobalConfig,
-        workspaceUri.fsPath,
+        workspaceUri.toString(),
       );
     } catch (err) {
       console.error("Failed to fetch global plugin configuration:", err);

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -475,7 +475,7 @@ export class PluginConfigurationProvider {
     // Collect sources in PRECEDENCE-LOWEST-FIRST order. Map-based merge
     // means later writes overwrite earlier writes, so listing
     // .pliplugin/ second makes it the winning source on key collisions.
-    const global = await this.fetchGlobalSettings();
+    const global = await this.fetchGlobalSettings(this.workspacePath);
 
     // Read every source concurrently. Precedence (settings < .pliplugin/)
     // is established by the order we assemble each array below, not by the
@@ -626,15 +626,15 @@ export class PluginConfigurationProvider {
    * and `pli.proc_grps`. Returns `undefined` when no connection is
    * available (e.g. tests) or the request fails.
    */
-  private async fetchGlobalSettings(): Promise<
-    Messages.GlobalConfig | undefined
-  > {
+  private async fetchGlobalSettings(
+    workspaceUri: URI,
+  ): Promise<Messages.GlobalConfig | undefined> {
     if (!this.connection) return undefined;
     try {
       return await sendRequest(
         this.connection,
         Messages.GetGlobalConfig,
-        undefined,
+        workspaceUri.fsPath,
       );
     } catch (err) {
       console.error("Failed to fetch global plugin configuration:", err);

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -469,15 +469,15 @@ export class PluginConfigurationProvider {
     // Collect sources in PRECEDENCE-LOWEST-FIRST order. Map-based merge
     // means later writes overwrite earlier writes, so listing
     // .pliplugin/ second makes it the winning source on key collisions.
-    const global = await this.fetchGlobalSettings(this.workspacePath);
+    const globalSettings = await this.fetchGlobalSettings(this.workspacePath);
 
     // Read every source concurrently. Precedence (settings < .pliplugin/)
     // is established by the order we assemble each array below, not by the
     // order the reads resolve, so reading in parallel is safe.
     const [globalPgm, globalProc, plipluginPgm, plipluginProc] =
       await Promise.all([
-        this.readConfigSource(global?.pgmConf),
-        this.readConfigSource(global?.procGrps),
+        this.readConfigSource(globalSettings?.pgmConf),
+        this.readConfigSource(globalSettings?.procGrps),
         this.readConfigSource(plipluginPgmConfUri),
         this.readConfigSource(plipluginProcGrpsUri),
       ]);

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -272,7 +272,11 @@ export class PluginConfigurationProvider {
   private readonly longRunningOperation: LongRunningOperation;
   private readonly globalConfigLoader: GlobalConfigLoader;
 
-  constructor(fs: FileSystemProvider, globalConfigLoader: GlobalConfigLoader, longRunningOperation: LongRunningOperation) {
+  constructor(
+    fs: FileSystemProvider,
+    globalConfigLoader: GlobalConfigLoader,
+    longRunningOperation: LongRunningOperation,
+  ) {
     this.fs = fs;
     this.longRunningOperation = longRunningOperation;
     this.globalConfigLoader = globalConfigLoader;
@@ -280,7 +284,6 @@ export class PluginConfigurationProvider {
     this.processGroupConfigs = new Map<string, GroupRecord>();
     this.workspacePath = UriUtils.parse(""); // empty workspace to start with
   }
-
 
   /**
    * Snapshot of the file the user is acting on, used by quick-fixes that
@@ -443,7 +446,7 @@ export class PluginConfigurationProvider {
   private async loadConfigurations(): Promise<PluginConfigLspDiagnostics> {
     const workspaceUri = UriUtils.toUri(this.workspacePath);
     const cancel = this.longRunningOperation.start(
-      "Processing plugin configuration..."
+      "Processing plugin configuration...",
     );
 
     this.programConfigs.clear();

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -1063,12 +1063,12 @@ export class PluginConfigurationProvider {
     // the path alone is sufficient.
     // Note that we just need the path of the URI in order to match against
     // the program config patterns
-    const uri = program.path;
+    const path = program.path;
 
     let best: ProgramRecord | undefined;
     let bestRank = Number.POSITIVE_INFINITY;
     for (const [pattern, config] of this.programConfigs.entries()) {
-      const rank = this.programMatchRank(uri, pattern, config);
+      const rank = this.programMatchRank(path, pattern, config);
       if (rank === undefined || rank >= bestRank) {
         continue; // no match, or not better than what we already have
       }
@@ -1086,25 +1086,25 @@ export class PluginConfigurationProvider {
    * `undefined` when its pattern does not match the file. Lower ranks win;
    * see {@link ProgramMatchRank}.
    *
-   * @param uri Decoded program URI being resolved.
+   * @param path Decoded program path being resolved.
    * @param pattern The program config's key (an exact path or a glob).
    * @param record The candidate program config.
    */
   private programMatchRank(
-    uri: string,
+    path: string,
     pattern: string,
     record: ProgramRecord,
   ): number | undefined {
-    const isExact = pattern === uri;
+    const isExact = pattern === path;
     if (!isExact) {
       try {
-        // attempt match on decoded URI
-        if (!minimatch(uri, decodeURIComponent(pattern), { nocase: true })) {
+        // attempt match on decoded path
+        if (!minimatch(path, decodeURIComponent(pattern), { nocase: true })) {
           return undefined;
         }
       } catch (e) {
         console.error(
-          `Invalid glob pattern "${pattern}" for program "${uri}": ${e}`,
+          `Invalid glob pattern "${pattern}" for program "${path}": ${e}`,
         );
         return undefined;
       }

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -222,6 +222,7 @@ export class PluginConfigurationProvider {
 
   /**
    * Map of program configs, keyed by their entry program.
+   * The key is a path without URI scheme at the beginning.
    * These correspond to the entry point of a compile unit.
    */
   private programConfigs: Map<string, ProgramRecord>;
@@ -925,7 +926,7 @@ export class PluginConfigurationProvider {
       // Wrap the loaded config into a ProgramRecord. `abstractOptions` and
       // `issues` are filled in by `postProcessProgramConfigs` once the
       // bound process group is also available.
-      this.programConfigs.set(resolvedUri.toString(), {
+      this.programConfigs.set(resolvedUri.path, {
         ...config,
         abstractOptions: { options: [], tokens: [], issues: [], comments: [] },
         issues: [],
@@ -1060,8 +1061,9 @@ export class PluginConfigurationProvider {
     // No PL/I-extension filtering here: callers only ever pass files already
     // identified as PL/I (client language id / auto-detect), so glob matching
     // the path alone is sufficient.
-    // Note that we need to decode the URI
-    const uri = program.toString(true);
+    // Note that we just need the path of the URI in order to match against
+    // the program config patterns
+    const uri = program.path;
 
     let best: ProgramRecord | undefined;
     let bestRank = Number.POSITIVE_INFINITY;

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -26,8 +26,7 @@ import {
   parseProgramConfigs,
   toLspDiagnostic,
 } from "../config/loader";
-import { Messages } from "../utils/messages";
-import { sendRequest } from "../language-server/connection-handler";
+import { GlobalConfigLoader, Messages } from "../utils/messages";
 import {
   GroupRecord,
   isLibsDir,
@@ -45,8 +44,7 @@ import { DEFAULT_INSTRUCTION_LIMIT } from "../preprocessor/instruction-interpret
 import { PluginConfiguration } from "../language-server/constants";
 import { type JSONPath } from "../utils/jsonc";
 import { LspCodes } from "../validation/lsp-codes";
-import { Connection } from "vscode-languageserver";
-import { startLongRunningOperation } from "../utils/promises";
+import { LongRunningOperation } from "../utils/promises";
 import { validatePgroupReferences } from "../config/cross-validation";
 import { MultiMap } from "../utils/collections";
 import { TextDocuments } from "../language-server/text-documents";
@@ -271,21 +269,18 @@ export class PluginConfigurationProvider {
    * construction so the provider has no dependency on a global FS singleton.
    */
   private readonly fs: FileSystemProvider;
+  private readonly longRunningOperation: LongRunningOperation;
+  private readonly globalConfigLoader: GlobalConfigLoader;
 
-  /**
-   * Connection used to send status updates about file loading and config parsing.
-   * In some cases, such as when working with remote file system, loading and processing of config files can be slow.
-   * Having the connection allows us to send progress updates to the client, so the user knows something is happening.
-   */
-  private readonly connection: Connection | undefined;
-
-  constructor(fs: FileSystemProvider, connection?: Connection) {
+  constructor(fs: FileSystemProvider, globalConfigLoader: GlobalConfigLoader, longRunningOperation: LongRunningOperation) {
     this.fs = fs;
-    this.connection = connection;
+    this.longRunningOperation = longRunningOperation;
+    this.globalConfigLoader = globalConfigLoader;
     this.programConfigs = new Map<string, ProgramRecord>();
     this.processGroupConfigs = new Map<string, GroupRecord>();
     this.workspacePath = UriUtils.parse(""); // empty workspace to start with
   }
+
 
   /**
    * Snapshot of the file the user is acting on, used by quick-fixes that
@@ -447,9 +442,8 @@ export class PluginConfigurationProvider {
    */
   private async loadConfigurations(): Promise<PluginConfigLspDiagnostics> {
     const workspaceUri = UriUtils.toUri(this.workspacePath);
-    const cancel = startLongRunningOperation(
-      this.connection,
-      "Processing plugin configuration...",
+    const cancel = this.longRunningOperation.start(
+      "Processing plugin configuration..."
     );
 
     this.programConfigs.clear();
@@ -629,17 +623,7 @@ export class PluginConfigurationProvider {
   private async fetchGlobalSettings(
     workspaceUri: URI,
   ): Promise<Messages.GlobalConfig | undefined> {
-    if (!this.connection) return undefined;
-    try {
-      return await sendRequest(
-        this.connection,
-        Messages.GetGlobalConfig,
-        workspaceUri.toString(),
-      );
-    } catch (err) {
-      console.error("Failed to fetch global plugin configuration:", err);
-      return undefined;
-    }
+    return this.globalConfigLoader.loadGlobalConfig(workspaceUri);
   }
 
   /**

--- a/packages/language/src/workspace/workspace-context.ts
+++ b/packages/language/src/workspace/workspace-context.ts
@@ -41,6 +41,7 @@ export class WorkspaceContext {
   public readonly config: PluginConfigurationProvider;
 
   constructor(
+    public readonly uri: URI,
     public readonly fs: FileSystemProvider,
     connection?: Connection,
   ) {

--- a/packages/language/src/workspace/workspace-context.ts
+++ b/packages/language/src/workspace/workspace-context.ts
@@ -9,11 +9,12 @@
  *
  */
 
-import { Connection } from "vscode-languageserver";
 import { FileSystemProvider } from "./file-system-provider";
 import { PluginConfigurationProvider } from "./plugin-configuration-provider";
 import { CompilationUnit, createCompilationUnit } from "./compilation-unit";
 import { URI, UriUtils } from "../utils/uri";
+import { LongRunningOperation, LongRunningOperationImpl } from "../utils/promises";
+import { GlobalConfigLoader } from "../utils/messages";
 
 /**
  * WorkspaceContext bundles the per-language-server-instance state that
@@ -42,9 +43,10 @@ export class WorkspaceContext {
 
   constructor(
     public readonly fs: FileSystemProvider,
-    connection?: Connection,
+    globalConfigLoader: GlobalConfigLoader,
+    longRunningOperation?: LongRunningOperation,
   ) {
-    this.config = new PluginConfigurationProvider(fs, connection);
+    this.config = new PluginConfigurationProvider(fs, globalConfigLoader, longRunningOperation ?? LongRunningOperationImpl.Dummy);
   }
 
   setCompilationUnit(uri: URI, unit: CompilationUnit): void {

--- a/packages/language/src/workspace/workspace-context.ts
+++ b/packages/language/src/workspace/workspace-context.ts
@@ -13,7 +13,10 @@ import { FileSystemProvider } from "./file-system-provider";
 import { PluginConfigurationProvider } from "./plugin-configuration-provider";
 import { CompilationUnit, createCompilationUnit } from "./compilation-unit";
 import { URI, UriUtils } from "../utils/uri";
-import { LongRunningOperation, LongRunningOperationImpl } from "../utils/promises";
+import {
+  LongRunningOperation,
+  LongRunningOperationImpl,
+} from "../utils/promises";
 import { GlobalConfigLoader } from "../utils/messages";
 
 /**
@@ -46,7 +49,11 @@ export class WorkspaceContext {
     globalConfigLoader: GlobalConfigLoader,
     longRunningOperation?: LongRunningOperation,
   ) {
-    this.config = new PluginConfigurationProvider(fs, globalConfigLoader, longRunningOperation ?? LongRunningOperationImpl.Dummy);
+    this.config = new PluginConfigurationProvider(
+      fs,
+      globalConfigLoader,
+      longRunningOperation ?? LongRunningOperationImpl.Dummy,
+    );
   }
 
   setCompilationUnit(uri: URI, unit: CompilationUnit): void {

--- a/packages/language/src/workspace/workspace-context.ts
+++ b/packages/language/src/workspace/workspace-context.ts
@@ -41,7 +41,6 @@ export class WorkspaceContext {
   public readonly config: PluginConfigurationProvider;
 
   constructor(
-    public readonly uri: URI,
     public readonly fs: FileSystemProvider,
     connection?: Connection,
   ) {

--- a/packages/language/src/workspace/workspace-context.ts
+++ b/packages/language/src/workspace/workspace-context.ts
@@ -12,6 +12,8 @@
 import { Connection } from "vscode-languageserver";
 import { FileSystemProvider } from "./file-system-provider";
 import { PluginConfigurationProvider } from "./plugin-configuration-provider";
+import { CompilationUnit, createCompilationUnit } from "./compilation-unit";
+import { URI, UriUtils } from "../utils/uri";
 
 /**
  * WorkspaceContext bundles the per-language-server-instance state that
@@ -31,6 +33,7 @@ import { PluginConfigurationProvider } from "./plugin-configuration-provider";
  * the helpers that build compilation units.
  */
 export class WorkspaceContext {
+  private compilationUnits: Map<string, CompilationUnit> = new Map();
   /**
    * Plugin configuration provider that owns the parsed `pgm_conf.json`
    * and `proc_grps.json` state and the lookups derived from them.
@@ -43,4 +46,73 @@ export class WorkspaceContext {
   ) {
     this.config = new PluginConfigurationProvider(fs, connection);
   }
+
+  setCompilationUnit(uri: URI, unit: CompilationUnit): void {
+    this.compilationUnits.set(uri.toString(), unit);
+  }
+
+  getCompilationUnit(uri: URI): CompilationUnit | undefined {
+    return this.compilationUnits.get(uri.toString());
+  }
+
+  /**
+   * Gets an existing or creates a new compilation unit for the given URI, except for standalone library files
+   *
+   * @returns Pre-existing or new compilation unit, or undefined if it's a standalone library file
+   */
+  async getOrCreateCompilationUnit(
+    uri: URI,
+  ): Promise<CompilationUnit | undefined> {
+    if (this.compilationUnits.has(uri.toString())) {
+      // existing compilation unit
+      return this.compilationUnits.get(uri.toString());
+    }
+    if (isPluginConfigurationUri(uri)) {
+      return undefined;
+    } else if (!this.config.isLibFileCandidate(uri)) {
+      // non-library files should always generate a compilation unit
+      const unit = await this.createAndStoreCompilationUnit(uri);
+      return unit;
+    } else {
+      // do not generate compilation units for standalone library files
+      return undefined;
+    }
+  }
+
+  async createAndStoreCompilationUnit(uri: URI): Promise<CompilationUnit> {
+    const unit = await createCompilationUnit(uri, this);
+    this.compilationUnits.set(uri.toString(), unit);
+    return unit;
+  }
+
+  deleteCompilationUnit(uri: URI): boolean {
+    const unit = this.compilationUnits.get(uri.toString());
+    if (!unit) {
+      return false;
+    }
+
+    for (const file of unit.services.files.keys()) {
+      this.compilationUnits.delete(file);
+    }
+    this.compilationUnits.delete(uri.toString());
+
+    return true;
+  }
+
+  getAllCompilationUnits(): CompilationUnit[] {
+    return Array.from(new Set(this.compilationUnits.values()));
+  }
+}
+
+/**
+ * JSON under `.pliplugin/` is not PL/I source. The client attaches the LS there for code actions;
+ * we skip compilation so only plugin-config diagnostics (e.g. COPC*) from the plugin loader show.
+ */
+function isPluginConfigurationUri(uri: URI): boolean {
+  const baseName = UriUtils.basename(uri);
+  if (baseName === "settings.json") {
+    return true;
+  }
+  const path = uri.path;
+  return path.includes("/.pliplugin/") && /\.json$/i.test(path);
 }

--- a/packages/language/src/workspace/workspace-folder-tree.ts
+++ b/packages/language/src/workspace/workspace-folder-tree.ts
@@ -12,71 +12,75 @@
 import { URI, UriUtils } from "../utils/uri";
 
 export type WorkspaceFolderNode<TData> = {
-    uri: string;
-    part: string;
-    parent: WorkspaceFolderNode<TData> | null;
-    children: Record<string, WorkspaceFolderNode<TData>>;
-    data?: TData;
-}
+  uri: string;
+  part: string;
+  parent: WorkspaceFolderNode<TData> | null;
+  children: Record<string, WorkspaceFolderNode<TData>>;
+  data?: TData;
+};
 
 export class WorkspaceFolderTree<TData> {
-    private root: WorkspaceFolderNode<TData> = {
-        uri: "",
-        part: "",
-        parent: null,
-        children: {},
-        data: undefined,
-    };
-    private dataByUri: Map<string, TData> = new Map();
+  private root: WorkspaceFolderNode<TData> = {
+    uri: "",
+    part: "",
+    parent: null,
+    children: {},
+    data: undefined,
+  };
+  private dataByUri: Map<string, TData> = new Map();
 
-    constructor(private readonly caseInsensitive: boolean = false) {}
+  constructor(private readonly caseInsensitive: boolean = false) {}
 
-    public getAllWorkspaceFolders(): TData[] {
-        return Array.from(this.dataByUri.values());
+  public getAllWorkspaceFolders(): TData[] {
+    return Array.from(this.dataByUri.values());
+  }
+
+  public addWorkspaceFolder(folderUri: string | URI, folder: TData): void {
+    const parts = this.prepareUriParts(folderUri);
+    let currentChildren = this.root.children;
+    let parent: WorkspaceFolderNode<TData> = this.root;
+    const currentPath = [];
+    for (const part of parts) {
+      currentPath.push(part);
+      if (currentChildren[part] === undefined) {
+        currentChildren[part] = {
+          uri: currentPath.join("/"),
+          part,
+          parent,
+          children: {},
+        };
+      }
+      parent = currentChildren[part];
+      currentChildren = parent.children;
     }
+    parent.data = folder;
+    this.dataByUri.set(folderUri.toString(), folder);
+  }
 
-    public addWorkspaceFolder(folderUri: string|URI, folder: TData): void {
-        const parts = this.prepareUriParts(folderUri);
-        let currentChildren = this.root.children;
-        let parent: WorkspaceFolderNode<TData> = this.root;
-        const currentPath = [];
-        for (const part of parts) {
-            currentPath.push(part);
-            if (currentChildren[part] === undefined) {
-                currentChildren[part] = {
-                    uri: currentPath.join("/"),
-                    part,
-                    parent,
-                    children: {},
-                };
-            }
-            parent = currentChildren[part];
-            currentChildren = parent.children;
-        }
-        parent.data = folder;
-        this.dataByUri.set(folderUri.toString(), folder);
-    }
+  private prepareUriParts(uri: string | URI) {
+    const normalized = UriUtils.normalizePath(
+      typeof uri === "string" ? uri : uri.toString(),
+    );
+    return UriUtils.parts(normalized).map((part) =>
+      this.caseInsensitive ? part.toLowerCase() : part,
+    );
+  }
 
-    private prepareUriParts(uri: string|URI) {
-        const normalized = UriUtils.normalizePath(typeof uri === "string" ? uri : uri.toString());
-        return UriUtils.parts(normalized).map(part => this.caseInsensitive ? part.toLowerCase() : part);
+  public getWorkspaceFolderOf(uri: string | URI): TData | undefined {
+    const parts = this.prepareUriParts(uri);
+    let currentChildren = this.root.children;
+    let parent: WorkspaceFolderNode<TData> = this.root;
+    let currentData: TData | undefined = parent.data;
+    for (const part of parts) {
+      if (currentChildren[part] === undefined) {
+        break;
+      }
+      parent = currentChildren[part];
+      currentChildren = parent.children;
+      if (parent.data !== undefined) {
+        currentData = parent.data;
+      }
     }
-
-    public getWorkspaceFolderOf(uri: string|URI): TData | undefined {
-        const parts = this.prepareUriParts(uri);
-        let currentChildren = this.root.children;
-        let parent: WorkspaceFolderNode<TData> = this.root;
-        let currentData: TData | undefined = parent.data;
-        for (const part of parts) {
-            if (currentChildren[part] === undefined) {
-                break;
-            }
-            parent = currentChildren[part];
-            currentChildren = parent.children;
-            if (parent.data !== undefined) {
-                currentData = parent.data;
-            }
-        }
-        return currentData;
-    }
+    return currentData;
+  }
 }

--- a/packages/language/src/workspace/workspace-folder-tree.ts
+++ b/packages/language/src/workspace/workspace-folder-tree.ts
@@ -1,0 +1,76 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { UriUtils } from "../utils/uri";
+
+export type WorkspaceFolderNode<TData> = {
+    uri: string;
+    part: string;
+    parent: WorkspaceFolderNode<TData> | null;
+    children: Record<string, WorkspaceFolderNode<TData>>;
+    data?: TData;
+}
+
+export class WorkspaceFolderTree<TData> {
+    private root: WorkspaceFolderNode<TData> = {
+        uri: "",
+        part: "",
+        parent: null,
+        children: {},
+        data: undefined,
+    };
+
+    constructor(private readonly caseInsensitive: boolean = false) {}
+
+    public addWorkspaceFolder(folderUri: string, folder: TData): void {
+        const parts = this.prepareUriParts(folderUri);
+        let currentChildren = this.root.children;
+        let parent: WorkspaceFolderNode<TData> = this.root;
+        const currentPath = [];
+        for (const part of parts) {
+            currentPath.push(part);
+            if (currentChildren[part] === undefined) {
+                currentChildren[part] = {
+                    uri: currentPath.join("/"),
+                    part,
+                    parent,
+                    children: {},
+                };
+            }
+            parent = currentChildren[part];
+            currentChildren = parent.children;
+        }
+        parent.data = folder;
+    }
+
+    private prepareUriParts(folderUri: string) {
+        const normalized = UriUtils.normalizePath(folderUri);
+        return UriUtils.parts(normalized).map(part => this.caseInsensitive ? part.toLowerCase() : part);
+    }
+
+    public getWorkspaceFolderOf(uri: string): TData | undefined {
+        const parts = this.prepareUriParts(uri);
+        let currentChildren = this.root.children;
+        let parent: WorkspaceFolderNode<TData> = this.root;
+        let currentData: TData | undefined = parent.data;
+        for (const part of parts) {
+            if (currentChildren[part] === undefined) {
+                break;
+            }
+            parent = currentChildren[part];
+            currentChildren = parent.children;
+            if (parent.data !== undefined) {
+                currentData = parent.data;
+            }
+        }
+        return currentData;
+    }
+}

--- a/packages/language/src/workspace/workspace-folder-tree.ts
+++ b/packages/language/src/workspace/workspace-folder-tree.ts
@@ -9,7 +9,7 @@
  *
  */
 
-import { UriUtils } from "../utils/uri";
+import { URI, UriUtils } from "../utils/uri";
 
 export type WorkspaceFolderNode<TData> = {
     uri: string;
@@ -27,10 +27,15 @@ export class WorkspaceFolderTree<TData> {
         children: {},
         data: undefined,
     };
+    private dataByUri: Map<string, TData> = new Map();
 
     constructor(private readonly caseInsensitive: boolean = false) {}
 
-    public addWorkspaceFolder(folderUri: string, folder: TData): void {
+    public getAllWorkspaceFolders(): TData[] {
+        return Array.from(this.dataByUri.values());
+    }
+
+    public addWorkspaceFolder(folderUri: string|URI, folder: TData): void {
         const parts = this.prepareUriParts(folderUri);
         let currentChildren = this.root.children;
         let parent: WorkspaceFolderNode<TData> = this.root;
@@ -49,14 +54,15 @@ export class WorkspaceFolderTree<TData> {
             currentChildren = parent.children;
         }
         parent.data = folder;
+        this.dataByUri.set(folderUri.toString(), folder);
     }
 
-    private prepareUriParts(folderUri: string) {
-        const normalized = UriUtils.normalizePath(folderUri);
+    private prepareUriParts(uri: string|URI) {
+        const normalized = UriUtils.normalizePath(typeof uri === "string" ? uri : uri.toString());
         return UriUtils.parts(normalized).map(part => this.caseInsensitive ? part.toLowerCase() : part);
     }
 
-    public getWorkspaceFolderOf(uri: string): TData | undefined {
+    public getWorkspaceFolderOf(uri: string|URI): TData | undefined {
         const parts = this.prepareUriParts(uri);
         let currentChildren = this.root.children;
         let parent: WorkspaceFolderNode<TData> = this.root;

--- a/packages/language/test/lsp/apply-quick-fixes.test.ts
+++ b/packages/language/test/lsp/apply-quick-fixes.test.ts
@@ -10,6 +10,7 @@
  */
 
 import { describe, test, expect, beforeEach } from "vitest";
+import { TestGlobalConfigLoader } from "../../src";
 import { CodeAction, Diagnostic } from "vscode-languageserver-types";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { VirtualFileSystemProvider } from "../../src/workspace/file-system-provider";
@@ -38,7 +39,7 @@ let workspace: WorkspaceContext;
 beforeEach(async () => {
   // Reset in-memory providers
   vfs = new VirtualFileSystemProvider();
-  workspace = new WorkspaceContext(vfs);
+  workspace = new WorkspaceContext(vfs, new TestGlobalConfigLoader({}));
   resetDocumentProviders(vfs);
   pluginConfig = workspace.config;
   await setupParsedProcGrps([]);

--- a/packages/language/test/lsp/apply-quick-fixes.test.ts
+++ b/packages/language/test/lsp/apply-quick-fixes.test.ts
@@ -38,8 +38,7 @@ let workspace: WorkspaceContext;
 beforeEach(async () => {
   // Reset in-memory providers
   vfs = new VirtualFileSystemProvider();
-  const uri = UriUtils.toUri("/workspace");
-  workspace = new WorkspaceContext(uri, vfs);
+  workspace = new WorkspaceContext(vfs);
   resetDocumentProviders(vfs);
   pluginConfig = workspace.config;
   await setupParsedProcGrps([]);

--- a/packages/language/test/lsp/apply-quick-fixes.test.ts
+++ b/packages/language/test/lsp/apply-quick-fixes.test.ts
@@ -38,7 +38,8 @@ let workspace: WorkspaceContext;
 beforeEach(async () => {
   // Reset in-memory providers
   vfs = new VirtualFileSystemProvider();
-  workspace = new WorkspaceContext(vfs);
+  const uri = UriUtils.toUri("/workspace");
+  workspace = new WorkspaceContext(uri, vfs);
   resetDocumentProviders(vfs);
   pluginConfig = workspace.config;
   await setupParsedProcGrps([]);

--- a/packages/language/test/lsp/command-create-config.test.ts
+++ b/packages/language/test/lsp/command-create-config.test.ts
@@ -33,7 +33,7 @@ describe("commandCreateConfig", () => {
 
   beforeEach(async () => {
     vfs = new VirtualFileSystemProvider();
-    workspace = new WorkspaceContext(vfs);
+    workspace = new WorkspaceContext(WORKSPACE_PATH, vfs);
     pluginConfig = workspace.config;
     await pluginConfig.init(WORKSPACE_PATH);
   });
@@ -104,7 +104,7 @@ describe("updateOrCreateConfig", () => {
 
   beforeEach(async () => {
     vfs = new VirtualFileSystemProvider();
-    workspace = new WorkspaceContext(vfs);
+    workspace = new WorkspaceContext(WORKSPACE_PATH, vfs);
     pluginConfig = workspace.config;
     await pluginConfig.init(WORKSPACE_PATH);
   });

--- a/packages/language/test/lsp/command-create-config.test.ts
+++ b/packages/language/test/lsp/command-create-config.test.ts
@@ -18,6 +18,7 @@ import { Commands } from "../../src/language-server/constants";
 import { UriUtils } from "../../src/utils/uri";
 import { updateOrCreateConfig } from "../../src/utils/config";
 import { makeProgramConfig } from "../config-fixtures";
+import { TestGlobalConfigLoader } from "../../src";
 
 const WORKSPACE_PATH = UriUtils.toUri("/workspace");
 const CONFIG_FILE_PATH = UriUtils.toUri("/workspace/.pliplugin/pgm_conf.json");
@@ -33,7 +34,7 @@ describe("commandCreateConfig", () => {
 
   beforeEach(async () => {
     vfs = new VirtualFileSystemProvider();
-    workspace = new WorkspaceContext(vfs);
+    workspace = new WorkspaceContext(vfs, new TestGlobalConfigLoader({}));
     pluginConfig = workspace.config;
     await pluginConfig.init(WORKSPACE_PATH);
   });
@@ -104,7 +105,7 @@ describe("updateOrCreateConfig", () => {
 
   beforeEach(async () => {
     vfs = new VirtualFileSystemProvider();
-    workspace = new WorkspaceContext(vfs);
+    workspace = new WorkspaceContext(vfs, new TestGlobalConfigLoader({}));
     pluginConfig = workspace.config;
     await pluginConfig.init(WORKSPACE_PATH);
   });

--- a/packages/language/test/lsp/command-create-config.test.ts
+++ b/packages/language/test/lsp/command-create-config.test.ts
@@ -33,7 +33,7 @@ describe("commandCreateConfig", () => {
 
   beforeEach(async () => {
     vfs = new VirtualFileSystemProvider();
-    workspace = new WorkspaceContext(WORKSPACE_PATH, vfs);
+    workspace = new WorkspaceContext(vfs);
     pluginConfig = workspace.config;
     await pluginConfig.init(WORKSPACE_PATH);
   });
@@ -104,7 +104,7 @@ describe("updateOrCreateConfig", () => {
 
   beforeEach(async () => {
     vfs = new VirtualFileSystemProvider();
-    workspace = new WorkspaceContext(WORKSPACE_PATH, vfs);
+    workspace = new WorkspaceContext(vfs);
     pluginConfig = workspace.config;
     await pluginConfig.init(WORKSPACE_PATH);
   });

--- a/packages/language/test/lsp/completion-plugin-configuration.test.ts
+++ b/packages/language/test/lsp/completion-plugin-configuration.test.ts
@@ -20,6 +20,7 @@ import { WorkspaceContext } from "../../src/workspace/workspace-context";
 import { VirtualFileSystemProvider } from "../../src/workspace/file-system-provider";
 import { PluginConfiguration } from "../../src/language-server/constants";
 import { configCompletionRequest } from "../../src/language-server/completion/completion-plugin-configuration";
+import { TestGlobalConfigLoader } from "../../src";
 
 const MARKER = "<CURSOR>";
 const PGROUP_DETAIL = "Process group from 'proc_grps.json'";
@@ -65,7 +66,7 @@ function makeProcessGroup(name: string) {
 beforeEach(async () => {
   const uri = UriUtils.toUri("/workspace");
   vfs = new VirtualFileSystemProvider();
-  workspace = new WorkspaceContext(vfs);
+  workspace = new WorkspaceContext(vfs, new TestGlobalConfigLoader({}));
   pluginConfig = workspace.config;
 
   await pluginConfig.init(uri);

--- a/packages/language/test/lsp/completion-plugin-configuration.test.ts
+++ b/packages/language/test/lsp/completion-plugin-configuration.test.ts
@@ -63,11 +63,12 @@ function makeProcessGroup(name: string) {
 }
 
 beforeEach(async () => {
+  const uri = UriUtils.toUri("/workspace");
   vfs = new VirtualFileSystemProvider();
-  workspace = new WorkspaceContext(vfs);
+  workspace = new WorkspaceContext(uri, vfs);
   pluginConfig = workspace.config;
 
-  await pluginConfig.init(UriUtils.toUri("/workspace"));
+  await pluginConfig.init(uri);
   await pluginConfig.setProcessGroupConfigs([makeProcessGroup("default")]);
 });
 

--- a/packages/language/test/lsp/completion-plugin-configuration.test.ts
+++ b/packages/language/test/lsp/completion-plugin-configuration.test.ts
@@ -65,7 +65,7 @@ function makeProcessGroup(name: string) {
 beforeEach(async () => {
   const uri = UriUtils.toUri("/workspace");
   vfs = new VirtualFileSystemProvider();
-  workspace = new WorkspaceContext(uri, vfs);
+  workspace = new WorkspaceContext(vfs);
   pluginConfig = workspace.config;
 
   await pluginConfig.init(uri);

--- a/packages/language/test/lsp/get-proc-group-config-from-lib.test.ts
+++ b/packages/language/test/lsp/get-proc-group-config-from-lib.test.ts
@@ -16,11 +16,13 @@ import {
 } from "../../src/workspace/plugin-configuration-provider";
 import { EmptyFileSystemProvider } from "../../src/workspace/file-system-provider";
 import { UriUtils } from "../../src/utils/uri";
+import { LongRunningOperationImpl } from "../../src/utils/promises";
+import { TestGlobalConfigLoader } from "../../src";
 
 async function setupConfig(
   testLibs: string[],
 ): Promise<PluginConfigurationProvider> {
-  const pluginConfig = new PluginConfigurationProvider(EmptyFileSystemProvider);
+  const pluginConfig = new PluginConfigurationProvider(EmptyFileSystemProvider, new TestGlobalConfigLoader({}), LongRunningOperationImpl.Dummy);
   const processGroup = deserializeProcessGroup({
     name: "default",
     "include-extensions": [".pli"],

--- a/packages/language/test/lsp/get-proc-group-config-from-lib.test.ts
+++ b/packages/language/test/lsp/get-proc-group-config-from-lib.test.ts
@@ -22,7 +22,11 @@ import { TestGlobalConfigLoader } from "../../src";
 async function setupConfig(
   testLibs: string[],
 ): Promise<PluginConfigurationProvider> {
-  const pluginConfig = new PluginConfigurationProvider(EmptyFileSystemProvider, new TestGlobalConfigLoader({}), LongRunningOperationImpl.Dummy);
+  const pluginConfig = new PluginConfigurationProvider(
+    EmptyFileSystemProvider,
+    new TestGlobalConfigLoader({}),
+    LongRunningOperationImpl.Dummy,
+  );
   const processGroup = deserializeProcessGroup({
     name: "default",
     "include-extensions": [".pli"],

--- a/packages/language/test/lsp/get-prog-config.test.ts
+++ b/packages/language/test/lsp/get-prog-config.test.ts
@@ -14,11 +14,13 @@ import { PluginConfigurationProvider } from "../../src/workspace/plugin-configur
 import { EmptyFileSystemProvider } from "../../src/workspace/file-system-provider";
 import { UriUtils } from "../../src/utils/uri";
 import { makeProgramConfig } from "../config-fixtures";
+import { LongRunningOperationImpl } from "../../src/utils/promises";
+import { TestGlobalConfigLoader } from "../../src";
 
 function setupConfig(
   programConfig: { program: string; pgroup: string }[],
 ): PluginConfigurationProvider {
-  const pluginConfig = new PluginConfigurationProvider(EmptyFileSystemProvider);
+  const pluginConfig = new PluginConfigurationProvider(EmptyFileSystemProvider, new TestGlobalConfigLoader({}), LongRunningOperationImpl.Dummy); 
   pluginConfig.setProgramConfigs(
     UriUtils.toUri("/workspace"),
     programConfig.map(makeProgramConfig),

--- a/packages/language/test/lsp/get-prog-config.test.ts
+++ b/packages/language/test/lsp/get-prog-config.test.ts
@@ -20,7 +20,11 @@ import { TestGlobalConfigLoader } from "../../src";
 function setupConfig(
   programConfig: { program: string; pgroup: string }[],
 ): PluginConfigurationProvider {
-  const pluginConfig = new PluginConfigurationProvider(EmptyFileSystemProvider, new TestGlobalConfigLoader({}), LongRunningOperationImpl.Dummy); 
+  const pluginConfig = new PluginConfigurationProvider(
+    EmptyFileSystemProvider,
+    new TestGlobalConfigLoader({}),
+    LongRunningOperationImpl.Dummy,
+  );
   pluginConfig.setProgramConfigs(
     UriUtils.toUri("/workspace"),
     programConfig.map(makeProgramConfig),

--- a/packages/language/test/lsp/workspace-symbol-request.test.ts
+++ b/packages/language/test/lsp/workspace-symbol-request.test.ts
@@ -53,7 +53,11 @@ async function expectWorkspaceSymbols(annotatedCode: string[]): Promise<void> {
   );
 
   const fs = new VirtualFileSystemProvider();
-  const handler = new CompilationUnitHandler(fs, new TestGlobalConfigLoader({}), LongRunningOperationImpl.Dummy);
+  const handler = new CompilationUnitHandler(
+    fs,
+    new TestGlobalConfigLoader({}),
+    LongRunningOperationImpl.Dummy,
+  );
   const workspace = defaultTestWorkspace();
   handler.addWorkspaceFolder("file:///", workspace);
   textDocuments.forEach((doc) => EditorDocuments.set(doc));

--- a/packages/language/test/lsp/workspace-symbol-request.test.ts
+++ b/packages/language/test/lsp/workspace-symbol-request.test.ts
@@ -50,11 +50,13 @@ async function expectWorkspaceSymbols(annotatedCode: string[]): Promise<void> {
     ),
   );
 
-  const handler = new CompilationUnitHandler(defaultTestWorkspace());
+  const handler = new CompilationUnitHandler();
+  const workspace = defaultTestWorkspace();
+  handler.addWorkspaceFolder("file:///", workspace);
   textDocuments.forEach((doc) => EditorDocuments.set(doc));
   await Promise.all(
     textDocuments.map(async (doc, i) => {
-      const unit = await handler.createAndStoreCompilationUnit(
+      const unit = await workspace.createAndStoreCompilationUnit(
         UriUtils.toUri(`/test${i}.pli`),
       );
 

--- a/packages/language/test/lsp/workspace-symbol-request.test.ts
+++ b/packages/language/test/lsp/workspace-symbol-request.test.ts
@@ -19,6 +19,7 @@ import { workspaceSymbolRequest } from "../../src/language-server/workspace-symb
 import { EditorDocuments } from "../../src/language-server/text-documents";
 import { CancellationToken } from "vscode-languageserver";
 import { defaultTestWorkspace } from "../test-workspace";
+import { VirtualFileSystemProvider } from "../../src";
 
 const formatTestPLI = (code: string): string =>
   code.startsWith("\n") ? code.slice(1) : code;
@@ -50,7 +51,8 @@ async function expectWorkspaceSymbols(annotatedCode: string[]): Promise<void> {
     ),
   );
 
-  const handler = new CompilationUnitHandler();
+  const fs = new VirtualFileSystemProvider();
+  const handler = new CompilationUnitHandler(fs);
   const workspace = defaultTestWorkspace();
   handler.addWorkspaceFolder("file:///", workspace);
   textDocuments.forEach((doc) => EditorDocuments.set(doc));

--- a/packages/language/test/lsp/workspace-symbol-request.test.ts
+++ b/packages/language/test/lsp/workspace-symbol-request.test.ts
@@ -19,7 +19,8 @@ import { workspaceSymbolRequest } from "../../src/language-server/workspace-symb
 import { EditorDocuments } from "../../src/language-server/text-documents";
 import { CancellationToken } from "vscode-languageserver";
 import { defaultTestWorkspace } from "../test-workspace";
-import { VirtualFileSystemProvider } from "../../src";
+import { TestGlobalConfigLoader, VirtualFileSystemProvider } from "../../src";
+import { LongRunningOperationImpl } from "../../src/utils/promises";
 
 const formatTestPLI = (code: string): string =>
   code.startsWith("\n") ? code.slice(1) : code;
@@ -52,7 +53,7 @@ async function expectWorkspaceSymbols(annotatedCode: string[]): Promise<void> {
   );
 
   const fs = new VirtualFileSystemProvider();
-  const handler = new CompilationUnitHandler(fs);
+  const handler = new CompilationUnitHandler(fs, new TestGlobalConfigLoader({}), LongRunningOperationImpl.Dummy);
   const workspace = defaultTestWorkspace();
   handler.addWorkspaceFolder("file:///", workspace);
   textDocuments.forEach((doc) => EditorDocuments.set(doc));

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -32,7 +32,7 @@ import {
 } from "../src/workspace/file-system-provider";
 import { completionRequest } from "../src/language-server/completion/completion-request";
 import { AssertionError, fail } from "assert";
-import { Connection, MarkupContent, Position } from "vscode-languageserver";
+import { MarkupContent, Position } from "vscode-languageserver";
 import { hoverRequest } from "../src/language-server/hover-request";
 import { semanticTokens } from "../src/language-server/semantic-tokens";
 import { TextDocument } from "vscode-languageserver-textdocument";
@@ -71,7 +71,6 @@ import {
   Label,
   TestDiagnostic,
 } from "./abstract-test-builder";
-import { Messages } from "../src/utils/messages";
 
 export type { DiagnosticExpectation, Label, TestDiagnostic };
 
@@ -206,9 +205,7 @@ export class TestBuilder extends AbstractTestBuilder {
       const fs = new VirtualFileSystemProvider();
       this.options.fs = fs;
     }
-    const globalConfig = this.extractGlobalConfig();
-    const connection = this.makeConnection(globalConfig);
-    setDefaultTestWorkspace(createTestWorkspace(this.options.fs, connection));
+    setDefaultTestWorkspace(createTestWorkspace(this.options.fs));
     for (const [uri, file] of this.files) {
       await this.options.fs.writeFile(UriUtils.toUri(uri), file.output);
     }
@@ -1535,59 +1532,42 @@ Available code actions for label "${label}" and URI "${uri}": ${codeActions.map(
     return `${uriOverride}:${line + lineOffset}:${character + characterOffset}`;
   }
 
-  /**
-   * Minimal connection stub that responds to `config/getGlobal` with the
-   * given `GlobalConfig`. Other request/notification methods are no-ops so
-   * the provider can run end-to-end without a real LSP transport.
-   */
-  private makeConnection(global: Messages.GlobalConfig): Connection {
-    return {
-      sendRequest: async (method: string) => {
-        if (method === Messages.GetGlobalConfig.method) return global;
-        return undefined;
-      },
-      sendNotification: async () => {},
-      onRequest: () => ({ dispose() {} }),
-      onNotification: () => ({ dispose() {} }),
-    } as unknown as Connection;
-  }
-
-  private extractGlobalConfig(): Messages.GlobalConfig {
-    const pliPgmConf = "pli.pgm_conf";
-    const pliProcGrps = "pli.proc_grps";
-    let pgmConf: Messages.GlobalConfigEntry | undefined;
-    let procGrps: Messages.GlobalConfigEntry | undefined;
-    const settingsFile = "/.vscode/settings.json";
-    for (const [uri, file] of this.files) {
-      if (uri.endsWith(settingsFile)) {
-        try {
-          const config = JSON.parse(file.textDocument.getText());
-          if (config && typeof config === "object") {
-            if (pliPgmConf in config) {
-              pgmConf = {
-                uri,
-                configKey: pliPgmConf,
-                containerPath: [],
-              };
-            }
-            if (pliProcGrps in config) {
-              procGrps = {
-                uri,
-                configKey: pliProcGrps,
-                containerPath: [],
-              };
-            }
-          }
-        } catch (e) {
-          // Ignore JSON parsing errors
-        }
-      }
-    }
-    return {
-      pgmConf,
-      procGrps,
-    };
-  }
+  // private extractGlobalConfig(): Messages.GlobalConfig {
+  //   const pliPgmConf = "pli.pgm_conf";
+  //   const pliProcGrps = "pli.proc_grps";
+  //   let pgmConf: Messages.GlobalConfigEntry | undefined;
+  //   let procGrps: Messages.GlobalConfigEntry | undefined;
+  //   const settingsFile = "/.vscode/settings.json";
+  //   for (const [uri, file] of this.files) {
+  //     if (uri.endsWith(settingsFile)) {
+  //       try {
+  //         const config = JSON.parse(file.textDocument.getText());
+  //         if (config && typeof config === "object") {
+  //           if (pliPgmConf in config) {
+  //             pgmConf = {
+  //               uri,
+  //               configKey: pliPgmConf,
+  //               containerPath: [],
+  //             };
+  //           }
+  //           if (pliProcGrps in config) {
+  //             procGrps = {
+  //               uri,
+  //               configKey: pliProcGrps,
+  //               containerPath: [],
+  //             };
+  //           }
+  //         }
+  //       } catch (e) {
+  //         // Ignore JSON parsing errors
+  //       }
+  //     }
+  //   }
+  //   return {
+  //     pgmConf,
+  //     procGrps,
+  //   };
+  // }
 }
 
 function formatPosition(position: Position): string {

--- a/packages/language/test/test-workspace.ts
+++ b/packages/language/test/test-workspace.ts
@@ -17,7 +17,6 @@ import {
   VirtualFileSystemProvider,
 } from "../src/workspace/file-system-provider";
 import { WorkspaceContext } from "../src/workspace/workspace-context";
-import { UriUtils } from "../src";
 
 let _defaultTestWorkspace: WorkspaceContext | undefined;
 
@@ -33,7 +32,6 @@ let _defaultTestWorkspace: WorkspaceContext | undefined;
 export function defaultTestWorkspace(): WorkspaceContext {
   if (!_defaultTestWorkspace) {
     _defaultTestWorkspace = new WorkspaceContext(
-      UriUtils.toUri("file:///"),
       EmptyFileSystemProvider,
     );
   }
@@ -62,5 +60,5 @@ export function createTestWorkspace(
   connection?: Connection,
 ): WorkspaceContext {
   resetDocumentProviders(fs);
-  return new WorkspaceContext(UriUtils.toUri("file:///"), fs, connection);
+  return new WorkspaceContext(fs, connection);
 }

--- a/packages/language/test/test-workspace.ts
+++ b/packages/language/test/test-workspace.ts
@@ -9,7 +9,6 @@
  *
  */
 
-import { Connection } from "vscode-languageserver";
 import { resetDocumentProviders } from "../src/language-server/text-documents";
 import {
   EmptyFileSystemProvider,
@@ -17,6 +16,7 @@ import {
   VirtualFileSystemProvider,
 } from "../src/workspace/file-system-provider";
 import { WorkspaceContext } from "../src/workspace/workspace-context";
+import { TestGlobalConfigLoader } from "../src";
 
 let _defaultTestWorkspace: WorkspaceContext | undefined;
 
@@ -31,7 +31,7 @@ let _defaultTestWorkspace: WorkspaceContext | undefined;
  */
 export function defaultTestWorkspace(): WorkspaceContext {
   if (!_defaultTestWorkspace) {
-    _defaultTestWorkspace = new WorkspaceContext(EmptyFileSystemProvider);
+    _defaultTestWorkspace = new WorkspaceContext(EmptyFileSystemProvider, new TestGlobalConfigLoader({}));
   }
   return _defaultTestWorkspace;
 }
@@ -55,8 +55,7 @@ export function setDefaultTestWorkspace(
  */
 export function createTestWorkspace(
   fs: FileSystemProvider = new VirtualFileSystemProvider(),
-  connection?: Connection,
 ): WorkspaceContext {
   resetDocumentProviders(fs);
-  return new WorkspaceContext(fs, connection);
+  return new WorkspaceContext(fs, new TestGlobalConfigLoader({}));
 }

--- a/packages/language/test/test-workspace.ts
+++ b/packages/language/test/test-workspace.ts
@@ -32,7 +32,10 @@ let _defaultTestWorkspace: WorkspaceContext | undefined;
  */
 export function defaultTestWorkspace(): WorkspaceContext {
   if (!_defaultTestWorkspace) {
-    _defaultTestWorkspace = new WorkspaceContext(UriUtils.toUri("file:///"), EmptyFileSystemProvider);
+    _defaultTestWorkspace = new WorkspaceContext(
+      UriUtils.toUri("file:///"),
+      EmptyFileSystemProvider,
+    );
   }
   return _defaultTestWorkspace;
 }

--- a/packages/language/test/test-workspace.ts
+++ b/packages/language/test/test-workspace.ts
@@ -17,6 +17,7 @@ import {
   VirtualFileSystemProvider,
 } from "../src/workspace/file-system-provider";
 import { WorkspaceContext } from "../src/workspace/workspace-context";
+import { UriUtils } from "../src";
 
 let _defaultTestWorkspace: WorkspaceContext | undefined;
 
@@ -31,7 +32,7 @@ let _defaultTestWorkspace: WorkspaceContext | undefined;
  */
 export function defaultTestWorkspace(): WorkspaceContext {
   if (!_defaultTestWorkspace) {
-    _defaultTestWorkspace = new WorkspaceContext(EmptyFileSystemProvider);
+    _defaultTestWorkspace = new WorkspaceContext(UriUtils.toUri("file:///"), EmptyFileSystemProvider);
   }
   return _defaultTestWorkspace;
 }
@@ -58,5 +59,5 @@ export function createTestWorkspace(
   connection?: Connection,
 ): WorkspaceContext {
   resetDocumentProviders(fs);
-  return new WorkspaceContext(fs, connection);
+  return new WorkspaceContext(UriUtils.toUri("file:///"), fs, connection);
 }

--- a/packages/language/test/test-workspace.ts
+++ b/packages/language/test/test-workspace.ts
@@ -31,7 +31,10 @@ let _defaultTestWorkspace: WorkspaceContext | undefined;
  */
 export function defaultTestWorkspace(): WorkspaceContext {
   if (!_defaultTestWorkspace) {
-    _defaultTestWorkspace = new WorkspaceContext(EmptyFileSystemProvider, new TestGlobalConfigLoader({}));
+    _defaultTestWorkspace = new WorkspaceContext(
+      EmptyFileSystemProvider,
+      new TestGlobalConfigLoader({}),
+    );
   }
   return _defaultTestWorkspace;
 }

--- a/packages/language/test/test-workspace.ts
+++ b/packages/language/test/test-workspace.ts
@@ -60,5 +60,19 @@ export function createTestWorkspace(
   fs: FileSystemProvider = new VirtualFileSystemProvider(),
 ): WorkspaceContext {
   resetDocumentProviders(fs);
-  return new WorkspaceContext(fs, new TestGlobalConfigLoader({}));
+  return new WorkspaceContext(
+    fs,
+    new TestGlobalConfigLoader({
+      pgmConf: {
+        configKey: "pli.pgm_conf",
+        containerPath: [],
+        uri: ".vscode/settings.json",
+      },
+      procGrps: {
+        configKey: "pli.proc_grps",
+        containerPath: [],
+        uri: ".vscode/settings.json",
+      },
+    }),
+  );
 }

--- a/packages/language/test/test-workspace.ts
+++ b/packages/language/test/test-workspace.ts
@@ -31,9 +31,7 @@ let _defaultTestWorkspace: WorkspaceContext | undefined;
  */
 export function defaultTestWorkspace(): WorkspaceContext {
   if (!_defaultTestWorkspace) {
-    _defaultTestWorkspace = new WorkspaceContext(
-      EmptyFileSystemProvider,
-    );
+    _defaultTestWorkspace = new WorkspaceContext(EmptyFileSystemProvider);
   }
   return _defaultTestWorkspace;
 }

--- a/packages/language/test/workspace/compilation-unit.test.ts
+++ b/packages/language/test/workspace/compilation-unit.test.ts
@@ -31,7 +31,10 @@ describe("Compilation Unit Tests", () => {
   test("Create", async () => {
     const uri = UriUtils.toUri("memory:///test/test.pli");
     const ch = new CompilationUnitHandler(fs);
-    ch.addWorkspaceFolder(UriUtils.toUri("memory:///test/"), defaultTestWorkspace());
+    ch.addWorkspaceFolder(
+      UriUtils.toUri("memory:///test/"),
+      defaultTestWorkspace(),
+    );
 
     const unit0 = ch.getCompilationUnit(uri);
     expect(unit0).toBeUndefined();
@@ -46,7 +49,10 @@ describe("Compilation Unit Tests", () => {
   test("Delete", async () => {
     const uri = UriUtils.toUri("memory:///test/test.pli");
     const ch = new CompilationUnitHandler(fs);
-    ch.addWorkspaceFolder(UriUtils.toUri("memory:///test/"), defaultTestWorkspace());
+    ch.addWorkspaceFolder(
+      UriUtils.toUri("memory:///test/"),
+      defaultTestWorkspace(),
+    );
 
     const unit1 = await ch.getOrCreateCompilationUnit(uri);
     expect(unit1).toBeDefined();
@@ -65,7 +71,10 @@ describe("Compilation Unit Tests", () => {
     const uriEntry = UriUtils.toUri("file:///test/entry.pli");
     const uriLib = UriUtils.toUri("file:///test/lib.pli");
     const ch = new CompilationUnitHandler(fs);
-    ch.addWorkspaceFolder(UriUtils.toUri("file:///test/"), defaultTestWorkspace());
+    ch.addWorkspaceFolder(
+      UriUtils.toUri("file:///test/"),
+      defaultTestWorkspace(),
+    );
 
     // register configs
     expect(defaultTestWorkspace().config.hasRegisteredProgramConfigs()).toBe(

--- a/packages/language/test/workspace/compilation-unit.test.ts
+++ b/packages/language/test/workspace/compilation-unit.test.ts
@@ -14,7 +14,11 @@ import { UriUtils } from "../../src/utils/uri";
 import { CompilationUnitHandler } from "../../src/workspace/compilation-unit";
 import { makeProcessGroup, makeProgramConfig } from "../config-fixtures";
 import { defaultTestWorkspace } from "../test-workspace";
-import { FileSystemProvider, TestGlobalConfigLoader, VirtualFileSystemProvider } from "../../src";
+import {
+  FileSystemProvider,
+  TestGlobalConfigLoader,
+  VirtualFileSystemProvider,
+} from "../../src";
 import { LongRunningOperationImpl } from "../../src/utils/promises";
 
 describe("Compilation Unit Tests", () => {
@@ -31,7 +35,11 @@ describe("Compilation Unit Tests", () => {
 
   test("Create", async () => {
     const uri = UriUtils.toUri("memory:///test/test.pli");
-    const ch = new CompilationUnitHandler(fs, new TestGlobalConfigLoader({}), LongRunningOperationImpl.Dummy);
+    const ch = new CompilationUnitHandler(
+      fs,
+      new TestGlobalConfigLoader({}),
+      LongRunningOperationImpl.Dummy,
+    );
     ch.addWorkspaceFolder(
       UriUtils.toUri("memory:///test/"),
       defaultTestWorkspace(),
@@ -49,7 +57,11 @@ describe("Compilation Unit Tests", () => {
 
   test("Delete", async () => {
     const uri = UriUtils.toUri("memory:///test/test.pli");
-    const ch = new CompilationUnitHandler(fs, new TestGlobalConfigLoader({}), LongRunningOperationImpl.Dummy);
+    const ch = new CompilationUnitHandler(
+      fs,
+      new TestGlobalConfigLoader({}),
+      LongRunningOperationImpl.Dummy,
+    );
     ch.addWorkspaceFolder(
       UriUtils.toUri("memory:///test/"),
       defaultTestWorkspace(),
@@ -71,7 +83,11 @@ describe("Compilation Unit Tests", () => {
   test("Create with config", async () => {
     const uriEntry = UriUtils.toUri("file:///test/entry.pli");
     const uriLib = UriUtils.toUri("file:///test/lib.pli");
-    const ch = new CompilationUnitHandler(fs, new TestGlobalConfigLoader({}), LongRunningOperationImpl.Dummy);
+    const ch = new CompilationUnitHandler(
+      fs,
+      new TestGlobalConfigLoader({}),
+      LongRunningOperationImpl.Dummy,
+    );
     ch.addWorkspaceFolder(
       UriUtils.toUri("file:///test/"),
       defaultTestWorkspace(),
@@ -104,7 +120,11 @@ describe("Compilation Unit Tests", () => {
     const uriEntry1 = UriUtils.toUri("file:///test/entry1.pli");
     const uriEntry2 = UriUtils.toUri("file:///test/entry2.pli");
     const uriOther = UriUtils.toUri("file:///other/entry3.pli");
-    const ch = new CompilationUnitHandler(fs, new TestGlobalConfigLoader({}), LongRunningOperationImpl.Dummy);
+    const ch = new CompilationUnitHandler(
+      fs,
+      new TestGlobalConfigLoader({}),
+      LongRunningOperationImpl.Dummy,
+    );
     ch.addWorkspaceFolder(UriUtils.toUri("file:///"), defaultTestWorkspace());
 
     // register wildcard config
@@ -136,7 +156,11 @@ describe("Compilation Unit Tests", () => {
   });
 
   test("Cannot create compile unit from copybook directly", async () => {
-    const ch = new CompilationUnitHandler(fs, new TestGlobalConfigLoader({}), LongRunningOperationImpl.Dummy);
+    const ch = new CompilationUnitHandler(
+      fs,
+      new TestGlobalConfigLoader({}),
+      LongRunningOperationImpl.Dummy,
+    );
     ch.addWorkspaceFolder(UriUtils.toUri("file:///"), defaultTestWorkspace());
 
     await defaultTestWorkspace().config.init(UriUtils.toUri("file:///"));

--- a/packages/language/test/workspace/compilation-unit.test.ts
+++ b/packages/language/test/workspace/compilation-unit.test.ts
@@ -14,7 +14,8 @@ import { UriUtils } from "../../src/utils/uri";
 import { CompilationUnitHandler } from "../../src/workspace/compilation-unit";
 import { makeProcessGroup, makeProgramConfig } from "../config-fixtures";
 import { defaultTestWorkspace } from "../test-workspace";
-import { FileSystemProvider, VirtualFileSystemProvider } from "../../src";
+import { FileSystemProvider, TestGlobalConfigLoader, VirtualFileSystemProvider } from "../../src";
+import { LongRunningOperationImpl } from "../../src/utils/promises";
 
 describe("Compilation Unit Tests", () => {
   let fs: FileSystemProvider;
@@ -30,7 +31,7 @@ describe("Compilation Unit Tests", () => {
 
   test("Create", async () => {
     const uri = UriUtils.toUri("memory:///test/test.pli");
-    const ch = new CompilationUnitHandler(fs);
+    const ch = new CompilationUnitHandler(fs, new TestGlobalConfigLoader({}), LongRunningOperationImpl.Dummy);
     ch.addWorkspaceFolder(
       UriUtils.toUri("memory:///test/"),
       defaultTestWorkspace(),
@@ -48,7 +49,7 @@ describe("Compilation Unit Tests", () => {
 
   test("Delete", async () => {
     const uri = UriUtils.toUri("memory:///test/test.pli");
-    const ch = new CompilationUnitHandler(fs);
+    const ch = new CompilationUnitHandler(fs, new TestGlobalConfigLoader({}), LongRunningOperationImpl.Dummy);
     ch.addWorkspaceFolder(
       UriUtils.toUri("memory:///test/"),
       defaultTestWorkspace(),
@@ -70,7 +71,7 @@ describe("Compilation Unit Tests", () => {
   test("Create with config", async () => {
     const uriEntry = UriUtils.toUri("file:///test/entry.pli");
     const uriLib = UriUtils.toUri("file:///test/lib.pli");
-    const ch = new CompilationUnitHandler(fs);
+    const ch = new CompilationUnitHandler(fs, new TestGlobalConfigLoader({}), LongRunningOperationImpl.Dummy);
     ch.addWorkspaceFolder(
       UriUtils.toUri("file:///test/"),
       defaultTestWorkspace(),
@@ -103,7 +104,7 @@ describe("Compilation Unit Tests", () => {
     const uriEntry1 = UriUtils.toUri("file:///test/entry1.pli");
     const uriEntry2 = UriUtils.toUri("file:///test/entry2.pli");
     const uriOther = UriUtils.toUri("file:///other/entry3.pli");
-    const ch = new CompilationUnitHandler(fs);
+    const ch = new CompilationUnitHandler(fs, new TestGlobalConfigLoader({}), LongRunningOperationImpl.Dummy);
     ch.addWorkspaceFolder(UriUtils.toUri("file:///"), defaultTestWorkspace());
 
     // register wildcard config
@@ -135,7 +136,7 @@ describe("Compilation Unit Tests", () => {
   });
 
   test("Cannot create compile unit from copybook directly", async () => {
-    const ch = new CompilationUnitHandler(fs);
+    const ch = new CompilationUnitHandler(fs, new TestGlobalConfigLoader({}), LongRunningOperationImpl.Dummy);
     ch.addWorkspaceFolder(UriUtils.toUri("file:///"), defaultTestWorkspace());
 
     await defaultTestWorkspace().config.init(UriUtils.toUri("file:///"));

--- a/packages/language/test/workspace/compilation-unit.test.ts
+++ b/packages/language/test/workspace/compilation-unit.test.ts
@@ -23,7 +23,8 @@ describe("Compilation Unit Tests", () => {
 
   test("Create", async () => {
     const uri = UriUtils.toUri("memory:///test/test.pli");
-    const ch = new CompilationUnitHandler(defaultTestWorkspace());
+    const ch = new CompilationUnitHandler();
+    ch.addWorkspaceFolder(UriUtils.toUri("memory:///test/"), defaultTestWorkspace());
 
     const unit0 = ch.getCompilationUnit(uri);
     expect(unit0).toBeUndefined();
@@ -37,7 +38,8 @@ describe("Compilation Unit Tests", () => {
 
   test("Delete", async () => {
     const uri = UriUtils.toUri("memory:///test/test.pli");
-    const ch = new CompilationUnitHandler(defaultTestWorkspace());
+    const ch = new CompilationUnitHandler();
+    ch.addWorkspaceFolder(UriUtils.toUri("memory:///test/"), defaultTestWorkspace());
 
     const unit1 = await ch.getOrCreateCompilationUnit(uri);
     expect(unit1).toBeDefined();
@@ -55,7 +57,8 @@ describe("Compilation Unit Tests", () => {
   test("Create with config", async () => {
     const uriEntry = UriUtils.toUri("file:///test/entry.pli");
     const uriLib = UriUtils.toUri("file:///test/lib.pli");
-    const ch = new CompilationUnitHandler(defaultTestWorkspace());
+    const ch = new CompilationUnitHandler();
+    ch.addWorkspaceFolder(UriUtils.toUri("file:///test/"), defaultTestWorkspace());
 
     // register configs
     expect(defaultTestWorkspace().config.hasRegisteredProgramConfigs()).toBe(
@@ -84,7 +87,8 @@ describe("Compilation Unit Tests", () => {
     const uriEntry1 = UriUtils.toUri("file:///test/entry1.pli");
     const uriEntry2 = UriUtils.toUri("file:///test/entry2.pli");
     const uriOther = UriUtils.toUri("file:///other/entry3.pli");
-    const ch = new CompilationUnitHandler(defaultTestWorkspace());
+    const ch = new CompilationUnitHandler();
+    ch.addWorkspaceFolder(UriUtils.toUri("file:///"), defaultTestWorkspace());
 
     // register wildcard config
     defaultTestWorkspace().config.setProgramConfigs(UriUtils.toUri(""), [
@@ -115,7 +119,8 @@ describe("Compilation Unit Tests", () => {
   });
 
   test("Cannot create compile unit from copybook directly", async () => {
-    const ch = new CompilationUnitHandler(defaultTestWorkspace());
+    const ch = new CompilationUnitHandler();
+    ch.addWorkspaceFolder(UriUtils.toUri("file:///"), defaultTestWorkspace());
 
     await defaultTestWorkspace().config.init(UriUtils.toUri("file:///"));
 

--- a/packages/language/test/workspace/compilation-unit.test.ts
+++ b/packages/language/test/workspace/compilation-unit.test.ts
@@ -9,13 +9,20 @@
  *
  */
 
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { UriUtils } from "../../src/utils/uri";
 import { CompilationUnitHandler } from "../../src/workspace/compilation-unit";
 import { makeProcessGroup, makeProgramConfig } from "../config-fixtures";
 import { defaultTestWorkspace } from "../test-workspace";
+import { FileSystemProvider, VirtualFileSystemProvider } from "../../src";
 
 describe("Compilation Unit Tests", () => {
+  let fs: FileSystemProvider;
+
+  beforeEach(() => {
+    fs = new VirtualFileSystemProvider();
+  });
+
   afterEach(async () => {
     defaultTestWorkspace().config.setProgramConfigs(UriUtils.toUri(""), []);
     await defaultTestWorkspace().config.setProcessGroupConfigs([]);
@@ -23,7 +30,7 @@ describe("Compilation Unit Tests", () => {
 
   test("Create", async () => {
     const uri = UriUtils.toUri("memory:///test/test.pli");
-    const ch = new CompilationUnitHandler();
+    const ch = new CompilationUnitHandler(fs);
     ch.addWorkspaceFolder(UriUtils.toUri("memory:///test/"), defaultTestWorkspace());
 
     const unit0 = ch.getCompilationUnit(uri);
@@ -38,7 +45,7 @@ describe("Compilation Unit Tests", () => {
 
   test("Delete", async () => {
     const uri = UriUtils.toUri("memory:///test/test.pli");
-    const ch = new CompilationUnitHandler();
+    const ch = new CompilationUnitHandler(fs);
     ch.addWorkspaceFolder(UriUtils.toUri("memory:///test/"), defaultTestWorkspace());
 
     const unit1 = await ch.getOrCreateCompilationUnit(uri);
@@ -57,7 +64,7 @@ describe("Compilation Unit Tests", () => {
   test("Create with config", async () => {
     const uriEntry = UriUtils.toUri("file:///test/entry.pli");
     const uriLib = UriUtils.toUri("file:///test/lib.pli");
-    const ch = new CompilationUnitHandler();
+    const ch = new CompilationUnitHandler(fs);
     ch.addWorkspaceFolder(UriUtils.toUri("file:///test/"), defaultTestWorkspace());
 
     // register configs
@@ -87,7 +94,7 @@ describe("Compilation Unit Tests", () => {
     const uriEntry1 = UriUtils.toUri("file:///test/entry1.pli");
     const uriEntry2 = UriUtils.toUri("file:///test/entry2.pli");
     const uriOther = UriUtils.toUri("file:///other/entry3.pli");
-    const ch = new CompilationUnitHandler();
+    const ch = new CompilationUnitHandler(fs);
     ch.addWorkspaceFolder(UriUtils.toUri("file:///"), defaultTestWorkspace());
 
     // register wildcard config
@@ -119,7 +126,7 @@ describe("Compilation Unit Tests", () => {
   });
 
   test("Cannot create compile unit from copybook directly", async () => {
-    const ch = new CompilationUnitHandler();
+    const ch = new CompilationUnitHandler(fs);
     ch.addWorkspaceFolder(UriUtils.toUri("file:///"), defaultTestWorkspace());
 
     await defaultTestWorkspace().config.init(UriUtils.toUri("file:///"));

--- a/packages/language/test/workspace/multi-workspace.test.ts
+++ b/packages/language/test/workspace/multi-workspace.test.ts
@@ -20,7 +20,8 @@ describe("Multi Workspace Tests", () => {
     const fs = new VirtualFileSystemProvider();
     const ch = new CompilationUnitHandler(fs);
     const firstWorkspace = await ch.initializeWorkspaceFolder("file:///first");
-    const secondWorkspace = await ch.initializeWorkspaceFolder("file:///second");
+    const secondWorkspace =
+      await ch.initializeWorkspaceFolder("file:///second");
     await firstWorkspace.config.setProcessGroupConfigs([
       createProcessGroup("default", ["cpy"]),
     ]);
@@ -29,10 +30,14 @@ describe("Multi Workspace Tests", () => {
     ]);
 
     const firstMainUri = UriUtils.joinPath(firstWorkspace.uri, "main.pli");
-    const firstWrongUri = UriUtils.joinPath(firstWorkspace.uri, "wrong", "xxx.pli");
+    const firstWrongUri = UriUtils.joinPath(
+      firstWorkspace.uri,
+      "wrong",
+      "xxx.pli",
+    );
     await fs.writeFile(firstMainUri, "");
     await fs.writeFile(firstWrongUri, "");
-    await (new Promise((resolve) => setTimeout(resolve, 500))); // Wait for the file system to update
+    await new Promise((resolve) => setTimeout(resolve, 500)); // Wait for the file system to update
     expect(await ch.getOrCreateCompilationUnit(firstMainUri)).toBeDefined();
   });
 });

--- a/packages/language/test/workspace/multi-workspace.test.ts
+++ b/packages/language/test/workspace/multi-workspace.test.ts
@@ -31,74 +31,85 @@ describe("Multi Workspace Tests", () => {
       program: UriUtils.toUri("file:///second/test2.pli"),
     };
 
-    await fs.writeFile(first.programConfig, JSON.stringify({
-      "pgms": [
-        {
-          "program": "*.pli",
-          "pgroup": "xxx"
-        }
-      ]
-    }));
-    await fs.writeFile(first.groupsConfig, JSON.stringify({
-      "pgroups": [
-        {
-          "name": "xxx",
-          "compiler-options": [
-            "AGGREGATE",
-          ],
-          "member-name-validation": true,
-          "libs": [
-            "cpy"
-          ],
-          "include-extensions": [
-            ".pli",
-            ".cpy",
-            ".inc"
-          ]
-        }
-      ]
-    }));
+    await fs.writeFile(
+      first.programConfig,
+      JSON.stringify({
+        pgms: [
+          {
+            program: "*.pli",
+            pgroup: "xxx",
+          },
+        ],
+      }),
+    );
+    await fs.writeFile(
+      first.groupsConfig,
+      JSON.stringify({
+        pgroups: [
+          {
+            name: "xxx",
+            "compiler-options": ["AGGREGATE"],
+            "member-name-validation": true,
+            libs: ["cpy"],
+            "include-extensions": [".pli", ".cpy", ".inc"],
+          },
+        ],
+      }),
+    );
     await fs.writeFile(first.program, "/* test1 */");
-    await fs.writeFile(second.programConfig, JSON.stringify({
-      "pgms": [
-        {
-          "program": "*.pli",
-          "pgroup": "yyy"
-        }
-      ]
-    }));
-    await fs.writeFile(second.groupsConfig, JSON.stringify({
-      "pgroups": [
-        {
-          "name": "yyy",
-          "compiler-options": [
-            "MARGINS(20,100)"
-          ],
-          "member-name-validation": true,
-          "libs": [
-            "cpy"
-          ],
-          "include-extensions": [
-            ".pli",
-            ".cpy",
-            ".inc"
-          ]
-        }
-      ]
-    }));
+    await fs.writeFile(
+      second.programConfig,
+      JSON.stringify({
+        pgms: [
+          {
+            program: "*.pli",
+            pgroup: "yyy",
+          },
+        ],
+      }),
+    );
+    await fs.writeFile(
+      second.groupsConfig,
+      JSON.stringify({
+        pgroups: [
+          {
+            name: "yyy",
+            "compiler-options": ["MARGINS(20,100)"],
+            "member-name-validation": true,
+            libs: ["cpy"],
+            "include-extensions": [".pli", ".cpy", ".inc"],
+          },
+        ],
+      }),
+    );
     await fs.writeFile(second.program, "/* test2 */");
 
     const firstWorkspace = await ch.initializeWorkspaceFolder("file:///first");
-    const secondWorkspace = await ch.initializeWorkspaceFolder("file:///second");
-    
+    const secondWorkspace =
+      await ch.initializeWorkspaceFolder("file:///second");
+
     expect(firstWorkspace.config.hasProgramConfig(first.program)).toBeTruthy();
     const firstConfig = firstWorkspace.config.getProgramConfig(first.program)!;
-    const firstGroup = firstWorkspace.config.getProcessGroupConfig(firstConfig.pgroup.value)!;
-    expect(firstGroup.compilerOptions.map(co => co.value).includes("AGGREGATE")).toBeTruthy();
+    const firstGroup = firstWorkspace.config.getProcessGroupConfig(
+      firstConfig.pgroup.value,
+    )!;
+    expect(
+      firstGroup.compilerOptions.map((co) => co.value).includes("AGGREGATE"),
+    ).toBeTruthy();
 
-    expect(secondWorkspace.config.hasProgramConfig(second.program)).toBeTruthy(); 
-    const secondConfig = secondWorkspace.config.getProgramConfig(second.program)!;
-    const secondGroup = secondWorkspace.config.getProcessGroupConfig(secondConfig.pgroup.value)!;
-    expect(secondGroup.compilerOptions.map(co => co.value).includes("MARGINS(20,100)")).toBeTruthy();
+    expect(
+      secondWorkspace.config.hasProgramConfig(second.program),
+    ).toBeTruthy();
+    const secondConfig = secondWorkspace.config.getProgramConfig(
+      second.program,
+    )!;
+    const secondGroup = secondWorkspace.config.getProcessGroupConfig(
+      secondConfig.pgroup.value,
+    )!;
+    expect(
+      secondGroup.compilerOptions
+        .map((co) => co.value)
+        .includes("MARGINS(20,100)"),
+    ).toBeTruthy();
   });
 });

--- a/packages/language/test/workspace/multi-workspace.test.ts
+++ b/packages/language/test/workspace/multi-workspace.test.ts
@@ -15,7 +15,7 @@ import { UriUtils, VirtualFileSystemProvider } from "../../src";
 import { resetDocumentProviders } from "../../src/language-server/text-documents";
 
 describe("Multi Workspace Tests", () => {
-  test("Example Test", async () => {
+  test("With plugin configs", async () => {
     const fs = new VirtualFileSystemProvider();
     resetDocumentProviders(fs);
     const ch = new CompilationUnitHandler(fs);
@@ -45,7 +45,6 @@ describe("Multi Workspace Tests", () => {
           "name": "xxx",
           "compiler-options": [
             "AGGREGATE",
-            "MARGINS(2,72)"
           ],
           "member-name-validation": true,
           "libs": [
@@ -90,8 +89,16 @@ describe("Multi Workspace Tests", () => {
     await fs.writeFile(second.program, "/* test2 */");
 
     const firstWorkspace = await ch.initializeWorkspaceFolder("file:///first");
-  // const secondWorkspace = await ch.initializeWorkspaceFolder("file:///second");
+    const secondWorkspace = await ch.initializeWorkspaceFolder("file:///second");
     
-    expect(firstWorkspace.config.hasProgramConfig(first.program)).toBeTruthy(); 
+    expect(firstWorkspace.config.hasProgramConfig(first.program)).toBeTruthy();
+    const firstConfig = firstWorkspace.config.getProgramConfig(first.program)!;
+    const firstGroup = firstWorkspace.config.getProcessGroupConfig(firstConfig.pgroup.value)!;
+    expect(firstGroup.compilerOptions.map(co => co.value).includes("AGGREGATE")).toBeTruthy();
+
+    expect(secondWorkspace.config.hasProgramConfig(second.program)).toBeTruthy(); 
+    const secondConfig = secondWorkspace.config.getProgramConfig(second.program)!;
+    const secondGroup = secondWorkspace.config.getProcessGroupConfig(secondConfig.pgroup.value)!;
+    expect(secondGroup.compilerOptions.map(co => co.value).includes("MARGINS(20,100)")).toBeTruthy();
   });
 });

--- a/packages/language/test/workspace/multi-workspace.test.ts
+++ b/packages/language/test/workspace/multi-workspace.test.ts
@@ -102,6 +102,8 @@ describe("Multi Workspace Tests", () => {
       second.workspaceFolder,
     );
 
+    expect(ch.getAllWorkspaceFolders().length).toBe(2);
+
     expect(firstWorkspace.config.hasProgramConfig(first.program)).toBeTruthy();
     const firstConfig = firstWorkspace.config.getProgramConfig(first.program)!;
     const firstGroup = firstWorkspace.config.getProcessGroupConfig(
@@ -212,6 +214,8 @@ describe("Multi Workspace Tests", () => {
     const secondWorkspace = await ch.initializeWorkspaceFolder(
       second.workspaceFolder,
     );
+
+    expect(ch.getAllWorkspaceFolders().length).toBe(2);
 
     expect(firstWorkspace.config.hasProgramConfig(first.program)).toBeTruthy();
     const firstConfig = firstWorkspace.config.getProgramConfig(first.program)!;
@@ -326,6 +330,8 @@ describe("Multi Workspace Tests", () => {
 
     await ch.initializeFallbackFolder();
     await ch.initializeWorkspaceFolder(first.workspaceFolder);
+
+    expect(ch.getAllWorkspaceFolders().length).toBe(2);
 
     const firstWorkspace = ch.getWorkspaceFolderOf(first.program);
     expect(firstWorkspace).toBeDefined();

--- a/packages/language/test/workspace/multi-workspace.test.ts
+++ b/packages/language/test/workspace/multi-workspace.test.ts
@@ -1,0 +1,27 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+describe("Multi Workspace Tests", () => {
+  beforeEach(async () => {
+    // Setup code for multi-workspace tests
+  });
+
+  afterEach(async () => {
+    // Cleanup code for multi-workspace tests
+  });
+
+  test("Example Test", async () => {
+    // Example test logic for multi-workspace functionality
+    expect(true).toBe(true);
+  });
+});

--- a/packages/language/test/workspace/multi-workspace.test.ts
+++ b/packages/language/test/workspace/multi-workspace.test.ts
@@ -11,16 +11,15 @@
 
 import { describe, expect, test } from "vitest";
 import { CompilationUnitHandler } from "../../src/workspace/compilation-unit";
-import { UriUtils, VirtualFileSystemProvider } from "../../src";
+import { TestGlobalConfigLoader, UriUtils, VirtualFileSystemProvider } from "../../src";
 import { resetDocumentProviders } from "../../src/language-server/text-documents";
-import { makeConnection } from "./plugin-configuration.test";
-import result from "lodash-es/result";
+import { LongRunningOperationImpl } from "../../src/utils/promises";
 
 describe("Multi Workspace Tests", () => {
   test("With plugin configs under disjoint folders", async () => {
     const fs = new VirtualFileSystemProvider();
     resetDocumentProviders(fs);
-    const ch = new CompilationUnitHandler(fs);
+    const ch = new CompilationUnitHandler(fs, new TestGlobalConfigLoader({}), LongRunningOperationImpl.Dummy);
 
     const first = {
       workspaceFolder: UriUtils.toUri("file:///first"),
@@ -123,7 +122,7 @@ describe("Multi Workspace Tests", () => {
   test("With plugin configs under nested folders", async () => {
     const fs = new VirtualFileSystemProvider();
     resetDocumentProviders(fs);
-    const ch = new CompilationUnitHandler(fs);
+    const ch = new CompilationUnitHandler(fs, new TestGlobalConfigLoader({}),LongRunningOperationImpl.Dummy);
 
     const first = {
       workspaceFolder: UriUtils.toUri("file:///first"),
@@ -230,9 +229,20 @@ describe("Multi Workspace Tests", () => {
   test("For files outside the specified folders", async () => {
     const fs = new VirtualFileSystemProvider();
     resetDocumentProviders(fs);
-    const ch = new CompilationUnitHandler(fs);
-
     const settingsUri = UriUtils.toUri("file:///settings.json");
+    const ch = new CompilationUnitHandler(fs, new TestGlobalConfigLoader({
+      pgmConf: {
+        configKey: "pli.pgm_conf",
+        uri: settingsUri.toString(),
+        containerPath: [],
+      },
+      procGrps: {
+        configKey: "pli.proc_grps",
+        uri: settingsUri.toString(),
+        containerPath: [],
+      },
+    }), LongRunningOperationImpl.Dummy);
+
     const first = {
       workspaceFolder: UriUtils.toUri("file:///first"),
       programConfig: UriUtils.toUri("file:///first/.pliplugin/pgm_conf.json"),
@@ -247,7 +257,7 @@ describe("Multi Workspace Tests", () => {
         "pli.pgm_conf": {
           pgms: [
             {
-              program: "*.pli",
+              program: "**/*.pli",
               pgroup: "xxx",
             },
           ],
@@ -311,6 +321,7 @@ describe("Multi Workspace Tests", () => {
 
     const workspaceOutside = ch.getWorkspaceFolderOf(outsideProgram);
     expect(workspaceOutside).toBeDefined();
-    expect(workspaceOutside!.config.hasProgramConfig(outsideProgram)).toBeFalsy();
+    expect(workspaceOutside!.config.hasProgramConfig(outsideProgram)).toBeTruthy();
+    expect(workspaceOutside!.config.getProgramConfig(outsideProgram)!.pgroup.value).toBe("xxx");
   });
 });

--- a/packages/language/test/workspace/multi-workspace.test.ts
+++ b/packages/language/test/workspace/multi-workspace.test.ts
@@ -278,7 +278,7 @@ describe("Multi Workspace Tests", () => {
           "pli.pgm_conf": {
             pgms: [
               {
-                program: "**/*.pli",
+                program: "*.pli",
                 pgroup: "xxx",
               },
             ],
@@ -348,9 +348,6 @@ describe("Multi Workspace Tests", () => {
     expect(workspaceOutside).toBeDefined();
     expect(
       workspaceOutside!.config.hasProgramConfig(outsideProgram),
-    ).toBeTruthy();
-    expect(
-      workspaceOutside!.config.getProgramConfig(outsideProgram)!.pgroup.value,
-    ).toBe("xxx");
+    ).toBeFalsy();
   });
 });

--- a/packages/language/test/workspace/multi-workspace.test.ts
+++ b/packages/language/test/workspace/multi-workspace.test.ts
@@ -15,17 +15,19 @@ import { UriUtils, VirtualFileSystemProvider } from "../../src";
 import { resetDocumentProviders } from "../../src/language-server/text-documents";
 
 describe("Multi Workspace Tests", () => {
-  test("With plugin configs", async () => {
+  test("With plugin configs under disjoint folders", async () => {
     const fs = new VirtualFileSystemProvider();
     resetDocumentProviders(fs);
     const ch = new CompilationUnitHandler(fs);
 
     const first = {
+      workspaceFolder: UriUtils.toUri("file:///first"),
       programConfig: UriUtils.toUri("file:///first/.pliplugin/pgm_conf.json"),
       groupsConfig: UriUtils.toUri("file:///first/.pliplugin/proc_grps.json"),
       program: UriUtils.toUri("file:///first/test1.pli"),
     };
     const second = {
+      workspaceFolder: UriUtils.toUri("file:///second"),
       programConfig: UriUtils.toUri("file:///second/.pliplugin/pgm_conf.json"),
       groupsConfig: UriUtils.toUri("file:///second/.pliplugin/proc_grps.json"),
       program: UriUtils.toUri("file:///second/test2.pli"),
@@ -84,9 +86,119 @@ describe("Multi Workspace Tests", () => {
     );
     await fs.writeFile(second.program, "/* test2 */");
 
-    const firstWorkspace = await ch.initializeWorkspaceFolder("file:///first");
-    const secondWorkspace =
-      await ch.initializeWorkspaceFolder("file:///second");
+    const firstWorkspace = await ch.initializeWorkspaceFolder(
+      first.workspaceFolder,
+    );
+    const secondWorkspace = await ch.initializeWorkspaceFolder(
+      second.workspaceFolder,
+    );
+
+    expect(firstWorkspace.config.hasProgramConfig(first.program)).toBeTruthy();
+    const firstConfig = firstWorkspace.config.getProgramConfig(first.program)!;
+    const firstGroup = firstWorkspace.config.getProcessGroupConfig(
+      firstConfig.pgroup.value,
+    )!;
+    expect(
+      firstGroup.compilerOptions.map((co) => co.value).includes("AGGREGATE"),
+    ).toBeTruthy();
+
+    expect(
+      secondWorkspace.config.hasProgramConfig(second.program),
+    ).toBeTruthy();
+    const secondConfig = secondWorkspace.config.getProgramConfig(
+      second.program,
+    )!;
+    const secondGroup = secondWorkspace.config.getProcessGroupConfig(
+      secondConfig.pgroup.value,
+    )!;
+    expect(
+      secondGroup.compilerOptions
+        .map((co) => co.value)
+        .includes("MARGINS(20,100)"),
+    ).toBeTruthy();
+  });
+
+  test("With plugin configs under nested folders", async () => {
+    const fs = new VirtualFileSystemProvider();
+    resetDocumentProviders(fs);
+    const ch = new CompilationUnitHandler(fs);
+
+    const first = {
+      workspaceFolder: UriUtils.toUri("file:///first"),
+      programConfig: UriUtils.toUri("file:///first/.pliplugin/pgm_conf.json"),
+      groupsConfig: UriUtils.toUri("file:///first/.pliplugin/proc_grps.json"),
+      program: UriUtils.toUri("file:///first/test1.pli"),
+    };
+    const second = {
+      workspaceFolder: UriUtils.toUri("file:///first/second"),
+      programConfig: UriUtils.toUri(
+        "file:///first/second/.pliplugin/pgm_conf.json",
+      ),
+      groupsConfig: UriUtils.toUri(
+        "file:///first/second/.pliplugin/proc_grps.json",
+      ),
+      program: UriUtils.toUri("file:///first/second/test2.pli"),
+    };
+
+    await fs.writeFile(
+      first.programConfig,
+      JSON.stringify({
+        pgms: [
+          {
+            program: "*.pli",
+            pgroup: "xxx",
+          },
+        ],
+      }),
+    );
+    await fs.writeFile(
+      first.groupsConfig,
+      JSON.stringify({
+        pgroups: [
+          {
+            name: "xxx",
+            "compiler-options": ["AGGREGATE"],
+            "member-name-validation": true,
+            libs: ["cpy"],
+            "include-extensions": [".pli", ".cpy", ".inc"],
+          },
+        ],
+      }),
+    );
+    await fs.writeFile(first.program, "/* test1 */");
+    await fs.writeFile(
+      second.programConfig,
+      JSON.stringify({
+        pgms: [
+          {
+            program: "*.pli",
+            pgroup: "yyy",
+          },
+        ],
+      }),
+    );
+    await fs.writeFile(
+      second.groupsConfig,
+      JSON.stringify({
+        pgroups: [
+          {
+            name: "yyy",
+            "compiler-options": ["MARGINS(20,100)"],
+            "member-name-validation": true,
+            libs: ["cpy"],
+            "include-extensions": [".pli", ".cpy", ".inc"],
+          },
+        ],
+      }),
+    );
+    await fs.writeFile(second.program, "/* test2 */");
+
+    const firstWorkspace = await ch.initializeWorkspaceFolder(
+      first.workspaceFolder,
+    );
+    const secondWorkspace = await ch.initializeWorkspaceFolder(
+      second.workspaceFolder,
+    );
 
     expect(firstWorkspace.config.hasProgramConfig(first.program)).toBeTruthy();
     const firstConfig = firstWorkspace.config.getProgramConfig(first.program)!;

--- a/packages/language/test/workspace/multi-workspace.test.ts
+++ b/packages/language/test/workspace/multi-workspace.test.ts
@@ -9,19 +9,41 @@
  *
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { describe, expect, test } from "vitest";
+import { CompilationUnitHandler } from "../../src/workspace/compilation-unit";
+import { UriUtils, VirtualFileSystemProvider } from "../../src";
+import { makeProcessGroup } from "../config-fixtures";
+import { ProcessGroup } from "../../src/config/schema";
 
 describe("Multi Workspace Tests", () => {
-  beforeEach(async () => {
-    // Setup code for multi-workspace tests
-  });
-
-  afterEach(async () => {
-    // Cleanup code for multi-workspace tests
-  });
-
   test("Example Test", async () => {
-    // Example test logic for multi-workspace functionality
-    expect(true).toBe(true);
+    const fs = new VirtualFileSystemProvider();
+    const ch = new CompilationUnitHandler(fs);
+    const firstWorkspace = await ch.initializeWorkspaceFolder("file:///first");
+    const secondWorkspace = await ch.initializeWorkspaceFolder("file:///second");
+    await firstWorkspace.config.setProcessGroupConfigs([
+      createProcessGroup("default", ["cpy"]),
+    ]);
+    await secondWorkspace.config.setProcessGroupConfigs([
+      createProcessGroup("default", ["lib"]),
+    ]);
+
+    const firstMainUri = UriUtils.joinPath(firstWorkspace.uri, "main.pli");
+    const firstWrongUri = UriUtils.joinPath(firstWorkspace.uri, "wrong", "xxx.pli");
+    await fs.writeFile(firstMainUri, "");
+    await fs.writeFile(firstWrongUri, "");
+    await (new Promise((resolve) => setTimeout(resolve, 500))); // Wait for the file system to update
+    expect(await ch.getOrCreateCompilationUnit(firstMainUri)).toBeDefined();
   });
 });
+
+function createProcessGroup(name: string, libs: string[]): ProcessGroup {
+  return makeProcessGroup({
+    name,
+    libs,
+    includeExtensions: [".inc"],
+    checkMargins: false,
+    instructionCounterLimit: 5000,
+    caseUpperValidation: false,
+  });
+}

--- a/packages/language/test/workspace/multi-workspace.test.ts
+++ b/packages/language/test/workspace/multi-workspace.test.ts
@@ -13,6 +13,8 @@ import { describe, expect, test } from "vitest";
 import { CompilationUnitHandler } from "../../src/workspace/compilation-unit";
 import { UriUtils, VirtualFileSystemProvider } from "../../src";
 import { resetDocumentProviders } from "../../src/language-server/text-documents";
+import { makeConnection } from "./plugin-configuration.test";
+import result from "lodash-es/result";
 
 describe("Multi Workspace Tests", () => {
   test("With plugin configs under disjoint folders", async () => {
@@ -223,5 +225,92 @@ describe("Multi Workspace Tests", () => {
         .map((co) => co.value)
         .includes("MARGINS(20,100)"),
     ).toBeTruthy();
+  });
+
+  test("For files outside the specified folders", async () => {
+    const fs = new VirtualFileSystemProvider();
+    resetDocumentProviders(fs);
+    const ch = new CompilationUnitHandler(fs);
+
+    const settingsUri = UriUtils.toUri("file:///settings.json");
+    const first = {
+      workspaceFolder: UriUtils.toUri("file:///first"),
+      programConfig: UriUtils.toUri("file:///first/.pliplugin/pgm_conf.json"),
+      groupsConfig: UriUtils.toUri("file:///first/.pliplugin/proc_grps.json"),
+      program: UriUtils.toUri("file:///first/test1.pli"),
+    };
+    const outsideProgram = UriUtils.toUri("file:///outside/test2.pli");
+
+    await fs.writeFile(
+      settingsUri,
+      JSON.stringify({
+        "pli.pgm_conf": {
+          pgms: [
+            {
+              program: "*.pli",
+              pgroup: "xxx",
+            },
+          ],
+        },
+        "pli.proc_grps": {
+          pgroups: [
+            {
+              name: "xxx",
+              "compiler-options": ["AGGREGATE"],
+              "member-name-validation": true,
+              libs: ["cpy"],
+              "include-extensions": [".pli", ".cpy", ".inc"],
+            },
+          ],
+        },
+      }, null, 2),
+    );
+
+    await fs.writeFile(
+      first.programConfig,
+      JSON.stringify({
+        pgms: [
+          {
+            program: "*.pli",
+            pgroup: "xxx",
+          },
+        ],
+      }),
+    );
+    await fs.writeFile(
+      first.groupsConfig,
+      JSON.stringify({
+        pgroups: [
+          {
+            name: "xxx",
+            "compiler-options": ["AGGREGATE"],
+            "member-name-validation": true,
+            libs: ["cpy"],
+            "include-extensions": [".pli", ".cpy", ".inc"],
+          },
+        ],
+      }),
+    );
+    await fs.writeFile(first.program, "/* test1 */");
+    await fs.writeFile(outsideProgram, "/* test2 */");
+
+    await ch.initializeFallbackFolderForScheme("file");
+
+    const firstWorkspace = await ch.initializeWorkspaceFolder(
+      first.workspaceFolder,
+    );
+
+    expect(firstWorkspace.config.hasProgramConfig(first.program)).toBeTruthy();
+    const firstConfig = firstWorkspace.config.getProgramConfig(first.program)!;
+    const firstGroup = firstWorkspace.config.getProcessGroupConfig(
+      firstConfig.pgroup.value,
+    )!;
+    expect(
+      firstGroup.compilerOptions.map((co) => co.value).includes("AGGREGATE"),
+    ).toBeTruthy();
+
+    const workspaceOutside = ch.getWorkspaceFolderOf(outsideProgram);
+    expect(workspaceOutside).toBeDefined();
+    expect(workspaceOutside!.config.hasProgramConfig(outsideProgram)).toBeFalsy();
   });
 });

--- a/packages/language/test/workspace/multi-workspace.test.ts
+++ b/packages/language/test/workspace/multi-workspace.test.ts
@@ -12,43 +12,86 @@
 import { describe, expect, test } from "vitest";
 import { CompilationUnitHandler } from "../../src/workspace/compilation-unit";
 import { UriUtils, VirtualFileSystemProvider } from "../../src";
-import { makeProcessGroup } from "../config-fixtures";
-import { ProcessGroup } from "../../src/config/schema";
+import { resetDocumentProviders } from "../../src/language-server/text-documents";
 
 describe("Multi Workspace Tests", () => {
   test("Example Test", async () => {
     const fs = new VirtualFileSystemProvider();
+    resetDocumentProviders(fs);
     const ch = new CompilationUnitHandler(fs);
-    const firstWorkspace = await ch.initializeWorkspaceFolder("file:///first");
-    const secondWorkspace =
-      await ch.initializeWorkspaceFolder("file:///second");
-    await firstWorkspace.config.setProcessGroupConfigs([
-      createProcessGroup("default", ["cpy"]),
-    ]);
-    await secondWorkspace.config.setProcessGroupConfigs([
-      createProcessGroup("default", ["lib"]),
-    ]);
 
-    const firstMainUri = UriUtils.joinPath(firstWorkspace.uri, "main.pli");
-    const firstWrongUri = UriUtils.joinPath(
-      firstWorkspace.uri,
-      "wrong",
-      "xxx.pli",
-    );
-    await fs.writeFile(firstMainUri, "");
-    await fs.writeFile(firstWrongUri, "");
-    await new Promise((resolve) => setTimeout(resolve, 500)); // Wait for the file system to update
-    expect(await ch.getOrCreateCompilationUnit(firstMainUri)).toBeDefined();
+    const first = {
+      programConfig: UriUtils.toUri("file:///first/.pliplugin/pgm_conf.json"),
+      groupsConfig: UriUtils.toUri("file:///first/.pliplugin/proc_grps.json"),
+      program: UriUtils.toUri("file:///first/test1.pli"),
+    };
+    const second = {
+      programConfig: UriUtils.toUri("file:///second/.pliplugin/pgm_conf.json"),
+      groupsConfig: UriUtils.toUri("file:///second/.pliplugin/proc_grps.json"),
+      program: UriUtils.toUri("file:///second/test2.pli"),
+    };
+
+    await fs.writeFile(first.programConfig, JSON.stringify({
+      "pgms": [
+        {
+          "program": "*.pli",
+          "pgroup": "xxx"
+        }
+      ]
+    }));
+    await fs.writeFile(first.groupsConfig, JSON.stringify({
+      "pgroups": [
+        {
+          "name": "xxx",
+          "compiler-options": [
+            "AGGREGATE",
+            "MARGINS(2,72)"
+          ],
+          "member-name-validation": true,
+          "libs": [
+            "cpy"
+          ],
+          "include-extensions": [
+            ".pli",
+            ".cpy",
+            ".inc"
+          ]
+        }
+      ]
+    }));
+    await fs.writeFile(first.program, "/* test1 */");
+    await fs.writeFile(second.programConfig, JSON.stringify({
+      "pgms": [
+        {
+          "program": "*.pli",
+          "pgroup": "yyy"
+        }
+      ]
+    }));
+    await fs.writeFile(second.groupsConfig, JSON.stringify({
+      "pgroups": [
+        {
+          "name": "yyy",
+          "compiler-options": [
+            "MARGINS(20,100)"
+          ],
+          "member-name-validation": true,
+          "libs": [
+            "cpy"
+          ],
+          "include-extensions": [
+            ".pli",
+            ".cpy",
+            ".inc"
+          ]
+        }
+      ]
+    }));
+    await fs.writeFile(second.program, "/* test2 */");
+
+    const firstWorkspace = await ch.initializeWorkspaceFolder("file:///first");
+  // const secondWorkspace = await ch.initializeWorkspaceFolder("file:///second");
+    
+    expect(firstWorkspace.config.hasProgramConfig(first.program)).toBeTruthy(); 
   });
 });
-
-function createProcessGroup(name: string, libs: string[]): ProcessGroup {
-  return makeProcessGroup({
-    name,
-    libs,
-    includeExtensions: [".inc"],
-    checkMargins: false,
-    instructionCounterLimit: 5000,
-    caseUpperValidation: false,
-  });
-}

--- a/packages/language/test/workspace/multi-workspace.test.ts
+++ b/packages/language/test/workspace/multi-workspace.test.ts
@@ -278,7 +278,7 @@ describe("Multi Workspace Tests", () => {
           "pli.pgm_conf": {
             pgms: [
               {
-                program: "*.pli",
+                program: "**/*",
                 pgroup: "xxx",
               },
             ],
@@ -348,6 +348,6 @@ describe("Multi Workspace Tests", () => {
     expect(workspaceOutside).toBeDefined();
     expect(
       workspaceOutside!.config.hasProgramConfig(outsideProgram),
-    ).toBeFalsy();
+    ).toBeTruthy();
   });
 });

--- a/packages/language/test/workspace/multi-workspace.test.ts
+++ b/packages/language/test/workspace/multi-workspace.test.ts
@@ -11,7 +11,11 @@
 
 import { describe, expect, test } from "vitest";
 import { CompilationUnitHandler } from "../../src/workspace/compilation-unit";
-import { TestGlobalConfigLoader, UriUtils, VirtualFileSystemProvider } from "../../src";
+import {
+  TestGlobalConfigLoader,
+  UriUtils,
+  VirtualFileSystemProvider,
+} from "../../src";
 import { resetDocumentProviders } from "../../src/language-server/text-documents";
 import { LongRunningOperationImpl } from "../../src/utils/promises";
 
@@ -19,7 +23,11 @@ describe("Multi Workspace Tests", () => {
   test("With plugin configs under disjoint folders", async () => {
     const fs = new VirtualFileSystemProvider();
     resetDocumentProviders(fs);
-    const ch = new CompilationUnitHandler(fs, new TestGlobalConfigLoader({}), LongRunningOperationImpl.Dummy);
+    const ch = new CompilationUnitHandler(
+      fs,
+      new TestGlobalConfigLoader({}),
+      LongRunningOperationImpl.Dummy,
+    );
 
     const first = {
       workspaceFolder: UriUtils.toUri("file:///first"),
@@ -122,7 +130,11 @@ describe("Multi Workspace Tests", () => {
   test("With plugin configs under nested folders", async () => {
     const fs = new VirtualFileSystemProvider();
     resetDocumentProviders(fs);
-    const ch = new CompilationUnitHandler(fs, new TestGlobalConfigLoader({}),LongRunningOperationImpl.Dummy);
+    const ch = new CompilationUnitHandler(
+      fs,
+      new TestGlobalConfigLoader({}),
+      LongRunningOperationImpl.Dummy,
+    );
 
     const first = {
       workspaceFolder: UriUtils.toUri("file:///first"),
@@ -230,18 +242,22 @@ describe("Multi Workspace Tests", () => {
     const fs = new VirtualFileSystemProvider();
     resetDocumentProviders(fs);
     const settingsUri = UriUtils.toUri("file:///settings.json");
-    const ch = new CompilationUnitHandler(fs, new TestGlobalConfigLoader({
-      pgmConf: {
-        configKey: "pli.pgm_conf",
-        uri: settingsUri.toString(),
-        containerPath: [],
-      },
-      procGrps: {
-        configKey: "pli.proc_grps",
-        uri: settingsUri.toString(),
-        containerPath: [],
-      },
-    }), LongRunningOperationImpl.Dummy);
+    const ch = new CompilationUnitHandler(
+      fs,
+      new TestGlobalConfigLoader({
+        pgmConf: {
+          configKey: "pli.pgm_conf",
+          uri: settingsUri.toString(),
+          containerPath: [],
+        },
+        procGrps: {
+          configKey: "pli.proc_grps",
+          uri: settingsUri.toString(),
+          containerPath: [],
+        },
+      }),
+      LongRunningOperationImpl.Dummy,
+    );
 
     const first = {
       workspaceFolder: UriUtils.toUri("file:///first"),
@@ -253,27 +269,31 @@ describe("Multi Workspace Tests", () => {
 
     await fs.writeFile(
       settingsUri,
-      JSON.stringify({
-        "pli.pgm_conf": {
-          pgms: [
-            {
-              program: "**/*.pli",
-              pgroup: "xxx",
-            },
-          ],
+      JSON.stringify(
+        {
+          "pli.pgm_conf": {
+            pgms: [
+              {
+                program: "**/*.pli",
+                pgroup: "xxx",
+              },
+            ],
+          },
+          "pli.proc_grps": {
+            pgroups: [
+              {
+                name: "xxx",
+                "compiler-options": ["AGGREGATE"],
+                "member-name-validation": true,
+                libs: ["cpy"],
+                "include-extensions": [".pli", ".cpy", ".inc"],
+              },
+            ],
+          },
         },
-        "pli.proc_grps": {
-          pgroups: [
-            {
-              name: "xxx",
-              "compiler-options": ["AGGREGATE"],
-              "member-name-validation": true,
-              libs: ["cpy"],
-              "include-extensions": [".pli", ".cpy", ".inc"],
-            },
-          ],
-        },
-      }, null, 2),
+        null,
+        2,
+      ),
     );
 
     await fs.writeFile(
@@ -304,15 +324,14 @@ describe("Multi Workspace Tests", () => {
     await fs.writeFile(first.program, "/* test1 */");
     await fs.writeFile(outsideProgram, "/* test2 */");
 
-    await ch.initializeFallbackFolderForScheme("file");
+    await ch.initializeFallbackFolder();
+    await ch.initializeWorkspaceFolder(first.workspaceFolder);
 
-    const firstWorkspace = await ch.initializeWorkspaceFolder(
-      first.workspaceFolder,
-    );
-
-    expect(firstWorkspace.config.hasProgramConfig(first.program)).toBeTruthy();
-    const firstConfig = firstWorkspace.config.getProgramConfig(first.program)!;
-    const firstGroup = firstWorkspace.config.getProcessGroupConfig(
+    const firstWorkspace = ch.getWorkspaceFolderOf(first.program);
+    expect(firstWorkspace).toBeDefined();
+    expect(firstWorkspace!.config.hasProgramConfig(first.program)).toBeTruthy();
+    const firstConfig = firstWorkspace!.config.getProgramConfig(first.program)!;
+    const firstGroup = firstWorkspace!.config.getProcessGroupConfig(
       firstConfig.pgroup.value,
     )!;
     expect(
@@ -321,7 +340,11 @@ describe("Multi Workspace Tests", () => {
 
     const workspaceOutside = ch.getWorkspaceFolderOf(outsideProgram);
     expect(workspaceOutside).toBeDefined();
-    expect(workspaceOutside!.config.hasProgramConfig(outsideProgram)).toBeTruthy();
-    expect(workspaceOutside!.config.getProgramConfig(outsideProgram)!.pgroup.value).toBe("xxx");
+    expect(
+      workspaceOutside!.config.hasProgramConfig(outsideProgram),
+    ).toBeTruthy();
+    expect(
+      workspaceOutside!.config.getProgramConfig(outsideProgram)!.pgroup.value,
+    ).toBe("xxx");
   });
 });

--- a/packages/language/test/workspace/plugin-configuration.test.ts
+++ b/packages/language/test/workspace/plugin-configuration.test.ts
@@ -46,7 +46,7 @@ describe("Plugin Configuration Tests", () => {
 
   beforeEach(() => {
     vfs = new VirtualFileSystemProvider();
-    workspace = new WorkspaceContext(vfs);
+    workspace = new WorkspaceContext(UriUtils.toUri("file:///"), vfs);
     resetDocumentProviders(vfs);
   });
 
@@ -245,6 +245,7 @@ describe("Plugin Configuration Tests", () => {
         }`,
       );
       workspace = new WorkspaceContext(
+        UriUtils.toUri(WORKSPACE),
         vfs,
         makeConnection(settingsConfig({ pgmConf: true, procGrps: true })),
       );
@@ -278,6 +279,7 @@ describe("Plugin Configuration Tests", () => {
         }`,
       );
       workspace = new WorkspaceContext(
+        UriUtils.toUri(WORKSPACE),
         vfs,
         makeConnection(settingsConfig({ procGrps: true })),
       );

--- a/packages/language/test/workspace/plugin-configuration.test.ts
+++ b/packages/language/test/workspace/plugin-configuration.test.ts
@@ -228,7 +228,9 @@ describe("Plugin Configuration Tests", () => {
       );
       workspace = new WorkspaceContext(
         vfs,
-        new TestGlobalConfigLoader(settingsConfig({ pgmConf: true, procGrps: true })),
+        new TestGlobalConfigLoader(
+          settingsConfig({ pgmConf: true, procGrps: true }),
+        ),
       );
 
       await workspace.config.init(UriUtils.toUri(WORKSPACE));

--- a/packages/language/test/workspace/plugin-configuration.test.ts
+++ b/packages/language/test/workspace/plugin-configuration.test.ts
@@ -46,7 +46,7 @@ describe("Plugin Configuration Tests", () => {
 
   beforeEach(() => {
     vfs = new VirtualFileSystemProvider();
-    workspace = new WorkspaceContext(UriUtils.toUri("file:///"), vfs);
+    workspace = new WorkspaceContext(vfs);
     resetDocumentProviders(vfs);
   });
 
@@ -245,7 +245,6 @@ describe("Plugin Configuration Tests", () => {
         }`,
       );
       workspace = new WorkspaceContext(
-        UriUtils.toUri(WORKSPACE),
         vfs,
         makeConnection(settingsConfig({ pgmConf: true, procGrps: true })),
       );
@@ -279,7 +278,6 @@ describe("Plugin Configuration Tests", () => {
         }`,
       );
       workspace = new WorkspaceContext(
-        UriUtils.toUri(WORKSPACE),
         vfs,
         makeConnection(settingsConfig({ procGrps: true })),
       );

--- a/packages/language/test/workspace/plugin-configuration.test.ts
+++ b/packages/language/test/workspace/plugin-configuration.test.ts
@@ -10,7 +10,6 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
-import type { Connection } from "vscode-languageserver";
 import { UriUtils } from "../../src/utils/uri";
 import { VirtualFileSystemProvider } from "../../src/workspace/file-system-provider";
 import {
@@ -18,27 +17,10 @@ import {
   ProcessGroup,
 } from "../../src/workspace/plugin-configuration-provider";
 import { WorkspaceContext } from "../../src/workspace/workspace-context";
-import { Messages } from "../../src/utils/messages";
 import { makeProcessGroup } from "../config-fixtures";
 import { Severity } from "../../src/language-server/types";
 import { resetDocumentProviders } from "../../src/language-server/text-documents";
-
-/**
- * Minimal connection stub that responds to `config/getGlobal` with the
- * given `GlobalConfig`. Other request/notification methods are no-ops so
- * the provider can run end-to-end without a real LSP transport.
- */
-export function makeConnection(global: Messages.GlobalConfig): Connection {
-  return {
-    sendRequest: async (method: string) => {
-      if (method === Messages.GetGlobalConfig.method) return global;
-      return undefined;
-    },
-    sendNotification: async () => {},
-    onRequest: () => ({ dispose() {} }),
-    onNotification: () => ({ dispose() {} }),
-  } as unknown as Connection;
-}
+import { Messages, TestGlobalConfigLoader } from "../../src";
 
 describe("Plugin Configuration Tests", () => {
   let vfs: VirtualFileSystemProvider;
@@ -46,7 +28,7 @@ describe("Plugin Configuration Tests", () => {
 
   beforeEach(() => {
     vfs = new VirtualFileSystemProvider();
-    workspace = new WorkspaceContext(vfs);
+    workspace = new WorkspaceContext(vfs, new TestGlobalConfigLoader({}));
     resetDocumentProviders(vfs);
   });
 
@@ -246,7 +228,7 @@ describe("Plugin Configuration Tests", () => {
       );
       workspace = new WorkspaceContext(
         vfs,
-        makeConnection(settingsConfig({ pgmConf: true, procGrps: true })),
+        new TestGlobalConfigLoader(settingsConfig({ pgmConf: true, procGrps: true })),
       );
 
       await workspace.config.init(UriUtils.toUri(WORKSPACE));
@@ -279,7 +261,7 @@ describe("Plugin Configuration Tests", () => {
       );
       workspace = new WorkspaceContext(
         vfs,
-        makeConnection(settingsConfig({ procGrps: true })),
+        new TestGlobalConfigLoader(settingsConfig({ procGrps: true })),
       );
 
       await workspace.config.init(UriUtils.toUri(WORKSPACE));

--- a/packages/language/test/workspace/plugin-configuration.test.ts
+++ b/packages/language/test/workspace/plugin-configuration.test.ts
@@ -28,7 +28,7 @@ import { resetDocumentProviders } from "../../src/language-server/text-documents
  * given `GlobalConfig`. Other request/notification methods are no-ops so
  * the provider can run end-to-end without a real LSP transport.
  */
-function makeConnection(global: Messages.GlobalConfig): Connection {
+export function makeConnection(global: Messages.GlobalConfig): Connection {
   return {
     sendRequest: async (method: string) => {
       if (method === Messages.GetGlobalConfig.method) return global;

--- a/packages/language/test/workspace/unknown-process-group.test.ts
+++ b/packages/language/test/workspace/unknown-process-group.test.ts
@@ -37,7 +37,7 @@ let pluginConfig: PluginConfigurationProvider;
 
 beforeEach(() => {
   vfs = new VirtualFileSystemProvider();
-  workspace = new WorkspaceContext(WORKSPACE_PATH, vfs);
+  workspace = new WorkspaceContext(vfs);
   pluginConfig = workspace.config;
   resetDocumentProviders(vfs);
 });

--- a/packages/language/test/workspace/unknown-process-group.test.ts
+++ b/packages/language/test/workspace/unknown-process-group.test.ts
@@ -37,7 +37,7 @@ let pluginConfig: PluginConfigurationProvider;
 
 beforeEach(() => {
   vfs = new VirtualFileSystemProvider();
-  workspace = new WorkspaceContext(vfs);
+  workspace = new WorkspaceContext(WORKSPACE_PATH, vfs);
   pluginConfig = workspace.config;
   resetDocumentProviders(vfs);
 });

--- a/packages/language/test/workspace/unknown-process-group.test.ts
+++ b/packages/language/test/workspace/unknown-process-group.test.ts
@@ -18,6 +18,7 @@ import { UriUtils } from "../../src/utils/uri";
 import { PluginConfiguration } from "../../src/language-server/constants";
 import { MultiMap } from "../../src/utils/collections";
 import { resetDocumentProviders } from "../../src/language-server/text-documents";
+import { TestGlobalConfigLoader } from "../../src";
 
 const WORKSPACE_PATH = UriUtils.toUri("/workspace");
 const PGM_CONF_URI = UriUtils.joinPath(
@@ -37,7 +38,7 @@ let pluginConfig: PluginConfigurationProvider;
 
 beforeEach(() => {
   vfs = new VirtualFileSystemProvider();
-  workspace = new WorkspaceContext(vfs);
+  workspace = new WorkspaceContext(vfs, new TestGlobalConfigLoader({}));
   pluginConfig = workspace.config;
   resetDocumentProviders(vfs);
 });

--- a/packages/language/test/workspace/workspace-folder-tree.test.ts
+++ b/packages/language/test/workspace/workspace-folder-tree.test.ts
@@ -19,21 +19,41 @@ describe("Workspace Folder Tree", () => {
     tree.addWorkspaceFolder("file:///home/user/project/some/nested/folder", 2);
     expect(tree.getWorkspaceFolderOf("file:///home/user/project")).toBe(1);
     expect(tree.getWorkspaceFolderOf("file:///home/user/project/sub")).toBe(1);
-    expect(tree.getWorkspaceFolderOf("file:///home/user/project/folder")).toBe(1);
+    expect(tree.getWorkspaceFolderOf("file:///home/user/project/folder")).toBe(
+      1,
+    );
     expect(tree.getWorkspaceFolderOf("file:///home/user")).toBe(undefined);
-    expect(tree.getWorkspaceFolderOf("file:///home/user/project/some/nested/folder")).toBe(2);
-    expect(tree.getWorkspaceFolderOf("file:///home/user/project/some/nested/folder/sub")).toBe(2);
-    expect(tree.getWorkspaceFolderOf("file:///home/user/project/some/nested/folder/other")).toBe(2);
-    expect(tree.getWorkspaceFolderOf("file:///home/user/project/some/nested")).toBe(1);
+    expect(
+      tree.getWorkspaceFolderOf("file:///home/user/project/some/nested/folder"),
+    ).toBe(2);
+    expect(
+      tree.getWorkspaceFolderOf(
+        "file:///home/user/project/some/nested/folder/sub",
+      ),
+    ).toBe(2);
+    expect(
+      tree.getWorkspaceFolderOf(
+        "file:///home/user/project/some/nested/folder/other",
+      ),
+    ).toBe(2);
+    expect(
+      tree.getWorkspaceFolderOf("file:///home/user/project/some/nested"),
+    ).toBe(1);
   });
   test("windows schema", async () => {
     const tree = new WorkspaceFolderTree<number>(true);
     tree.addWorkspaceFolder("C:\\Users\\User\\Project", 1);
     expect(tree.getWorkspaceFolderOf("C:\\Users\\User\\Project")).toBe(1);
     expect(tree.getWorkspaceFolderOf("C:\\Users\\User\\Project\\Sub")).toBe(1);
-    expect(tree.getWorkspaceFolderOf("C:\\Users\\User\\Project\\Folder")).toBe(1);
-    expect(tree.getWorkspaceFolderOf("c:\\users\\user\\project\\folder")).toBe(1);
+    expect(tree.getWorkspaceFolderOf("C:\\Users\\User\\Project\\Folder")).toBe(
+      1,
+    );
+    expect(tree.getWorkspaceFolderOf("c:\\users\\user\\project\\folder")).toBe(
+      1,
+    );
     expect(tree.getWorkspaceFolderOf("C:\\Users\\User")).toBe(undefined);
-    expect(tree.getWorkspaceFolderOf("D:\\Users\\User\\Project")).toBe(undefined);
+    expect(tree.getWorkspaceFolderOf("D:\\Users\\User\\Project")).toBe(
+      undefined,
+    );
   });
 });

--- a/packages/language/test/workspace/workspace-folder-tree.test.ts
+++ b/packages/language/test/workspace/workspace-folder-tree.test.ts
@@ -1,0 +1,39 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { describe, expect, test } from "vitest";
+import { WorkspaceFolderTree } from "../../src/workspace/workspace-folder-tree";
+
+describe("Workspace Folder Tree", () => {
+  test("file:// schema", async () => {
+    const tree = new WorkspaceFolderTree<number>(false);
+    tree.addWorkspaceFolder("file:///home/user/project", 1);
+    tree.addWorkspaceFolder("file:///home/user/project/some/nested/folder", 2);
+    expect(tree.getWorkspaceFolderOf("file:///home/user/project")).toBe(1);
+    expect(tree.getWorkspaceFolderOf("file:///home/user/project/sub")).toBe(1);
+    expect(tree.getWorkspaceFolderOf("file:///home/user/project/folder")).toBe(1);
+    expect(tree.getWorkspaceFolderOf("file:///home/user")).toBe(undefined);
+    expect(tree.getWorkspaceFolderOf("file:///home/user/project/some/nested/folder")).toBe(2);
+    expect(tree.getWorkspaceFolderOf("file:///home/user/project/some/nested/folder/sub")).toBe(2);
+    expect(tree.getWorkspaceFolderOf("file:///home/user/project/some/nested/folder/other")).toBe(2);
+    expect(tree.getWorkspaceFolderOf("file:///home/user/project/some/nested")).toBe(1);
+  });
+  test("windows schema", async () => {
+    const tree = new WorkspaceFolderTree<number>(true);
+    tree.addWorkspaceFolder("C:\\Users\\User\\Project", 1);
+    expect(tree.getWorkspaceFolderOf("C:\\Users\\User\\Project")).toBe(1);
+    expect(tree.getWorkspaceFolderOf("C:\\Users\\User\\Project\\Sub")).toBe(1);
+    expect(tree.getWorkspaceFolderOf("C:\\Users\\User\\Project\\Folder")).toBe(1);
+    expect(tree.getWorkspaceFolderOf("c:\\users\\user\\project\\folder")).toBe(1);
+    expect(tree.getWorkspaceFolderOf("C:\\Users\\User")).toBe(undefined);
+    expect(tree.getWorkspaceFolderOf("D:\\Users\\User\\Project")).toBe(undefined);
+  });
+});

--- a/packages/vscode-extension/src/common/missing-config-handler.ts
+++ b/packages/vscode-extension/src/common/missing-config-handler.ts
@@ -13,6 +13,7 @@ import * as vscode from "vscode";
 import * as path from "node:path";
 import * as fs from "node:fs";
 import { PluginConfiguration, UriUtils } from "pli-language";
+import { locateWorkspaceFolder } from "../extension/config-loader";
 
 let shouldShowInfoMessage = true;
 
@@ -23,24 +24,7 @@ export async function handleMissingConfig(
     return;
   }
 
-  const workspaceFolders = (vscode.workspace.workspaceFolders ?? []).map(
-    (folder) => folder.uri,
-  );
-  const textEditorUri = textEditor.document.uri;
-  let workspaceFolderUri: vscode.Uri | undefined;
-
-  for (const folder of workspaceFolders) {
-    if (UriUtils.contains(folder, textEditorUri)) {
-      if (
-        !workspaceFolderUri ||
-        UriUtils.toNormalizedKey(folder).length >
-          UriUtils.toNormalizedKey(workspaceFolderUri).length
-      ) {
-        workspaceFolderUri = folder;
-      }
-    }
-  }
-
+  const workspaceFolderUri = locateWorkspaceFolder(textEditor.document.uri);
   if (!workspaceFolderUri) {
     return;
   }

--- a/packages/vscode-extension/src/common/missing-config-handler.ts
+++ b/packages/vscode-extension/src/common/missing-config-handler.ts
@@ -30,13 +30,14 @@ export async function handleMissingConfig(
   let workspaceFolderUri: vscode.Uri | undefined;
 
   for (const folder of workspaceFolders) {
-    if (
-      !workspaceFolderUri ||
-      (UriUtils.contains(textEditorUri, folder) &&
+    if (UriUtils.contains(folder, textEditorUri)) {
+      if (
+        !workspaceFolderUri ||
         UriUtils.toNormalizedKey(folder).length >
-          UriUtils.toNormalizedKey(workspaceFolderUri).length)
-    ) {
-      workspaceFolderUri = folder;
+          UriUtils.toNormalizedKey(workspaceFolderUri).length
+      ) {
+        workspaceFolderUri = folder;
+      }
     }
   }
 

--- a/packages/vscode-extension/src/common/missing-config-handler.ts
+++ b/packages/vscode-extension/src/common/missing-config-handler.ts
@@ -23,12 +23,20 @@ export async function handleMissingConfig(
     return;
   }
 
-  // settle on the 1st workspace folder available
-  // TODO @montymxb May 15th, 2025: Support configs across multiple workspace folders
-  const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-  if (!workspaceFolder) {
+  const workspaceFolders = (vscode.workspace.workspaceFolders ?? []).map((folder) => folder.uri);
+  const textEditorUri = textEditor.document.uri;
+  let workspaceFolderUri: vscode.Uri | undefined;
+
+  for (const folder of workspaceFolders) {
+    if (!workspaceFolderUri || (UriUtils.contains(textEditorUri, folder) && UriUtils.toNormalizedKey(folder).length > UriUtils.toNormalizedKey(workspaceFolderUri).length)) {
+      workspaceFolderUri = folder;
+    }
+  }
+
+  if (!workspaceFolderUri) {
     return;
   }
+  const workspaceFolder = workspaceFolderUri.fsPath;
 
   // check if we can create a .pliplugin folder
   const plipluginPath = path.join(workspaceFolder, ".pliplugin");

--- a/packages/vscode-extension/src/common/missing-config-handler.ts
+++ b/packages/vscode-extension/src/common/missing-config-handler.ts
@@ -23,12 +23,19 @@ export async function handleMissingConfig(
     return;
   }
 
-  const workspaceFolders = (vscode.workspace.workspaceFolders ?? []).map((folder) => folder.uri);
+  const workspaceFolders = (vscode.workspace.workspaceFolders ?? []).map(
+    (folder) => folder.uri,
+  );
   const textEditorUri = textEditor.document.uri;
   let workspaceFolderUri: vscode.Uri | undefined;
 
   for (const folder of workspaceFolders) {
-    if (!workspaceFolderUri || (UriUtils.contains(textEditorUri, folder) && UriUtils.toNormalizedKey(folder).length > UriUtils.toNormalizedKey(workspaceFolderUri).length)) {
+    if (
+      !workspaceFolderUri ||
+      (UriUtils.contains(textEditorUri, folder) &&
+        UriUtils.toNormalizedKey(folder).length >
+          UriUtils.toNormalizedKey(workspaceFolderUri).length)
+    ) {
       workspaceFolderUri = folder;
     }
   }

--- a/packages/vscode-extension/src/extension/config-loader.ts
+++ b/packages/vscode-extension/src/extension/config-loader.ts
@@ -9,25 +9,17 @@
  *
  */
 
-import { GlobalConfigLoader, Messages, sendRequest, UriUtils } from "pli-language";
+import { Messages, UriUtils } from "pli-language";
 import * as vscode from "vscode";
 import { BaseLanguageClient } from "vscode-languageclient";
 import { sendNotification } from "./messages";
-import { Connection } from "vscode-languageserver";
 
 type ConfigKey = "pgm_conf" | "proc_grps";
 
-export class VscodeGlobalConfigLoader implements GlobalConfigLoader {
-  static register(client: BaseLanguageClient, context: vscode.ExtensionContext): void {
-    client.onRequest(Messages.GetUserSettingsUriRequest.method, async () => {
-      return deriveUserSettingsUri(context.globalStorageUri).toString();
-    });
-  }
-  constructor(private readonly connection: Connection) {}
-  async loadGlobalConfig(workspaceUri: vscode.Uri): Promise<Messages.GlobalConfig> {
-    const userSettingsUri = await sendRequest(this.connection, Messages.GetUserSettingsUriRequest, undefined);
-    return getGlobalConfig(workspaceUri, UriUtils.toUri(userSettingsUri));
-  }
+export function registerConfigLoader(client: BaseLanguageClient, context: vscode.ExtensionContext): void {
+  client.onRequest(Messages.GetGlobalConfig.method, async (workspaceUri) => {
+    return getGlobalConfig(UriUtils.toUri(workspaceUri), deriveUserSettingsUri(context.globalStorageUri));
+  });
 }
 
 /**

--- a/packages/vscode-extension/src/extension/config-loader.ts
+++ b/packages/vscode-extension/src/extension/config-loader.ts
@@ -9,31 +9,25 @@
  *
  */
 
-import { Messages, UriUtils } from "pli-language";
+import { GlobalConfigLoader, Messages, sendRequest, UriUtils } from "pli-language";
 import * as vscode from "vscode";
 import { BaseLanguageClient } from "vscode-languageclient";
-import { onRequest, sendNotification } from "./messages";
+import { sendNotification } from "./messages";
+import { Connection } from "vscode-languageserver";
 
 type ConfigKey = "pgm_conf" | "proc_grps";
 
-/**
- * Registers the LS-side handler for {@link Messages.GetGlobalConfig}.
- * Called once per language client (desktop + browser) so the LS can
- * fall back to VS Code settings when no `.pliplugin/` directory exists.
- *
- * `userSettingsUri` is the URI of the user-scope `settings.json` —
- * derived from {@link vscode.ExtensionContext.globalStorageUri} in the
- * caller, which is the only documented way to reach the user data
- * directory without platform-specific path math. (`vscode-userdata:/`
- * is unreliable on desktop and is NOT used here.)
- */
-export function registerConfigLoader(
-  client: BaseLanguageClient,
-  userSettingsUri: vscode.Uri,
-): void {
-  onRequest(client, Messages.GetGlobalConfig, (workspaceUri) => {
-    return getGlobalConfig(vscode.Uri.parse(workspaceUri), userSettingsUri);
-  });
+export class VscodeGlobalConfigLoader implements GlobalConfigLoader {
+  static register(client: BaseLanguageClient, context: vscode.ExtensionContext): void {
+    client.onRequest(Messages.GetUserSettingsUriRequest.method, async () => {
+      return deriveUserSettingsUri(context.globalStorageUri).toString();
+    });
+  }
+  constructor(private readonly connection: Connection) {}
+  async loadGlobalConfig(workspaceUri: vscode.Uri): Promise<Messages.GlobalConfig> {
+    const userSettingsUri = await sendRequest(this.connection, Messages.GetUserSettingsUriRequest, undefined);
+    return getGlobalConfig(workspaceUri, UriUtils.toUri(userSettingsUri));
+  }
 }
 
 /**
@@ -48,7 +42,7 @@ export function registerConfigLoader(
  * reference (etc.) squiggle inside the right `settings.json` or
  * `.code-workspace` file.
  */
-export async function getGlobalConfig(
+async function getGlobalConfig(
   workspaceUri: vscode.Uri,
   userSettingsUri: vscode.Uri,
 ): Promise<Messages.GlobalConfig> {

--- a/packages/vscode-extension/src/extension/config-loader.ts
+++ b/packages/vscode-extension/src/extension/config-loader.ts
@@ -31,9 +31,9 @@ export function registerConfigLoader(
   client: BaseLanguageClient,
   userSettingsUri: vscode.Uri,
 ): void {
-  onRequest(client, Messages.GetGlobalConfig, () =>
-    getGlobalConfig(userSettingsUri),
-  );
+  onRequest(client, Messages.GetGlobalConfig, (workspaceUri) => {
+    return getGlobalConfig(vscode.Uri.parse(workspaceUri), userSettingsUri);
+  });
 }
 
 /**
@@ -49,9 +49,10 @@ export function registerConfigLoader(
  * `.code-workspace` file.
  */
 export async function getGlobalConfig(
+  workspaceUri: vscode.Uri,
   userSettingsUri: vscode.Uri,
 ): Promise<Messages.GlobalConfig> {
-  const workspaceFolder = locateWorkspaceFolder(userSettingsUri);
+  const workspaceFolder = locateWorkspaceFolder(workspaceUri);
   const result: Messages.GlobalConfig = {};
   if (workspaceFolder) {
     const pgmConf = locate("pgm_conf", workspaceFolder, userSettingsUri);

--- a/packages/vscode-extension/src/extension/config-loader.ts
+++ b/packages/vscode-extension/src/extension/config-loader.ts
@@ -9,7 +9,7 @@
  *
  */
 
-import { Messages } from "pli-language";
+import { Messages, UriUtils } from "pli-language";
 import * as vscode from "vscode";
 import { BaseLanguageClient } from "vscode-languageclient";
 import { onRequest, sendNotification } from "./messages";
@@ -51,13 +51,12 @@ export function registerConfigLoader(
 export async function getGlobalConfig(
   userSettingsUri: vscode.Uri,
 ): Promise<Messages.GlobalConfig> {
-  // TODO: support multi-root workspaces here as well
-  const folder = vscode.workspace.workspaceFolders?.[0];
+  const workspaceFolder = locateWorkspaceFolder(userSettingsUri);
   const result: Messages.GlobalConfig = {};
-  if (folder) {
-    const pgmConf = locate("pgm_conf", folder, userSettingsUri);
+  if (workspaceFolder) {
+    const pgmConf = locate("pgm_conf", workspaceFolder, userSettingsUri);
     if (pgmConf) result.pgmConf = pgmConf;
-    const procGrps = locate("proc_grps", folder, userSettingsUri);
+    const procGrps = locate("proc_grps", workspaceFolder, userSettingsUri);
     if (procGrps) result.procGrps = procGrps;
   }
   return result;
@@ -65,7 +64,7 @@ export async function getGlobalConfig(
 
 function locate(
   key: ConfigKey,
-  folder: vscode.WorkspaceFolder,
+  folder: vscode.Uri,
   userSettingsUri: vscode.Uri,
 ): Messages.GlobalConfigEntry | undefined {
   const inspect = vscode.workspace.getConfiguration("pli", folder).inspect(key);
@@ -80,7 +79,7 @@ function locate(
     configKey: `pli.${key}`,
   });
   const vscodeSettingsUri = vscode.Uri.joinPath(
-    folder.uri,
+    folder,
     ".vscode",
     "settings.json",
   );
@@ -139,4 +138,26 @@ export function watchPluginSettings(
       );
     }
   });
+}
+
+export function locateWorkspaceFolder(
+  textEditorUri: vscode.Uri,
+): vscode.Uri | undefined {
+  const workspaceFolders = (vscode.workspace.workspaceFolders ?? []).map(
+    (folder) => folder.uri,
+  );
+  let workspaceFolderUri: vscode.Uri | undefined;
+
+  for (const folder of workspaceFolders) {
+    if (UriUtils.contains(folder, textEditorUri)) {
+      if (
+        !workspaceFolderUri ||
+        UriUtils.toNormalizedKey(folder).length >
+          UriUtils.toNormalizedKey(workspaceFolderUri).length
+      ) {
+        workspaceFolderUri = folder;
+      }
+    }
+  }
+  return workspaceFolderUri;
 }

--- a/packages/vscode-extension/src/extension/config-loader.ts
+++ b/packages/vscode-extension/src/extension/config-loader.ts
@@ -16,10 +16,19 @@ import { sendNotification } from "./messages";
 
 type ConfigKey = "pgm_conf" | "proc_grps";
 
-export function registerConfigLoader(client: BaseLanguageClient, context: vscode.ExtensionContext): vscode.Disposable {
-  return client.onRequest(Messages.GetGlobalConfig.method, async (workspaceUri) => {
-    return getGlobalConfig(UriUtils.toUri(workspaceUri), deriveUserSettingsUri(context.globalStorageUri));
-  });
+export function registerConfigLoader(
+  client: BaseLanguageClient,
+  context: vscode.ExtensionContext,
+): vscode.Disposable {
+  return client.onRequest(
+    Messages.GetGlobalConfig.method,
+    async (workspaceUri) => {
+      return getGlobalConfig(
+        UriUtils.toUri(workspaceUri),
+        deriveUserSettingsUri(context.globalStorageUri),
+      );
+    },
+  );
 }
 
 /**

--- a/packages/vscode-extension/src/extension/config-loader.ts
+++ b/packages/vscode-extension/src/extension/config-loader.ts
@@ -16,8 +16,8 @@ import { sendNotification } from "./messages";
 
 type ConfigKey = "pgm_conf" | "proc_grps";
 
-export function registerConfigLoader(client: BaseLanguageClient, context: vscode.ExtensionContext): void {
-  client.onRequest(Messages.GetGlobalConfig.method, async (workspaceUri) => {
+export function registerConfigLoader(client: BaseLanguageClient, context: vscode.ExtensionContext): vscode.Disposable {
+  return client.onRequest(Messages.GetGlobalConfig.method, async (workspaceUri) => {
     return getGlobalConfig(UriUtils.toUri(workspaceUri), deriveUserSettingsUri(context.globalStorageUri));
   });
 }
@@ -45,6 +45,17 @@ async function getGlobalConfig(
     if (pgmConf) result.pgmConf = pgmConf;
     const procGrps = locate("proc_grps", workspaceFolder, userSettingsUri);
     if (procGrps) result.procGrps = procGrps;
+  } else {
+    result.pgmConf = {
+      uri: userSettingsUri.toString(),
+      containerPath: [],
+      configKey: "pli.pgm_conf",
+    };
+    result.procGrps = {
+      uri: userSettingsUri.toString(),
+      containerPath: [],
+      configKey: "pli.proc_grps",
+    };
   }
   return result;
 }

--- a/packages/vscode-extension/src/extension/main-browser.ts
+++ b/packages/vscode-extension/src/extension/main-browser.ts
@@ -18,7 +18,7 @@ import { registerProgressReporter } from "./progress";
 import { registerCustomDecorators } from "./decorators";
 import { Settings } from "./settings";
 import {
-  VscodeGlobalConfigLoader,
+  registerConfigLoader,
   watchPluginSettings,
 } from "./config-loader";
 import { registerConfigFileSystem } from "./config-file-system";
@@ -67,7 +67,7 @@ async function startLanguageClient(
     watchPluginSettings(client),
   );
   registerFileSystemProvider(client);
-  VscodeGlobalConfigLoader.register(client, context);
+  registerConfigLoader(client, context);
   context.subscriptions.push(
     registerProgressReporter(client),
     registerCustomDecorators(client, settings),

--- a/packages/vscode-extension/src/extension/main-browser.ts
+++ b/packages/vscode-extension/src/extension/main-browser.ts
@@ -17,10 +17,7 @@ import { registerFileSystemProvider } from "./file-system-provider";
 import { registerProgressReporter } from "./progress";
 import { registerCustomDecorators } from "./decorators";
 import { Settings } from "./settings";
-import {
-  registerConfigLoader,
-  watchPluginSettings,
-} from "./config-loader";
+import { registerConfigLoader, watchPluginSettings } from "./config-loader";
 import { registerConfigFileSystem } from "./config-file-system";
 import { registerCommands } from "./commands";
 

--- a/packages/vscode-extension/src/extension/main-browser.ts
+++ b/packages/vscode-extension/src/extension/main-browser.ts
@@ -18,8 +18,7 @@ import { registerProgressReporter } from "./progress";
 import { registerCustomDecorators } from "./decorators";
 import { Settings } from "./settings";
 import {
-  deriveUserSettingsUri,
-  registerConfigLoader,
+  VscodeGlobalConfigLoader,
   watchPluginSettings,
 } from "./config-loader";
 import { registerConfigFileSystem } from "./config-file-system";
@@ -68,7 +67,7 @@ async function startLanguageClient(
     watchPluginSettings(client),
   );
   registerFileSystemProvider(client);
-  registerConfigLoader(client, deriveUserSettingsUri(context.globalStorageUri));
+  VscodeGlobalConfigLoader.register(client, context);
   context.subscriptions.push(
     registerProgressReporter(client),
     registerCustomDecorators(client, settings),

--- a/packages/vscode-extension/src/extension/main-browser.ts
+++ b/packages/vscode-extension/src/extension/main-browser.ts
@@ -67,8 +67,8 @@ async function startLanguageClient(
     watchPluginSettings(client),
   );
   registerFileSystemProvider(client);
-  registerConfigLoader(client, context);
   context.subscriptions.push(
+    registerConfigLoader(client, context),
     registerProgressReporter(client),
     registerCustomDecorators(client, settings),
   );

--- a/packages/vscode-extension/src/extension/main.ts
+++ b/packages/vscode-extension/src/extension/main.ts
@@ -27,7 +27,7 @@ import { registerFileSystemProvider } from "./file-system-provider";
 import { registerProgressReporter } from "./progress";
 import {
   locateWorkspaceFolder,
-  VscodeGlobalConfigLoader,
+  registerConfigLoader,
   watchPluginSettings,
 } from "./config-loader";
 import { registerConfigFileSystem } from "./config-file-system";
@@ -165,7 +165,7 @@ async function startLanguageClient(
 
   // Register custom connection message handlers.
   registerFileSystemProvider(client);
-  VscodeGlobalConfigLoader.register(client, context);
+  registerConfigLoader(client, context);
   context.subscriptions.push(
     client,
     registerProgressReporter(client),

--- a/packages/vscode-extension/src/extension/main.ts
+++ b/packages/vscode-extension/src/extension/main.ts
@@ -165,9 +165,9 @@ async function startLanguageClient(
 
   // Register custom connection message handlers.
   registerFileSystemProvider(client);
-  registerConfigLoader(client, context);
   context.subscriptions.push(
     client,
+    registerConfigLoader(client, context),
     registerProgressReporter(client),
     registerCustomDecorators(client, settings),
   );

--- a/packages/vscode-extension/src/extension/main.ts
+++ b/packages/vscode-extension/src/extension/main.ts
@@ -26,9 +26,8 @@ import { registerPliDocumentIdentifier } from "./document-identification";
 import { registerFileSystemProvider } from "./file-system-provider";
 import { registerProgressReporter } from "./progress";
 import {
-  deriveUserSettingsUri,
   locateWorkspaceFolder,
-  registerConfigLoader,
+  VscodeGlobalConfigLoader,
   watchPluginSettings,
 } from "./config-loader";
 import { registerConfigFileSystem } from "./config-file-system";
@@ -166,7 +165,7 @@ async function startLanguageClient(
 
   // Register custom connection message handlers.
   registerFileSystemProvider(client);
-  registerConfigLoader(client, deriveUserSettingsUri(context.globalStorageUri));
+  VscodeGlobalConfigLoader.register(client, context);
   context.subscriptions.push(
     client,
     registerProgressReporter(client),

--- a/packages/vscode-extension/src/extension/main.ts
+++ b/packages/vscode-extension/src/extension/main.ts
@@ -27,6 +27,7 @@ import { registerFileSystemProvider } from "./file-system-provider";
 import { registerProgressReporter } from "./progress";
 import {
   deriveUserSettingsUri,
+  locateWorkspaceFolder,
   registerConfigLoader,
   watchPluginSettings,
 } from "./config-loader";
@@ -78,13 +79,13 @@ function registerOnDidOpenTextDocListener(
   const listener = async (document: vscode.TextDocument) => {
     // settle on the 1st workspace folder available
     // TODO @montymxb May 15th, 2025: Support configs across multiple workspace folders
-    const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    const workspaceFolder = locateWorkspaceFolder(document.uri);
     if (!workspaceFolder) {
       return;
     }
 
     // check if we can create a .pliplugin folder
-    const plipluginPath = path.join(workspaceFolder, ".pliplugin");
+    const plipluginPath = path.join(workspaceFolder.fsPath, ".pliplugin");
     if (document.languageId !== "pli" || fs.existsSync(plipluginPath)) {
       // not a pli file or config already exists
       return;

--- a/packages/vscode-extension/src/extension/main.ts
+++ b/packages/vscode-extension/src/extension/main.ts
@@ -77,8 +77,6 @@ function registerOnDidOpenTextDocListener(
   telemetryReporter: TelemetryReporter | undefined,
 ) {
   const listener = async (document: vscode.TextDocument) => {
-    // settle on the 1st workspace folder available
-    // TODO @montymxb May 15th, 2025: Support configs across multiple workspace folders
     const workspaceFolder = locateWorkspaceFolder(document.uri);
     if (!workspaceFolder) {
       return;

--- a/packages/vscode-extension/src/language/config-loader.ts
+++ b/packages/vscode-extension/src/language/config-loader.ts
@@ -1,0 +1,9 @@
+import { GlobalConfigLoader, Messages, sendRequest, URI } from "pli-language";
+import { Connection } from "vscode-languageserver";
+
+export class VscodeGlobalConfigLoader implements GlobalConfigLoader {
+  constructor(private readonly connection: Connection) {}
+  async loadGlobalConfig(workspaceUri: URI): Promise<Messages.GlobalConfig> {
+    return await sendRequest(this.connection, Messages.GetGlobalConfig, workspaceUri.toString());
+  }
+}

--- a/packages/vscode-extension/src/language/config-loader.ts
+++ b/packages/vscode-extension/src/language/config-loader.ts
@@ -1,3 +1,13 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
 import { GlobalConfigLoader, Messages, sendRequest, URI } from "pli-language";
 import { Connection } from "vscode-languageserver";
 

--- a/packages/vscode-extension/src/language/config-loader.ts
+++ b/packages/vscode-extension/src/language/config-loader.ts
@@ -4,6 +4,10 @@ import { Connection } from "vscode-languageserver";
 export class VscodeGlobalConfigLoader implements GlobalConfigLoader {
   constructor(private readonly connection: Connection) {}
   async loadGlobalConfig(workspaceUri: URI): Promise<Messages.GlobalConfig> {
-    return await sendRequest(this.connection, Messages.GetGlobalConfig, workspaceUri.toString());
+    return await sendRequest(
+      this.connection,
+      Messages.GetGlobalConfig,
+      workspaceUri.toString(),
+    );
   }
 }

--- a/packages/vscode-extension/src/language/main-browser.ts
+++ b/packages/vscode-extension/src/language/main-browser.ts
@@ -16,6 +16,7 @@ import {
 } from "vscode-languageserver/browser.js";
 import { startLanguageServer } from "pli-language";
 import { VSCodeFileSystemProvider } from "./file-system";
+import { VscodeGlobalConfigLoader } from "../extension/config-loader";
 
 /* browser specific setup code */
 const messageReader = new BrowserMessageReader(self);
@@ -23,4 +24,6 @@ const messageWriter = new BrowserMessageWriter(self);
 
 const connection = createConnection(messageReader, messageWriter);
 
-startLanguageServer(connection, new VSCodeFileSystemProvider(connection));
+const globalConfigLoader = new VscodeGlobalConfigLoader(connection);
+
+startLanguageServer(connection, new VSCodeFileSystemProvider(connection), globalConfigLoader);

--- a/packages/vscode-extension/src/language/main-browser.ts
+++ b/packages/vscode-extension/src/language/main-browser.ts
@@ -26,4 +26,8 @@ const connection = createConnection(messageReader, messageWriter);
 
 const globalConfigLoader = new VscodeGlobalConfigLoader(connection);
 
-startLanguageServer(connection, new VSCodeFileSystemProvider(connection), globalConfigLoader);
+startLanguageServer(
+  connection,
+  new VSCodeFileSystemProvider(connection),
+  globalConfigLoader,
+);

--- a/packages/vscode-extension/src/language/main-browser.ts
+++ b/packages/vscode-extension/src/language/main-browser.ts
@@ -16,7 +16,7 @@ import {
 } from "vscode-languageserver/browser.js";
 import { startLanguageServer } from "pli-language";
 import { VSCodeFileSystemProvider } from "./file-system";
-import { VscodeGlobalConfigLoader } from "../extension/config-loader";
+import { VscodeGlobalConfigLoader } from "./config-loader";
 
 /* browser specific setup code */
 const messageReader = new BrowserMessageReader(self);

--- a/packages/vscode-extension/src/language/main.ts
+++ b/packages/vscode-extension/src/language/main.ts
@@ -146,4 +146,8 @@ class NodeFileSystemProvider extends VSCodeFileSystemProvider {
 
 const connection = createConnection(ProposedFeatures.all);
 const globalConfigLoader = new VscodeGlobalConfigLoader(connection);
-startLanguageServer(connection, new NodeFileSystemProvider(connection), globalConfigLoader);
+startLanguageServer(
+  connection,
+  new NodeFileSystemProvider(connection),
+  globalConfigLoader,
+);

--- a/packages/vscode-extension/src/language/main.ts
+++ b/packages/vscode-extension/src/language/main.ts
@@ -24,7 +24,7 @@ import * as fs from "fs";
 import * as glob from "glob";
 import { dirname, join } from "path";
 import { VSCodeFileSystemProvider } from "./file-system";
-import { VscodeGlobalConfigLoader } from "../extension/config-loader";
+import { VscodeGlobalConfigLoader } from "./config-loader";
 
 // Node-specific file system provider
 // This provider is used when running the language server in a Node environment

--- a/packages/vscode-extension/src/language/main.ts
+++ b/packages/vscode-extension/src/language/main.ts
@@ -24,6 +24,7 @@ import * as fs from "fs";
 import * as glob from "glob";
 import { dirname, join } from "path";
 import { VSCodeFileSystemProvider } from "./file-system";
+import { VscodeGlobalConfigLoader } from "../extension/config-loader";
 
 // Node-specific file system provider
 // This provider is used when running the language server in a Node environment
@@ -144,4 +145,5 @@ class NodeFileSystemProvider extends VSCodeFileSystemProvider {
 }
 
 const connection = createConnection(ProposedFeatures.all);
-startLanguageServer(connection, new NodeFileSystemProvider(connection));
+const globalConfigLoader = new VscodeGlobalConfigLoader(connection);
+startLanguageServer(connection, new NodeFileSystemProvider(connection), globalConfigLoader);


### PR DESCRIPTION
### Done

* introducing multiple `WorkspaceContexts` under `CompilationUnitHandler`
* each `WorkspaceContext` manages its `CompilationUnits`
* `CompilationUnitHandler` is the place to initialize new workspaces
* getting the right `CompilationUnit` is still hidden by `CompilationUnitHandler` which delegates to the specific `WorkspaceContext`
* it is actually very simple :-)
* missing configuration is handled apart from this mechanism
* quick fixes reach out to the specific `WorkspaceContext`

### TODO for further PRs

- lazy loading of libs
- automatically test features like this