### PR TITLE
Compile program entries that live in a lib directory, and warn on the ambiguity

### DIFF
--- a/packages/language/src/validation/lsp-codes.ts
+++ b/packages/language/src/validation/lsp-codes.ts
@@ -99,6 +99,15 @@ export const LspCodes = {
       severity: Severity.E,
       message: (pgroup: string) => `Unknown process group '${pgroup}'.`,
     },
+
+    AmbiguousProgramLibOverlap: {
+      code: "COPC05",
+      severity: Severity.W,
+      message: (dir: string, ext: string, pgroup: string) =>
+        `Directory '${dir}' is both a library in process group '${pgroup}' and a program-entry location for '${ext}' files. ` +
+        `Files ending in '${ext}' there are compiled as standalone programs and also used as includes, which is ambiguous. ` +
+        `Consider using a separate directory for includes, or removing '${ext}' from this group's include-extensions.`,
+    },
   },
 
   Cics: {

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -148,21 +148,6 @@ export function deserializeProcessGroup(
   };
 }
 
-function validatePluginConfig(
-  configs: Map<string, ProgramRecord>,
-  pGroups: Map<string, ProcessGroup>,
-): Diagnostic[] {
-  const diagnostics: Diagnostic[] = [];
-  // Check for unknown process groups references under "pgm_conf.json"
-  const pgroupReferences: Iterable<ProgramConfig> = configs.values();
-  const unknownProcessGroupsDiagnostic = validatePgroupReferences(
-    pgroupReferences,
-    new Set(pGroups.keys()),
-  );
-  diagnostics.push(...unknownProcessGroupsDiagnostic);
-  return diagnostics;
-}
-
 export type PluginConfigLspDiagnostics = MultiMap<string, LspDiagnostic>;
 export type PluginConfigDiagnostics = Diagnostic[];
 
@@ -561,16 +546,14 @@ export class PluginConfigurationProvider {
         computedLibs: [],
       });
     }
-    const validationResult = validatePluginConfig(
-      this.programConfigs,
-      mergedGroups,
-    );
-    diagnostics.push(...validationResult);
 
     this.postProcessProgramConfigs();
     const procGrpsDiagnostics =
       await this.postProcessProcessGroups(procGrpsDocuments);
     diagnostics.push(...procGrpsDiagnostics);
+    // Runs AFTER the post-processing above so the program/lib overlap check
+    // sees each group's expanded `computedLibs`.
+    diagnostics.push(...this.validatePluginConfig());
     this.libFileMatchers = undefined;
     this.configDiagnostics = diagnostics;
     const lspDiagnostics = await this.convertDiagnosticsToLsp();
@@ -843,6 +826,88 @@ export class PluginConfigurationProvider {
         text: document.getText(),
         uri: UriUtils.toUri(document.uri),
       });
+    }
+    return diagnostics;
+  }
+
+  /**
+   * Validates the merged plugin configuration and returns the accumulated
+   * diagnostics. Single entry point for the config-level checks, called from
+   * {@link loadConfigurations} *after* the configs are post-processed.
+   */
+  private validatePluginConfig(): Diagnostic[] {
+    const diagnostics: Diagnostic[] = [];
+    diagnostics.push(
+      ...validatePgroupReferences(
+        this.programConfigs.values(),
+        new Set(this.processGroupConfigs.keys()),
+      ),
+    );
+    diagnostics.push(...this.validateProgramLibOverlap());
+    return diagnostics;
+  }
+
+  /**
+   * Warns when a directory is both a configured lib and a program-entry
+   * location for one of the lib's include extensions, since such files are
+   * ambiguously both compiled standalone and offered as includes. Emits at
+   * most one diagnostic per (program entry, lib directory) pair.
+   */
+  private validateProgramLibOverlap(): Diagnostic[] {
+    const diagnostics: Diagnostic[] = [];
+    for (const processGroup of this.processGroupConfigs.values()) {
+      const extSet = new Set(
+        processGroup.includeExtensions.map((item) =>
+          (item.value.startsWith(".")
+            ? item.value
+            : `.${item.value}`
+          ).toLowerCase(),
+        ),
+      );
+      if (extSet.size === 0) {
+        // No include extensions → nothing can overlap on.
+        continue;
+      }
+      for (const lib of processGroup.computedLibs) {
+        // Only real directories carry a `files` map; skip dataset/DD libs.
+        if (!isLibsDir(lib)) {
+          continue;
+        }
+        const libUri = resolveLibUri(lib.path, this.workspacePath);
+        // Dedupe: one warning per program entry overlapping this lib dir,
+        // even if many files in the dir match that entry.
+        const seenProgramKeys = new Set<string>();
+        for (const realName of lib.files.values()) {
+          const dotIdx = realName.lastIndexOf(".");
+          const ext = dotIdx >= 0 ? realName.slice(dotIdx).toLowerCase() : "";
+          if (!extSet.has(ext)) {
+            continue;
+          }
+          const fileUri = UriUtils.joinPath(libUri, realName);
+          const program = this.getProgramConfig(fileUri);
+          if (!program) {
+            continue;
+          }
+          const key = program.program.value;
+          if (seenProgramKeys.has(key)) {
+            continue;
+          }
+          seenProgramKeys.add(key);
+          const uri = program.program.meta?.uri?.toString();
+          const range =
+            program.program.meta?.range ?? offsetLengthToRange(0, 1);
+          diagnostics.push(
+            diagnosticFromCodeAtRange(
+              LspCodes.PluginConfiguration.AmbiguousProgramLibOverlap,
+              uri,
+              range,
+              lib.path,
+              ext,
+              processGroup.name.value,
+            ),
+          );
+        }
+      }
     }
     return diagnostics;
   }

--- a/packages/language/src/workspace/workspace-context.ts
+++ b/packages/language/src/workspace/workspace-context.ts
@@ -78,8 +78,15 @@ export class WorkspaceContext {
     }
     if (isPluginConfigurationUri(uri)) {
       return undefined;
-    } else if (!this.config.isLibFileCandidate(uri)) {
-      // non-library files should always generate a compilation unit
+    } else if (
+      this.config.hasProgramConfig(uri) ||
+      !this.config.isLibFileCandidate(uri)
+    ) {
+      // A registered program entry point always heads its own compilation
+      // unit, even when its directory is also configured as a lib — program
+      // status takes precedence over lib membership. Ordinary (non-lib) files
+      // get a unit too. Only files that are lib members *and* not entry points
+      // are treated as standalone library files (handled by the else branch).
       const unit = await this.createAndStoreCompilationUnit(uri);
       return unit;
     } else {

--- a/packages/language/test/fourslash/preprocessor/include/program-lib-overlap-diagnostic.ts
+++ b/packages/language/test/fourslash/preprocessor/include/program-lib-overlap-diagnostic.ts
@@ -1,0 +1,62 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+// A directory listed as a lib (with ".pli" in its include-extensions) that is
+// also covered by a program entry matching ".pli" files is genuinely
+// ambiguous: every ".pli" file there is compiled standalone AND offered as an
+// include. This surfaces the ambiguity as a warning (COPC05W) attributed to
+// the program entry in pgm_conf.json.
+
+/// <reference path="../../framework.ts" />
+
+// @filename: .pliplugin/pgm_conf.json
+//// {
+////   "pgms": [
+////     {
+////       "program": <|overlap:"source/*.pli"|>,
+////       "pgroup": "default"
+////     }
+////   ]
+//// }
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////             "name": "default",
+////             "libs": [
+////                 "source"
+////             ],
+////             "include-extensions": [
+////                 ".pli",
+////                 ".inc"
+////             ]
+////         }
+////     ]
+//// }
+
+// Two ".pli" files in the lib dir both match the program pattern; the warning
+// must still be emitted exactly once (deduped per program-entry / lib-dir
+// pair). `expectExclusiveDiagnosticsAt` asserts the label has *only* this one
+// diagnostic, which is what pins the dedup guarantee.
+// @filename: source/x.pli
+//// DECLARE X FIXED;
+
+// @filename: source/main.pli
+//// DECLARE Y FIXED;
+
+verify.expectExclusiveDiagnosticsAt("overlap", {
+  message: code.LSP.PluginConfiguration.AmbiguousProgramLibOverlap.message(
+    "source",
+    ".pli",
+    "default",
+  ),
+});

--- a/packages/language/test/fourslash/preprocessor/include/program-lib-overlap-exact-entry-diagnostic.ts
+++ b/packages/language/test/fourslash/preprocessor/include/program-lib-overlap-exact-entry-diagnostic.ts
@@ -1,0 +1,52 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+// The overlap warning (COPC05W) fires for an EXACT program entry too, not just
+// globs: an exact "source/plifs01s.pli" entry pointing at a ".pli" file inside
+// a lib whose include-extensions list ".pli" is just as ambiguous.
+
+/// <reference path="../../framework.ts" />
+
+// @filename: .pliplugin/pgm_conf.json
+//// {
+////   "pgms": [
+////     {
+////       "program": <|overlap:"source/plifs01s.pli"|>,
+////       "pgroup": "default"
+////     }
+////   ]
+//// }
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////             "name": "default",
+////             "libs": [
+////                 "source"
+////             ],
+////             "include-extensions": [
+////                 ".pli"
+////             ]
+////         }
+////     ]
+//// }
+
+// @filename: source/plifs01s.pli
+//// DECLARE X FIXED;
+
+verify.expectExclusiveDiagnosticsAt("overlap", {
+  message: code.LSP.PluginConfiguration.AmbiguousProgramLibOverlap.message(
+    "source",
+    ".pli",
+    "default",
+  ),
+});

--- a/packages/language/test/fourslash/preprocessor/include/program-lib-overlap-no-diagnostic.ts
+++ b/packages/language/test/fourslash/preprocessor/include/program-lib-overlap-no-diagnostic.ts
@@ -1,0 +1,53 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+// When the program entry matches ".pli" files but the lib's include-extensions
+// only list ".inc", there is no overlapping include type, so no ambiguity
+// warning (COPC05W) is emitted. The ".pli" files are only ever programs, never
+// includes.
+
+/// <reference path="../../framework.ts" />
+
+// @filename: .pliplugin/pgm_conf.json
+//// {
+////   "pgms": [
+////     {
+////       "program": <|overlap:"source/*.pli"|>,
+////       "pgroup": "default"
+////     }
+////   ]
+//// }
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////             "name": "default",
+////             "libs": [
+////                 "source"
+////             ],
+////             "include-extensions": [
+////                 ".inc"
+////             ]
+////         }
+////     ]
+//// }
+
+// @filename: source/x.pli
+//// DECLARE X FIXED;
+
+// @filename: source/main.pli
+//// DECLARE Y FIXED;
+
+verify.noDiagnostics(
+  "overlap",
+  code.LSP.PluginConfiguration.AmbiguousProgramLibOverlap,
+);

--- a/packages/language/test/fourslash/preprocessor/include/program-lib-overlap-no-matching-file.ts
+++ b/packages/language/test/fourslash/preprocessor/include/program-lib-overlap-no-matching-file.ts
@@ -1,0 +1,51 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+// The detection is file-based: even though ".pli" is both a program-entry
+// extension and an include extension, the lib directory contains no ".pli"
+// file (only a ".inc" one), so there is no real ambiguity yet and no warning
+// (COPC05W) is emitted.
+
+/// <reference path="../../framework.ts" />
+
+// @filename: .pliplugin/pgm_conf.json
+//// {
+////   "pgms": [
+////     {
+////       "program": <|overlap:"source/*.pli"|>,
+////       "pgroup": "default"
+////     }
+////   ]
+//// }
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////             "name": "default",
+////             "libs": [
+////                 "source"
+////             ],
+////             "include-extensions": [
+////                 ".pli"
+////             ]
+////         }
+////     ]
+//// }
+
+// Only a ".inc" file lives in the lib — no ".pli" file to be ambiguous.
+// @filename: source/only.inc
+//// DECLARE Z FIXED;
+
+verify.noDiagnostics(
+  "overlap",
+  code.LSP.PluginConfiguration.AmbiguousProgramLibOverlap,
+);

--- a/packages/language/test/workspace/compilation-unit.test.ts
+++ b/packages/language/test/workspace/compilation-unit.test.ts
@@ -10,10 +10,13 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { CancellationToken } from "vscode-languageserver";
 import { UriUtils } from "../../src/utils/uri";
 import { CompilationUnitHandler } from "../../src/workspace/compilation-unit";
+import * as lifecycle from "../../src/workspace/lifecycle";
+import { TextDocuments } from "../../src/language-server/text-documents";
 import { makeProcessGroup, makeProgramConfig } from "../config-fixtures";
-import { defaultTestWorkspace } from "../test-workspace";
+import { createTestWorkspace, defaultTestWorkspace } from "../test-workspace";
 import {
   FileSystemProvider,
   TestGlobalConfigLoader,
@@ -194,5 +197,55 @@ describe("Compilation Unit Tests", () => {
     // Should create a compilation unit for a file in the src folder
     const mainUnit = await ch.getOrCreateCompilationUnit(mainUri);
     expect(mainUnit).toBeDefined();
+  });
+
+  test("Creates and reads a compilation unit for an entry point inside a lib directory", async () => {
+    const testFs = new VirtualFileSystemProvider();
+    const workspace = createTestWorkspace(testFs);
+    const wsUri = UriUtils.toUri("file:///");
+
+    // The program entry lives in `src`, which is ALSO configured as a lib, and
+    // pulls in a neighbouring include from that same directory.
+    const entryUri = UriUtils.toUri("file:///src/a.pli");
+    await testFs.writeFile(entryUri, " DCL B CHAR;\n %INCLUDE inc;\n");
+    await testFs.writeFile(
+      UriUtils.toUri("file:///src/inc.inc"),
+      " DCL A CHAR;\n",
+    );
+
+    await workspace.config.init(wsUri);
+    workspace.config.setProgramConfigs(wsUri, [
+      makeProgramConfig({ program: "src/a.pli", pgroup: "default" }),
+    ]);
+    await workspace.config.setProcessGroupConfigs([
+      makeProcessGroup({
+        name: "default",
+        libs: ["src"],
+        includeExtensions: [".pli", ".inc"],
+      }),
+    ]);
+
+    const ch = new CompilationUnitHandler(
+      testFs,
+      new TestGlobalConfigLoader({}),
+      LongRunningOperationImpl.Dummy,
+    );
+    ch.addWorkspaceFolder(wsUri, workspace);
+
+    // Entry point gets a unit even though `src` is also a lib directory — and
+    // (the actual bug) its text is read and its include resolved through the lib.
+    const entryUnit = await ch.getOrCreateCompilationUnit(entryUri);
+    expect(entryUnit).toBeDefined();
+    const doc = await TextDocuments.get(entryUri);
+    await lifecycle.lifecycle(entryUnit!, doc!, CancellationToken.None);
+    const tokens = entryUnit!.tokens.map((t) => t.image);
+    expect(tokens).toContain("B");
+    expect(tokens).toContain("A");
+
+    // A non-entry file in the same lib directory stays a standalone lib file.
+    const libUnit = await ch.getOrCreateCompilationUnit(
+      UriUtils.toUri("file:///src/inc.inc"),
+    );
+    expect(libUnit).toBeUndefined();
   });
 });


### PR DESCRIPTION
### Summary
A file can be both a **program entry point** (`pgm_conf.json`) and sit inside a directory configured as a **lib** (`proc_grps.json`) using an extension listed in that lib's `include-extensions`. This branch makes such files compile as standalone programs, and adds a config-level warning so users can spot and resolve the ambiguity intentionally.

### Changes
- **Program entries in lib dirs now get their own compilation unit** (`CompilationUnitHandler.getOrCreateCompilationUnit`). A registered program entry point always heads its own unit, even when its directory is also a lib — program status takes precedence over lib membership. Previously these files could be treated purely as library members and never compiled standalone.
- **New warning `COPC05` (`AmbiguousProgramLibOverlap`)**. Fires when a real file in a lib directory has an extension present in that group's `include-extensions` **and** is matched by a program entry (exact or glob). It's a **warning only** — it never blocks compilation. Emitted at most once per `(program entry, lib directory)` pair and attributed to the program entry in `pgm_conf.json`.

### Why
The compilation-unit change is correct but means files a user intended purely as copybooks may now compile standalone and emit surprising diagnostics. Rather than silently changing behavior, the warning surfaces the ambiguous config shape and suggests fixes (use a separate include directory, or drop the extension from `include-extensions`).

### Testing
- Unit tests for the compilation-unit gate and for the provider (`program-lib-overlap.test.ts`): glob overlap (deduped to one), exact-entry overlap, non-include extension (no warning), no matching files (no warning).
- Fourslash tests: positive (`program-lib-overlap-diagnostic.ts`) and negative (`program-lib-overlap-no-diagnostic.ts`).
