### PR TITLE
Add cics compiler options

### DIFF
--- a/packages/language/src/preprocessor/compiler-options/codes.ts
+++ b/packages/language/src/preprocessor/compiler-options/codes.ts
@@ -1226,4 +1226,39 @@ export const CompilerOptionsCodes = {
       },
     },
   },
+
+  PPCICS: {
+    Flag: {
+      InvalidParameter: {
+        code: "COPPICS01",
+        severity: Severity.E,
+        message: (value: string) =>
+          `Expected "I", "W", "E" or "S", but received '${value}'.`,
+      },
+    },
+
+    NatLang: {
+      InvalidParameter: {
+        code: "COPPICS02",
+        severity: Severity.E,
+        message: (value: string) =>
+          `Expected "EN" or "KA", but received '${value}'.`,
+      },
+    },
+
+    Margins: {
+      InvalidMarginPosition: {
+        code: "COPPICS03",
+        severity: Severity.E,
+        message: () => `The left margin must be less than the right margin.`,
+      },
+
+      InvalidAnsPosition: {
+        code: "COPPICS04",
+        severity: Severity.E,
+        message: () =>
+          `The ANS character should be located outside of the values specified by m and n.`,
+      },
+    },
+  },
 };

--- a/packages/language/src/preprocessor/compiler-options/options-cics.ts
+++ b/packages/language/src/preprocessor/compiler-options/options-cics.ts
@@ -1,0 +1,87 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+export interface CompilerOptions {
+  cics?: boolean;
+  cpsm?: boolean;
+  debug?: boolean;
+  dli?: boolean;
+  edf?: boolean;
+  exci?: boolean;
+  fepi?: boolean;
+  flag?: CompilerOptions.Flag;
+  graphic?: boolean;
+  length?: boolean;
+  lineCount?: number;
+  margins?: CompilerOptions.Margins;
+  natLang?: CompilerOptions.NatLang;
+  opMargins?: CompilerOptions.Margins;
+  opSequence?: CompilerOptions.Sequence | false;
+  options?: boolean;
+  sequence?: CompilerOptions.Sequence | false;
+  source?: boolean;
+  sp?: boolean;
+  spie?: boolean;
+  sysEib?: boolean;
+  vbref?: boolean;
+}
+
+export namespace CompilerOptions {
+  export enum Flag {
+    I,
+    W,
+    E,
+    S,
+  }
+
+  export enum NatLang {
+    EN,
+    KA,
+  }
+
+  export interface Margins {
+    m: number;
+    n: number;
+    c?: number;
+  }
+
+  export interface Sequence {
+    m: number;
+    n: number;
+  }
+}
+
+export function getDefaultCompilerOptions(): CompilerOptions {
+  return {
+    cics: true,
+    cpsm: false,
+    debug: true,
+    dli: false,
+    edf: true,
+    exci: false,
+    fepi: false,
+    flag: CompilerOptions.Flag.W,
+    graphic: false,
+    length: true,
+    lineCount: 60,
+    margins: { m: 2, n: 72, c: 0 },
+    natLang: CompilerOptions.NatLang.EN,
+    opMargins: { m: 2, n: 72, c: 0 },
+    opSequence: { m: 73, n: 80 },
+    options: true,
+    sequence: { m: 73, n: 80 },
+    source: true,
+    sp: false,
+    spie: true,
+    sysEib: false,
+    vbref: false,
+  };
+}

--- a/packages/language/src/preprocessor/compiler-options/options-pli.ts
+++ b/packages/language/src/preprocessor/compiler-options/options-pli.ts
@@ -391,7 +391,7 @@ export interface CompilerOptions {
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-ppcics
    */
-  ppCics?: string | false;
+  ppCics?: CompilerOptions.PPValue | false;
   /**
    * https://www.ibm.com/docs/en/epfz/6.1?topic=descriptions-ppinclude
    */

--- a/packages/language/src/preprocessor/compiler-options/options.ts
+++ b/packages/language/src/preprocessor/compiler-options/options.ts
@@ -14,16 +14,19 @@ import { Token } from "../../parser/tokens";
 import * as Pli from "./options-pli";
 import * as Macro from "./options-macro";
 import * as SQL from "./options-sql";
+import * as CICS from "./options-cics";
 import { NOT_CHARACTER } from "../../utils/const";
 
 export type CompilerOptionsPP =
   | Pli.CompilerOptions
   | Macro.CompilerOptions
-  | SQL.CompilerOptions;
+  | SQL.CompilerOptions
+  | CICS.CompilerOptions;
 
 export interface CompilerOptions extends Pli.CompilerOptions {
   macroOptions: Macro.CompilerOptions;
   sqlOptions: SQL.CompilerOptions;
+  cicsOptions: CICS.CompilerOptions;
 }
 
 export interface CompilerOptionResult {
@@ -111,5 +114,6 @@ export function getDefaultCompilerOptions(): CompilerOptions {
     ...Pli.getDefaultCompilerOptions(),
     macroOptions: Macro.getDefaultCompilerOptions(),
     sqlOptions: SQL.getDefaultCompilerOptions(),
+    cicsOptions: CICS.getDefaultCompilerOptions(),
   };
 }

--- a/packages/language/src/preprocessor/compiler-options/translate.ts
+++ b/packages/language/src/preprocessor/compiler-options/translate.ts
@@ -22,12 +22,14 @@ import { CompilerOption, SyntaxKind } from "../../syntax-tree/ast";
 import { getTranslator as getTranslatorPLI } from "./translator-pli";
 import { getTranslator as getTranslatorMacro } from "./translator-macro";
 import { getTranslator as getTranslatorSQL } from "./translator-sql";
+import { getTranslator as getTranslatorCICS } from "./translator-cics";
 import {
   CompilerOptions,
   CompilerOptions as CompilerOptionsPLI,
 } from "./options-pli";
 import { CompilerOptions as CompilerOptionsMacro } from "./options-macro";
 import { CompilerOptions as CompilerOptionsSQL } from "./options-sql";
+import { CompilerOptions as CompilerOptionsCICS } from "./options-cics";
 import {
   CompilerOptionSource,
   RuleConfiguration,
@@ -44,6 +46,7 @@ export class CompilerOptionTranslator {
   protected translator = getTranslatorPLI();
   protected translatorMacro = getTranslatorMacro();
   protected translatorSQL = getTranslatorSQL();
+  protected translatorCICS = getTranslatorCICS();
 
   protected result: CompilerOptionResult = {
     options: getDefaultCompilerOptions(),
@@ -84,11 +87,18 @@ export class CompilerOptionTranslator {
       this.translator.options.ppSql,
       configuration,
     );
+    this.parseNestedOptions(
+      this.translatorCICS,
+      CompilerOptions.PPItemName.CICS,
+      this.translator.options.ppCics,
+      configuration,
+    );
 
     this.result.options = {
       ...(this.translator.options as CompilerOptionsPLI),
       macroOptions: this.translatorMacro.options as CompilerOptionsMacro,
       sqlOptions: this.translatorSQL.options as CompilerOptionsSQL,
+      cicsOptions: this.translatorCICS.options as CompilerOptionsCICS,
     };
     if (configuration?.source === CompilerOptionSource.SOURCE_FILE) {
       this.result.tokens.push(...input.tokens);
@@ -99,17 +109,20 @@ export class CompilerOptionTranslator {
         ...this.translator.diagnostics,
         ...this.translatorMacro.diagnostics,
         ...this.translatorSQL.diagnostics,
+        ...this.translatorCICS.diagnostics,
       ]),
     );
     this.translator.clearIssues();
     this.translatorMacro.clearIssues();
     this.translatorSQL.clearIssues();
+    this.translatorCICS.clearIssues();
   }
 
   clear(): void {
     this.translator.clear();
     this.translatorMacro.clear();
     this.translatorSQL.clear();
+    this.translatorCICS.clear();
     this.result = {
       options: getDefaultCompilerOptions(),
       tokens: [],
@@ -124,13 +137,14 @@ export class CompilerOptionTranslator {
 
   /**
    * Returns a stable fingerprint of all forceRecompile-flagged rules and their arguments
-   * across PLI, Macro, and SQL translators. Used to invalidate InstructionCache.
+   * across PLI, Macro, SQL, and CICS translators. Used to invalidate InstructionCache.
    */
   getRecompileFingerprint(): string {
     return [
       this.translator.getRecompileFingerprint(),
       this.translatorMacro.getRecompileFingerprint("MACRO"),
       this.translatorSQL.getRecompileFingerprint("SQL"),
+      this.translatorCICS.getRecompileFingerprint("CICS"),
     ].join("\n--\n");
   }
 

--- a/packages/language/src/preprocessor/compiler-options/translator-cics.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator-cics.ts
@@ -1,0 +1,228 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { diagnosticFromCode } from "../../language-server/types";
+import { CompilerOptionsCodes } from "./codes";
+import { CompilerOptions, getDefaultCompilerOptions } from "./options-cics";
+import {
+  ensureArguments,
+  ensureEnum,
+  ensureNumberValue,
+  ensureType,
+  Translator,
+} from "./translator";
+
+const translator = new Translator<CompilerOptions>(() =>
+  getDefaultCompilerOptions(),
+);
+
+/** {@link CompilerOptions.cics} */
+translator.rule(["CICS"], (option, options) => {
+  ensureArguments(option, 0, 0);
+  options.cics = true;
+});
+
+translator.flag("cpsm", ["CPSM"], ["NOCPSM"]);
+
+translator.flag("debug", ["DEBUG"], ["NODEBUG"]);
+
+/** {@link CompilerOptions.dli} */
+translator.rule(["DLI"], (option, options) => {
+  ensureArguments(option, 0, 0);
+  options.dli = true;
+});
+
+translator.flag("edf", ["EDF"], ["NOEDF"]);
+
+/** {@link CompilerOptions.exci} */
+translator.rule(["EXCI"], (option, options) => {
+  ensureArguments(option, 0, 0);
+  options.exci = true;
+});
+
+translator.flag("fepi", ["FEPI"], ["NOFEPI"]);
+
+/** {@link CompilerOptions.flag} */
+translator.rule(["FLAG", "F"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "plainNotEmpty");
+  options.flag = ensureEnum(
+    value,
+    CompilerOptionsCodes.PPCICS.Flag.InvalidParameter,
+    CompilerOptions.Flag,
+  );
+});
+
+/** {@link CompilerOptions.graphic} */
+translator.flag("graphic", ["GRAPHIC"], ["NOGRAPHIC"], undefined, {
+  recompile: true,
+});
+
+translator.flag("length", ["LENGTH"], ["NOLENGTH"]);
+
+/** {@link CompilerOptions.lineCount} */
+translator.rule(["LINECOUNT", "LC"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "plainNotEmpty");
+  options.lineCount = ensureNumberValue(value, 1, 255);
+});
+
+/** {@link CompilerOptions.margins} */
+translator.rule(
+  ["MARGINS", "MAR"],
+  (option, options) => {
+    ensureArguments(option, 2, 3);
+    const m = option.values[0];
+    const n = option.values[1];
+    ensureType(m, "plainNotEmpty");
+    ensureType(n, "plainNotEmpty");
+    const mValue = ensureNumberValue(m, 1, 100);
+    const nValue = ensureNumberValue(n, 1, 100);
+    if (mValue >= nValue) {
+      throw diagnosticFromCode(
+        CompilerOptionsCodes.PPCICS.Margins.InvalidMarginPosition,
+        m.token,
+      );
+    }
+    let cValue = 0;
+    if (option.values.length > 2) {
+      const c = option.values[2];
+      ensureType(c, "plainNotEmpty");
+      cValue = ensureNumberValue(c, 0, 100);
+      if (cValue >= mValue && cValue <= nValue) {
+        throw diagnosticFromCode(
+          CompilerOptionsCodes.PPCICS.Margins.InvalidAnsPosition,
+          c.token,
+        );
+      }
+    }
+    options.margins = { m: mValue, n: nValue, c: cValue };
+  },
+  undefined,
+  undefined,
+  { recompile: true },
+);
+
+/** {@link CompilerOptions.natLang} */
+translator.rule(["NATLANG"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "plainNotEmpty");
+  options.natLang = ensureEnum(
+    value,
+    CompilerOptionsCodes.PPCICS.NatLang.InvalidParameter,
+    CompilerOptions.NatLang,
+  );
+});
+
+/** {@link CompilerOptions.opMargins} */
+translator.rule(
+  ["OPMARGINS", "OM"],
+  (option, options) => {
+    ensureArguments(option, 2, 3);
+    const m = option.values[0];
+    const n = option.values[1];
+    ensureType(m, "plainNotEmpty");
+    ensureType(n, "plainNotEmpty");
+    const mValue = ensureNumberValue(m, 1, 80);
+    const nValue = ensureNumberValue(n, 1, 80);
+    if (mValue >= nValue) {
+      throw diagnosticFromCode(
+        CompilerOptionsCodes.PPCICS.Margins.InvalidMarginPosition,
+        m.token,
+      );
+    }
+    let cValue = 0;
+    if (option.values.length > 2) {
+      const c = option.values[2];
+      ensureType(c, "plainNotEmpty");
+      cValue = ensureNumberValue(c, 0, 80);
+      if (cValue >= mValue && cValue <= nValue) {
+        throw diagnosticFromCode(
+          CompilerOptionsCodes.PPCICS.Margins.InvalidAnsPosition,
+          c.token,
+        );
+      }
+    }
+    options.opMargins = { m: mValue, n: nValue, c: cValue };
+  },
+  undefined,
+  undefined,
+  { recompile: true },
+);
+
+/** {@link CompilerOptions.opSequence} */
+translator.rule(
+  ["OPSEQUENCE", "OS"],
+  (option, options) => {
+    ensureArguments(option, 2, 2);
+    const m = option.values[0];
+    const n = option.values[1];
+    ensureType(m, "plainNotEmpty");
+    ensureType(n, "plainNotEmpty");
+    const mValue = ensureNumberValue(m, 1, 100);
+    const nValue = ensureNumberValue(n, 1, 100);
+    options.opSequence = { m: mValue, n: nValue };
+  },
+  ["NOOPSEQUENCE", "NOS"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.opSequence = false;
+  },
+  { recompile: true },
+);
+
+translator.flag("options", ["OPTIONS", "OP"], ["NOOPTIONS", "NOP"]);
+
+/** {@link CompilerOptions.sequence} */
+translator.rule(
+  ["SEQUENCE", "SEQ"],
+  (option, options) => {
+    ensureArguments(option, 2, 2);
+    const m = option.values[0];
+    const n = option.values[1];
+    ensureType(m, "plainNotEmpty");
+    ensureType(n, "plainNotEmpty");
+    const mValue = ensureNumberValue(m, 1, 100);
+    const nValue = ensureNumberValue(n, 1, 100);
+    options.sequence = { m: mValue, n: nValue };
+  },
+  ["NOSEQUENCE", "NSEQ"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.sequence = false;
+  },
+  { recompile: true },
+);
+
+translator.flag("source", ["SOURCE"], ["NOSOURCE"]);
+
+/** {@link CompilerOptions.sp} */
+translator.rule(["SP"], (option, options) => {
+  ensureArguments(option, 0, 0);
+  options.sp = true;
+});
+
+translator.flag("spie", ["SPIE"], ["NOSPIE"]);
+
+/** {@link CompilerOptions.sysEib} */
+translator.rule(["SYSEIB"], (option, options) => {
+  ensureArguments(option, 0, 0);
+  options.sysEib = true;
+});
+
+translator.flag("vbref", ["VBREF", "XREF"], ["NOVBREF", "NOXREF"]);
+
+export function getTranslator(): Translator<CompilerOptions> {
+  return translator;
+}

--- a/packages/language/src/preprocessor/compiler-options/translator-pli.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator-pli.ts
@@ -2329,7 +2329,10 @@ translator.rule(
     ensureArguments(option, 1, 1);
     const value = option.values[0];
     ensureType(value, "string");
-    options.ppCics = value.value;
+    options.ppCics = {
+      value: value.value,
+      token: value.token,
+    };
   },
   ["NOPPCICS"],
   (option, options) => {

--- a/packages/language/test/fourslash-harness/harness-interface.ts
+++ b/packages/language/test/fourslash-harness/harness-interface.ts
@@ -15,6 +15,7 @@ import { CompilerOptionsCodes } from "../../src/preprocessor/compiler-options/co
 import { CompilerOptions as PliCompilerOptions } from "../../src/preprocessor/compiler-options/options-pli";
 import { CompilerOptions as MacroCompilerOptions } from "../../src/preprocessor/compiler-options/options-macro";
 import { CompilerOptions as SQLCompilerOptions } from "../../src/preprocessor/compiler-options/options-sql";
+import { CompilerOptions as CICSCompilerOptions } from "../../src/preprocessor/compiler-options/options-cics";
 import { PliMarginsProcessor } from "../../src/preprocessor/pli-margins-processor";
 import { DefaultAttribute, SyntaxKind } from "../../src/syntax-tree/ast";
 import {
@@ -67,6 +68,7 @@ export type SemanticTokenModifiersValues =
 export type CompilerOptions = PliCompilerOptions & {
   macroOptions: MacroCompilerOptions;
   sqlOptions: SQLCompilerOptions;
+  cicsOptions: CICSCompilerOptions;
 };
 
 export type Not<T> = Omit<T, "not">;
@@ -442,6 +444,7 @@ export interface HarnessTesterInterface {
     CompilerOptions: typeof PliCompilerOptions & {
       Macro: typeof MacroCompilerOptions;
       SQL: typeof SQLCompilerOptions;
+      CICS: typeof CICSCompilerOptions;
     };
   };
 }

--- a/packages/language/test/fourslash-harness/implementation/constants.ts
+++ b/packages/language/test/fourslash-harness/implementation/constants.ts
@@ -16,6 +16,7 @@ import { DefaultAttribute } from "../../../src/syntax-tree/ast";
 import { CompilerOptions as PliCompilerOptions } from "../../../src/preprocessor/compiler-options/options-pli";
 import { CompilerOptions as MacroCompilerOptions } from "../../../src/preprocessor/compiler-options/options-macro";
 import { CompilerOptions as SQLCompilerOptions } from "../../../src/preprocessor/compiler-options/options-sql";
+import { CompilerOptions as CICSCompilerOptions } from "../../../src/preprocessor/compiler-options/options-cics";
 
 export const HarnessConstants: HarnessTesterInterface["constants"] = {
   CompletionKeywords,
@@ -24,5 +25,6 @@ export const HarnessConstants: HarnessTesterInterface["constants"] = {
   CompilerOptions: Object.assign(PliCompilerOptions, {
     Macro: MacroCompilerOptions,
     SQL: SQLCompilerOptions,
+    CICS: CICSCompilerOptions,
   }),
 };

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-cics/cpsm.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-cics/cpsm.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(CICS("CPSM"));
+
+verify.expectCompilerOptions({
+  cicsOptions: {
+    cpsm: true,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-cics/flag.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-cics/flag.ts
@@ -1,0 +1,26 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(CICS("FLAG(<|1:X|>)"));
+////*PROCESS PP(CICS("FLAG(S)"));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.PPCICS.Flag.InvalidParameter.message("X"),
+});
+
+verify.expectCompilerOptions({
+  cicsOptions: {
+    flag: constants.CompilerOptions.CICS.Flag.S,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-cics/flags.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-cics/flags.ts
@@ -1,0 +1,35 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(CICS("NODEBUG"));
+////*PROCESS PP(CICS("NOEDF"));
+////*PROCESS PP(CICS("NOLENGTH"));
+////*PROCESS PP(CICS("NOOPTIONS"));
+////*PROCESS PP(CICS("NOSOURCE"));
+////*PROCESS PP(CICS("NOSPIE"));
+////*PROCESS PP(CICS("XREF"));
+
+verify.noDiagnostics();
+
+verify.expectCompilerOptions({
+  cicsOptions: {
+    debug: false,
+    edf: false,
+    length: false,
+    options: false,
+    source: false,
+    spie: false,
+    vbref: true,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-cics/linecount.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-cics/linecount.ts
@@ -1,0 +1,30 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(CICS("LINECOUNT(<|1:INVALID|>)"));
+////*PROCESS PP(CICS("LINECOUNT(<|2:0|>)"));
+////*PROCESS PP(CICS("LC(120)"));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedNumber.message(),
+});
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.ExpectedNumberRange.message(0, 1, 255),
+});
+
+verify.expectCompilerOptions({
+  cicsOptions: {
+    lineCount: 120,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-cics/margins.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-cics/margins.ts
@@ -1,0 +1,34 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(CICS("MARGINS(<|1:80|>, 4)"));
+////*PROCESS PP(CICS("MARGINS(2, 80, <|2:10|>)"));
+////*PROCESS PP(CICS("MAR(10, 90, 0)"));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.PPCICS.Margins.InvalidMarginPosition.message(),
+});
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.PPCICS.Margins.InvalidAnsPosition.message(),
+});
+
+verify.expectCompilerOptions({
+  cicsOptions: {
+    margins: {
+      m: 10,
+      n: 90,
+      c: 0,
+    },
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-cics/natlang.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-cics/natlang.ts
@@ -1,0 +1,27 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(CICS("NATLANG(<|1:INVALID|>)"));
+////*PROCESS PP(CICS("NATLANG(KA)"));
+
+verify.expectDiagnosticsAt(1, {
+  message:
+    code.CompilerOptions.PPCICS.NatLang.InvalidParameter.message("INVALID"),
+});
+
+verify.expectCompilerOptions({
+  cicsOptions: {
+    natLang: constants.CompilerOptions.CICS.NatLang.KA,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-cics/opmargins.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-cics/opmargins.ts
@@ -1,0 +1,30 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(CICS("OPMARGINS(<|1:90|>, 4)"));
+////*PROCESS PP(CICS("OM(4, 72, 0)"));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedNumberRange.message(90, 1, 80),
+});
+
+verify.expectCompilerOptions({
+  cicsOptions: {
+    opMargins: {
+      m: 4,
+      n: 72,
+      c: 0,
+    },
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-cics/opsequence.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-cics/opsequence.ts
@@ -1,0 +1,26 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(CICS("OS(73, 80)"));
+////*PROCESS PP(CICS("<|1:NOS|>"));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.MutexOptionIssue.message("NOS"),
+});
+
+verify.expectCompilerOptions({
+  cicsOptions: {
+    opSequence: false,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-cics/ppcics.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-cics/ppcics.ts
@@ -1,0 +1,34 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS <|1:PPCICS|>;
+////*PROCESS <|2:PPCICS|>(<|3:)|>;
+////*PROCESS <|4:PPCICS|>(<|5:INVALID|>);
+////*PROCESS <|6:PPCICS|>('CPSM');
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.InvalidParameterCount.message(0, 1, 1),
+});
+verify.expectDiagnosticsAt([2, 4, 6], {
+  message: code.CompilerOptions.DupeOptionIssue.message("PPCICS"),
+});
+verify.expectDiagnosticsAt([3, 5], {
+  message: code.CompilerOptions.ExpectedString.message(),
+});
+
+verify.expectCompilerOptions({
+  cicsOptions: {
+    cpsm: true,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-cics/presence-only.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-cics/presence-only.ts
@@ -1,0 +1,29 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(CICS("DLI"));
+////*PROCESS PP(CICS("EXCI"));
+////*PROCESS PP(CICS("SP"));
+////*PROCESS PP(CICS("SYSEIB"));
+
+verify.noDiagnostics();
+
+verify.expectCompilerOptions({
+  cicsOptions: {
+    dli: true,
+    exci: true,
+    sp: true,
+    sysEib: true,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-cics/sequence.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-cics/sequence.ts
@@ -1,0 +1,26 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(CICS("SEQ(1, 8)"));
+////*PROCESS PP(CICS("<|1:NSEQ|>"));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.MutexOptionIssue.message("NSEQ"),
+});
+
+verify.expectCompilerOptions({
+  cicsOptions: {
+    sequence: false,
+  },
+});


### PR DESCRIPTION
Closes https://github.com/zowe/zowe-pli-language-support/issues/774

Implements the cicsOptions model (options-cics.ts + translator-cics.ts), covering all PL/I-applicable CICS translator options:

- Boolean flags (on/off pairs): CPSM/NOCPSM, DEBUG/NODEBUG, EDF/NOEDF, FEPI/NOFEPI, GRAPHIC/NOGRAPHIC, LENGTH/NOLENGTH, OPTIONS/NOOPTIONS (OP/NOP), SOURCE/NOSOURCE, SPIE/NOSPIE, VBREF/NOVBREF (legacy XREF/NOXREF aliases)
- Presence-only flags: CICS, DLI, EXCI, SP, SYSEIB
- Enums: FLAG(I|W|E|S), NATLANG(EN|KA)
- Numeric: LINECOUNT(n) (1–255)
- Margin/sequence structures: MARGINS/OPMARGINS, SEQUENCE/OPSEQUENCE 

Note that cross-option mutual exclusivity, as also valid for CICS in the presence-only flags, are deferred to a later PR solving https://github.com/zowe/zowe-pli-language-support/issues/780.