### PR TITLE
Fix more CICS findings

### DIFF
--- a/packages/preprocessor-cics/src/checks/base.ts
+++ b/packages/preprocessor-cics/src/checks/base.ts
@@ -34,6 +34,17 @@ export class CICSCheckUtilityParameters {
   public literalChecks: CICSLiteralCheckOption = CICSLiteralCheckOption.APOST;
 }
 
+export type AggregatableDiagnostic = Diagnostic & {
+  commonMessage: string;
+  enumerablePart: string;
+};
+
+export function isAggregatableDiagnostic(
+  diagnostic: Diagnostic,
+): diagnostic is AggregatableDiagnostic {
+  return "commonMessage" in diagnostic && "enumerablePart" in diagnostic;
+}
+
 export abstract class CICSOptionsCheckerBase {
   //private context: DialectProcessingContext;
 
@@ -91,11 +102,13 @@ export abstract class CICSOptionsCheckerBase {
     msg: string,
     wrongToken: string,
   ): void {
-    const error: Diagnostic = {
+    const error: AggregatableDiagnostic = {
       ...range,
       severity: errorSeverity,
       message: msg + wrongToken,
       code: "cics.invalid.options",
+      commonMessage: msg,
+      enumerablePart: wrongToken,
     };
     this.errors.push(error);
   }

--- a/packages/preprocessor-cics/src/checks/base.ts
+++ b/packages/preprocessor-cics/src/checks/base.ts
@@ -83,6 +83,8 @@ export abstract class CICSOptionsCheckerBase {
    */
   abstract checkOptions<E extends ParserRuleContext>(ctx: E): void;
 
+  checkRootRule<E extends ParserRuleContext>(ctx: E): void {}
+
   protected throwException(
     errorSeverity: Severity,
     range: WithRange,

--- a/packages/preprocessor-cics/src/checks/check-allocate-options.ts
+++ b/packages/preprocessor-cics/src/checks/check-allocate-options.ts
@@ -13,11 +13,13 @@ import {
   Cics_allocate_appc_mro_lut61_sysidContext,
   Cics_allocate_appc_partnerContext,
   Cics_allocate_lut61_sessionContext,
+  Cics_allocateContext,
   CICSParser,
 } from "../generated/CICSParser";
 import { CICSCheckUtilityParameters, CICSOptionsCheckerBase } from "./base";
 import { CICSLexer } from "../generated/CICSLexer";
 import { ParserRuleContext } from "antlr4ng";
+import { assertType } from "./utils";
 
 export class AllocateOptionsChecker extends CICSOptionsCheckerBase {
   public static readonly RULE_INDEX = CICSParser.RULE_cics_allocate;
@@ -41,6 +43,18 @@ export class AllocateOptionsChecker extends CICSOptionsCheckerBase {
     super(errors, AllocateOptionsChecker.DUPLICATE_CHECK_OPTIONS, params);
   }
 
+  override checkRootRule<E extends ParserRuleContext>(ctx: E): void {
+    if (ctx.ruleIndex === CICSParser.RULE_cics_allocate) {
+      assertType<Cics_allocateContext>(ctx);
+      if (
+        !ctx.cics_allocate_appc_partner() &&
+        !ctx.cics_allocate_appc_mro_lut61_sysid() &&
+        !ctx.cics_allocate_lut61_session()
+      ) {
+        this.checkHasAtLeastOneOption("SESSION, SYSID, PARTNER", ctx);
+      }
+    }
+  }
   /**
    * Entrypoint to check CICS Allocate rule options
    *

--- a/packages/preprocessor-cics/src/checks/check-define-options.ts
+++ b/packages/preprocessor-cics/src/checks/check-define-options.ts
@@ -193,6 +193,9 @@ export class DefineOptionsChecker extends CICSOptionsCheckerBase {
         // Neither AT nor AND
         this.checkHasMandatoryOptions(ctx.AFTER(), ctx, "AFTER");
       }
+      if (ctx.ON().length !== 0) {
+        this.checkHasMandatoryOptions(ctx.YEAR(), ctx, "YEAR");
+      }
     } else if (
       ctx.AT().length === 0 &&
       this.checkHasMandatoryOptions(ctx.AFTER(), ctx, "AFTER")

--- a/packages/preprocessor-cics/src/checks/check-dump-transaction-options.ts
+++ b/packages/preprocessor-cics/src/checks/check-dump-transaction-options.ts
@@ -59,6 +59,7 @@ export class DumpTransactionOptionsChecker extends CICSOptionsCheckerBase {
     if (ctx.ruleIndex === CICSParser.RULE_cics_dump) {
       assertType<Cics_dumpContext>(ctx);
       if (
+        !ctx.DUMPCODE()?.length &&
         !ctx.cics_dump_transaction_from()?.length &&
         !ctx.cics_dump_transaction_segmentlist()?.length &&
         !ctx.cics_dump_code_opts()?.length

--- a/packages/preprocessor-cics/src/checks/check-dump-transaction-options.ts
+++ b/packages/preprocessor-cics/src/checks/check-dump-transaction-options.ts
@@ -18,6 +18,7 @@ import {
 import { CICSCheckUtilityParameters, CICSOptionsCheckerBase } from "./base";
 import { CICSLexer } from "../generated/CICSLexer";
 import { ParserRuleContext } from "antlr4ng";
+import { assertType } from "./utils";
 
 export class DumpTransactionOptionsChecker extends CICSOptionsCheckerBase {
   public static readonly RULE_INDEX = CICSParser.RULE_cics_dump;
@@ -52,6 +53,22 @@ export class DumpTransactionOptionsChecker extends CICSOptionsCheckerBase {
       DumpTransactionOptionsChecker.DUPLICATE_CHECK_OPTIONS,
       params,
     );
+  }
+
+  override checkRootRule<E extends ParserRuleContext>(ctx: E): void {
+    if (ctx.ruleIndex === CICSParser.RULE_cics_dump) {
+      assertType<Cics_dumpContext>(ctx);
+      if (
+        !ctx.cics_dump_transaction_from()?.length &&
+        !ctx.cics_dump_transaction_segmentlist()?.length &&
+        !ctx.cics_dump_code_opts()?.length
+      ) {
+        this.checkHasExactlyOneOption(
+          "DUMPCODE, DUMPID, FROM, COMPLETE, TRT, TASK, STORAGE, PROGRAM, TERMINAL, TABLES, FCT, PCT, PPT, SIT, TCT, SEGMENTLIST, LENGTHLIST, NUMSEGMENTS",
+          ctx,
+        );
+      }
+    }
   }
 
   /**

--- a/packages/preprocessor-cics/src/checks/check-inquire-options.ts
+++ b/packages/preprocessor-cics/src/checks/check-inquire-options.ts
@@ -66,11 +66,18 @@ export class InquireOptionsChecker extends CICSOptionsCheckerBase {
           containerContext.ACTIVITYID(),
           containerContext.PROCESS(),
         );
-        if (containerContext.PROCESS().length === 0)
+        if (containerContext.PROCESS().length !== 0) {
+          this.checkHasMandatoryOptions(
+            containerContext.PROCESSTYPE(),
+            ctx,
+            "PROCESSTYPE",
+          );
+        } else {
           this.checkHasIllegalOptions(
             containerContext.PROCESSTYPE(),
             "PROCESSTYPE without PROCESS",
           );
+        }
         break;
       }
       case CICSParser.RULE_cics_inquire_process: {

--- a/packages/preprocessor-cics/src/checks/check-issue-options.ts
+++ b/packages/preprocessor-cics/src/checks/check-issue-options.ts
@@ -335,10 +335,14 @@ export class IssueOptionsChecker extends CICSOptionsCheckerBase {
   }
 
   private checkReceive(ctx: Cics_issue_receiveContext) {
+    this.checkMutuallyExclusiveOptions("INTO or SET", ctx.INTO(), ctx.SET());
     this.checkHasMandatoryOptions(ctx.RECEIVE(), ctx, "RECEIVE");
     if (ctx.INTO().length === 0)
       this.checkHasMandatoryOptions(ctx.SET(), ctx, "INTO or SET");
     if (this.noLengthOptionsEnabled()) {
+      this.checkHasMandatoryOptions(ctx.LENGTH(), ctx, "LENGTH");
+    }
+    if (ctx.SET().length !== 0) {
       this.checkHasMandatoryOptions(ctx.LENGTH(), ctx, "LENGTH");
     }
   }

--- a/packages/preprocessor-cics/src/checks/check-run-options.ts
+++ b/packages/preprocessor-cics/src/checks/check-run-options.ts
@@ -46,7 +46,7 @@ export class RunOptionsChecker extends CICSOptionsCheckerBase {
       assertType<Cics_runContext>(ctx);
       if (!ctx.cics_run_default() && !ctx.cics_run_transid()) {
         this.checkHasExactlyOneOption(
-          "ACQACTIVITY or ACQPROCESS or ACTIVITY or TRANSID",
+          "ACQACTIVITY, ACQPROCESS, ACTIVITY or TRANSID",
           ctx,
         );
       }

--- a/packages/preprocessor-cics/src/checks/check-run-options.ts
+++ b/packages/preprocessor-cics/src/checks/check-run-options.ts
@@ -12,11 +12,13 @@ import { Diagnostic, Severity } from "preprocessor-api";
 import {
   Cics_run_defaultContext,
   Cics_run_transidContext,
+  Cics_runContext,
   CICSParser,
 } from "../generated/CICSParser";
 import { CICSCheckUtilityParameters, CICSOptionsCheckerBase } from "./base";
 import { CICSLexer } from "../generated/CICSLexer";
 import { ParserRuleContext, TerminalNode } from "antlr4ng";
+import { assertType } from "./utils";
 
 export class RunOptionsChecker extends CICSOptionsCheckerBase {
   public static readonly RULE_INDEX = CICSParser.RULE_cics_run;
@@ -37,6 +39,18 @@ export class RunOptionsChecker extends CICSOptionsCheckerBase {
 
   constructor(errors: Diagnostic[], params: CICSCheckUtilityParameters) {
     super(errors, RunOptionsChecker.DUPLICATE_CHECK_OPTIONS, params);
+  }
+
+  override checkRootRule<E extends ParserRuleContext>(ctx: E): void {
+    if (ctx.ruleIndex === CICSParser.RULE_cics_run) {
+      assertType<Cics_runContext>(ctx);
+      if (!ctx.cics_run_default() && !ctx.cics_run_transid()) {
+        this.checkHasExactlyOneOption(
+          "ACQACTIVITY or ACQPROCESS or ACTIVITY or TRANSID",
+          ctx,
+        );
+      }
+    }
   }
 
   /**

--- a/packages/preprocessor-cics/src/checks/options-registry.ts
+++ b/packages/preprocessor-cics/src/checks/options-registry.ts
@@ -570,5 +570,9 @@ export class OptionsRegistry {
       if (this.utilityParameters.spEnabled) spOptions.checkOptions(ctx);
       else spOptions.throwIfMissingTranslatorOption(ctx, '"SP"');
     }
+    const rootUtiltiy = this.optionsMap.get(ctx.ruleIndex);
+    if (rootUtiltiy != null) {
+      rootUtiltiy.checkRootRule(ctx);
+    }
   }
 }

--- a/packages/preprocessor-cics/src/checks/utils.ts
+++ b/packages/preprocessor-cics/src/checks/utils.ts
@@ -35,3 +35,16 @@ export function assertType<T>(
     throw new Error(message || "Assertion failed");
   }
 }
+
+export function orify(items: string[]): string {
+  if (items.length === 0) {
+    return "";
+  } else if (items.length === 1) {
+    return items[0];
+  } else if (items.length === 2) {
+    return `${items[0]} or ${items[1]}`;
+  } else {
+    const lastItem = items.pop();
+    return `${items.join(", ")} or ${lastItem}`;
+  }
+}

--- a/packages/preprocessor-cics/src/engine/collect-semantic-errors.ts
+++ b/packages/preprocessor-cics/src/engine/collect-semantic-errors.ts
@@ -11,8 +11,10 @@
 import { ParserRuleContext, ParseTree } from "antlr4ng";
 import { CICSParserVisitor } from "../generated/CICSParserVisitor";
 import {
+  AggregatableDiagnostic,
   CICSCheckUtilityParameters,
   CICSLiteralCheckOption,
+  isAggregatableDiagnostic,
 } from "../checks/base";
 import { OptionsRegistry } from "../checks/options-registry";
 import { Diagnostic } from "preprocessor-api";
@@ -20,6 +22,39 @@ import { Diagnostic } from "preprocessor-api";
 export class CollectingSemanticErrorVisitor extends CICSParserVisitor<
   ParseTree[] | null
 > {
+  static aggregateErrors(errors: Diagnostic[]): Diagnostic[] {
+    const nonAggregatableErrors: Diagnostic[] = [];
+    const aggregatableErrors: AggregatableDiagnostic[] = [];
+    for (const error of errors) {
+      if (isAggregatableDiagnostic(error)) {
+        aggregatableErrors.push(error);
+      } else {
+        nonAggregatableErrors.push(error);
+      }
+    }
+    const groups = Object.groupBy(
+      aggregatableErrors,
+      (error) =>
+        `${error.startOffset}-${error.endOffset}:${error.code}:${error.commonMessage}`,
+    );
+    for (const group of Object.values(groups)) {
+      if (group && group.length > 0) {
+        nonAggregatableErrors.push({
+          code: group[0].code,
+          message:
+            group[0].commonMessage +
+            group
+              .map((e) => e.enumerablePart)
+              .sort()
+              .join(" or "),
+          severity: group[0].severity,
+          startOffset: group[0].startOffset,
+          endOffset: group[0].endOffset,
+        });
+      }
+    }
+    return nonAggregatableErrors;
+  }
   private readonly optionsRegistry: OptionsRegistry;
   private readonly cicsOptionsCheckUtilityParams: CICSCheckUtilityParameters;
   public readonly errors: Diagnostic[] = [];

--- a/packages/preprocessor-cics/src/engine/collect-semantic-errors.ts
+++ b/packages/preprocessor-cics/src/engine/collect-semantic-errors.ts
@@ -18,6 +18,7 @@ import {
 } from "../checks/base";
 import { OptionsRegistry } from "../checks/options-registry";
 import { Diagnostic } from "preprocessor-api";
+import { orify } from "../checks/utils";
 
 export class CollectingSemanticErrorVisitor extends CICSParserVisitor<
   ParseTree[] | null
@@ -43,10 +44,7 @@ export class CollectingSemanticErrorVisitor extends CICSParserVisitor<
           code: group[0].code,
           message:
             group[0].commonMessage +
-            group
-              .map((e) => e.enumerablePart)
-              .sort()
-              .join(" or "),
+            orify(group.map((e) => e.enumerablePart).sort()),
           severity: group[0].severity,
           startOffset: group[0].startOffset,
           endOffset: group[0].endOffset,

--- a/packages/preprocessor-cics/src/engine/preprocessor.ts
+++ b/packages/preprocessor-cics/src/engine/preprocessor.ts
@@ -32,7 +32,6 @@ import {
   Preprocessor,
   PreprocessorResult,
   SemanticsKind,
-  Severity,
   Token,
 } from "preprocessor-api";
 import { CollectingSemanticErrorVisitor } from "./collect-semantic-errors";
@@ -116,7 +115,11 @@ export class CICSPreprocessor implements Preprocessor {
     const diagnostics: Diagnostic[] = [];
     diagnostics.push(...lexerErrors.errors);
     diagnostics.push(...parserErrors.errors);
-    diagnostics.push(...semanticErrorCollector.errors);
+    diagnostics.push(
+      ...CollectingSemanticErrorVisitor.aggregateErrors(
+        semanticErrorCollector.errors,
+      ),
+    );
     return {
       diagnostics,
       tokens,

--- a/packages/preprocessor-cics/test/allocate.test.ts
+++ b/packages/preprocessor-cics/test/allocate.test.ts
@@ -23,6 +23,17 @@ describe("CICS ALLOCATE", async () => {
     expect(diagnostics).toHaveLength(0);
   });
 
+  test("Alone allocate", async () => {
+    const { diagnostics } = await cicsPreprocessor.execute("ALLOCATE");
+    expect(diagnostics).toHaveLength(2);
+    expect(diagnostics[0].severity).toBe(Severity.Error);
+    expect(diagnostics[0].message).toMatch(/Unexpected end of file/);
+    expect(diagnostics[1].severity).toBe(Severity.Error);
+    expect(diagnostics[1].message).toMatch(
+      /Must include one or more of the following: SESSION, SYSID, PARTNER/,
+    );
+  });
+
   test("Positive (SYSID)", async () => {
     const { diagnostics } = await cicsPreprocessor.execute("ALLOCATE SYSID(1)");
     expect(diagnostics).toHaveLength(0);

--- a/packages/preprocessor-cics/test/define.test.ts
+++ b/packages/preprocessor-cics/test/define.test.ts
@@ -23,6 +23,19 @@ describe("CICS DEFINE", async () => {
     expect(diagnostics).toHaveLength(0);
   });
 
+  test("Define timer", async () => {
+    const { diagnostics } = await cicsPreprocessor.execute(
+      "DEFINE TIMER('TIMEER1')",
+    );
+    expect(diagnostics).toHaveLength(3);
+    expect(diagnostics[0].severity).toBe(Severity.Error);
+    expect(diagnostics[0].message).toMatch(/Unexpected end of file/);
+    expect(diagnostics[1].severity).toBe(Severity.Error);
+    expect(diagnostics[1].message).toMatch(/Missing required option: AT/);
+    expect(diagnostics[2].severity).toBe(Severity.Error);
+    expect(diagnostics[2].message).toMatch(/Missing required option: AFTER/);
+  });
+
   test("Expecting EOF", async () => {
     const { diagnostics } = await cicsPreprocessor.execute(
       "DEFINE ACTIVITY(1) TRANSID(2) BLA",

--- a/packages/preprocessor-cics/test/define.test.ts
+++ b/packages/preprocessor-cics/test/define.test.ts
@@ -25,15 +25,35 @@ describe("CICS DEFINE", async () => {
 
   test("Define timer", async () => {
     const { diagnostics } = await cicsPreprocessor.execute(
-      "DEFINE TIMER('TIMEER1')",
+      "DEFINE TIMER('TIMER1')",
     );
-    expect(diagnostics).toHaveLength(3);
+    expect(diagnostics).toHaveLength(2);
     expect(diagnostics[0].severity).toBe(Severity.Error);
     expect(diagnostics[0].message).toMatch(/Unexpected end of file/);
     expect(diagnostics[1].severity).toBe(Severity.Error);
-    expect(diagnostics[1].message).toMatch(/Missing required option: AT/);
-    expect(diagnostics[2].severity).toBe(Severity.Error);
-    expect(diagnostics[2].message).toMatch(/Missing required option: AFTER/);
+    expect(diagnostics[1].message).toMatch(
+      /Missing required option: AFTER or AT/,
+    );
+  });
+
+  test("Define timer with aggregated missing options on missing year", async () => {
+    const { diagnostics } = await cicsPreprocessor.execute(
+      "DEFINE TIMER('TIMER1') AT HOURS(1) ON",
+    );
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].severity).toBe(Severity.Error);
+    expect(diagnostics[0].message).toMatch(/Missing required option: YEAR/);
+  });
+
+  test("Define timer with aggregated missing options on missing month", async () => {
+    const { diagnostics } = await cicsPreprocessor.execute(
+      "DEFINE TIMER('TIMER1') AT HOURS(1) ON YEAR(2026)",
+    );
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].severity).toBe(Severity.Error);
+    expect(diagnostics[0].message).toMatch(
+      /Missing required option: DAYOFMONTH or MONTH/,
+    );
   });
 
   test("Expecting EOF", async () => {

--- a/packages/preprocessor-cics/test/dump-transaction.test.ts
+++ b/packages/preprocessor-cics/test/dump-transaction.test.ts
@@ -21,6 +21,17 @@ describe("CICS DUMP TRANSACTION", async () => {
     expect(diagnostics).toHaveLength(0);
   });
 
+  test("Command alone", async () => {
+    const { diagnostics } = await cicsPreprocessor.execute("DUMP TRANSACTION");
+    expect(diagnostics).toHaveLength(2);
+    expect(diagnostics[0].severity).toBe(Severity.Error);
+    expect(diagnostics[0].message).toMatch(/Unexpected end of file/);
+    expect(diagnostics[1].severity).toBe(Severity.Error);
+    expect(diagnostics[1].message).toMatch(
+      /Exactly one option required, none provided: DUMPCODE, DUMPID, FROM, COMPLETE, TRT, TASK, STORAGE, PROGRAM, TERMINAL, TABLES, FCT, PCT, PPT, SIT, TCT, SEGMENTLIST, LENGTHLIST, NUMSEGMENTS/,
+    );
+  });
+
   test("Expecting EOF", async () => {
     const { diagnostics } = await cicsPreprocessor.execute(
       "DUMP DUMPCODE(1) BLA",

--- a/packages/preprocessor-cics/test/inquire.test.ts
+++ b/packages/preprocessor-cics/test/inquire.test.ts
@@ -43,6 +43,17 @@ describe("CICS INQUIRE", async () => {
     );
   });
 
+  test("CONTAINER PROCESS without PROCESSTYPE", async () => {
+    const { diagnostics } = await cicsPreprocessor.execute(
+      "INQUIRE CONTAINER(1) PROCESS(2)",
+    );
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].severity).toBe(Severity.Error);
+    expect(diagnostics[0].message).toMatch(
+      /Missing required option: PROCESSTYPE/,
+    );
+  });
+
   // process branch -> checkHasMandatoryOptions(PROCESSTYPE)
   test("PROCESS missing PROCESSTYPE", async () => {
     const { diagnostics } =

--- a/packages/preprocessor-cics/test/issue.test.ts
+++ b/packages/preprocessor-cics/test/issue.test.ts
@@ -177,6 +177,18 @@ describe("CICS ISSUE", async () => {
     );
     expect(diagnostics).toHaveLength(0);
   });
+  test("RECEIVE with conflicting INTO/SET and missing LENGTH", async () => {
+    const { diagnostics } = await cicsPreprocessor.execute(
+      "ISSUE RECEIVE INTO(IN) SET(NAME)",
+    );
+    expect(diagnostics).toHaveLength(2);
+    expect(diagnostics[0].severity).toBe(Severity.Error);
+    expect(diagnostics[0].message).toMatch(
+      /Options "INTO or SET" are mutually exclusive/,
+    );
+    expect(diagnostics[1].severity).toBe(Severity.Error);
+    expect(diagnostics[1].message).toMatch(/Missing required option: LENGTH/);
+  });
   test("RECEIVE without INTO or SET", async () => {
     const { diagnostics } = await cicsPreprocessor.execute("ISSUE RECEIVE");
     expect(diagnostics).toHaveLength(1);

--- a/packages/preprocessor-cics/test/run.test.ts
+++ b/packages/preprocessor-cics/test/run.test.ts
@@ -23,6 +23,17 @@ describe("CICS RUN", async () => {
     expect(diagnostics).toHaveLength(0);
   });
 
+  test("RUN without any options", async () => {
+    const { diagnostics } = await cicsPreprocessor.execute("RUN");
+    expect(diagnostics).toHaveLength(2);
+    expect(diagnostics[0].severity).toBe(Severity.Error);
+    expect(diagnostics[0].message).toMatch(/Unexpected end of file/);
+    expect(diagnostics[1].severity).toBe(Severity.Error);
+    expect(diagnostics[1].message).toMatch(
+      /Exactly one option required, none provided: ACQACTIVITY or ACQPROCESS or ACTIVITY or TRANSID/,
+    );
+  });
+
   test("Expecting EOF", async () => {
     const { diagnostics } = await cicsPreprocessor.execute(
       "RUN ACTIVITY(1) SYNCHRONOUS BLA",

--- a/packages/preprocessor-cics/test/run.test.ts
+++ b/packages/preprocessor-cics/test/run.test.ts
@@ -30,7 +30,7 @@ describe("CICS RUN", async () => {
     expect(diagnostics[0].message).toMatch(/Unexpected end of file/);
     expect(diagnostics[1].severity).toBe(Severity.Error);
     expect(diagnostics[1].message).toMatch(
-      /Exactly one option required, none provided: ACQACTIVITY or ACQPROCESS or ACTIVITY or TRANSID/,
+      /Exactly one option required, none provided: ACQACTIVITY, ACQPROCESS, ACTIVITY or TRANSID/,
     );
   });
 

--- a/packages/preprocessor-cics/test/web.test.ts
+++ b/packages/preprocessor-cics/test/web.test.ts
@@ -64,7 +64,7 @@ describe("CICS WEB", async () => {
     const { diagnostics } = await cicsPreprocessor.execute(
       "WEB CONVERSE SESSTOKEN(TK) DOCTOKEN(DT) NODOCDELETE USERNAME(UN)",
     );
-    expect(diagnostics).toHaveLength(3);
+    expect(diagnostics).toHaveLength(2);
   });
   test("ENDBROWSE", async () => {
     const { diagnostics } = await cicsPreprocessor.execute(


### PR DESCRIPTION
- [x] `EXEC CICS DUMP TRANSACTION` shall have a better error message since the `DUMPCODE(...)` option is required.
- [x] `EXEC CICS ALLOCATE;` throws errors on mainframe
  - `'( SESSION() | SYSID() | PARTNER() )' REQUIRED BUT NOT SPECIFIED FOR COMMAND. COMMAND NOT TRANSLATED.`
  - `'SYSID()' CONFLICTS WITH 'PARTNER()' AND HAS BEEN IGNORED.`
We should adapt the checkers for `ALLOCATE`
- [x] `ISSUE RECEIVE` must result in a conflict if `INTO` and `SET` are given
- [x] `ISSUE RECEIVE` needs `LENGTH` only if `SET` is given
- [x] `ISSUE REPLACE` requires `KEYLENGTH or RNN` if not given, confusing case
- `RECEIVE MAP` should show that `SET` or `INTO` are required
  - was NOT a bug. There is already a test for that
- `ACQUIRE PROCESS`: if you only write `ACQUIRE`, no meaningful error like "PROCESS required" appears
   - THIS ONE cannot be solved with the usual checkers. Must be implemented differently, since "ACQUIRE PROCESS" decides to visit the corresponding checker, not "ACQUIRE" alone.
- `DEFINE TIMER(XXX)`
  - [x] requires only `AT`, but `AFTER` is also a valid continuation. Add `AFTER` to the missing required options
  - [x] When `MONTH` is a missing option `DAYOFYEAR`should also be listed
  - [x] Same for `YEAR`
- [x] `INQUIRE CONTAINER` must use `PROCESSTYPE` if `PROCESS` is given
- [x] `RUN` without options, result in mainframe saying: `RUN FUNCTION NOT COMPLETELY SPECIFIED. ACQACTIVITY OR ACQPROCESS OR ACTIVITY OR TRANSID MUST BE SPECIFIED. COMMAND NOT TRANSLATED.`. We have no meaningful error here