### PR TITLE
Support dimensions on labels

### DIFF
--- a/packages/language/src/language-server/document-symbol-builder.ts
+++ b/packages/language/src/language-server/document-symbol-builder.ts
@@ -13,11 +13,11 @@ import { SymbolKind } from "vscode-languageserver-types";
 import {
   DeclaredItem,
   DeclareStatement,
-  Statement,
   SyntaxKind,
   DefaultAttribute,
   ProcedureStatement,
 } from "../syntax-tree/ast";
+import { getLabelPrefixName } from "../syntax-tree/ast-utils";
 import { Range, getSyntaxNodeRange, DocumentSymbol } from "./types";
 import { CstNodeKind } from "../syntax-tree/cst";
 import { isValidToken } from "../linking/tokens";
@@ -60,7 +60,8 @@ class ProcedureSymbolBuilder implements SymbolBuilder {
       return [];
     }
     const procedureName = labelPrefixStatement.labels
-      .map((label) => label.name)
+      .map((label) => getLabelPrefixName(label))
+      .filter((name) => name !== null)
       .join(" ");
     const range = getSyntaxNodeRange(labelPrefixStatement.labels[0]);
 
@@ -246,13 +247,14 @@ class LevelHierarchyBuilder {
 class LabelSymbolBuilder implements SymbolBuilder {
   canHandle(token: Token): boolean {
     if (
-      token.kind !== CstNodeKind.LabelPrefix_Name ||
-      token.element?.kind !== SyntaxKind.LabelPrefix
+      token.kind !== CstNodeKind.ReferenceItem_Ref ||
+      token.element?.kind !== SyntaxKind.ReferenceItem ||
+      token.element.container?.kind !== SyntaxKind.LabelPrefix
     ) {
       return false;
     }
 
-    const container = token.element.container;
+    const container = token.element.container.container;
     if (!container || container.kind !== SyntaxKind.Statement) {
       return true;
     }
@@ -265,27 +267,25 @@ class LabelSymbolBuilder implements SymbolBuilder {
     elementTokens: Token[],
     childSymbols: DocumentSymbol[],
   ): DocumentSymbol[] {
-    const labelPrefixStatement = token.element?.container as Statement;
-    if (!labelPrefixStatement?.labels?.length) {
+    const labelPrefixStatement = token.element?.container?.container;
+    if (
+      labelPrefixStatement?.kind !== SyntaxKind.Statement ||
+      !labelPrefixStatement.labels.length
+    ) {
       return [];
     }
 
     const documentSymbols: DocumentSymbol[] = [];
     for (const label of labelPrefixStatement.labels) {
       const range = getSyntaxNodeRange(label);
+      const name = getLabelPrefixName(label);
 
-      if (!label.name || !range) {
+      if (!name || !range) {
         continue;
       }
 
       documentSymbols.push(
-        createDocumentSymbol(
-          label.name,
-          SymbolKind.Key,
-          range,
-          range,
-          childSymbols,
-        ),
+        createDocumentSymbol(name, SymbolKind.Key, range, range, childSymbols),
       );
     }
 

--- a/packages/language/src/language-server/hover-request.ts
+++ b/packages/language/src/language-server/hover-request.ts
@@ -27,6 +27,10 @@ import {
   SyntaxKind,
   SyntaxNode,
 } from "../syntax-tree/ast";
+import {
+  getLabelPrefixName,
+  getLabelPrefixNameToken,
+} from "../syntax-tree/ast-utils";
 import { formatPliCodeBlock } from "../utils/code-block";
 import {
   binaryTokenIndexRightMost,
@@ -167,7 +171,7 @@ function getLabelPrefixRepresentation(labelPrefix: LabelPrefix): string | null {
   }
 
   return formatPliCodeBlock(
-    `${labelPrefix.name ?? ""}: PROC${paramsStr} ${optionsStr};`,
+    `${getLabelPrefixName(labelPrefix) ?? ""}: PROC${paramsStr} ${optionsStr};`,
   );
 }
 
@@ -337,7 +341,9 @@ const generateReferenceTokenMarkup: MarkupGenerator = ({ unit, token }) => {
     }
     let jsDocsComment = "";
     if (ref.node.kind === SyntaxKind.LabelPrefix) {
-      if (ref.node.nameToken?.uri?.scheme !== BuiltinsUriSchema) {
+      if (
+        getLabelPrefixNameToken(ref.node)?.uri?.scheme !== BuiltinsUriSchema
+      ) {
         // JSDoc is only for builtins
         return getNodeRepresentation(unit, ref.node);
       }
@@ -463,10 +469,11 @@ export function getJSDocCommentBeforeLabelPrefix(
   labelPrefix: LabelPrefix,
   compilationUnit: CompilationUnit,
 ): JSDocComment | null {
-  if (!labelPrefix.nameToken) {
+  const nameToken = getLabelPrefixNameToken(labelPrefix);
+  if (!nameToken) {
     return null;
   }
-  const uri = labelPrefix.nameToken.uri;
+  const uri = nameToken.uri;
   if (!uri || uri.scheme !== BuiltinsUriSchema) {
     //if it's not a builtin, we can skip the work of looking for comments entirely
     //only JSDoc on builtins is currently supported
@@ -477,13 +484,10 @@ export function getJSDocCommentBeforeLabelPrefix(
   if (!tokens || !commentTokens) {
     return null;
   }
-  let tokenIndex = binaryTokenIndexSearch(
-    tokens,
-    labelPrefix.nameToken.startOffset,
-  );
+  let tokenIndex = binaryTokenIndexSearch(tokens, nameToken.startOffset);
   const commentIndex = binaryTokenIndexRightMost(
     commentTokens,
-    labelPrefix.nameToken.startOffset,
+    nameToken.startOffset,
   );
   if (commentIndex > -1) {
     const commentToken = commentTokens[commentIndex];

--- a/packages/language/src/language-server/semantic-tokens.ts
+++ b/packages/language/src/language-server/semantic-tokens.ts
@@ -294,8 +294,11 @@ function isProcedureType(token: Token): boolean {
   switch (token.kind) {
     case CstNodeKind.Exports_Procedure:
       return true;
-    case CstNodeKind.LabelPrefix_Name:
-      return isProcedurePrefix(token.element);
+    case CstNodeKind.ReferenceItem_Ref:
+      if (token.element?.kind === SyntaxKind.ReferenceItem) {
+        return isProcedurePrefix(token.element.container);
+      }
+      return false;
   }
   return false;
 }

--- a/packages/language/src/linking/resolver.ts
+++ b/packages/language/src/linking/resolver.ts
@@ -333,13 +333,20 @@ function getMatchingSymbols(
    */
 
   const firstImplicitSymbol = implicitSymbols[0];
-  reporter.reportImplicitDeclaration(firstImplicitSymbol);
+  // Implicit declarations created by dimensioned label prefixes (e.g. `L(1): ...;`)
+  // are label constants, not variables — forward `GOTO L(1);` is perfectly fine.
+  if (firstImplicitSymbol.node.kind !== SyntaxKind.LabelPrefix) {
+    reporter.reportImplicitDeclaration(firstImplicitSymbol);
 
-  if (
-    unit.statementOrderCache.isBefore(reference.owner, firstImplicitSymbol.node)
-  ) {
-    // If the node is before the first implicit symbol, we report a potential unset variable.
-    reporter.reportPotentialUnsetVariable(reference.token, getFullName());
+    if (
+      unit.statementOrderCache.isBefore(
+        reference.owner,
+        firstImplicitSymbol.node,
+      )
+    ) {
+      // If the node is before the first implicit symbol, we report a potential unset variable.
+      reporter.reportPotentialUnsetVariable(reference.token, getFullName());
+    }
   }
 
   /**

--- a/packages/language/src/linking/symbol-table.ts
+++ b/packages/language/src/linking/symbol-table.ts
@@ -598,15 +598,30 @@ function handleNode(
     case SyntaxKind.DefineOrdinalStatement:
       parentScope.symbolTable.addOrdinalDefinition(node, context.reporter);
       break;
-    // E.g. `MY_PROC: PROCEDURE;`
-    case SyntaxKind.LabelPrefix:
-      parentScope.symbolTable.addLabelStatement(
-        node,
-        node.name,
-        node.nameToken,
-        context.reporter,
-      );
+    // E.g. `MY_PROC: PROCEDURE;` or `MY_LABEL(1): PUT("HELLO");`
+    case SyntaxKind.LabelPrefix: {
+      const labelRef = node.item?.ref;
+      if (labelRef) {
+        if (node.item!.dimensions.length > 0) {
+          // A dimensioned label prefix implicitly declares the label array.
+          // An explicit `DCL ... LABEL` declaration takes precedence during resolution.
+          parentScope.symbolTable.addImplicitDeclaration(
+            labelRef.text,
+            labelRef.token,
+            node,
+            context.reporter,
+          );
+        } else {
+          parentScope.symbolTable.addLabelStatement(
+            node,
+            labelRef.text,
+            labelRef.token,
+            context.reporter,
+          );
+        }
+      }
       break;
+    }
     // E.g. `DCL A FIXED;`
     case SyntaxKind.DeclareStatement:
       parentScope.symbolTable.addExplicitDeclarationStatement(

--- a/packages/language/src/linking/tokens.ts
+++ b/packages/language/src/linking/tokens.ts
@@ -25,7 +25,6 @@ export function isValidToken(token: Token): boolean {
 export function isNameToken(kind: CstNodeKind | undefined): boolean {
   switch (kind) {
     case CstNodeKind.DeclaredVariable_Name:
-    case CstNodeKind.LabelPrefix_Name:
     case CstNodeKind.OrdinalValue_Name:
     case CstNodeKind.ReplaceStatement_Id:
     case CstNodeKind.DefineOrdinalStatement_Name:
@@ -43,8 +42,9 @@ export function getNameToken(node: SyntaxNode): Token | undefined {
     case SyntaxKind.ProcedureParameter:
     case SyntaxKind.ReferenceItem:
       return node.ref?.token ?? undefined;
-    case SyntaxKind.DeclaredVariable:
     case SyntaxKind.LabelPrefix:
+      return node.item?.ref?.token ?? undefined;
+    case SyntaxKind.DeclaredVariable:
     case SyntaxKind.OrdinalValue:
     case SyntaxKind.ReplaceStatement:
     case SyntaxKind.DefineOrdinalStatement:

--- a/packages/language/src/parser/parser-lookahead.ts
+++ b/packages/language/src/parser/parser-lookahead.ts
@@ -92,6 +92,56 @@ export function performAssignmentLookahead(state: ParserState): boolean {
   return false;
 }
 
+/**
+ * Checks whether the tokens starting at lookahead position `index` form a
+ * label prefix: `ID [ ( ...balanced... ) ]* :`
+ * Dimensions are allowed since labels can reference declared label arrays,
+ * e.g. `DCL L(2) LABEL; L(1): PUT("HELLO");`
+ *
+ * @returns the lookahead index directly after the colon, or undefined if no label prefix is present
+ */
+export function skipLabelPrefixLookahead(
+  state: ParserState,
+  index: number,
+): number | undefined {
+  // The compiler will not use more than 160 tokens to perform the lookahead
+  const max = index + 160;
+  let token = state.peek(index);
+  if (!token || !tokenMatcher(token, tokens.ID)) {
+    return undefined;
+  }
+  let i = index + 1;
+  token = state.peek(i);
+  // Skip any number of balanced parenthesis groups (label array dimensions)
+  while (token && tokenMatcher(token, tokens.OpenParen)) {
+    let parenthesis = 1;
+    i++;
+    while (parenthesis > 0) {
+      if (i >= max) {
+        return undefined;
+      }
+      const inner = state.peek(i++);
+      if (!inner || tokenMatcher(inner, tokens.Semicolon)) {
+        return undefined;
+      }
+      if (tokenMatcher(inner, tokens.OpenParen)) {
+        parenthesis++;
+      } else if (tokenMatcher(inner, tokens.CloseParen)) {
+        parenthesis--;
+      }
+    }
+    token = state.peek(i);
+  }
+  if (token && tokenMatcher(token, tokens.Colon)) {
+    return i + 1;
+  }
+  return undefined;
+}
+
+export function performLabelPrefixLookahead(state: ParserState): boolean {
+  return skipLabelPrefixLookahead(state, 1) !== undefined;
+}
+
 function performIfLookahead(state: ParserState): boolean {
   let i = 1;
   let token = state.peek(i++);
@@ -162,18 +212,11 @@ export function performEndStatementLookahead(
   let token: tokens.Token | undefined = undefined;
 
   while ((token = lookahead(index)) && !tokenMatcher(token, tokens.END)) {
-    const idToken = lookahead(index);
-    const colonToken = lookahead(index + 1);
-    if (!idToken || !colonToken) {
+    const next = skipLabelPrefixLookahead(state, index);
+    if (next === undefined) {
       return { endStatement: false };
     }
-    if (
-      !tokenMatcher(idToken, tokens.ID) ||
-      !tokenMatcher(colonToken, tokens.Colon)
-    ) {
-      return { endStatement: false };
-    }
-    index += 2;
+    index = next;
   }
 
   if (!token || !tokenMatcher(token, tokens.END)) {

--- a/packages/language/src/parser/parser-state.ts
+++ b/packages/language/src/parser/parser-state.ts
@@ -146,7 +146,7 @@ export class ParserState {
       return true;
     }
     return this.currentStatementLabels.some(
-      (labelPrefix) => labelPrefix.name === endLabel,
+      (labelPrefix) => labelPrefix.item?.ref?.text === endLabel,
     );
   }
 

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -33,6 +33,7 @@ import {
   hasEndStatementLookahead,
   performAssignmentLookahead,
   performEndStatementLookahead,
+  performLabelPrefixLookahead,
 } from "./parser-lookahead";
 import { Token } from "./tokens";
 import { CompilerOptions } from "../preprocessor/compiler-options/options";
@@ -518,15 +519,7 @@ const labelPrefix = rule(
   sequence(tokens.ID, tokens.Colon),
   (state: ParserState): ast.LabelPrefix => {
     const element = ast.createLabelPrefix();
-    const idToken = state.consume(
-      element,
-      CstNodeKind.LabelPrefix_Name,
-      tokens.ID,
-    );
-    if (idToken) {
-      element.name = idToken.image;
-      element.nameToken = idToken;
-    }
+    element.item = referenceItem.rule(state, ast.ReferenceType.Variable);
     state.consume(element, CstNodeKind.LabelPrefix_Colon, tokens.Colon);
     return element;
   },
@@ -661,7 +654,7 @@ const statement = rule(
     }
 
     const { inc } = state.createLoopContext("Statement");
-    while (state.canConsumeFirst(labelPrefix.first())) {
+    while (performLabelPrefixLookahead(state)) {
       inc();
       const label = labelPrefix.rule(state);
       label && element.labels.push(label);
@@ -1214,7 +1207,7 @@ const endStatement = rule(
 
     // Parse optional label prefixes
     const { inc } = state.createLoopContext("EndStatement");
-    while (state.canConsumeFirst(labelPrefix.first())) {
+    while (performLabelPrefixLookahead(state)) {
       inc();
       const prefix = labelPrefix.rule(state);
       prefix && element.labels.push(prefix);

--- a/packages/language/src/parser/preprocessor-parser.ts
+++ b/packages/language/src/parser/preprocessor-parser.ts
@@ -114,11 +114,11 @@ export async function statement(
 
 function labels(state: ParserState): ast.LabelPrefix[] {
   const labels: ast.LabelPrefix[] = [];
+  // Preprocessor labels never carry dimensions (macro label arrays are not
+  // a supported construct), so a plain `ID :` lookahead is sufficient here.
   while (state.canConsume(t.ID, t.Colon)) {
     const label = ast.createLabelPrefix();
-    const labelToken = state.consume(label, CstNodeKind.LabelPrefix_Name, t.ID);
-    label.name = labelToken?.image ?? null;
-    label.nameToken = labelToken;
+    label.item = parseReferenceItem(state, false);
     state.consume(label, CstNodeKind.LabelPrefix_Colon, t.Colon);
     labels.push(label);
   }

--- a/packages/language/src/preprocessor/instruction-generator.ts
+++ b/packages/language/src/preprocessor/instruction-generator.ts
@@ -11,6 +11,7 @@
 
 import * as inst from "./instructions";
 import * as ast from "../syntax-tree/ast";
+import { getLabelPrefixName } from "../syntax-tree/ast-utils";
 import { assertType, getAttributes } from "./util";
 import { createCicsResponseInstruction } from "./instructions";
 import { SemanticTokenTypes } from "../language-server/semantic-tokens";
@@ -86,9 +87,10 @@ function generateProcedureInstructionContainer(
   const labels = new Map<string, ast.LabelPrefix>();
   const params: string[] = [];
   for (const label of statement.labels) {
-    if (label.name) {
-      names.push(label.name);
-      labels.set(label.name, label);
+    const name = getLabelPrefixName(label);
+    if (name) {
+      names.push(name);
+      labels.set(name, label);
     }
   }
   const procedure = statement.value as ast.ProcedureStatement;
@@ -123,8 +125,9 @@ function generateInstructionForStatement(
     return undefined; // No value to generate instructions for
   }
   for (const label of statement.labels) {
-    if (label.name) {
-      labels.push(label.name);
+    const name = getLabelPrefixName(label);
+    if (name) {
+      labels.push(name);
     }
   }
   let instruction: inst.Instruction | undefined = undefined;

--- a/packages/language/src/syntax-tree/ast-iterator.ts
+++ b/packages/language/src/syntax-tree/ast-iterator.ts
@@ -595,6 +595,9 @@ export function forEachNode(
     case SyntaxKind.KeywordCondition:
       break;
     case SyntaxKind.LabelPrefix:
+      if (node.item) {
+        action(node.item);
+      }
       break;
     case SyntaxKind.LabelReference:
       if (node.label) {

--- a/packages/language/src/syntax-tree/ast-utils.ts
+++ b/packages/language/src/syntax-tree/ast-utils.ts
@@ -16,9 +16,22 @@ import {
   DeclaredVariable,
   DefineStructureStatement,
   getContainer,
+  LabelPrefix,
   SyntaxKind,
   TypeExtendingAttribute,
 } from "./ast";
+
+export function getLabelPrefixName(
+  label: LabelPrefix | null | undefined,
+): string | null {
+  return label?.item?.ref?.text ?? null;
+}
+
+export function getLabelPrefixNameToken(
+  label: LabelPrefix | null | undefined,
+): Token | null {
+  return label?.item?.ref?.token ?? null;
+}
 
 export function getTypeExtendingAttribute(
   attributes: DeclarationAttribute[],

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -3014,15 +3014,13 @@ export function createKeywordCondition(): KeywordCondition {
 
 export interface LabelPrefix extends AstNode {
   kind: SyntaxKind.LabelPrefix;
-  nameToken: Token | null;
-  name: string | null;
+  item: ReferenceItem | null;
 }
 export function createLabelPrefix(): LabelPrefix {
   return {
     kind: SyntaxKind.LabelPrefix,
     container: null,
-    nameToken: null,
-    name: null,
+    item: null,
   };
 }
 export interface LabelReference extends AstNode {

--- a/packages/language/src/syntax-tree/cst.ts
+++ b/packages/language/src/syntax-tree/cst.ts
@@ -86,7 +86,6 @@ export enum CstNodeKind {
   ProcedureStatement_Semicolon,
   ProcedureStatement_PROCEDURE_END,
   ScopeAttribute_Scope,
-  LabelPrefix_Name,
   LabelPrefix_Colon,
   EntryStatement_ENTRY,
   EntryStatement_OpenParenParams,

--- a/packages/language/src/typesystem/descriptions.ts
+++ b/packages/language/src/typesystem/descriptions.ts
@@ -423,6 +423,10 @@ export const AttributeStringifiers: {
     }
   },
   [AttributeKind.DataType]: function (value: DataType): string | undefined {
+    switch (value) {
+      case DataType.Label:
+        return "LABEL";
+    }
     return undefined;
   },
   [AttributeKind.Dimension]: function (

--- a/packages/language/src/validation/compiler/IBM1213I-unreferenced-procedure.ts
+++ b/packages/language/src/validation/compiler/IBM1213I-unreferenced-procedure.ts
@@ -11,6 +11,10 @@
 
 import { diagnosticFromCode } from "../../language-server/types";
 import * as ast from "../../syntax-tree/ast";
+import {
+  getLabelPrefixName,
+  getLabelPrefixNameToken,
+} from "../../syntax-tree/ast-utils";
 import { CompilationUnit } from "../../workspace/compilation-unit";
 import { PLICodes } from "../pli-codes";
 import { ValidationAcceptor } from "../validator";
@@ -36,12 +40,18 @@ export function IBM1213I_unreferenced_procedure(
   }
   const labels = container.labels;
   const label = labels[0];
-  if (!label || !label.nameToken || !label.name) {
+  const nameToken = getLabelPrefixNameToken(label);
+  const name = getLabelPrefixName(label);
+  if (!label || !nameToken || !name) {
     return;
   }
   for (const label of labels) {
     const references = compilationUnit.referencesCache.findReferences(label);
     for (const ref of references) {
+      if (ref.owner.container?.kind === ast.SyntaxKind.LabelPrefix) {
+        // The label prefix's own name reference — not a real usage
+        continue;
+      }
       if (
         ref.owner.container?.container?.container?.kind !==
         ast.SyntaxKind.EndStatement
@@ -51,7 +61,5 @@ export function IBM1213I_unreferenced_procedure(
       }
     }
   }
-  acceptor(
-    diagnosticFromCode(PLICodes.Warning.IBM1213I, label.nameToken, label.name),
-  );
+  acceptor(diagnosticFromCode(PLICodes.Warning.IBM1213I, nameToken, name));
 }

--- a/packages/language/src/validation/compiler/IBM2412I-IBM2410I-IBM2409I-handle-return-stmt-and-returns-att.ts
+++ b/packages/language/src/validation/compiler/IBM2412I-IBM2410I-IBM2409I-handle-return-stmt-and-returns-att.ts
@@ -11,6 +11,7 @@
 
 import { ValidationAcceptor } from "../validator";
 import * as AST from "../../syntax-tree/ast";
+import { getLabelPrefixNameToken } from "../../syntax-tree/ast-utils";
 import { diagnosticFromCode } from "../../language-server/types";
 import * as PLICodes from "../pli-codes";
 import {
@@ -81,9 +82,9 @@ export function IBM2412I_IBM2410I_IBM2409I_handle_return_stmt_and_returns_att(
   //IBM2410I: Procedures with RETURNS attribute must contain at least one RETURN statement.
   if (hasReturnsAtt && returnStmts.length === 0) {
     const procName =
-      node.container?.kind === AST.SyntaxKind.Statement &&
-      node.container.labels[0]?.nameToken?.originalImage
-        ? node.container.labels[0].nameToken.originalImage
+      node.container?.kind === AST.SyntaxKind.Statement
+        ? (getLabelPrefixNameToken(node.container.labels[0])?.originalImage ??
+          "<unnamed>")
         : "<unnamed>";
 
     acceptor(diagnosticFromCode(PLICodes.Error.IBM2410I, procToken, procName));

--- a/packages/language/src/validation/language-server/implicit-builtins.ts
+++ b/packages/language/src/validation/language-server/implicit-builtins.ts
@@ -13,6 +13,7 @@ import { diagnosticFromCode, Severity } from "../../language-server/types";
 import { BuiltinsUri, KNOWN_BUILTINS } from "../../workspace/builtins";
 import { PLICodes } from "../pli-codes";
 import * as AST from "../../syntax-tree/ast";
+import { getNameToken } from "../../linking/tokens";
 import { CompilationUnit } from "../../workspace/compilation-unit";
 import { ValidationAcceptor } from "../validator";
 
@@ -35,7 +36,7 @@ export function checkImplicitBuiltins(
     return;
   }
 
-  const nameToken = node.ref?.node?.nameToken;
+  const nameToken = node.ref?.node ? getNameToken(node.ref.node) : undefined;
   const uri = nameToken?.uri?.toString();
 
   // Check if the reference item is a builtin.

--- a/packages/language/src/validation/language-server/label-prefix-syntax.ts
+++ b/packages/language/src/validation/language-server/label-prefix-syntax.ts
@@ -1,0 +1,50 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { diagnosticFromCode } from "../../language-server/types";
+import { PLICodes } from "../pli-codes";
+import * as AST from "../../syntax-tree/ast";
+import { CompilationUnit } from "../../workspace/compilation-unit";
+import { ValidationAcceptor } from "../validator";
+
+export function checkLabelPrefixSyntax(
+  node: AST.ReferenceItem,
+  acceptor: ValidationAcceptor,
+  compilationUnit: CompilationUnit,
+): void {
+  if (
+    node.dimensions.length === 0 ||
+    node.container?.kind !== AST.SyntaxKind.LabelPrefix
+  ) {
+    // No need to check anything if its not a label, or if there are no dimensions attached
+    return;
+  }
+  if (node.dimensions.length > 1) {
+    acceptor(diagnosticFromCode(PLICodes.Severe.IBM3988I, node.ref?.token));
+  }
+  const dim = node.dimensions[0];
+  for (const entry of dim.dimensions) {
+    if (entry.lower !== null) {
+      // Can only have a direct reference to a label, not a range
+      acceptor(diagnosticFromCode(PLICodes.Severe.IBM3988I, entry.lower.token));
+      continue;
+    }
+    if (entry.upper !== null) {
+      const value = entry.upper.expression;
+      if (value && value.kind !== AST.SyntaxKind.NumberLiteral) {
+        // Label prefixes can only be indexed using a number literal
+        acceptor(
+          diagnosticFromCode(PLICodes.Severe.IBM3988I, entry.upper.token),
+        );
+      }
+    }
+  }
+}

--- a/packages/language/src/validation/language-server/label-prefix-syntax.ts
+++ b/packages/language/src/validation/language-server/label-prefix-syntax.ts
@@ -11,18 +11,18 @@
 
 import { diagnosticFromCode } from "../../language-server/types";
 import { PLICodes } from "../pli-codes";
-import * as AST from "../../syntax-tree/ast";
+import * as ast from "../../syntax-tree/ast";
 import { CompilationUnit } from "../../workspace/compilation-unit";
 import { ValidationAcceptor } from "../validator";
 
 export function checkLabelPrefixSyntax(
-  node: AST.ReferenceItem,
+  node: ast.ReferenceItem,
   acceptor: ValidationAcceptor,
   compilationUnit: CompilationUnit,
 ): void {
   if (
     node.dimensions.length === 0 ||
-    node.container?.kind !== AST.SyntaxKind.LabelPrefix
+    node.container?.kind !== ast.SyntaxKind.LabelPrefix
   ) {
     // No need to check anything if its not a label, or if there are no dimensions attached
     return;
@@ -39,12 +39,22 @@ export function checkLabelPrefixSyntax(
     }
     if (entry.upper !== null) {
       const value = entry.upper.expression;
-      if (value && value.kind !== AST.SyntaxKind.NumberLiteral) {
-        // Label prefixes can only be indexed using a number literal
+      if (value && !isSimpleNumericExpression(value)) {
+        // Label prefixes can only be indexed using a numeric expression
         acceptor(
           diagnosticFromCode(PLICodes.Severe.IBM3988I, entry.upper.token),
         );
       }
     }
   }
+}
+
+function isSimpleNumericExpression(node: ast.Expression): boolean {
+  if (node.kind === ast.SyntaxKind.NumberLiteral) {
+    return true;
+  }
+  if (node.kind === ast.SyntaxKind.UnaryExpression && node.expr !== null) {
+    return isSimpleNumericExpression(node.expr);
+  }
+  return false;
 }

--- a/packages/language/src/validation/macro/deprecate.ts
+++ b/packages/language/src/validation/macro/deprecate.ts
@@ -11,6 +11,7 @@
 
 import { diagnosticFromCode } from "../../language-server/types";
 import * as AST from "../../syntax-tree/ast";
+import { getLabelPrefixNameToken } from "../../syntax-tree/ast-utils";
 import { ValidationAcceptor } from "../validator";
 import { CompilationUnit } from "../../workspace/compilation-unit";
 import { PLICodes } from "../pli-codes";
@@ -37,7 +38,7 @@ export function MACRO_Deprecate(
   const nameTokens =
     node.container?.kind === AST.SyntaxKind.Statement
       ? node.container.labels
-          ?.map((label) => label.nameToken)
+          ?.map((label) => getLabelPrefixNameToken(label))
           .filter((token) => token !== null) || []
       : [];
 

--- a/packages/language/src/validation/macro/nameprefix.ts
+++ b/packages/language/src/validation/macro/nameprefix.ts
@@ -11,6 +11,7 @@
 
 import { diagnosticFromCode } from "../../language-server/types";
 import * as AST from "../../syntax-tree/ast";
+import { getLabelPrefixNameToken } from "../../syntax-tree/ast-utils";
 import { ValidationAcceptor } from "../validator";
 import { CompilationUnit } from "../../workspace/compilation-unit";
 import { Token } from "../../parser/tokens";
@@ -34,7 +35,7 @@ export function MACRO_NamePrefix(
     nameTokens =
       node.container?.kind === AST.SyntaxKind.Statement
         ? node.container.labels
-            ?.map((label) => label.nameToken)
+            ?.map((label) => getLabelPrefixNameToken(label))
             .filter((token) => token !== null) || []
         : [];
   }

--- a/packages/language/src/validation/pli-validator.ts
+++ b/packages/language/src/validation/pli-validator.ts
@@ -29,6 +29,7 @@ import {
 } from "./compiler/IBM2444Iff-deprecate";
 import { IBM1213I_unreferenced_procedure } from "./compiler/IBM1213I-unreferenced-procedure";
 import { checkProcedureCallsDimensions } from "./language-server/call-dimensions";
+import { checkLabelPrefixSyntax } from "./language-server/label-prefix-syntax";
 
 /**
  * A function that accepts a diagnostic for PL/I validation
@@ -56,7 +57,11 @@ export function registerPliValidationChecks(): ValidationChecks {
       IBM2412I_IBM2410I_IBM2409I_handle_return_stmt_and_returns_att,
       IBM1213I_unreferenced_procedure,
     ],
-    ReferenceItem: [checkImplicitBuiltins, checkProcedureCallsDimensions],
+    ReferenceItem: [
+      checkImplicitBuiltins,
+      checkProcedureCallsDimensions,
+      checkLabelPrefixSyntax,
+    ],
     Statement: [DeprecateStatements],
     // TODO @wagner-laranjeiras -> When adding ReturnStatement to this list, make sure to include comment about IBM2412/10/09I.
   };

--- a/packages/language/test/fourslash/linker/goto-label-array-prefix-declared.ts
+++ b/packages/language/test/fourslash/linker/goto-label-array-prefix-declared.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// @wrap: main
+//// DCL <|TEST_LABEL|>(2) LABEL;
+//// <|TEST_LABEL>TEST_LABEL(1): PUT("HELLO");
+//// <|TEST_LABEL>TEST_LABEL(2): PUT("WORLD");
+//// GOTO <|TEST_LABEL>TEST_LABEL(1);
+
+verify.noParserDiagnostics();
+linker.expectLinks();

--- a/packages/language/test/fourslash/linker/goto-label-array-prefix-forward.ts
+++ b/packages/language/test/fourslash/linker/goto-label-array-prefix-forward.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// Forward GOTO to an implicitly declared label array, with a dimensioned
+// label prefix directly on the END statement.
+
+//// AVERAGE: PROCEDURE OPTIONS (MAIN);
+////   GOTO <|L>L(2);
+////   <|L|>(1): PUT("HELLO");
+////   L(2): END AVERAGE;
+
+verify.noParserDiagnostics();
+linker.expectLinks();

--- a/packages/language/test/fourslash/linker/goto-label-array-prefix-implicit.ts
+++ b/packages/language/test/fourslash/linker/goto-label-array-prefix-implicit.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// Without a `DCL ... LABEL` declaration, the dimensioned label prefixes
+// act as implicit declarations of the label array.
+
+// @wrap: main
+//// <|TEST_LABEL|>(1): PUT("HELLO");
+//// TEST_LABEL(2): PUT("WORLD");
+//// GOTO <|TEST_LABEL>TEST_LABEL(1);
+
+verify.noParserDiagnostics();
+linker.expectLinks();

--- a/packages/language/test/fourslash/validate/label-variable-declaration.ts
+++ b/packages/language/test/fourslash/validate/label-variable-declaration.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../framework.ts" />
+
+// An explicit declaration of a LABEL variable counts as a repetition
+// when the same variable name is used for a label prefix
+
+// @wrap: main
+//// DCL <|TEST_VALUE|> LABEL;
+//// TEST_VALUE: PUT("HELLO WORLD");
+
+verify.expectDiagnosticsAt("TEST_VALUE", code.Error.IBM1306I);

--- a/packages/language/test/fourslash/validate/label-with-non-number.ts
+++ b/packages/language/test/fourslash/validate/label-with-non-number.ts
@@ -11,13 +11,11 @@
 
 /// <reference path="../framework.ts" />
 
-// Forward GOTO to an implicitly declared label array, with a dimensioned
-// label prefix directly on the END statement.
+// An explicit declaration of a LABEL variable counts as a repetition
+// when the same variable name is used for a label prefix
 
-//// AVERAGE: PROCEDURE OPTIONS (MAIN);
-////   GOTO <|TEST_LABEL>TEST_LABEL(2);
-////   <|TEST_LABEL|>(1): PUT("HELLO");
-////   TEST_LABEL(2): END AVERAGE;
+// @wrap: main
+//// DCL TEST_VALUE(2) LABEL;
+//// TEST_VALUE(<|1|> + 1): PUT("HELLO WORLD");
 
-verify.noParserDiagnostics();
-linker.expectLinks();
+verify.expectDiagnosticsAt("1", code.Severe.IBM3988I);

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -583,7 +583,7 @@ Available code actions for label "${label}" and URI "${uri}": ${codeActions.map(
     }
     if (isSyntaxNode(value)) {
       if (value.kind === SyntaxKind.LabelPrefix) {
-        return value.name;
+        return value.item?.ref?.text ?? null;
       } else if (value.kind === SyntaxKind.Statement) {
         return {
           ...value.value,


### PR DESCRIPTION
Closes https://github.com/zowe/zowe-pli-language-support/issues/790.

Can also be seen in the `code_samples/PDUMP/S99VFR1.pli` file.

Adds AST/parser and linking support for dimensions on labels. The interesting part: If a `DCL TEST_LABEL(X) LABEL` declaration exists, a label prefix like `TEST_LABEL(1): ...` actually points to that label, so that it can later be referenced using `GOTO TEST_LABEL(1)`.