### PR TITLE
Fix various parser issues

### DIFF
--- a/packages/language/src/language-server/semantic-tokens.ts
+++ b/packages/language/src/language-server/semantic-tokens.ts
@@ -258,11 +258,6 @@ function getReferenceTarget(token: Token): SyntaxNode | undefined {
         return token.element.ref?.node ?? undefined;
       }
       break;
-    case CstNodeKind.LabelReference_LabelRef:
-      if (token.element?.kind === SyntaxKind.LabelReference) {
-        return token.element.label?.node ?? undefined;
-      }
-      break;
     case CstNodeKind.TypeAttribute_TypeId0:
     case CstNodeKind.TypeAttribute_TypeId1:
       if (token.element?.kind === SyntaxKind.TypeAttribute) {
@@ -325,7 +320,6 @@ function isVariableType(token: Token): boolean {
     case CstNodeKind.TypeAttribute_TypeId1:
     case CstNodeKind.HandleAttribute_TypeId0:
     case CstNodeKind.HandleAttribute_TypeId1:
-    case CstNodeKind.LabelReference_LabelRef:
     case CstNodeKind.IncludeItem_FileID:
     case CstNodeKind.IncludeItem_MemberID:
     case CstNodeKind.SqlHostVariableReference_HostVariable:

--- a/packages/language/src/linking/tokens.ts
+++ b/packages/language/src/linking/tokens.ts
@@ -60,7 +60,6 @@ export function isReferenceToken(kind: CstNodeKind | undefined): boolean {
     case CstNodeKind.TypeAttribute_TypeId1:
     case CstNodeKind.HandleAttribute_TypeId0:
     case CstNodeKind.HandleAttribute_TypeId1:
-    case CstNodeKind.LabelReference_LabelRef:
     case CstNodeKind.ReferenceItem_Ref:
     case CstNodeKind.Exports_Procedure:
     case CstNodeKind.ProcedureParameter_Id:
@@ -92,8 +91,6 @@ export function getReference(node: SyntaxNode): Reference | undefined {
       return node.ref ?? undefined;
     case SyntaxKind.HandleAttribute:
       return node.type ?? undefined;
-    case SyntaxKind.LabelReference:
-      return node.label ?? undefined;
     case SyntaxKind.ReferenceItem:
       return node.ref ?? undefined;
     case SyntaxKind.TypeAttribute:

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -1085,19 +1085,26 @@ const attachStatement = rule(
 
     state.consume(element, CstNodeKind.AttachStatement_ATTACH, tokens.ATTACH);
     element.reference = locatorCall.rule(state);
-    state.consume(element, CstNodeKind.AttachStatement_THREAD, tokens.THREAD);
-    state.consume(
-      element,
-      CstNodeKind.AttachStatement_OpenParenTask,
-      tokens.OpenParen,
-    );
-    element.task = locatorCall.rule(state);
-    state.consume(
-      element,
-      CstNodeKind.AttachStatement_CloseParenTask,
-      tokens.CloseParen,
-    );
-
+    // Optional THREAD clause
+    if (
+      state.tryConsume(
+        element,
+        CstNodeKind.AttachStatement_THREAD,
+        tokens.THREAD,
+      )
+    ) {
+      state.consume(
+        element,
+        CstNodeKind.AttachStatement_OpenParenTask,
+        tokens.OpenParen,
+      );
+      element.task = locatorCall.rule(state);
+      state.consume(
+        element,
+        CstNodeKind.AttachStatement_CloseParenTask,
+        tokens.CloseParen,
+      );
+    }
     // Optional ENVIRONMENT clause
     if (
       state.tryConsume(
@@ -3267,7 +3274,7 @@ const genericReference = rule(
         tokens.OpenParen,
       );
 
-      if (state.canConsumeFirst(genericDescriptor.first())) {
+      while (state.canConsumeFirst(genericDescriptor.first())) {
         const descr = genericDescriptor.rule(state);
         descr && element.descriptors.push(descr);
       }
@@ -5933,11 +5940,20 @@ const entryAttribute = rule(
         tokens.OpenParen,
       )
     ) {
+      const startsWithComma = state.canConsume(tokens.Comma);
       // DISCREPANCY: The language spec says that the parameter list cannot be empty
       // But the compiler seems to allow it, so we do the same here
-      if (state.canConsumeFirst(entryDescription.first())) {
-        const lhs = entryDescription.rule(state);
-        lhs && element.attributes.push(lhs);
+      if (startsWithComma || state.canConsumeFirst(entryDescription.first())) {
+        // DISCREPANCY: The language spec says that the attribute cannot be empty
+        // But the compiler accepts an empty attribute as a * (wildcard).
+        if (startsWithComma) {
+          const emptyAttribute = ast.createEntryParameterDescription();
+          emptyAttribute.star = true;
+          element.attributes.push(emptyAttribute);
+        } else {
+          const lhs = entryDescription.rule(state);
+          lhs && element.attributes.push(lhs);
+        }
 
         const { inc } = state.createLoopContext("EntryAttribute 2");
         while (
@@ -5948,6 +5964,17 @@ const entryAttribute = rule(
           )
         ) {
           inc();
+          const emptyAttribute = ast.createEntryParameterDescription();
+          emptyAttribute.star = true;
+          if (state.canConsume(tokens.CloseParen)) {
+            // Empty attribute at the end, e.g., ENTRY(A,B,)
+            element.attributes.push(emptyAttribute);
+            break;
+          } else if (state.canConsume(tokens.Comma)) {
+            // Empty attribute between commas, e.g., ENTRY(A,,B)
+            element.attributes.push(emptyAttribute);
+            continue;
+          }
           const rhs = entryDescription.rule(state);
           rhs && element.attributes.push(rhs);
         }
@@ -6358,7 +6385,13 @@ const parenthesizedExpression = rule(
     );
 
     // See documentation of RepeatedExpression for details on this syntax
-    if (params.init && repeatedExpressionLookahead(state)) {
+    if (
+      (params.init && repeatedExpressionLookahead(state)) ||
+      // Even if not within an INITIAL attribute, we still allow repeated expressions
+      // for constant values (strings and numbers)
+      state.canConsume(tokens.STRING_TERM) ||
+      state.canConsume(tokens.NUMBER)
+    ) {
       const repeated = expression.rule(state, params);
       if (repeated !== null) {
         const repeatedExpr = ast.createRepeatedExpression();
@@ -6480,20 +6513,7 @@ const labelReference = rule(
   sequence(tokens.ID),
   (state: ParserState): ast.LabelReference => {
     const element = ast.createLabelReference();
-
-    const idToken = state.consume(
-      element,
-      CstNodeKind.LabelReference_LabelRef,
-      tokens.ID,
-    );
-    if (idToken) {
-      element.label = ast.createReference(
-        element,
-        idToken,
-        ast.ReferenceType.Variable,
-      );
-    }
-
+    element.label = memberCall.rule(state, ast.ReferenceType.Variable);
     return element;
   },
 );

--- a/packages/language/src/parser/preprocessor-parser.ts
+++ b/packages/language/src/parser/preprocessor-parser.ts
@@ -670,16 +670,7 @@ function goToStatement(state: ParserState): ast.GoToStatement {
 
 function labelReference(state: ParserState): ast.LabelReference {
   const reference = ast.createLabelReference();
-  const label = state.consume(
-    reference,
-    CstNodeKind.LabelReference_LabelRef,
-    t.ID,
-  );
-  reference.label = ast.createReference(
-    reference,
-    label,
-    ast.ReferenceType.Variable,
-  );
+  reference.label = memberCall(state, true);
   return reference;
 }
 
@@ -783,12 +774,29 @@ function includeStatement(state: ParserState): ast.IncludeDirective {
         item.memberName = ddnameOrMember;
         item.token = nextIdToken;
       }
+    } else if (
+      state.tryConsume(item, CstNodeKind.IncludeItem_OpenParen, t.OpenParen)
+    ) {
+      // DISCREPANCY: The compiler also accepts (ID) here (with parenthesis)
+      item = ast.createIncludeItemMember();
+      const memberToken = state.consume(
+        item,
+        CstNodeKind.IncludeItem_MemberID,
+        t.ID,
+      );
+      if (memberToken) {
+        range = tokenToRange(memberToken);
+        item.memberName = memberToken?.image ?? null;
+        item.token = memberToken;
+      } else {
+        parseError = true;
+      }
+      state.consume(item, CstNodeKind.IncludeItem_CloseParen, t.CloseParen);
+      if (parseError) {
+        break;
+      }
     } else {
       item = ast.createIncludeItemFile();
-      for (const idToken of idTokens) {
-        idToken.element = item;
-      }
-
       // direct file include, not a member (from string)
       const stringToken = state.tryConsume(
         item,
@@ -881,16 +889,7 @@ function endStatement(
   if (state.canConsume(t.ID)) {
     const label = ast.createLabelReference();
     statement.label = label;
-    const labelToken = state.consume(
-      label,
-      CstNodeKind.LabelReference_LabelRef,
-      t.ID,
-    );
-    label.label = ast.createReference(
-      label,
-      labelToken,
-      ast.ReferenceType.Variable,
-    );
+    label.label = memberCall(state, false);
   }
   statement.semicolon = state.consume(
     statement,

--- a/packages/language/src/preprocessor/instruction-generator.ts
+++ b/packages/language/src/preprocessor/instruction-generator.ts
@@ -682,7 +682,7 @@ function generateIterateInstruction(
   const gotoInstruction: inst.GotoInstruction = {
     kind: inst.InstructionKind.Goto,
   };
-  const label = node.label?.label?.text;
+  const label = node.label?.label?.element?.ref?.text;
   context.onFinish(() => {
     const doNode = lookupDoNode(context, node, label);
     if (doNode) {
@@ -700,7 +700,7 @@ function generateLeaveInstruction(
   const gotoInstruction: inst.GotoInstruction = {
     kind: inst.InstructionKind.Goto,
   };
-  const label = node.label?.label?.text;
+  const label = node.label?.label?.element?.ref?.text;
   context.onFinish(() => {
     const doNode = lookupDoNode(context, node, label);
     if (doNode) {
@@ -718,7 +718,7 @@ function generateGotoInstruction(
   const gotoInstruction: inst.GotoInstruction = {
     kind: inst.InstructionKind.Goto,
   };
-  const label = node.label?.label?.text;
+  const label = node.label?.label?.element?.ref?.text;
   if (label) {
     context.onFinish(() => {
       const nodeByLabel = context.labels.get(label);

--- a/packages/language/src/syntax-tree/ast-iterator.ts
+++ b/packages/language/src/syntax-tree/ast-iterator.ts
@@ -597,6 +597,9 @@ export function forEachNode(
     case SyntaxKind.LabelPrefix:
       break;
     case SyntaxKind.LabelReference:
+      if (node.label) {
+        action(node.label);
+      }
       break;
     case SyntaxKind.LeaveStatement:
       if (node.label) {

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -3027,7 +3027,7 @@ export function createLabelPrefix(): LabelPrefix {
 }
 export interface LabelReference extends AstNode {
   kind: SyntaxKind.LabelReference;
-  label: Reference<LabelPrefix> | null;
+  label: MemberCall | null;
 }
 export function createLabelReference(): LabelReference {
   return {

--- a/packages/language/src/syntax-tree/cst.ts
+++ b/packages/language/src/syntax-tree/cst.ts
@@ -683,7 +683,6 @@ export enum CstNodeKind {
   ProcedureCallArgs_Comma,
   ProcedureCallArgs_Star1,
   ProcedureCallArgs_CloseParen,
-  LabelReference_LabelRef,
   TypeReference_StartColon,
   TypeReference_Ref,
   TypeReference_EndColon,

--- a/packages/language/src/typesystem/descriptions.ts
+++ b/packages/language/src/typesystem/descriptions.ts
@@ -475,8 +475,18 @@ export const AttributeStringifiers: {
 
     let parameters = "";
     if (data.parameters.length > 0) {
-      parameters = data.parameters.map((param) => param.toString()).join(", ");
-      parameters = `(${parameters})`;
+      let values = "";
+      for (const param of data.parameters) {
+        if (values !== "") {
+          values += ", ";
+        }
+        if (param.type === DataType.Unknown) {
+          values += "*";
+        } else {
+          values += param.toString();
+        }
+      }
+      parameters = `(${values})`;
     }
 
     let returns = "";

--- a/packages/language/src/validation/compiler/IBM1213I-unreferenced-procedure.ts
+++ b/packages/language/src/validation/compiler/IBM1213I-unreferenced-procedure.ts
@@ -42,7 +42,10 @@ export function IBM1213I_unreferenced_procedure(
   for (const label of labels) {
     const references = compilationUnit.referencesCache.findReferences(label);
     for (const ref of references) {
-      if (ref.owner.container?.kind !== ast.SyntaxKind.EndStatement) {
+      if (
+        ref.owner.container?.container?.container?.kind !==
+        ast.SyntaxKind.EndStatement
+      ) {
         // The label is referenced somewhere, so we don't generate a warning
         return;
       }

--- a/packages/language/test/fourslash/linker/goto-label-with-dimensions-init.ts
+++ b/packages/language/test/fourslash/linker/goto-label-with-dimensions-init.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// <|BEFORE|>: PUT("BEFORE");
+//// DCL READY(2) LABEL INIT(<|BEFORE>BEFORE, <|AFTER>AFTER);
+//// GO TO READY(2);
+//// <|AFTER|>: PUT("AFTER");
+
+verify.noParserDiagnostics();
+linker.expectLinks();

--- a/packages/language/test/fourslash/linker/goto-label-with-dimensions.ts
+++ b/packages/language/test/fourslash/linker/goto-label-with-dimensions.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// DCL <|READY|>(2) LABEL;
+//// DCL <|GOTO|> FIXED INIT(1);
+//// GO TO <|READY>READY(<|GOTO>GOTO);
+
+verify.noParserDiagnostics();
+linker.expectLinks();

--- a/packages/language/test/fourslash/parser/assignment-repeated-expression.ts
+++ b/packages/language/test/fourslash/parser/assignment-repeated-expression.ts
@@ -1,0 +1,18 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// DCL TEST CHAR(10);
+//// TEST = (5)"AB";
+
+verify.noParserDiagnostics();

--- a/packages/language/test/fourslash/parser/attach-statement.ts
+++ b/packages/language/test/fourslash/parser/attach-statement.ts
@@ -1,0 +1,22 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// DCL TEST ENTRY();
+//// DCL TEST_TASK CHAR;
+//// ATTACH TEST;
+//// ATTACH TEST THREAD(TEST_TASK);
+//// ATTACH TEST ENVIRONMENT();
+//// ATTACH TEST ENVIRONMENT(TSTACK(10));
+
+verify.noParserDiagnostics();

--- a/packages/language/test/fourslash/parser/entry-attribute-empty-parameter-end.ts
+++ b/packages/language/test/fourslash/parser/entry-attribute-empty-parameter-end.ts
@@ -1,0 +1,17 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// DCL TEST ENTRY(FIXED,);
+
+verify.noParserDiagnostics();

--- a/packages/language/test/fourslash/parser/entry-attribute-empty-parameter-start.ts
+++ b/packages/language/test/fourslash/parser/entry-attribute-empty-parameter-start.ts
@@ -1,0 +1,17 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// DCL TEST ENTRY(,FIXED);
+
+verify.noParserDiagnostics();

--- a/packages/language/test/fourslash/parser/entry-attribute-empty-parameter.ts
+++ b/packages/language/test/fourslash/parser/entry-attribute-empty-parameter.ts
@@ -1,0 +1,17 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// DCL TEST ENTRY(,);
+
+verify.noParserDiagnostics();

--- a/packages/language/test/fourslash/parser/generic-descriptors.ts
+++ b/packages/language/test/fourslash/parser/generic-descriptors.ts
@@ -1,0 +1,18 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// DCL CH GENERIC (CH31 WHEN(FIXED BIN(31)),
+////                 CH15 WHEN(FIXED BIN(15)));
+
+verify.noParserDiagnostics();

--- a/packages/language/test/fourslash/parser/if-with-parenthesis-last.ts
+++ b/packages/language/test/fourslash/parser/if-with-parenthesis-last.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// The parser could think that the last parenthesis in the IF statement
+// is the start of a repeated expression, but it is actually the end of the IF condition.
+// This asserts that the parser completes without errors
+
+// @wrap: main
+//// IF F<1|F>32760|T<0|T>32760|(T<F&T>0) THEN DO; END;
+
+verify.noParserDiagnostics();

--- a/packages/language/test/fourslash/preprocessor/include/from-lib-identifier-parenthesis.ts
+++ b/packages/language/test/fourslash/preprocessor/include/from-lib-identifier-parenthesis.ts
@@ -1,0 +1,22 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+// @filename: cpy/lib.pli
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: main.pli
+//// %INCLUDE (lib);
+
+preprocessor.expectTokens(`
+  DECLARE LIB_VAR FIXED;
+`);

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -590,7 +590,7 @@ Available code actions for label "${label}" and URI "${uri}": ${codeActions.map(
           labels: value.labels,
         };
       } else if (value.kind === SyntaxKind.LabelReference) {
-        return value.label?.text;
+        return value.label?.element?.ref?.text;
       }
     }
     return value;


### PR DESCRIPTION
Closes https://github.com/zowe/zowe-pli-language-support/issues/549
Follow up: https://github.com/zowe/zowe-pli-language-support/issues/790

Fixes a few different parser issues:
* This include syntax is allowed (per the compiler): `%INCLUDE (member);`.
* Make `THREAD` part of `ATTACH` statement optional (fixes https://github.com/zowe/zowe-pli-language-support/issues/549).
* Support repetitions of basic constants, i.e. `(3)"ab"` (should result in `"ababab"` on the compiler).
* Support label references with dimensions. For example:
  ```
  DCL READY(2) LABEL;
  GOTO READY(1);
  ```
* Support empty entry attribute. These are simply supplemented with a `*` (any type).
  ```
  DCL TEST ENTRY(,FIXED);
  // same as:
  DCL TEST ENTRY(*, FIXED);
  ```