### PR TITLE
Add completion request support for compiler options

### DIFF
--- a/packages/language/src/language-server/completion/compiler-options-completion-request.ts
+++ b/packages/language/src/language-server/completion/compiler-options-completion-request.ts
@@ -1,0 +1,508 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import {
+  CompletionItemKind,
+  InsertTextFormat,
+} from "vscode-languageserver-types";
+import {
+  CURSOR_MARKER,
+  getOptionCompletion,
+  getValueAlternatives,
+  PLI_OPTION_NAMES,
+} from "../../preprocessor/compiler-options/completion-pli";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { fuzzyMatch } from "../../utils/fuzzy-matcher";
+import { URI } from "../../utils/uri";
+import { CompilationUnit } from "../../workspace/compilation-unit";
+import { CompletionItem } from "../types";
+
+const PROCESS_KEYWORD_LENGTH = 8; // including [*%]
+
+function escapeSnippetText(text: string): string {
+  return text.replace(/[\\$}]/g, "\\$&");
+}
+
+function escapeChoiceText(text: string): string {
+  return text.replace(/[\\,|]/g, "\\$&");
+}
+
+function editItem(
+  label: string,
+  kind: CompletionItemKind,
+  text: string,
+  start: number,
+  end: number = start,
+  sortText?: string,
+): CompletionItem {
+  const item: CompletionItem = {
+    label,
+    kind,
+    edit: { range: { start, end }, text },
+  };
+  if (sortText !== undefined) item.sortText = sortText;
+  return item;
+}
+
+/**
+ * Provides completion items when the cursor is in a compiler-options context:
+ *
+ * - **Case A** - cursor is inside a `*PROCESS` / `%PROCESS` directive and NOT inside a
+ *   parameter list: returns the canonical PLI option names filtered by fuzzy match.
+ *   Parameter completion is not yet implemented.
+ *
+ * - **Case B** - cursor is on a fresh line whose only content so far is `*` or `%`
+ *   (optionally followed by a partial `PROCESS`): returns `PROCESS` as a single
+ *   keyword completion.
+ *
+ * Returns `[]` when neither case applies, signalling that the caller should fall
+ * through to the normal PLI completion handler.
+ */
+export function compilerOptionsCompletionRequest(
+  unit: CompilationUnit,
+  uri: URI,
+  offset: number,
+): CompletionItem[] {
+  // Case A: cursor inside a known PROCESS directive region
+  for (const range of unit.compilerOptions.ranges) {
+    if (offset > range.start + PROCESS_KEYWORD_LENGTH && offset <= range.end) {
+      return getOptionNameCompletions(unit, uri, range, offset);
+    }
+  }
+
+  // Case B: cursor after * / % at the start of a line (PROCESS keyword itself)
+  return getProcessKeywordCompletion(unit, uri, offset);
+}
+
+function getOptionNameCompletions(
+  unit: CompilationUnit,
+  uri: URI,
+  range: { start: number; end: number },
+  offset: number,
+): CompletionItem[] {
+  const doc = unit.services.files.getDocument(uri);
+  if (!doc) {
+    return [];
+  }
+
+  const optionsOffset = range.start + PROCESS_KEYWORD_LENGTH;
+
+  // Fetch only the directive slice from after *PROCESS up to the cursor.
+  const directiveText = doc.getText({
+    start: doc.positionAt(optionsOffset),
+    end: doc.positionAt(offset),
+  });
+
+  const analysis = analyzeDirectiveText(directiveText);
+  if (!analysis) {
+    // The cursor is inside an open parameter list. Only options with fixed
+    // literal alternatives support completion here.
+    return getParamAlternativeCompletions(
+      doc,
+      directiveText,
+      optionsOffset,
+      offset,
+    );
+  }
+
+  const { query, immediateChar, prevNonWs } = analysis;
+  // A separator is needed only when the cursor is immediately adjacent to ')'
+  // with no intervening space or comma. A space is already a valid separator.
+  const needsSeparator = query === "" && immediateChar === ")";
+  const queryStart = optionsOffset + directiveText.length - query.length;
+
+  const items: CompletionItem[] = PLI_OPTION_NAMES.filter((name) =>
+    fuzzyMatch(query, name),
+  ).map((name): CompletionItem => {
+    const meta = getOptionCompletion(name);
+    let baseText: string;
+    let detail: string | undefined;
+    let insertTextFormat: InsertTextFormat | undefined;
+
+    const params = meta?.params;
+
+    if (meta && meta.mandatoryParams > 0 && params && params.length > 1) {
+      // Mandatory parameter with at least two candidate values: offer a single LSP snippet "choice".
+      const choices = params.map(escapeChoiceText).join(",");
+      baseText = `${name}(\${1|${choices}|})`;
+      detail = `(${params.join("|")})`;
+      insertTextFormat = InsertTextFormat.Snippet;
+    } else if (meta && meta.mandatoryParams > 0) {
+      // A single or no candidate value: use it as the snippet's tab-stop
+      // default, honoring a cursor marker if present.
+      const singleParam = params?.[0];
+      if (singleParam !== undefined && singleParam.includes(CURSOR_MARKER)) {
+        const [before, after] = singleParam.split(CURSOR_MARKER);
+        baseText = `${name}(${escapeSnippetText(before)}$0${escapeSnippetText(after)})`;
+        detail = `(${before}${after})`;
+      } else {
+        baseText = `${name}(\${1:${singleParam ?? ""}})`;
+        detail = singleParam !== undefined ? `(${singleParam})` : "(...)";
+      }
+      insertTextFormat = InsertTextFormat.Snippet;
+    } else {
+      baseText = name;
+    }
+
+    const insertText = needsSeparator ? `, ${baseText}` : baseText;
+
+    const item: CompletionItem = {
+      label: name,
+      kind: CompletionItemKind.Keyword,
+      edit: {
+        range: { start: queryStart, end: offset },
+        text: insertText,
+      },
+    };
+    if (detail !== undefined) item.detail = detail;
+    if (insertTextFormat !== undefined)
+      item.insertTextFormat = insertTextFormat;
+    // When the insert text is prefixed with ', ', set filterText to the bare
+    // name so the LSP client can still filter by what the user types.
+    if (needsSeparator) item.filterText = name;
+    return item;
+  });
+
+  // Offer ';' as a directive terminator when no partial name is being typed,
+  // unless one is already present right after the cursor.
+  const nextChar = doc.getText({
+    start: doc.positionAt(offset),
+    end: doc.positionAt(offset + 1),
+  });
+  if (
+    query === "" &&
+    prevNonWs !== "," &&
+    !(needsSeparator && nextChar === ";")
+  ) {
+    items.unshift(
+      editItem(";", CompletionItemKind.Operator, ";", offset, offset, " "),
+    );
+  }
+
+  // When a full option name that only offers optional parameter alternatives
+  // has just been typed, let the user go straight to `NAME;` or `NAME(alternative)` in one shot.
+  const nextStepItems = getNextStepItems(query, prevNonWs, offset);
+  return nextStepItems ?? items;
+}
+
+function getNextStepItems(
+  query: string,
+  prevNonWs: string,
+  offset: number,
+): CompletionItem[] | undefined {
+  if (query === "") return undefined;
+  const meta = getOptionCompletion(query);
+  const alternatives = meta ? getValueAlternatives(meta) : undefined;
+  if (
+    !meta ||
+    meta.name !== query.toUpperCase() ||
+    meta.mandatoryParams !== 0 ||
+    !alternatives?.length
+  ) {
+    return undefined;
+  }
+
+  const items: CompletionItem[] = [];
+  if (prevNonWs !== ",") {
+    items.push(
+      editItem(";", CompletionItemKind.Operator, ";", offset, offset, " "),
+    );
+  }
+  for (const alternative of alternatives) {
+    items.push(
+      editItem(
+        `(${alternative})`,
+        CompletionItemKind.Value,
+        `(${alternative})`,
+        offset,
+        offset,
+        "  ",
+      ),
+    );
+  }
+  return items;
+}
+
+/**
+ * Offers completion for the value inside an option's parentheses when that
+ * option only has a fixed set of literal alternatives (e.g. `AGGREGATE(<|>)`
+ * offers `DECIMAL` / `HEXADEC`). Returns `[]` when the cursor is not inside such a parameter list.
+ */
+function getParamAlternativeCompletions(
+  doc: TextDocument,
+  directiveText: string,
+  optionsOffset: number,
+  offset: number,
+): CompletionItem[] {
+  const ctx = findEnclosingParamContext(directiveText);
+  if (!ctx) {
+    return [];
+  }
+
+  const meta = getOptionCompletion(ctx.name);
+  const alternatives = meta ? getValueAlternatives(meta) : undefined;
+  if (!alternatives || alternatives.length === 0) {
+    return [];
+  }
+
+  // Once a full, exact alternative has been typed, the (single) parameter is
+  // complete: offer ONLY ways to close the parentheses and terminate the
+  // directive.
+  const isCompleteValue = alternatives.some(
+    (alternative) => alternative.toUpperCase() === ctx.paramText.toUpperCase(),
+  );
+  if (isCompleteValue) {
+    const nextChar = doc.getText({
+      start: doc.positionAt(offset),
+      end: doc.positionAt(offset + 1),
+    });
+    if (nextChar === ")") {
+      // The closing paren already exists: the directive is already
+      // structurally complete, so there's nothing left to suggest.
+      return [];
+    }
+    // No closing paren yet: offer both a bare ')' and ');'.
+    return [
+      editItem(")", CompletionItemKind.Operator, ")", offset, offset, " "),
+      editItem(");", CompletionItemKind.Operator, ");", offset, offset, "  "),
+    ];
+  }
+
+  const paramStart = optionsOffset + ctx.paramStartIndex;
+  return alternatives
+    .filter((alternative) => fuzzyMatch(ctx.paramText, alternative))
+    .map((alternative) =>
+      editItem(
+        alternative,
+        CompletionItemKind.Value,
+        alternative,
+        paramStart,
+        offset,
+      ),
+    );
+}
+
+/**
+ * Scans `text` character by character, skipping over string literals
+ * and comments, and invoking `onChar` for every other character.
+ * A `\n` that closes a line comment is reported too, since it still acts
+ * as a token separator.
+ *
+ * Returns `true` if the scan ended inside an unterminated string, line
+ * comment, or block comment.
+ */
+function scanCode(
+  text: string,
+  onChar: (ch: string, index: number) => void,
+): boolean {
+  let stringChar = "";
+  let inLineComment = false;
+  let inBlockComment = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+
+    if (inLineComment) {
+      if (ch === "\n") {
+        inLineComment = false;
+        onChar(ch, i);
+      }
+      continue;
+    }
+    if (inBlockComment) {
+      if (ch === "*" && text[i + 1] === "/") {
+        inBlockComment = false;
+        i++;
+      }
+      continue;
+    }
+    if (stringChar) {
+      if (ch === stringChar) {
+        if (text[i + 1] === stringChar) i++;
+        else stringChar = "";
+      }
+      continue;
+    }
+    if (ch === "/" && text[i + 1] === "/") {
+      inLineComment = true;
+      i++;
+      continue;
+    }
+    if (ch === "/" && text[i + 1] === "*") {
+      inBlockComment = true;
+      i++;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      stringChar = ch;
+      continue;
+    }
+
+    onChar(ch, i);
+  }
+
+  return !(inLineComment || inBlockComment || stringChar !== "");
+}
+
+/**
+ * Scans `text` to find the option name and partial parameter text for the
+ * innermost parenthesised group directly enclosing the cursor
+ * Returns `null` for top-level cursors, nested parens, or when
+ * inside a string/comment.
+ */
+function findEnclosingParamContext(
+  text: string,
+): { name: string; paramStartIndex: number; paramText: string } | null {
+  let parenDepth = 0;
+  let currentIdentifier = "";
+  let paramStartIndex = -1;
+  let enclosingName = "";
+
+  scanCode(text, (ch, i) => {
+    if (parenDepth === 0) {
+      if (ch === "(") {
+        enclosingName = currentIdentifier.toUpperCase();
+        currentIdentifier = "";
+        parenDepth = 1;
+        paramStartIndex = i + 1;
+      } else if (/[A-Za-z0-9_]/.test(ch)) {
+        currentIdentifier += ch;
+      } else {
+        currentIdentifier = "";
+      }
+    } else if (ch === "(") {
+      parenDepth++;
+    } else if (ch === ")") {
+      parenDepth--;
+      if (parenDepth === 0) {
+        paramStartIndex = -1;
+        enclosingName = "";
+      }
+    }
+  });
+
+  if (parenDepth !== 1 || paramStartIndex < 0) {
+    return null;
+  }
+
+  return {
+    name: enclosingName,
+    paramStartIndex,
+    paramText: text.slice(paramStartIndex),
+  };
+}
+
+const IS_WHITESPACE = new Set([" ", "\t", "\n", "\r"]);
+const IS_DELIMITER = new Set([",", ")", ...IS_WHITESPACE]); // Characters that terminate the partial option name being typed.
+
+/**
+ * Analyses the directive text (from after `*PROCESS` up to the cursor) to
+ * determine the completion context.
+ *
+ * Returns `null` when option-name completion is not applicable, i.e. when the
+ * cursor is inside an open parameter list (paren depth > 0), inside a block
+ * or line comment, or inside a string literal.
+ *
+ * Otherwise returns:
+ *  - `query`        - the partial option name being typed at the cursor
+ *  - `immediateChar`- the character sitting directly before the query (used to
+ *                     detect a cursor that is flush against a closing `)`)
+ *  - `prevNonWs`    - the last non-whitespace character before the query (used
+ *                     to suppress a `;` offer after a dangling `,`)
+ */
+function analyzeDirectiveText(text: string): {
+  query: string;
+  immediateChar: string;
+  prevNonWs: string;
+} | null {
+  let parenDepth = 0;
+  let query = "";
+  let immediateChar = "";
+  let prevNonWs = "";
+  let lastNonWs = ""; // last non-whitespace top-level char seen so far
+
+  const wellFormed = scanCode(text, (ch) => {
+    if (ch === "(") parenDepth++;
+    else if (ch === ")") parenDepth--;
+
+    if (IS_DELIMITER.has(ch)) {
+      immediateChar = ch;
+      prevNonWs = IS_WHITESPACE.has(ch) ? lastNonWs : ch;
+      query = "";
+    } else {
+      query += ch;
+    }
+    if (!IS_WHITESPACE.has(ch)) lastNonWs = ch;
+  });
+
+  // Cursor is inside an open paren, a comment, or an unterminated string -> no completion
+  if (parenDepth > 0 || !wellFormed) {
+    return null;
+  }
+
+  return { query, immediateChar, prevNonWs };
+}
+
+function getProcessKeywordCompletion(
+  unit: CompilationUnit,
+  uri: URI,
+  offset: number,
+): CompletionItem[] {
+  const doc = unit.services.files.getDocument(uri);
+  if (!doc) {
+    return [];
+  }
+
+  const pos = doc.positionAt(offset);
+
+  if (pos.character > PROCESS_KEYWORD_LENGTH) {
+    return [];
+  }
+
+  if (pos.character === 0) {
+    // Cursor is at column 0 with nothing typed yet. Offer *PROCESS / %PROCESS
+    // as long as we are still in the compiler-options preamble (before the first
+    // PL/I token).
+    const tokens = unit.services.files.getTokens(uri);
+    if (tokens && tokens.length > 0 && offset >= tokens[0].startOffset) {
+      return [];
+    }
+    return [
+      editItem("*PROCESS", CompletionItemKind.Keyword, "*PROCESS", offset),
+      editItem("%PROCESS", CompletionItemKind.Keyword, "%PROCESS", offset),
+    ];
+  }
+
+  const lineUpToCursor = doc.getText({
+    start: { line: pos.line, character: 0 },
+    end: pos,
+  });
+
+  const marker = lineUpToCursor[0];
+  const partial = lineUpToCursor.slice(1).toUpperCase();
+  if ((marker !== "*" && marker !== "%") || !"PROCESS".startsWith(partial)) {
+    return [];
+  }
+
+  // Edit range: from right after the [*%] character to the cursor, replacing
+  // any partially typed "PROCESS" text.
+  const editStart = doc.offsetAt({ line: pos.line, character: 1 });
+
+  return [
+    editItem(
+      "PROCESS",
+      CompletionItemKind.Keyword,
+      "PROCESS",
+      editStart,
+      offset,
+    ),
+  ];
+}

--- a/packages/language/src/language-server/completion/completion-request.ts
+++ b/packages/language/src/language-server/completion/completion-request.ts
@@ -25,12 +25,17 @@ import {
 import { generateCompletionItems } from "./completion-generator";
 import { fuzzyMatch } from "../../utils/fuzzy-matcher";
 import { Token } from "../../parser/tokens";
+import { compilerOptionsCompletionRequest } from "./compiler-options-completion-request";
 
 export function completionRequest(
   unit: CompilationUnit,
   uri: URI,
   offset: number,
 ): CompletionItem[] {
+  const coItems = compilerOptionsCompletionRequest(unit, uri, offset);
+  if (coItems.length > 0) {
+    return coItems;
+  }
   const tokens = unit.services.files.getTokens(uri);
   if (!tokens) {
     return [];

--- a/packages/language/src/preprocessor/compiler-options-processor.ts
+++ b/packages/language/src/preprocessor/compiler-options-processor.ts
@@ -127,8 +127,11 @@ export class CompilerOptionsProcessor {
 
     this.translator.postProcessCompilerOptions();
 
+    const result = this.translator.getResults();
+    result.options.ranges = ranges;
+
     return {
-      result: this.translator.getResults(),
+      result,
       text: newText,
       recompileFingerprint: this.translator.getRecompileFingerprint(),
     };

--- a/packages/language/src/preprocessor/compiler-options/completion-pli.ts
+++ b/packages/language/src/preprocessor/compiler-options/completion-pli.ts
@@ -1,0 +1,338 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/**
+ * Completion metadata for PLI compiler options
+ *
+ * This file is intentionally kept separate from translator-pli.ts so that
+ * completion behaviour can be declared without touching the translation logic.
+ * A future refactoring could derive these entries automatically from the
+ * translator rule definitions.
+ */
+export interface CompilerOptionCompletion {
+  /** Canonical option name (uppercase). */
+  name: string;
+  /**
+   * Mandatory number of parameters this option requires.
+   * `0`: no parentheses inserted (plain name).
+   * `>0`: a snippet with parentheses is offered: `NAME(${1:...})`.
+   */
+  mandatoryParams: number;
+  /**
+   * Candidate value(s) for the (typically single) parameter:
+   * - One entry: used as the snippet tab-stop default, e.g. `["2, 72"]` is
+   *   inserted as `MARGINS(${1:2, 72})`. May contain a single `<|>`
+   *   marker to indicate where the cursor should land after completion.
+   * - Multiple entries: rendered as an LSP snippet "choice", e.g.
+   *   `["DECIMAL", "HEXADEC"]` inserted as `AGGREGATE(${1|DECIMAL,HEXADEC|})`,
+   *   letting the user tab into the parentheses and cycle through the
+   *   offered values. These are also offered as completions when typing
+   *   inside the parentheses directly.
+   */
+  params?: readonly string[];
+}
+
+export const CURSOR_MARKER = "<|>";
+
+export function getValueAlternatives(
+  meta: CompilerOptionCompletion,
+): readonly string[] | undefined {
+  const values = meta.params?.filter((value) => !value.includes(CURSOR_MARKER));
+  return values && values.length > 0 ? values : undefined;
+}
+
+function completion(
+  name: string,
+  mandatoryParams: number,
+  params?: string | readonly string[],
+): CompilerOptionCompletion {
+  if (params === undefined) {
+    return { name, mandatoryParams };
+  }
+  return {
+    name,
+    mandatoryParams,
+    params: Array.isArray(params) ? params : [params],
+  };
+}
+
+const COMPLETIONS: CompilerOptionCompletion[] = [
+  completion("AGGREGATE", 0, ["DECIMAL", "HEXADEC"]),
+  completion("NOAGGREGATE", 0),
+  completion("ARCH", 1, ["10", "11", "12", "13", "14"]),
+  completion("ASSERT", 1, ["ENTRY", "CONDITION"]),
+  completion("ATTRIBUTES", 0, ["FULL", "SHORT"]),
+  completion("NOATTRIBUTES", 0),
+
+  completion("BACKREG", 1, ["5", "11"]),
+  completion("BIFPREC", 1, ["31", "15"]),
+  completion("BLANK", 1),
+  completion("BLKOFF", 0),
+  completion("NOBLKOFF", 0),
+  completion("BRACKETS", 1),
+
+  completion("CASE", 1, ["ASIS", "UPPER"]),
+  completion("CASERULES", 1, [
+    "KEYWORD(MIXED)",
+    "KEYWORD(UPPER)",
+    "KEYWORD(LOWER)",
+    "KEYWORD(START)",
+  ]),
+  completion("CHECK", 1, ["NOSTORAGE", "STORAGE"]),
+  completion("CMPAT", 1, ["V2", "LE", "V1", "V3"]),
+
+  completion("CODEPAGE", 1, [
+    "01140",
+    "01047",
+    "01141",
+    "01143",
+    "01144",
+    "01025",
+    "01145",
+    "01146",
+    "01147",
+    "01148",
+    "01149",
+    "00037",
+    "01155",
+    "00273",
+    "00277",
+    "00278",
+    "00280",
+    "00284",
+    "00285",
+    "00297",
+    "00500",
+    "00871",
+    "00819",
+    "00813",
+    "00920",
+  ]),
+  completion("COMMON", 0),
+  completion("NOCOMMON", 0),
+  completion("COMPILE", 0),
+  completion("NOCOMPILE", 0, ["S", "W", "E"]),
+  completion("COPYRIGHT", 1),
+  completion("NOCOPYRIGHT", 0),
+  completion("CSECT", 0),
+  completion("NOCSECT", 0),
+  completion("CSECTCUT", 1, ["4", "0", "1", "2", "3", "5", "6", "7"]),
+  completion("CURRENCY", 1, "$"),
+
+  completion("DBCS", 0),
+  completion("NODBCS", 0),
+  completion("DBRMLIB", 0),
+  completion("NODBRMLIB", 0),
+  completion("DD", 0),
+  completion("DDSQL", 1),
+  completion("DECIMAL", 1),
+  completion("DECOMP", 0),
+  completion("NODECOMP", 0),
+  completion("DEFAULT", 1),
+  completion("DEPRECATE", 1),
+  completion("DEPRECATENEXT", 1),
+  completion("DISPLAY", 1),
+  completion("DLL", 0),
+  completion("NODLL", 0),
+  completion("DLLINIT", 0),
+  completion("NODLLINIT", 0),
+
+  completion("EXIT", 0),
+  completion("NOEXIT", 0),
+  completion("EXPORTALL", 0),
+  completion("NOEXPORTALL", 0),
+  completion("EXTRN", 1, ["FULL", "SHORT"]),
+
+  completion("FILEREF", 0, ["HASH", "NOHASH"]),
+  completion("NOFILEREF", 0),
+  completion("FLAG", 0, ["W", "I", "E", "S"]),
+  completion("FLOAT", 1, ["NODFP", "DFP"]),
+  completion("FLOATINMATH", 1, ["ASIS", "LONG", "EXTENDED"]),
+
+  completion("GOFF", 0),
+  completion("NOGOFF", 0),
+  completion("GONUMBER", 1, ["NOSEPARATE", "SEPARATE"]),
+  completion("NOGONUMBER", 0),
+  completion("GRAPHIC", 0),
+  completion("NOGRAPHIC", 0),
+
+  completion("HEADER", 1, ["ALL", "FILE", "FIRST", "SOURCE"]),
+  completion("HGPR", 1, ["NOPRESERVE", "PRESERVE"]),
+
+  completion("IGNORE", 1),
+  completion("NOIGNORE", 0),
+  completion("INCAFTER", 1, "PROCESS(<|>)"),
+  completion("INCDIR", 1),
+  completion("INCLUDE", 0),
+  completion("NOINCLUDE", 0),
+  completion("INCPDS", 1),
+  completion("NOINCPDS", 0),
+  completion("INITAUTO", 0, ["FULL", "SHORT"]),
+  completion("NOINITAUTO", 0),
+  completion("INITBASED", 0),
+  completion("NOINITBASED", 0),
+  completion("INITCTL", 0),
+  completion("NOINITCTL", 0),
+  completion("INITSTATIC", 0),
+  completion("NOINITSTATIC", 0),
+  completion("INSOURCE", 0),
+  completion("NOINSOURCE", 0),
+  completion("INTERRUPT", 0),
+  completion("NOINTERRUPT", 0),
+
+  completion("JSON", 1, ""),
+
+  completion("LANGLVL", 1, ["OS", "NOEXT"]),
+  completion("LIMITS", 1),
+  completion("LINECOUNT", 1, "31415"),
+  completion("LINEDIR", 0),
+  completion("NOLINEDIR", 0),
+  completion("LIST", 0),
+  completion("NOLIST", 0),
+  completion("LISTVIEW", 1, [
+    "SOURCE",
+    "AFTERALL",
+    "AFTERCICS",
+    "AFTERMACRO",
+    "AFTERSQL",
+  ]),
+  completion("LP", 1, ["32", "64"]),
+
+  completion("MACRO", 0),
+  completion("NOMACRO", 0),
+  completion("MAP", 0),
+  completion("NOMAP", 0),
+  completion("MARGINI", 1),
+  completion("NOMARGINI", 0),
+  completion("MARGINS", 2, "2, 72"),
+  completion("NOMARGINS", 0),
+  completion("MAXBRANCH", 1, "2000"),
+  completion("MAXINIT", 1, "64k"),
+  completion("MAXGEN", 1, "100000"),
+  completion("MAXMEM", 1, "1048576"),
+  completion("MAXMSG", 1),
+  completion("MAXNEST", 1),
+  completion("MAXRUNONIF", 1, "10"),
+  completion("MAXSTATIC", 1, "1M"),
+  completion("MAXSTMT", 1, "4096"),
+  completion("MAXTEMP", 1, "50000"),
+  completion("MDECK", 1, ["AFTERALL", "AFTERMACRO"]),
+  completion("NOMDECK", 0),
+  completion("MSGSUMMARY", 0, ["NOXREF", "XREF"]),
+  completion("NOMSGSUMMARY", 0),
+
+  completion("NAME", 0),
+  completion("NONAME", 0),
+  completion("NAMES", 1),
+  completion("NATLANG", 1, ["ENU", "UEN"]),
+  completion("NEST", 0),
+  completion("NONEST", 0),
+  completion("NOT", 1),
+  completion("NULLDATE", 0),
+  completion("NONULLDATE", 0),
+
+  completion("OBJECT", 0),
+  completion("NOOBJECT", 0),
+  completion("OFFSET", 0),
+  completion("NOOFFSET", 0),
+  completion("OFFSETSIZE", 1, ["4", "8"]),
+  completion("ONSNAP", 1, ["STRINGRANGE", "STRINGSIZE"]),
+  completion("NOONSNAP", 0),
+  completion("OPTIMIZE", 0, ["0", "TIME", "2", "3"]),
+  completion("NOOPTIMIZE", 0),
+  completion("OPTIONS", 0, ["DOC", "ALL"]),
+  completion("NOOPTIONS", 0),
+  completion("OR", 1),
+
+  completion("PP", 1, "MACRO, SQL, CICS"),
+  completion("NOPP", 0),
+  completion("PPCICS", 1),
+  completion("NOPPCICS", 0),
+  completion("PPINCLUDE", 1),
+  completion("NOPPINCLUDE", 0),
+  completion("PPLIST", 1, ["KEEP", "ERASE"]),
+  completion("PPMACRO", 1),
+  completion("NOPPMACRO", 0),
+  completion("PPSQL", 1),
+  completion("NOPPSQL", 0),
+  completion("PPTRACE", 0),
+  completion("NOPPTRACE", 0),
+  completion("PRECTYPE", 1, ["ANS", "DECDIGIT", "DECRESULT"]),
+  completion("PREFIX", 1),
+  completion("PROCEED", 0),
+  completion("NOPROCEED", 0, ["S", "W", "E"]),
+  completion("PROCESS", 0, ["DELETE", "KEEP"]),
+  completion("NOPROCESS", 0),
+
+  completion("QUOTE", 1),
+
+  completion("REDUCE", 0),
+  completion("NOREDUCE", 0),
+  completion("RENT", 0),
+  completion("NORENT", 0),
+  completion("RESEXP", 0),
+  completion("NORESEXP", 0),
+  completion("RESPECT", 1),
+  completion("RTCHECK", 1, ["NONULLPTR", "NULLPTR", "NULL370"]),
+  completion("RULES", 1),
+
+  completion("SEMANTIC", 0),
+  completion("NOSEMANTIC", 0, ["S", "W", "E"]),
+  completion("SERVICE", 1),
+  completion("NOSERVICE", 0),
+  completion("SOURCE", 0),
+  completion("NOSOURCE", 0),
+  completion("SPILL", 1, "2048"),
+  completion("STATIC", 1, ["FULL", "SHORT"]),
+  completion("STDSYS", 0),
+  completion("NOSTDSYS", 0),
+  completion("STMT", 0),
+  completion("NOSTMT", 0),
+  completion("STORAGE", 0),
+  completion("NOSTORAGE", 0),
+  completion("STRINGOFGRAPHIC", 1, ["GRAPHIC", "CHARACTER"]),
+  completion("SYNTAX", 0),
+  completion("NOSYNTAX", 0, ["S", "W", "E"]),
+  completion("SYSPARM", 1),
+  completion("SYSTEM", 1, ["MVS", "CICS", "IMS", "OS", "TSO"]),
+
+  completion("TERMINAL", 0),
+  completion("NOTERMINAL", 0),
+  completion("TEST", 0),
+  completion("NOTEST", 0),
+
+  completion("UNROLL", 1, ["AUTO", "NO"]),
+  completion("USAGE", 1),
+
+  completion("WIDECHAR", 1, ["BIGENDIAN", "LITTLEENDIAN"]),
+  completion("WINDOW", 1, "1950"),
+  completion("WRITABLE", 0),
+  completion("NOWRITABLE", 0, ["FWS", "PRV"]),
+
+  completion("XINFO", 1),
+  completion("XML", 1),
+  completion("XREF", 0),
+  completion("NOXREF", 0),
+];
+
+export const PLI_OPTION_NAMES: readonly string[] = COMPLETIONS.map(
+  (c) => c.name,
+);
+
+const COMPLETION_MAP = new Map<string, CompilerOptionCompletion>(
+  COMPLETIONS.map((c) => [c.name, c]),
+);
+
+export function getOptionCompletion(
+  name: string,
+): CompilerOptionCompletion | undefined {
+  return COMPLETION_MAP.get(name.toUpperCase());
+}

--- a/packages/language/src/preprocessor/compiler-options/options.ts
+++ b/packages/language/src/preprocessor/compiler-options/options.ts
@@ -9,7 +9,7 @@
  *
  */
 
-import { Diagnostic } from "../../language-server/types";
+import { Diagnostic, Range } from "../../language-server/types";
 import { Token } from "../../parser/tokens";
 import * as Pli from "./options-pli";
 import * as Macro from "./options-macro";
@@ -27,6 +27,13 @@ export interface CompilerOptions extends Pli.CompilerOptions {
   macroOptions: Macro.CompilerOptions;
   sqlOptions: SQL.CompilerOptions;
   cicsOptions: CICS.CompilerOptions;
+  /**
+   * The source ranges of the PROCESS directives from which these compiler
+   * options were parsed. Since the ranges are no longer needed for the
+   * options themselves after parsing, they are kept primarily for LSP
+   * requests (e.g. compiler-option completion).
+   */
+  ranges: Range[];
 }
 
 export interface CompilerOptionResult {
@@ -115,5 +122,6 @@ export function getDefaultCompilerOptions(): CompilerOptions {
     macroOptions: Macro.getDefaultCompilerOptions(),
     sqlOptions: SQL.getDefaultCompilerOptions(),
     cicsOptions: CICS.getDefaultCompilerOptions(),
+    ranges: [],
   };
 }

--- a/packages/language/src/preprocessor/compiler-options/translate.ts
+++ b/packages/language/src/preprocessor/compiler-options/translate.ts
@@ -110,6 +110,8 @@ export class CompilerOptionTranslator {
       macroOptions: this.translatorMacro.options as CompilerOptionsMacro,
       sqlOptions: this.translatorSQL.options as CompilerOptionsSQL,
       cicsOptions: this.translatorCICS.options as CompilerOptionsCICS,
+      // Preserved as-is; the processor may set the real ranges after translation.
+      ranges: this.result.options.ranges,
     };
     if (configuration?.source === CompilerOptionSource.SOURCE_FILE) {
       this.result.tokens.push(...input.tokens);

--- a/packages/language/test/fourslash/completion/compiler-options/aggregate-param-alternatives.ts
+++ b/packages/language/test/fourslash/completion/compiler-options/aggregate-param-alternatives.ts
@@ -1,0 +1,82 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS AGGREG<|1>;
+////*PROCESS AGGREGATE<|2>;
+////*PROCESS AGGREGATE(<|3>);
+////*PROCESS AGGREGATE(DECIMAL<|4>);
+////*PROCESS AGGREGATE(DECIMAL<|5>)
+////*PROCESS AGGREGATE(DECIMAL<|6>
+////*PROCESS ARCH(13<|7>);
+////*PROCESS ARCH(13)<|8>;
+////*PROCESS AGGREGATE(DECIMAL)<|9>;
+
+// A partial name completes to the canonical option name.
+completion.expectAt(1, { includes: ["AGGREGATE"] });
+
+// Once the option name is fully typed, ';' (to terminate the directive) and
+// one '(alternative)' item per alternative are offered directly - not a bare
+// '(' step, the option name itself, other option names, or the bare
+// alternative values.
+completion.expectAt(2, {
+  includes: [";", "(DECIMAL)", "(HEXADEC)"],
+  excludes: ["(", "AGGREGATE", "NOAGGREGATE", "DECIMAL", "HEXADEC"],
+});
+
+// Inside the (still empty) parentheses, only the option's literal
+// alternatives are offered - not option names.
+completion.expectAt(3, {
+  includes: ["DECIMAL", "HEXADEC"],
+  excludes: ["AGGREGATE", "OPTIMIZE"],
+});
+
+// Once a full, valid alternative has been typed and the closing ')' already
+// exists in the source (with a trailing ';'), nothing is offered - the
+// directive is already complete, same as a mandatory-parameter option like
+// `ARCH(13);`.
+completion.expectAt(4, {
+  excludes: ["DECIMAL", "HEXADEC", ")", ");", ";"],
+});
+
+// Same as above, but without a trailing ';' yet: still nothing is offered,
+// since the parentheses are already closed.
+completion.expectAt(5, {
+  excludes: ["DECIMAL", "HEXADEC", ")", ");", ";"],
+});
+
+// Once a full, valid alternative has been typed and there is no closing ')'
+// yet at all, both a bare ')' and the combined ');' are offered - not ';' on
+// its own, and not the alternatives.
+completion.expectAt(6, {
+  includes: [")", ");"],
+  excludes: ["DECIMAL", "HEXADEC", ";"],
+});
+
+// A mandatory-parameter option with alternatives (ARCH) behaves the same way
+// once its value and closing ')' already exist: nothing is offered.
+completion.expectAt(7, {
+  excludes: ["10", "11", "12", "13", "14", ")", ");", ";"],
+});
+
+// Right after a completed option's closing ')', with a ';' already right
+// there, the redundant/duplicate ';' suggestion is suppressed - but other
+// option names (to continue the directive before the existing ';') are
+// still offered.
+completion.expectAt(8, {
+  includes: ["AGGREGATE", "OPTIMIZE"],
+  excludes: [";"],
+});
+completion.expectAt(9, {
+  includes: ["AGGREGATE", "OPTIMIZE"],
+  excludes: [";"],
+});

--- a/packages/language/test/fourslash/completion/compiler-options/no-completion-in-params.ts
+++ b/packages/language/test/fourslash/completion/compiler-options/no-completion-in-params.ts
@@ -1,0 +1,18 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS AGGREGATE(<|1>);
+
+completion.expectAt(1, {
+  excludes: ["AGGREGATE", "OPTIMIZE"],
+});

--- a/packages/language/test/fourslash/completion/compiler-options/no-leak-after-unterminated-process.ts
+++ b/packages/language/test/fourslash/completion/compiler-options/no-leak-after-unterminated-process.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS LIST
+////MAIN: PROC
+//// DCL X FIXED<|1> BIN
+
+// The processor sets range.end = text.length when there is no closing
+// semicolon on the *PROCESS directive. Once the cursor is inside ordinary
+// PL/I code, no compiler-option completions should leak in.
+completion.expectAt(1, {
+  excludes: ["LIST", "AGGREGATE", "MARGINS", "RULES", ";"],
+});

--- a/packages/language/test/fourslash/completion/compiler-options/option-names.ts
+++ b/packages/language/test/fourslash/completion/compiler-options/option-names.ts
@@ -1,0 +1,25 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS <|1>;
+////*PROCESS OPT<|2>;
+
+completion.expectAt(1, {
+  includes: ["AGGREGATE", "NOAGGREGATE", "OPTIMIZE", "LIST"],
+  excludes: ["AG"], // short alias not in canonical list
+});
+
+completion.expectAt(2, {
+  includes: ["OPTIMIZE"],
+  excludes: ["AGGREGATE"],
+});

--- a/packages/language/test/fourslash/completion/compiler-options/process-keyword.ts
+++ b/packages/language/test/fourslash/completion/compiler-options/process-keyword.ts
@@ -1,0 +1,22 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////<|0>
+////*<|1>
+////%<|2>
+////*PRO<|3>
+
+completion.expectAt(0, { includes: ["*PROCESS", "%PROCESS"] });
+completion.expectAt(1, { includes: ["PROCESS"] });
+completion.expectAt(2, { includes: ["PROCESS"] });
+completion.expectAt(3, { includes: ["PROCESS"] });

--- a/packages/language/test/fourslash/completion/compiler-options/semicolon-terminator.ts
+++ b/packages/language/test/fourslash/completion/compiler-options/semicolon-terminator.ts
@@ -1,0 +1,28 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+////*PROCESS <|1>;
+////*PROCESS AGGREGATE <|2>;
+////*PROCESS MAR<|3>;
+////*PROCESS AGGREGATE,<|4>;
+
+// ';' is offered as a directive terminator when no partial name is being
+// typed and there is no dangling comma.
+completion.expectAt(1, { includes: [";"] });
+completion.expectAt(2, { includes: [";"] });
+
+// ';' is NOT offered while a partial option name is being typed.
+completion.expectAt(3, { excludes: [";"] });
+
+// ';' is NOT offered right after a trailing comma.
+completion.expectAt(4, { excludes: [";"] });


### PR DESCRIPTION
Provides completion support for compiler options on the top level. 
This is intentionally kept separate from `translator-pli` so that completion behavior can be declared without touching the translation logic. A future refactoring could derive these entries automatically from the translator rule definitions.