### PR TITLE
Preserve original path casing when creating config / adding INCLUDE libs

### DIFF
--- a/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
+++ b/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
@@ -137,19 +137,10 @@ export async function quickFixCreateConfig(
   if (!workspaceUri || !entryUri) {
     return;
   }
-  const resolvedEntry = UriUtils.toFilePath(entryUri);
-  const workspacePath = UriUtils.toFilePath(workspaceUri);
-
-  const workspaceParts = UriUtils.parts(workspacePath);
-  const entryParts = UriUtils.parts(resolvedEntry);
-
-  const isInsideWorkspace = workspaceParts.every(
-    (part, index) => part === entryParts[index],
+  const programPath = UriUtils.workspaceRelativeEntryPath(
+    workspaceUri,
+    entryUri,
   );
-
-  const programPath = isInsideWorkspace
-    ? entryParts.slice(workspaceParts.length).join("/")
-    : resolvedEntry;
 
   const action: CodeAction = {
     title: `Create a startup configuration for this file.`,

--- a/packages/language/src/utils/uri.ts
+++ b/packages/language/src/utils/uri.ts
@@ -241,19 +241,9 @@ export namespace UriUtils {
   }
 
   /**
-   * Computes the entry-point path to record for a program (e.g. the `program`
-   * field of `pgm_conf.json` and the value shown when offering to create a
-   * startup configuration).
-   *
-   * - If `entry` is inside `workspace`, returns the workspace-relative path
-   *   with forward slashes and the **original casing preserved**.
-   * - Otherwise returns the absolute file path of `entry`.
-   *
-   * Both inputs are run through {@link toFilePath}, so backslashes are
-   * normalized and Windows drive letters are uppercased consistently. The
-   * inside-workspace check is case-insensitive so it behaves correctly on
-   * case-insensitive file systems (Windows, default macOS) without discarding
-   * the original casing of the returned path.
+   * Returns `entry` relative to `workspace` (original casing preserved), or its
+   * absolute path when outside the workspace. Membership is matched
+   * case-insensitively for correctness on case-insensitive file systems.
    */
   export function workspaceRelativeEntryPath(
     workspace: URI | string,
@@ -271,22 +261,9 @@ export namespace UriUtils {
   }
 
   /**
-   * Compute the workspace-relative parent folder for a found file candidate,
-   * preserving the candidate's original casing.
-   *
-   * Examples:
-   *  - workspace root: /repo/plugin-example
-   *  - candidate: /repo/plugin-example/CopyBooks/Common/nested.pli
-   *  -> returns "CopyBooks/Common"
-   *
-   * Built on {@link workspaceRelativeEntryPath}, so the inside-workspace check
-   * is case-insensitive (correct on case-insensitive file systems) while the
-   * returned folder keeps the candidate's on-disk casing — important because
-   * this value is written into `proc_grps.json` as a lib path, which must match
-   * the real directory name on case-sensitive file systems.
-   *
-   * Returns "" when the candidate sits directly in the workspace root, and
-   * `undefined` when the candidate is outside the workspace (or invalid).
+   * Returns the candidate's workspace-relative parent folder (original casing
+   * preserved), `""` when it sits in the workspace root, or `undefined` when it
+   * is outside the workspace or invalid.
    */
   export function computeWorkspaceRelativeParentFolder(
     candidateRaw: URI,

--- a/packages/language/src/utils/uri.ts
+++ b/packages/language/src/utils/uri.ts
@@ -271,15 +271,22 @@ export namespace UriUtils {
   }
 
   /**
-   * Compute workspace-relative parent folder for a found file candidate.
+   * Compute the workspace-relative parent folder for a found file candidate,
+   * preserving the candidate's original casing.
    *
    * Examples:
    *  - workspace root: /repo/plugin-example
-   *  - candidate: /repo/plugin-example/cpy/test-nested-included/nested-not-here.pli
-   *  -> returns "cpy/test-nested-included"
+   *  - candidate: /repo/plugin-example/CopyBooks/Common/nested.pli
+   *  -> returns "CopyBooks/Common"
    *
-   * If workspace-relative cannot be computed, returns the parent folder name (e.g. "test-nested-included").
-   * Returns undefined if candidate looks invalid.
+   * Built on {@link workspaceRelativeEntryPath}, so the inside-workspace check
+   * is case-insensitive (correct on case-insensitive file systems) while the
+   * returned folder keeps the candidate's on-disk casing — important because
+   * this value is written into `proc_grps.json` as a lib path, which must match
+   * the real directory name on case-sensitive file systems.
+   *
+   * Returns "" when the candidate sits directly in the workspace root, and
+   * `undefined` when the candidate is outside the workspace (or invalid).
    */
   export function computeWorkspaceRelativeParentFolder(
     candidateRaw: URI,
@@ -287,18 +294,19 @@ export namespace UriUtils {
   ): string | undefined {
     if (!candidateRaw) return undefined;
 
-    const candidate = toNormalizedKey(candidateRaw);
-    const workspaceFolder = toNormalizedKey(workspaceFolderUri);
+    const relativePath = workspaceRelativeEntryPath(
+      workspaceFolderUri,
+      candidateRaw,
+    );
 
-    if (!candidate.startsWith(workspaceFolder)) return undefined;
+    // Outside the workspace the relative computation falls back to an absolute
+    // path; there's no meaningful workspace-relative lib folder to suggest.
+    if (computePathType(relativePath) !== PathType.Relative) {
+      return undefined;
+    }
 
-    const relativePath = candidate.slice(workspaceFolder.length);
-    const parentDir = relativePath.substring(0, relativePath.lastIndexOf("/"));
-    const parentRelativePath = parentDir.startsWith("/")
-      ? parentDir.slice(1)
-      : parentDir;
-
-    return parentRelativePath;
+    const lastSlash = relativePath.lastIndexOf("/");
+    return lastSlash === -1 ? "" : relativePath.slice(0, lastSlash);
   }
 }
 

--- a/packages/language/src/utils/uri.ts
+++ b/packages/language/src/utils/uri.ts
@@ -241,6 +241,36 @@ export namespace UriUtils {
   }
 
   /**
+   * Computes the entry-point path to record for a program (e.g. the `program`
+   * field of `pgm_conf.json` and the value shown when offering to create a
+   * startup configuration).
+   *
+   * - If `entry` is inside `workspace`, returns the workspace-relative path
+   *   with forward slashes and the **original casing preserved**.
+   * - Otherwise returns the absolute file path of `entry`.
+   *
+   * Both inputs are run through {@link toFilePath}, so backslashes are
+   * normalized and Windows drive letters are uppercased consistently. The
+   * inside-workspace check is case-insensitive so it behaves correctly on
+   * case-insensitive file systems (Windows, default macOS) without discarding
+   * the original casing of the returned path.
+   */
+  export function workspaceRelativeEntryPath(
+    workspace: URI | string,
+    entry: URI | string,
+  ): string {
+    const entryPath = toFilePath(entry);
+    const workspaceParts = parts(toFilePath(workspace));
+    const entryParts = parts(entryPath);
+    const isInsideWorkspace = workspaceParts.every(
+      (part, index) => part.toLowerCase() === entryParts[index]?.toLowerCase(),
+    );
+    return isInsideWorkspace
+      ? entryParts.slice(workspaceParts.length).join("/")
+      : entryPath;
+  }
+
+  /**
    * Compute workspace-relative parent folder for a found file candidate.
    *
    * Examples:

--- a/packages/language/test/utils/uri.test.ts
+++ b/packages/language/test/utils/uri.test.ts
@@ -478,3 +478,53 @@ describe("UriUtils.composeRelativePath", () => {
     );
   });
 });
+
+describe("UriUtils.workspaceRelativeEntryPath", () => {
+  test("preserves original casing of the workspace-relative path", () => {
+    expect(
+      UriUtils.workspaceRelativeEntryPath(
+        "/Users/dev/Project",
+        "/Users/dev/Project/SOURCE/Foo.pli",
+      ),
+    ).toBe("SOURCE/Foo.pli");
+  });
+
+  test("matches the workspace prefix case-insensitively", () => {
+    // Same file/workspace, but the workspace prefix casing differs from the
+    // entry's (as can happen on case-insensitive file systems). The relative
+    // remainder must still keep its own original casing.
+    expect(
+      UriUtils.workspaceRelativeEntryPath(
+        "/users/DEV/project",
+        "/Users/dev/Project/SOURCE/Foo.pli",
+      ),
+    ).toBe("SOURCE/Foo.pli");
+  });
+
+  test("normalizes Windows backslashes while preserving casing", () => {
+    expect(
+      UriUtils.workspaceRelativeEntryPath(
+        "C:\\Users\\Dev\\Project",
+        "C:\\Users\\Dev\\Project\\SOURCE\\Foo.pli",
+      ),
+    ).toBe("SOURCE/Foo.pli");
+  });
+
+  test("returns the absolute file path when entry is outside the workspace", () => {
+    expect(
+      UriUtils.workspaceRelativeEntryPath(
+        "/Users/dev/project",
+        "/Users/dev/other/Foo.pli",
+      ),
+    ).toBe("/Users/dev/other/Foo.pli");
+  });
+
+  test("accepts URI string inputs and strips the scheme", () => {
+    expect(
+      UriUtils.workspaceRelativeEntryPath(
+        "file:///workspace",
+        "file:///workspace/SOURCE/Foo.pli",
+      ),
+    ).toBe("SOURCE/Foo.pli");
+  });
+});

--- a/packages/language/test/utils/uri.test.ts
+++ b/packages/language/test/utils/uri.test.ts
@@ -528,3 +528,45 @@ describe("UriUtils.workspaceRelativeEntryPath", () => {
     ).toBe("SOURCE/Foo.pli");
   });
 });
+
+describe("UriUtils.computeWorkspaceRelativeParentFolder", () => {
+  const workspace = UriUtils.toUri("/repo/Project");
+
+  test("preserves the original casing of the parent lib folder", () => {
+    expect(
+      UriUtils.computeWorkspaceRelativeParentFolder(
+        UriUtils.toUri("/repo/Project/CopyBooks/Common/Foo.inc"),
+        workspace,
+      ),
+    ).toBe("CopyBooks/Common");
+  });
+
+  test("detects workspace membership case-insensitively", () => {
+    // Workspace prefix casing differs from the candidate's; membership must
+    // still be detected while the folder keeps the candidate's casing.
+    expect(
+      UriUtils.computeWorkspaceRelativeParentFolder(
+        UriUtils.toUri("/repo/Project/CopyBooks/Foo.inc"),
+        UriUtils.toUri("/REPO/project"),
+      ),
+    ).toBe("CopyBooks");
+  });
+
+  test("returns undefined when the candidate is outside the workspace", () => {
+    expect(
+      UriUtils.computeWorkspaceRelativeParentFolder(
+        UriUtils.toUri("/repo/Other/Foo.inc"),
+        workspace,
+      ),
+    ).toBeUndefined();
+  });
+
+  test("returns empty string when the candidate is in the workspace root", () => {
+    expect(
+      UriUtils.computeWorkspaceRelativeParentFolder(
+        UriUtils.toUri("/repo/Project/Foo.inc"),
+        workspace,
+      ),
+    ).toBe("");
+  });
+});

--- a/packages/vscode-extension/src/common/missing-config-handler.ts
+++ b/packages/vscode-extension/src/common/missing-config-handler.ts
@@ -37,18 +37,10 @@ export async function handleMissingConfig(
     return;
   }
 
-  const workspaceParts = UriUtils.parts(
-    UriUtils.toNormalizedKey(workspaceFolder),
+  const currentFileRelativePath = UriUtils.workspaceRelativeEntryPath(
+    workspaceFolder,
+    textEditor.document.fileName,
   );
-  const entryParts = UriUtils.parts(
-    UriUtils.toNormalizedKey(textEditor.document.fileName),
-  );
-  const isInsideWorkspace = workspaceParts.every(
-    (part, index) => part === entryParts[index],
-  );
-  const currentFileRelativePath = isInsideWorkspace
-    ? entryParts.slice(workspaceParts.length).join("/")
-    : UriUtils.normalizePath(textEditor.document.fileName);
 
   const options = {
     DONT_SHOW_AGAIN: "Don't show again",


### PR DESCRIPTION
**Preserve original path casing when creating config / adding INCLUDE libs**

Fixes [#793](https://github.com/zowe/zowe-pli-language-support/issues/793).

### Problem
When we auto-generate a startup configuration (missing-config toast + "Create a startup configuration" quick fix) or suggest a folder for the "Add to INCLUDE libs" quick fix, the path was lower-cased before being shown and written into `pgm_conf.json` / `proc_grps.json`. 

### Change
- Added `UriUtils.workspaceRelativeEntryPath(workspace, entry)`: normalizes backslashes and strips the scheme via `toFilePath`, detects workspace membership **case-insensitively**, and returns the relative path with **original casing preserved** (or the absolute path when outside the workspace).
- Refactored `handleMissingConfig` and `quickFixCreateConfig` to use it, replacing two divergent hand-rolled copies.
- Rebuilt `computeWorkspaceRelativeParentFolder` on the same helper so the "Add to INCLUDE libs" quick fix keeps the folder's on-disk casing.

### Notes
- Downstream config resolution is case-insensitive (`minimatch nocase`), so correctly-cased values are safe and now match as *exact* rather than glob.
- Tests: added focused `UriUtils` unit tests (casing preservation, case-insensitive membership, Windows paths, outside-workspace fallback);