### PR TITLE
Add go to configuration

### DIFF
--- a/packages/language/src/language-server/connection-handler.ts
+++ b/packages/language/src/language-server/connection-handler.ts
@@ -46,7 +46,11 @@ import { documentSymbolRequest } from "./document-symbol-request";
 import { workspaceSymbolRequest } from "./workspace-symbol-request";
 import { FileSystemProvider } from "../workspace/file-system-provider";
 import { WorkspaceContext } from "../workspace/workspace-context";
-import { EditorDocuments, resetDocumentProviders } from "./text-documents";
+import {
+  EditorDocuments,
+  resetDocumentProviders,
+  TextDocuments as PliTextDocuments,
+} from "./text-documents";
 import { completionRequest } from "./completion/completion-request";
 import { hoverRequest } from "./hover-request";
 import { applyQuickFixes } from "./code-actions/apply-quick-fixes";
@@ -57,6 +61,7 @@ import { signatureHelpRequest } from "./signature-help-request";
 import { Messages, NotificationType, RequestType } from "../utils/messages";
 import { configCompletionRequest } from "./completion/completion-plugin-configuration";
 import { MultiMap } from "../utils/collections";
+import { JsonItemMeta } from "../config/schema";
 export { PluginConfiguration, Commands } from "./constants";
 
 export function startLanguageServer(
@@ -542,6 +547,74 @@ export function startLanguageServer(
     const compilationUnit = compilationUnitHandler.getCompilationUnit(uri);
     return compilationUnit !== undefined;
   });
+
+  /**
+   * Resolves a {@link JsonItemMeta} into a client-facing
+   * {@link Messages.PluginConfigEntryLocation}.
+   */
+  async function resolveConfigEntryLocation(
+    meta: JsonItemMeta | undefined,
+  ): Promise<Messages.PluginConfigEntryLocation | null> {
+    if (!meta) return null;
+    const configDoc = await PliTextDocuments.get(meta.uri.toString());
+    if (!configDoc) return null;
+
+    const lspRange = rangeToLSP(configDoc, meta.range);
+    return {
+      uri: meta.uri.toString(),
+      range: lspRange,
+    };
+  }
+
+  /**
+   * Resolves the {@link ProgramRecord} that applies to `uri`.
+   *
+   * `uri` may be an included file rather than a compilation unit's entry
+   * point (e.g. a `%INCLUDE`d copybook opened directly in the editor).
+   * `pgm_conf.json` only lists entry points, so looking up `uri` itself
+   * would fail to find a match in that case. Instead, resolve the owning
+   * compilation unit first (`compilationUnitHandler` already maps every
+   * file that's part of a processed unit back to that unit - see
+   * `CompilationUnitHandler.process`) and use its cached `programConfig`,
+   * which was already resolved from the unit's actual entry-point URI.
+   */
+  function resolveProgramConfig(
+    uri: URI,
+    compilationUnit: CompilationUnit | undefined,
+  ) {
+    if (compilationUnit) {
+      return compilationUnit.programConfig;
+    }
+    return workspace.config.getProgramConfig(uri);
+  }
+
+  onRequest(
+    connection,
+    Messages.GetProgramConfigLocation,
+    (uriString: string): Promise<Messages.PluginConfigEntryLocation | null> =>
+      withReadMutex(uriString, async (uri, compilationUnit) => {
+        const programConfig = resolveProgramConfig(uri, compilationUnit);
+        if (!programConfig) return null;
+
+        return resolveConfigEntryLocation(programConfig.program.meta);
+      }),
+  );
+
+  onRequest(
+    connection,
+    Messages.GetProcessGroupLocation,
+    (uriString: string): Promise<Messages.PluginConfigEntryLocation | null> =>
+      withReadMutex(uriString, async (uri, compilationUnit) => {
+        const programConfig = resolveProgramConfig(uri, compilationUnit);
+        if (!programConfig) return null;
+
+        const pgroupName = programConfig.pgroup.value;
+        const groupConfig = workspace.config.getProcessGroupConfig(pgroupName);
+        if (!groupConfig) return null;
+
+        return resolveConfigEntryLocation(groupConfig.meta);
+      }),
+  );
 
   connection.onCodeAction(async (params) => {
     const requestedKinds = params.context.only;

--- a/packages/language/src/language-server/constants.ts
+++ b/packages/language/src/language-server/constants.ts
@@ -38,11 +38,26 @@ export namespace PluginConfiguration {
 
 export namespace Commands {
   export const CREATE_CONFIG = "pli.applyQuickFixCreateConfig";
+
   /**
    * Client-side command (registered in the VS Code extension, NOT in the
    * server's `executeCommandProvider`). Attached to quick fixes that edit a
    * plugin config file so the file is saved after the edit is applied — the
    * config reload only fires on save.
    */
+
   export const SAVE_FILES = "pli.saveFiles";
+  /**
+   * Client-side command to navigate from a .pli file to its program
+   * configuration entry in pgm_conf.json or VS Code settings.
+   */
+
+  export const GO_TO_PROGRAM_CONFIG = "pli.goToProgramConfiguration";
+
+  /**
+   * Client-side command to navigate from a .pli file to the process
+   * group entry (in proc_grps.json, or VS Code settings) that its
+   * program configuration is bound to.
+   */
+  export const GO_TO_PROCESS_GROUP = "pli.goToProcessGroup";
 }

--- a/packages/language/src/utils/messages.ts
+++ b/packages/language/src/utils/messages.ts
@@ -81,4 +81,43 @@ export namespace Messages {
   export const GetGlobalConfig = createRequestType<void, GlobalConfig>(
     "config/getGlobal",
   );
+
+  /**
+   * Location information for a plugin configuration entry (either a
+   * program entry in pgm_conf.json or a process group entry in
+   * proc_grps.json). Used by the "Go to Program Configuration" and
+   * "Go to Process Group" commands to navigate to the entry that
+   * applies to a given .pli file.
+   */
+  export interface PluginConfigEntryLocation {
+    /** URI of the config file (or settings.json / .code-workspace file) */
+    uri: string;
+    /** Range of the entry in the file */
+    range: {
+      start: { line: number; character: number };
+      end: { line: number; character: number };
+    };
+  }
+
+  /**
+   * Request sent to the LS to get the source location of the program
+   * configuration that applies to a given file URI.
+   * Returns null if no configuration matches the file.
+   */
+  export const GetProgramConfigLocation = createRequestType<
+    string,
+    PluginConfigEntryLocation | null
+  >("pli/getProgramConfigLocation");
+
+  /**
+   * Request sent to the LS to get the source location of the process
+   * group configuration bound to the program configuration that applies
+   * to a given file URI.
+   * Returns null if no configuration matches the file, or the matching
+   * program configuration has no resolvable process group.
+   */
+  export const GetProcessGroupLocation = createRequestType<
+    string,
+    PluginConfigEntryLocation | null
+  >("pli/getProcessGroupLocation");
 }

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -30,6 +30,30 @@
     "code4z"
   ],
   "contributes": {
+    "commands": [
+      {
+        "command": "pli.goToProgramConfiguration",
+        "title": "Go to Program Configuration"
+      },
+      {
+        "command": "pli.goToProcessGroup",
+        "title": "Go to Process Group"
+      }
+    ],
+    "menus": {
+      "editor/context": [
+        {
+          "command": "pli.goToProgramConfiguration",
+          "when": "resourceLangId == pli",
+          "group": "navigation@10"
+        },
+        {
+          "command": "pli.goToProcessGroup",
+          "when": "resourceLangId == pli",
+          "group": "navigation@11"
+        }
+      ]
+    },
     "languages": [
       {
         "id": "pli",

--- a/packages/vscode-extension/src/extension/commands.ts
+++ b/packages/vscode-extension/src/extension/commands.ts
@@ -9,10 +9,70 @@
  *
  */
 
-import { Commands } from "pli-language";
+import { Commands, Messages } from "pli-language";
 import * as vscode from "vscode";
+import { BaseLanguageClient } from "vscode-languageclient";
 
-export function registerCommands(context: vscode.ExtensionContext): void {
+/**
+ * Opens (or focuses) the config entry described by `configLocation` and
+ * positions the cursor at it. This works uniformly whether the entry is
+ * sourced from a `.pliplugin/` file or from VS Code settings: `uri`/`range`
+ * always point at the real, openable document (e.g. `settings.json`) that
+ * the LS parsed the entry from.
+ */
+async function navigateToConfigEntry(
+  configLocation: Messages.PluginConfigEntryLocation | null,
+): Promise<void> {
+  if (!configLocation) {
+    // No configuration found - do nothing
+    return;
+  }
+
+  const configUri = vscode.Uri.parse(configLocation.uri);
+  const doc = await vscode.workspace.openTextDocument(configUri);
+  const position = new vscode.Position(
+    configLocation.range.start.line,
+    configLocation.range.start.character,
+  );
+
+  const editor = await vscode.window.showTextDocument(doc, {
+    selection: new vscode.Range(position, position),
+    preserveFocus: false,
+    preview: false,
+  });
+
+  // Reveal the line to ensure it's visible
+  editor.revealRange(
+    new vscode.Range(position, position),
+    vscode.TextEditorRevealType.InCenter,
+  );
+}
+
+function registerGoToConfigCommand(
+  commandId: string,
+  requestMethod: string,
+  client: BaseLanguageClient,
+): vscode.Disposable {
+  return vscode.commands.registerCommand(commandId, async () => {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== "pli") {
+      return;
+    }
+
+    try {
+      const configLocation: Messages.PluginConfigEntryLocation | null =
+        await client.sendRequest(requestMethod, editor.document.uri.toString());
+      await navigateToConfigEntry(configLocation);
+    } catch (error) {
+      console.error(`Failed to execute command "${commandId}":`, error);
+    }
+  });
+}
+
+export function registerCommands(
+  context: vscode.ExtensionContext,
+  client: BaseLanguageClient,
+): void {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       Commands.SAVE_FILES,
@@ -28,6 +88,18 @@ export function registerCommands(context: vscode.ExtensionContext): void {
           }
         }
       },
+    ),
+
+    registerGoToConfigCommand(
+      Commands.GO_TO_PROGRAM_CONFIG,
+      "pli/getProgramConfigLocation",
+      client,
+    ),
+
+    registerGoToConfigCommand(
+      Commands.GO_TO_PROCESS_GROUP,
+      "pli/getProcessGroupLocation",
+      client,
     ),
   );
 }

--- a/packages/vscode-extension/src/extension/main-browser.ts
+++ b/packages/vscode-extension/src/extension/main-browser.ts
@@ -36,8 +36,8 @@ export async function activate(
   registerConfigFileSystem(context);
   settings = Settings.getInstance();
   context.subscriptions.push(settings);
-  registerCommands(context);
   client = await startLanguageClient(context);
+  registerCommands(context, client);
 }
 
 // This function is called when the extension is deactivated.

--- a/packages/vscode-extension/src/extension/main.ts
+++ b/packages/vscode-extension/src/extension/main.ts
@@ -56,7 +56,7 @@ export async function activate(
     watchPluginSettings(client),
   );
 
-  registerCommands(context);
+  registerCommands(context, client);
 
   void handleMissingConfig(vscode.window.activeTextEditor);
 }


### PR DESCRIPTION
Closes https://github.com/zowe/zowe-pli-language-support/issues/789

Adds two commands to jump to the configuration files. 
Not sure if I got all edge cases, but it works for the settings.json as well.