### PR TITLE
Introduce workspace settings and config fallback

### DIFF
--- a/packages/language/src/config/schema.ts
+++ b/packages/language/src/config/schema.ts
@@ -106,13 +106,6 @@ export interface GroupRecord extends ProcessGroup {
 }
 
 /**
- * Where a {@link ProgramRecord} was loaded from. Project (`.pliplugin/`)
- * entries take precedence over user-scope `settings.json` entries when a file
- * matches program configs from both sources — see `getProgramConfig`.
- */
-export type ProgramOrigin = "project" | "settings";
-
-/**
  * A {@link ProgramConfig} together with its merged compiler options. The
  * pli-options strings (this config's plus the bound process group's) are
  * parsed once at load time so each lookup hands back a ready-to-use
@@ -125,12 +118,6 @@ export interface ProgramRecord extends ProgramConfig {
    * compiler-options translator doesn't double-report them.
    */
   issues: Diagnostic[];
-  /**
-   * Configuration source this record came from. Absent is treated as
-   * `"project"` (highest precedence) so non-merge callers (quick-fix add,
-   * tests, `.pliplugin/`-only parse) keep binding at project precedence.
-   */
-  origin?: ProgramOrigin;
 }
 
 /**

--- a/packages/language/src/utils/messages.ts
+++ b/packages/language/src/utils/messages.ts
@@ -101,6 +101,12 @@ export namespace Messages {
   );
 
   /**
+   * VS Code settings scope of a {@link GlobalConfigEntry}. `workspace` (folder
+   * or workspace-file settings) ranks above `user`, matching VS Code.
+   */
+  export type GlobalConfigScope = "user" | "workspace";
+
+  /**
    * A single config entry sourced from VS Code settings.
    *
    * The LS reads the file, navigates to the entry, and parses the
@@ -111,11 +117,16 @@ export namespace Messages {
     uri: string;
     containerPath: (string | number)[];
     configKey: string;
+    scope: GlobalConfigScope;
   }
 
+  /**
+   * VS Code settings backing for the plugin config. Each key may carry a
+   * `user` and/or `workspace` entry.
+   */
   export interface GlobalConfig {
-    pgmConf?: GlobalConfigEntry;
-    procGrps?: GlobalConfigEntry;
+    pgmConf?: GlobalConfigEntry[];
+    procGrps?: GlobalConfigEntry[];
   }
 
   /**

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -404,6 +404,9 @@ export class CompilationUnitHandler {
       this.configLoader,
       this.longRunningOperation,
     );
+    // The fallback workspace has no real root; relative library paths from
+    // user-scope settings can't be resolved here and must not be flagged.
+    workspace.config.markAsFallbackWorkspace();
     this.fallbackWorkspace = workspace;
     const diagnosticsByUri = await workspace.config.init(uri);
     if (this.connection) {

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -34,7 +34,6 @@ import {
   plainItem,
   ProcessGroup,
   ProgramConfig,
-  ProgramOrigin,
   ProgramRecord,
 } from "../config/schema";
 import { isBoolean, isNumber, isStringArray } from "../utils/types";
@@ -64,7 +63,6 @@ export {
   type ProcessGroup,
   type ProgramConfig,
   type ProgramEntry,
-  type ProgramOrigin,
   type ProgramRecord,
 } from "../config/schema";
 
@@ -173,22 +171,13 @@ interface ConfigSource {
 
 /**
  * Precedence of a program-config match against a file, **lowest value wins**.
- * Used by {@link PluginConfigurationProvider["getProgramConfig"]} to pick the
- * best match rather than the first hit, so a user-scope `settings.json` entry
- * can never shadow a project `.pliplugin/` entry that also matches:
- *
- *  1. source — project (`.pliplugin/`) beats settings;
- *  2. specificity — an exact path beats a glob (within the same source).
- *
- * Ties beyond this are broken by insertion order (project entries are merged
- * first). `ProjectExact` is the best possible rank, so matching it lets the
- * lookup stop early.
+ * Used by {@link PluginConfigurationProvider.getProgramConfig} to prefer an
+ * exact path match over a glob match. `Exact` is the best rank, so matching it
+ * stops the lookup early.
  */
 const ProgramMatchRank = {
-  ProjectExact: 0,
-  ProjectGlob: 1,
-  SettingsExact: 2,
-  SettingsGlob: 3,
+  Exact: 0,
+  Glob: 1,
 } as const;
 
 /**
@@ -224,12 +213,11 @@ export class PluginConfigurationProvider {
   private workspacePath: URI;
 
   /**
-   * Per-source snapshots from the most recent postProcessProcessGroups run.
-   * Keyed by source URI string. With merge enabled, this can hold up to two
-   * entries — `.pliplugin/proc_grps.json` and the `settings.json` /
-   * `.code-workspace` file the `pli.proc_grps` value came from. Quick-fix
-   * code actions look up the snapshot by the URI of the document the user
-   * is acting on.
+   * Per-source snapshots from the most recent postProcessProcessGroups run,
+   * keyed by source URI. `proc_grps` comes from a single selected source, so
+   * this normally holds one entry (`.pliplugin/proc_grps.json` or the
+   * `settings.json` / `.code-workspace` file it came from). Quick-fix code
+   * actions look it up by the acted-on document's URI.
    */
   private procGrpsSnapshots: Map<string, ProcGrpsSnapshot> = new Map();
 
@@ -258,6 +246,15 @@ export class PluginConfigurationProvider {
   private readonly longRunningOperation: LongRunningOperation;
   private readonly globalConfigLoader: GlobalConfigLoader;
 
+  /**
+   * True when this provider backs the fallback workspace (rooted at the
+   * filesystem root) that serves files outside any real workspace folder.
+   * A fallback workspace has no base to resolve workspace-relative library
+   * paths against, so it must not report such libs as unresolved. Set once
+   * via {@link markAsFallbackWorkspace} right after construction.
+   */
+  private isFallbackWorkspace = false;
+
   constructor(
     fs: FileSystemProvider,
     globalConfigLoader: GlobalConfigLoader,
@@ -272,14 +269,20 @@ export class PluginConfigurationProvider {
   }
 
   /**
+   * Marks this provider as backing the fallback workspace. See
+   * {@link isFallbackWorkspace}. Must be called before {@link init}.
+   */
+  public markAsFallbackWorkspace(): void {
+    this.isFallbackWorkspace = true;
+  }
+
+  /**
    * Snapshot of the file the user is acting on, used by quick-fixes that
    * rewrite `proc_grps` to remove unresolved libs.
    *
-   * Pass the diagnostic's source URI (i.e. `params.textDocument.uri` from
-   * the code-action request) to disambiguate when both `.pliplugin/` and
-   * settings contribute a `proc_grps`. Without a URI, returns the only
-   * snapshot if there's exactly one — preserves the legacy single-source
-   * call sites without changing them.
+   * Pass the diagnostic's source URI (`params.textDocument.uri`) to select the
+   * matching snapshot. Without a URI, returns the only snapshot when there's
+   * exactly one — the common case, since `proc_grps` has a single source.
    */
   public getLastProcGrpsSnapshot(
     uri?: string,
@@ -415,15 +418,13 @@ export class PluginConfigurationProvider {
   /**
    * Loads the plugin configurations, overwriting any existing configs.
    *
-   * Both sources contribute unconditionally and are merged: the
-   * `.pliplugin/` files (when present in the workspace) and the
-   * `pli.pgm_conf` / `pli.proc_grps` VS Code settings (when set; the
-   * extension resolves them to whichever `settings.json` /
-   * `.code-workspace` file VS Code attributes the effective value to).
+   * Each config file (`pgm_conf`, `proc_grps`) is taken from exactly one source
+   * by precedence — project `.pliplugin/`, else workspace settings, else user
+   * settings — and the two files are selected independently.
    *
-   * On key collisions (same program path or same `pgroup` name in both
-   * sources), `.pliplugin/` wins — project files override personal /
-   * workspace settings.
+   * Fallback happens only when a `.pliplugin/` file is *missing*. One that
+   * exists (even empty or invalid) is used as-is and blocks fallback; sources
+   * are selected whole, never merged property-by-property.
    *
    * @returns Diagnostics keyed by source URI. Every file we loaded *or*
    *   previously loaded gets an entry — including empty lists, so the
@@ -455,92 +456,62 @@ export class PluginConfigurationProvider {
       "proc_grps.json",
     );
 
-    // Collect sources in PRECEDENCE-LOWEST-FIRST order. Map-based merge
-    // means later writes overwrite earlier writes, so listing
-    // .pliplugin/ second makes it the winning source on key collisions.
-    const globalSettings = await this.fetchGlobalSettings(this.workspacePath);
+    const global = await this.fetchGlobalSettings(this.workspacePath);
 
-    // Read every source concurrently. Precedence (settings < .pliplugin/)
-    // is established by the order we assemble each array below, not by the
-    // order the reads resolve, so reading in parallel is safe.
-    const [globalPgm, globalProc, plipluginPgm, plipluginProc] =
-      await Promise.all([
-        this.readConfigSource(globalSettings?.pgmConf),
-        this.readConfigSource(globalSettings?.procGrps),
-        this.readConfigSource(plipluginPgmConfUri),
-        this.readConfigSource(plipluginProcGrpsUri),
-      ]);
+    const [pgmSource, procGrpsSource] = await Promise.all([
+      this.resolveConfigSource(plipluginPgmConfUri, global?.pgmConf),
+      this.resolveConfigSource(plipluginProcGrpsUri, global?.procGrps),
+    ]);
 
-    const pgmSources = [globalPgm, plipluginPgm].filter(
-      (source): source is ConfigSource => source !== undefined,
-    );
-    const procGrpsSources = [globalProc, plipluginProc].filter(
-      (source): source is ConfigSource => source !== undefined,
-    );
-
-    // Parse pgm_conf sources and merge by resolved program URI, tagging each
-    // entry with its origin (project `.pliplugin/` vs. user-scope settings).
-    //
-    // Two layers of precedence work together:
-    //  1. Here, `.pliplugin/` sources are processed FIRST (the reverse of
-    //     `pgmSources`) and the `has` guard keeps the first entry per key, so a
-    //     project entry wins any exact-key collision with settings.
-    //  2. `getProgramConfig` then prefers project entries over settings entries
-    //     at lookup time (see its ranking). Together these guarantee a settings
-    //     program entry can never shadow a project entry that also matches the
-    //     file — whether the settings entry is a broad glob (e.g. `**/*`) or an
-    //     exact path (e.g. `a.pli`, which a plain `Map.get` would otherwise let
-    //     win via a direct key hit).
-    const projectPgmConfUri = plipluginPgmConfUri.toString();
-    const mergedPrograms = new Map<
-      string,
-      { config: ProgramConfig; origin: ProgramOrigin }
-    >();
-    for (const source of [...pgmSources].reverse()) {
-      this.knownPgmConfUris.add(source.uri.toString());
-      const result = parseProgramConfigs(source.text, source.uri, source.entry);
+    // Parse the selected pgm_conf source (if any). Only one source contributes,
+    // so the `has` guard just dedupes program keys within that file.
+    const selectedPrograms = new Map<string, ProgramConfig>();
+    if (pgmSource) {
+      this.knownPgmConfUris.add(pgmSource.uri.toString());
+      const result = parseProgramConfigs(
+        pgmSource.text,
+        pgmSource.uri,
+        pgmSource.entry,
+      );
       diagnostics.push(...result.diagnostics);
       if (result.config) {
-        const origin: ProgramOrigin =
-          source.uri.toString() === projectPgmConfUri ? "project" : "settings";
         for (const config of result.config) {
           const resolvedUri = this.resolveProgramPath(
             config.program.value,
             this.workspacePath,
           );
           const key = resolvedUri.toString();
-          if (!mergedPrograms.has(key)) {
-            mergedPrograms.set(key, { config, origin });
+          if (!selectedPrograms.has(key)) {
+            selectedPrograms.set(key, config);
           }
         }
       }
     }
     this.applyProgramConfigs(
       this.workspacePath,
-      Array.from(mergedPrograms.values()),
+      Array.from(selectedPrograms.values()),
     );
 
-    // Parse proc_grps sources and merge by pgroup name.
-    const mergedGroups = new Map<string, ProcessGroup>();
-    const procGrpsDocuments = new Map<string, TextDocument>();
-    for (const source of procGrpsSources) {
-      this.knownProcGrpsUris.add(source.uri.toString());
-      procGrpsDocuments.set(source.uri.toString(), source.document);
+    // Parse the selected proc_grps source (if any), keyed by pgroup name;
+    // duplicate names within it are won by the later entry.
+    const selectedGroups = new Map<string, ProcessGroup>();
+    if (procGrpsSource) {
+      this.knownProcGrpsUris.add(procGrpsSource.uri.toString());
       const result = parseProcessGroupConfigs(
-        source.text,
-        source.uri,
-        source.entry,
+        procGrpsSource.text,
+        procGrpsSource.uri,
+        procGrpsSource.entry,
       );
       diagnostics.push(...result.diagnostics);
       if (result.config) {
         for (const config of result.config) {
-          mergedGroups.set(config.name.value, config);
+          selectedGroups.set(config.name.value, config);
         }
       }
     }
     // `processGroupConfigs` was already cleared at the top of this method
     // and nothing has repopulated it since, so we can write straight in.
-    for (const config of mergedGroups.values()) {
+    for (const config of selectedGroups.values()) {
       this.processGroupConfigs.set(config.name.value, {
         ...config,
         computedLibs: [],
@@ -548,8 +519,9 @@ export class PluginConfigurationProvider {
     }
 
     this.postProcessProgramConfigs();
-    const procGrpsDiagnostics =
-      await this.postProcessProcessGroups(procGrpsDocuments);
+    const procGrpsDiagnostics = await this.postProcessProcessGroups(
+      procGrpsSource?.document,
+    );
     diagnostics.push(...procGrpsDiagnostics);
     // Runs AFTER the post-processing above so the program/lib overlap check
     // sees each group's expanded `computedLibs`.
@@ -603,9 +575,9 @@ export class PluginConfigurationProvider {
   private previouslyPublishedUris: Set<string> = new Set();
 
   /**
-   * Asks the client for the VS Code settings backing for `pli.pgm_conf`
-   * and `pli.proc_grps`. Returns `undefined` when no connection is
-   * available (e.g. tests) or the request fails.
+   * Asks the {@link GlobalConfigLoader} for the VS Code settings backing for
+   * `pli.pgm_conf` and `pli.proc_grps` for the given workspace. In production
+   * this round-trips to the client; in tests it's a fixture-backed loader.
    */
   private async fetchGlobalSettings(
     workspaceUri: URI,
@@ -647,6 +619,39 @@ export class PluginConfigurationProvider {
       entry,
       document: textDocument,
     };
+  }
+
+  /**
+   * Returns the highest-priority settings source for one config key —
+   * workspace scope before user scope — or `undefined` if neither resolves
+   * to a document. A file that exists wins its tier even if empty/invalid.
+   */
+  private async readPreferredGlobalConfigSource(
+    entries: Messages.GlobalConfigEntry[] | undefined,
+  ): Promise<ConfigSource | undefined> {
+    for (const scope of ["workspace", "user"] as const) {
+      const entry = entries?.find((e) => e.scope === scope);
+      const source = await this.readConfigSource(entry);
+      if (source) {
+        return source;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Resolves the winning {@link ConfigSource} for one config file by precedence:
+   * project (`.pliplugin/`) first, then settings (workspace before user, read
+   * lazily). Returns `undefined` if no tier provides the file.
+   */
+  private async resolveConfigSource(
+    pluginUri: URI,
+    entries: Messages.GlobalConfigEntry[] | undefined,
+  ): Promise<ConfigSource | undefined> {
+    return (
+      (await this.readConfigSource(pluginUri)) ??
+      (await this.readPreferredGlobalConfigSource(entries))
+    );
   }
 
   /**
@@ -753,10 +758,9 @@ export class PluginConfigurationProvider {
    * file the lib came from (via `libItem.meta?.uri`).
    *
    * Returns diagnostics grouped by source URI string so the caller can
-   * publish to each file separately; the merged config can contribute
-   * diagnostics to multiple sources at once. Also rebuilds
-   * `procGrpsSnapshots`, one entry per source document — quick-fix code
-   * actions need the right document text + entries to rewrite.
+   * publish to each file separately. Also rebuilds `procGrpsSnapshots`, one
+   * entry per source document — quick-fix code actions need the right
+   * document text + entries to rewrite.
    *
    * `documents` maps source URI string → TextDocument; it must include
    * every URI referenced by `libItem.meta?.uri` for ranges to convert
@@ -765,7 +769,7 @@ export class PluginConfigurationProvider {
    * available document.
    */
   private async postProcessProcessGroups(
-    documents: Map<string, TextDocument>,
+    document?: TextDocument,
   ): Promise<Diagnostic[]> {
     this.procGrpsSnapshots.clear();
     const diagnostics: Diagnostic[] = [];
@@ -773,6 +777,10 @@ export class PluginConfigurationProvider {
       string,
       PluginConfigUnresolvedLibData
     >();
+
+    // The fallback workspace has no base for workspace-relative paths, so skip
+    // "unresolved" diagnostics for them (absolute-path libs are still checked).
+    const isFallback = this.isFallbackWorkspace;
 
     for (const record of this.processGroupConfigs.values()) {
       const expanded = await expandGroup(
@@ -793,6 +801,10 @@ export class PluginConfigurationProvider {
         .filter((item) => !unresolvedItems.has(item))
         .map((item) => item.value);
       for (const libItem of expanded.unresolved) {
+        // Skip relative libs in the fallback workspace (see above).
+        if (isFallback && !this.isAbsolutePath(libItem.value)) {
+          continue;
+        }
         const fallbackRange = offsetLengthToRange(0, 1);
         const range = libItem.meta?.range ?? fallbackRange;
         const path = libItem.meta?.path;
@@ -820,13 +832,14 @@ export class PluginConfigurationProvider {
       }
     }
 
-    for (const [uri, document] of documents) {
-      this.procGrpsSnapshots.set(uri, {
-        entries: Array.from(entriesBySource.get(uri)),
+    if (document) {
+      this.procGrpsSnapshots.set(document.uri, {
+        entries: Array.from(entriesBySource.get(document.uri)),
         text: document.getText(),
         uri: UriUtils.toUri(document.uri),
       });
     }
+
     return diagnostics;
   }
 
@@ -963,27 +976,21 @@ export class PluginConfigurationProvider {
     workspaceUri: URI,
     programConfigs: ProgramConfig[],
   ): void {
-    // Direct callers (quick-fix add, `.pliplugin/`-only parse, tests) are all
-    // project-scoped, so their entries bind at project precedence.
-    this.applyProgramConfigs(
-      workspaceUri,
-      programConfigs.map((config) => ({ config, origin: "project" as const })),
-    );
+    this.applyProgramConfigs(workspaceUri, programConfigs);
   }
 
   /**
-   * Rebuilds the program-config map from the given entries, each tagged with
-   * the source it came from ({@link ProgramOrigin}). Program paths are
+   * Rebuilds the program-config map from the given configs. Program paths are
    * normalized and resolved relative to the workspace (unless absolute), then
    * post-processed so abstract options are built.
    */
   private applyProgramConfigs(
     workspaceUri: URI,
-    entries: Array<{ config: ProgramConfig; origin: ProgramOrigin }>,
+    programConfigs: ProgramConfig[],
   ): void {
     this.programConfigs.clear();
 
-    for (const { config, origin } of entries) {
+    for (const config of programConfigs) {
       const resolvedUri = this.resolveProgramPath(
         config.program.value,
         workspaceUri,
@@ -995,7 +1002,6 @@ export class PluginConfigurationProvider {
         ...config,
         abstractOptions: { options: [], tokens: [], issues: [], comments: [] },
         issues: [],
-        origin,
       });
     }
     this.postProcessProgramConfigs();
@@ -1084,11 +1090,7 @@ export class PluginConfigurationProvider {
       });
     }
     this.postProcessProgramConfigs();
-    const documents = new Map<string, TextDocument>();
-    if (configDocument) {
-      documents.set(configDocument.uri, configDocument);
-    }
-    const diagnostics = await this.postProcessProcessGroups(documents);
+    const diagnostics = await this.postProcessProcessGroups(configDocument);
     this.libFileMatchers = undefined;
     return diagnostics;
   }
@@ -1112,77 +1114,53 @@ export class PluginConfigurationProvider {
   /**
    * Returns the program config for the given program URI.
    *
-   * Rather than returning the first hit, this picks the *highest-precedence*
-   * match (see {@link ProgramMatchRank}) so a user-scope `settings.json` entry
-   * can never shadow a project `.pliplugin/` entry that also matches. This is
-   * what fixes the exact-path settings case: a plain `Map.get(uri)` direct hit
-   * would return a settings `program: "a.pli"` entry even when a project glob
-   * (e.g. `*.pli`) also matches; ranking lets the project glob win instead.
+   * An exact path match wins outright; otherwise the first matching glob entry
+   * is returned (see {@link ProgramMatchRank}). This keeps an exact key like
+   * `a.pli` from being shadowed by a broader glob such as `*.pli` that also
+   * matches the same file.
    *
    * @param program Name of the program to get a config for
    * @returns Associated program config, or undefined if not found
    */
   public getProgramConfig(program: URI): ProgramRecord | undefined {
-    // No PL/I-extension filtering here: callers only ever pass files already
-    // identified as PL/I (client language id / auto-detect), so glob matching
-    // the path alone is sufficient.
-    // Note that we just need the path of the URI in order to match against
-    // the program config patterns
     const path = program.path;
 
-    let best: ProgramRecord | undefined;
-    let bestRank = Number.POSITIVE_INFINITY;
+    let globMatch: ProgramRecord | undefined;
     for (const [pattern, config] of this.programConfigs.entries()) {
-      const rank = this.programMatchRank(path, pattern, config);
-      if (rank === undefined || rank >= bestRank) {
-        continue; // no match, or not better than what we already have
+      const rank = this.programMatchRank(path, pattern);
+      if (rank === ProgramMatchRank.Exact) {
+        return config;
       }
-      best = config;
-      bestRank = rank;
-      if (rank === ProgramMatchRank.ProjectExact) {
-        break; // best possible rank
+      if (rank === ProgramMatchRank.Glob) {
+        globMatch = globMatch ?? config;
       }
     }
-    return best;
+    return globMatch;
   }
 
   /**
-   * Precedence of a single program-config entry as a match for `uri`, or
+   * Precedence of a single program-config entry as a match for `path`, or
    * `undefined` when its pattern does not match the file. Lower ranks win;
    * see {@link ProgramMatchRank}.
    *
    * @param path Decoded program path being resolved.
    * @param pattern The program config's key (an exact path or a glob).
-   * @param record The candidate program config.
    */
-  private programMatchRank(
-    path: string,
-    pattern: string,
-    record: ProgramRecord,
-  ): number | undefined {
-    const isExact = pattern === path;
-    if (!isExact) {
-      try {
-        // attempt match on decoded path
-        if (!minimatch(path, decodeURIComponent(pattern), { nocase: true })) {
-          return undefined;
-        }
-      } catch (e) {
-        console.error(
-          `Invalid glob pattern "${pattern}" for program "${path}": ${e}`,
-        );
+  private programMatchRank(path: string, pattern: string): number | undefined {
+    if (pattern === path) {
+      return ProgramMatchRank.Exact;
+    }
+    try {
+      if (!minimatch(path, decodeURIComponent(pattern), { nocase: true })) {
         return undefined;
       }
+    } catch (e) {
+      console.error(
+        `Invalid glob pattern "${pattern}" for program "${path}": ${e}`,
+      );
+      return undefined;
     }
-    // Absent origin is treated as "project" (see ProgramRecord.origin).
-    if (record.origin === "settings") {
-      return isExact
-        ? ProgramMatchRank.SettingsExact
-        : ProgramMatchRank.SettingsGlob;
-    }
-    return isExact
-      ? ProgramMatchRank.ProjectExact
-      : ProgramMatchRank.ProjectGlob;
+    return ProgramMatchRank.Glob;
   }
 
   /**

--- a/packages/language/test/fourslash/preprocessor/include/program-config-empty-file-blocks-fallback.ts
+++ b/packages/language/test/fourslash/preprocessor/include/program-config-empty-file-blocks-fallback.ts
@@ -1,0 +1,48 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+// Fallback only happens when a `.pliplugin/` config file is *entirely missing* —
+// not when it exists but is empty. Here `.pliplugin/proc_grps.json` is present
+// but declares no groups, so it wins its tier and blocks the workspace-settings
+// `proc_grps` (which *would* have resolved the include via `cpyla`).
+//
+// `pgm_conf` is absent from `.pliplugin/`, so it still falls back to settings
+// and binds `*.pli` to `default`; but the `default` process group is undefined
+// because the empty project `proc_grps.json` shadows the settings one. The
+// include therefore cannot resolve.
+//
+// Contrast with `program-config-precedence-workspace-over-user.ts`, where the
+// project `proc_grps.json` is missing and the same settings group *does*
+// resolve the include.
+
+/// <reference path="../../framework.ts" />
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": []
+//// }
+
+// @filename: .vscode/settings.json
+//// {
+////   "pli.pgm_conf": { "pgms": [{ "pgroup": "default", "program": "*.pli" }] },
+////   "pli.proc_grps": { "pgroups": [{ "name": "default", "libs": ["cpyla"], "include-extensions": [".pli"] }] }
+//// }
+
+// @filename: cpyla/b.pli
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: main.pli
+// @noDefaultConfig
+//// %INCLUDE "b.pli";
+
+// The empty project `proc_grps.json` blocks the settings fallback, so the
+// include never resolves and `LIB_VAR` is not pulled in.
+preprocessor.not.containsTokens("LIB_VAR");

--- a/packages/language/test/fourslash/preprocessor/include/program-config-fallback-to-user.ts
+++ b/packages/language/test/fourslash/preprocessor/include/program-config-fallback-to-user.ts
@@ -1,0 +1,39 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+// Fallback reaches user-scope settings when neither `.pliplugin/` nor
+// workspace-scope settings provide configuration. Only `user-settings.json`
+// defines `pgm_conf`/`proc_grps` here, and `main.pli` resolves its include via
+// the user `default` group.
+//
+// This is the lowest tier of the precedence chain
+// (`.pliplugin/` > workspace settings > user settings) and proves the fallback
+// keeps descending until it finds a source that exists.
+
+/// <reference path="../../framework.ts" />
+
+// @filename: user-settings.json
+//// {
+////   "pli.pgm_conf": { "pgms": [{ "pgroup": "default", "program": "*.pli" }] },
+////   "pli.proc_grps": { "pgroups": [{ "name": "default", "libs": ["cpyla"], "include-extensions": [".pli"] }] }
+//// }
+
+// @filename: cpyla/b.pli
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: main.pli
+// @noDefaultConfig
+//// %INCLUDE "b.pli";
+
+// The include resolves via the user `default` group.
+preprocessor.expectTokens(`
+  DECLARE LIB_VAR FIXED;
+`);

--- a/packages/language/test/fourslash/preprocessor/include/program-config-invalid-file-blocks-fallback.ts
+++ b/packages/language/test/fourslash/preprocessor/include/program-config-invalid-file-blocks-fallback.ts
@@ -1,0 +1,42 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+// Sibling of `program-config-empty-file-blocks-fallback.ts`, covering the other
+// "present but unusable" branch: a project `proc_grps.json` that fails to
+// parse. A malformed file is still *present*, so it is selected for its tier
+// and blocks the settings `proc_grps` fallback — a parse error must NOT be
+// mistaken for a missing file.
+//
+// `pgm_conf` falls back to settings and binds `*.pli` -> `default`, but the
+// `default` process group is undefined because the unparseable project
+// `proc_grps.json` shadows the settings one, so the include cannot resolve.
+
+/// <reference path="../../framework.ts" />
+
+// @filename: .pliplugin/proc_grps.json
+//// { not valid json
+
+// @filename: .vscode/settings.json
+//// {
+////   "pli.pgm_conf": { "pgms": [{ "pgroup": "default", "program": "*.pli" }] },
+////   "pli.proc_grps": { "pgroups": [{ "name": "default", "libs": ["cpyla"], "include-extensions": [".pli"] }] }
+//// }
+
+// @filename: cpyla/b.pli
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: main.pli
+// @noDefaultConfig
+//// %INCLUDE "b.pli";
+
+// The unparseable project `proc_grps.json` blocks the settings fallback, so the
+// include never resolves and `LIB_VAR` is not pulled in.
+preprocessor.not.containsTokens("LIB_VAR");

--- a/packages/language/test/fourslash/preprocessor/include/program-config-per-file-selection.ts
+++ b/packages/language/test/fourslash/preprocessor/include/program-config-per-file-selection.ts
@@ -1,0 +1,48 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+// Source selection happens per config FILE, not all-or-nothing across the whole
+// `.pliplugin/` folder. Here the project provides `pgm_conf.json` but no
+// `proc_grps.json`:
+//
+//   - `pgm_conf` -> project is selected: `main.pli` binds `*.pli` -> `grpA`,
+//     and the settings `pli.pgm_conf` (`**/*` -> `grpZ`) is ignored.
+//   - `proc_grps` -> project file is missing, so it falls back to the settings
+//     `pli.proc_grps`, which defines `grpA` with the resolvable `cpyla` lib.
+//
+// The include only resolves if `main.pli` is bound to `grpA` (project pgm_conf)
+// AND `grpA`'s libs come from settings (proc_grps fallback) — i.e. the two
+// files were selected from different sources independently. If the settings
+// `pgm_conf` had won, `main.pli` would bind `grpZ` (undefined here) and fail.
+
+/// <reference path="../../framework.ts" />
+
+// @filename: .pliplugin/pgm_conf.json
+//// { "pgms": [{ "program": "*.pli", "pgroup": "grpA" }] }
+
+// @filename: .vscode/settings.json
+//// {
+////   "pli.pgm_conf": { "pgms": [{ "pgroup": "grpZ", "program": "**/*" }] },
+////   "pli.proc_grps": { "pgroups": [{ "name": "grpA", "libs": ["cpyla"], "include-extensions": [".pli"] }] }
+//// }
+
+// @filename: cpyla/b.pli
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: main.pli
+// @noDefaultConfig
+//// %INCLUDE "b.pli";
+
+// pgm_conf from the project (binds grpA), proc_grps from settings (grpA has
+// cpyla) -> the include resolves.
+preprocessor.expectTokens(`
+  DECLARE LIB_VAR FIXED;
+`);

--- a/packages/language/test/fourslash/preprocessor/include/program-config-pliplugin-only.ts
+++ b/packages/language/test/fourslash/preprocessor/include/program-config-pliplugin-only.ts
@@ -1,0 +1,38 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+// `.pliplugin/`-only mode: the global-config loader contributes NOTHING because
+// no `.vscode/settings.json` / `user-settings.json` fixtures are present, so
+// the harness builds an empty `TestGlobalConfigLoader`. The provider must fall
+// back entirely to the project's `.pliplugin/` files: `pgm_conf.json` binds
+// `main.pli` to `default`, and `proc_grps.json` gives `default` the resolvable
+// `mylib` lib. The include only resolves if both `.pliplugin/` files drive the
+// configuration on their own, with no settings backing them.
+
+/// <reference path="../../framework.ts" />
+
+// @filename: .pliplugin/pgm_conf.json
+//// { "pgms": [{ "program": "*.pli", "pgroup": "default" }] }
+
+// @filename: .pliplugin/proc_grps.json
+//// { "pgroups": [{ "name": "default", "libs": ["mylib"], "include-extensions": [".pli"] }] }
+
+// @filename: mylib/b.pli
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: main.pli
+// @noDefaultConfig
+//// %INCLUDE "b.pli";
+
+// Resolves purely via the project `.pliplugin/` config (empty global loader).
+preprocessor.expectTokens(`
+  DECLARE LIB_VAR FIXED;
+`);

--- a/packages/language/test/fourslash/preprocessor/include/program-config-precedence-exact-settings.ts
+++ b/packages/language/test/fourslash/preprocessor/include/program-config-precedence-exact-settings.ts
@@ -9,16 +9,17 @@
  *
  */
 
-// A project `.pliplugin/pgm_conf.json` entry must win over a user-scope
-// `pli.pgm_conf` entry even when the settings entry is an EXACT path match for
-// the file. Here the settings bind `main.pli` (exact) to `DFLT` (no libs),
-// while the project binds `*.pli` (glob) to `default` (has the `cpyla` lib).
+// Because a present `.pliplugin/pgm_conf.json` is selected as the sole pgm_conf
+// source, the settings `pli.pgm_conf` is ignored even when it is an EXACT path
+// match for the file. Here the settings bind `main.pli` (exact) to `DFLT` (no
+// libs), while the project binds `*.pli` (glob) to `default` (has the `cpyla`
+// lib).
 //
 // This is the harder sibling of `program-config-precedence-over-settings.ts`:
-// a plain `Map.get(uri)` direct lookup would return the settings exact-path
-// entry and the include would fail with IBM1848I. `getProgramConfig` instead
-// ranks project matches above settings matches, so the project glob wins and
-// the include resolves.
+// under a per-key merge, a plain `Map.get(uri)` direct lookup could return the
+// settings exact-path entry and the include would fail with IBM1848I. With
+// per-file source selection the settings entry is never loaded at all, so the
+// project glob binds `main.pli` and the include resolves.
 
 /// <reference path="../../framework.ts" />
 

--- a/packages/language/test/fourslash/preprocessor/include/program-config-precedence-over-settings.ts
+++ b/packages/language/test/fourslash/preprocessor/include/program-config-precedence-over-settings.ts
@@ -9,12 +9,12 @@
  *
  */
 
-// A project `.pliplugin/pgm_conf.json` entry must win over a broader user-scope
-// `pli.pgm_conf` glob when binding a file to its process group. Here the user
-// settings bind every file (`**/*`) to `DFLT` (which has no libs), while the
-// project binds `*.pli` to `default` (which has the `cpyla` lib). `main.pli`
-// must resolve against `default`, so the include is found — otherwise it would
-// pick the empty settings group and fail with IBM1848I.
+// When both `.pliplugin/` and VS Code settings provide a config file, the
+// project file is selected and the settings file is ignored (no merge). Here
+// both `pgm_conf.json` and `proc_grps.json` exist under `.pliplugin/`, so the
+// settings `pli.pgm_conf`/`pli.proc_grps` are dropped entirely: `main.pli`
+// binds `*.pli` -> `default` (which has the `cpyla` lib) and the include is
+// found — the settings `**/*` -> `DFLT` (no libs) never applies.
 //
 // Regression test for the include that "could not be found" even though the
 // resolvable lib was listed in the project proc_grps.json.

--- a/packages/language/test/fourslash/preprocessor/include/program-config-precedence-workspace-over-user.ts
+++ b/packages/language/test/fourslash/preprocessor/include/program-config-precedence-workspace-over-user.ts
@@ -1,0 +1,52 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+// When `.pliplugin/` is missing entirely, configuration falls back to VS Code
+// settings, and workspace-scope settings (`.vscode/settings.json`) win over
+// user-scope settings (`user-settings.json`) — mirroring VS Code's native
+// scope precedence.
+//
+// Both scopes bind `*.pli` to `default`, but the workspace `default` lists the
+// resolvable `cpyla` lib while the user `default` has no libs. `main.pli` must
+// resolve its include via the workspace group — otherwise it would pick the
+// empty user group and fail.
+//
+// `@noDefaultConfig` (on the last file block) stops the harness from
+// materializing default `.pliplugin/` files, which would otherwise be
+// "present" and block the fallback. The workspace root defaults to the test
+// root, so no `.pliplugin/` anchor file is needed.
+
+/// <reference path="../../framework.ts" />
+
+// @filename: .vscode/settings.json
+//// {
+////   "pli.pgm_conf": { "pgms": [{ "pgroup": "default", "program": "*.pli" }] },
+////   "pli.proc_grps": { "pgroups": [{ "name": "default", "libs": ["cpyla"], "include-extensions": [".pli"] }] }
+//// }
+
+// @filename: user-settings.json
+//// {
+////   "pli.pgm_conf": { "pgms": [{ "pgroup": "default", "program": "*.pli" }] },
+////   "pli.proc_grps": { "pgroups": [{ "name": "default", "libs": [], "include-extensions": [".pli"] }] }
+//// }
+
+// @filename: cpyla/b.pli
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: main.pli
+// @noDefaultConfig
+//// %INCLUDE "b.pli";
+
+// The include resolves via the workspace `default` group (which lists `cpyla`),
+// not the user `default` group (which has no libs).
+preprocessor.expectTokens(`
+  DECLARE LIB_VAR FIXED;
+`);

--- a/packages/language/test/fourslash/validate/unresolved-lib-in-vscode-settings.ts
+++ b/packages/language/test/fourslash/validate/unresolved-lib-in-vscode-settings.ts
@@ -12,11 +12,12 @@
 /// <reference path="../framework.ts" />
 
 /**
- * Suppression rule: when proc_grps.json declares zero process groups,
- * the set of known names is empty, so every reference is technically
- * unresolved. We deliberately suppress UnknownProcessGroup here rather
- * than flagging every program — the empty proc_grps file is the real,
- * more fundamental problem to fix first.
+ * An unresolved lib in a VS Code settings `pli.proc_grps` is flagged inside the
+ * settings file itself. `.pliplugin/proc_grps.json` is absent, so proc_grps
+ * falls back to the settings source; `.pliplugin/pgm_conf.json` is present only
+ * to anchor the workspace root, and `@noDefaultConfig` (on the last file block)
+ * keeps the harness from materializing a default `.pliplugin/proc_grps.json`
+ * that would block the fallback.
  */
 
 // @filename: .vscode/settings.json
@@ -27,11 +28,9 @@
 // @filename: .pliplugin/pgm_conf.json
 //// { "pgms": [] }
 
-// @filename: .pliplugin/proc_grps.json
-//// { "pgroups": [] }
-
 // @filename: main.pli
 // @wrap: main
+// @noDefaultConfig
 //// DCL A CHAR(8);
 
 verify.expectDiagnosticsAt(

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -72,6 +72,7 @@ import {
   Label,
   TestDiagnostic,
 } from "./abstract-test-builder";
+import { Messages, TestGlobalConfigLoader } from "../src/utils/messages";
 
 export type { DiagnosticExpectation, Label, TestDiagnostic };
 
@@ -206,7 +207,8 @@ export class TestBuilder extends AbstractTestBuilder {
       const fs = new VirtualFileSystemProvider();
       this.options.fs = fs;
     }
-    setDefaultTestWorkspace(createTestWorkspace(this.options.fs));
+    const loader = new TestGlobalConfigLoader(this.extractGlobalConfig());
+    setDefaultTestWorkspace(createTestWorkspace(this.options.fs, loader));
     for (const [uri, file] of this.files) {
       await this.options.fs.writeFile(UriUtils.toUri(uri), file.output);
     }
@@ -1593,42 +1595,59 @@ Available code actions for label "${label}" and URI "${uri}": ${codeActions.map(
     return `${uriOverride}:${line + lineOffset}:${character + characterOffset}`;
   }
 
-  // private extractGlobalConfig(): Messages.GlobalConfig {
-  //   const pliPgmConf = "pli.pgm_conf";
-  //   const pliProcGrps = "pli.proc_grps";
-  //   let pgmConf: Messages.GlobalConfigEntry | undefined;
-  //   let procGrps: Messages.GlobalConfigEntry | undefined;
-  //   const settingsFile = "/.vscode/settings.json";
-  //   for (const [uri, file] of this.files) {
-  //     if (uri.endsWith(settingsFile)) {
-  //       try {
-  //         const config = JSON.parse(file.textDocument.getText());
-  //         if (config && typeof config === "object") {
-  //           if (pliPgmConf in config) {
-  //             pgmConf = {
-  //               uri,
-  //               configKey: pliPgmConf,
-  //               containerPath: [],
-  //             };
-  //           }
-  //           if (pliProcGrps in config) {
-  //             procGrps = {
-  //               uri,
-  //               configKey: pliProcGrps,
-  //               containerPath: [],
-  //             };
-  //           }
-  //         }
-  //       } catch (e) {
-  //         // Ignore JSON parsing errors
-  //       }
-  //     }
-  //   }
-  //   return {
-  //     pgmConf,
-  //     procGrps,
-  //   };
-  // }
+  /**
+   * Builds the fake {@link Messages.GlobalConfig} from special test files:
+   * `.vscode/settings.json` -> `workspace` scope, `user-settings.json` ->
+   * `user` scope. Both may be present to test workspace-over-user precedence.
+   */
+  private extractGlobalConfig(): Messages.GlobalConfig {
+    const pliPgmConf = "pli.pgm_conf";
+    const pliProcGrps = "pli.proc_grps";
+    const scopeFiles: Array<{
+      suffix: string;
+      scope: Messages.GlobalConfigScope;
+    }> = [
+      { suffix: "/.vscode/settings.json", scope: "workspace" },
+      { suffix: "/user-settings.json", scope: "user" },
+    ];
+    const pgmConf: Messages.GlobalConfigEntry[] = [];
+    const procGrps: Messages.GlobalConfigEntry[] = [];
+    for (const [uri, file] of this.files) {
+      const match = scopeFiles.find(
+        ({ suffix }) => uri.endsWith(suffix) || uri === suffix.slice(1),
+      );
+      if (!match) {
+        continue;
+      }
+      try {
+        const config = JSON.parse(file.textDocument.getText());
+        if (config && typeof config === "object") {
+          if (pliPgmConf in config) {
+            pgmConf.push({
+              uri,
+              configKey: pliPgmConf,
+              containerPath: [],
+              scope: match.scope,
+            });
+          }
+          if (pliProcGrps in config) {
+            procGrps.push({
+              uri,
+              configKey: pliProcGrps,
+              containerPath: [],
+              scope: match.scope,
+            });
+          }
+        }
+      } catch (e) {
+        // Ignore JSON parsing errors
+      }
+    }
+    return {
+      pgmConf: pgmConf.length > 0 ? pgmConf : undefined,
+      procGrps: procGrps.length > 0 ? procGrps : undefined,
+    };
+  }
 }
 
 function formatPosition(position: Position): string {

--- a/packages/language/test/test-workspace.ts
+++ b/packages/language/test/test-workspace.ts
@@ -16,7 +16,7 @@ import {
   VirtualFileSystemProvider,
 } from "../src/workspace/file-system-provider";
 import { WorkspaceContext } from "../src/workspace/workspace-context";
-import { TestGlobalConfigLoader } from "../src";
+import { GlobalConfigLoader, TestGlobalConfigLoader } from "../src";
 
 let _defaultTestWorkspace: WorkspaceContext | undefined;
 
@@ -58,21 +58,25 @@ export function setDefaultTestWorkspace(
  */
 export function createTestWorkspace(
   fs: FileSystemProvider = new VirtualFileSystemProvider(),
-): WorkspaceContext {
-  resetDocumentProviders(fs);
-  return new WorkspaceContext(
-    fs,
-    new TestGlobalConfigLoader({
-      pgmConf: {
+  loader: GlobalConfigLoader = new TestGlobalConfigLoader({
+    pgmConf: [
+      {
         configKey: "pli.pgm_conf",
         containerPath: [],
         uri: ".vscode/settings.json",
+        scope: "workspace",
       },
-      procGrps: {
+    ],
+    procGrps: [
+      {
         configKey: "pli.proc_grps",
         containerPath: [],
         uri: ".vscode/settings.json",
+        scope: "workspace",
       },
-    }),
-  );
+    ],
+  }),
+): WorkspaceContext {
+  resetDocumentProviders(fs);
+  return new WorkspaceContext(fs, loader);
 }

--- a/packages/language/test/workspace/multi-workspace.test.ts
+++ b/packages/language/test/workspace/multi-workspace.test.ts
@@ -18,6 +18,8 @@ import {
 } from "../../src";
 import { resetDocumentProviders } from "../../src/language-server/text-documents";
 import { LongRunningOperationImpl } from "../../src/utils/promises";
+import { LspCodes } from "../../src/validation/lsp-codes";
+import { fullCode } from "../../src/language-server/types";
 
 describe("Multi Workspace Tests", () => {
   test("With plugin configs under disjoint folders", async () => {
@@ -249,16 +251,22 @@ describe("Multi Workspace Tests", () => {
     const ch = new CompilationUnitHandler(
       fs,
       new TestGlobalConfigLoader({
-        pgmConf: {
-          configKey: "pli.pgm_conf",
-          uri: settingsUri.toString(),
-          containerPath: [],
-        },
-        procGrps: {
-          configKey: "pli.proc_grps",
-          uri: settingsUri.toString(),
-          containerPath: [],
-        },
+        pgmConf: [
+          {
+            configKey: "pli.pgm_conf",
+            uri: settingsUri.toString(),
+            containerPath: [],
+            scope: "user",
+          },
+        ],
+        procGrps: [
+          {
+            configKey: "pli.proc_grps",
+            uri: settingsUri.toString(),
+            containerPath: [],
+            scope: "user",
+          },
+        ],
       }),
       LongRunningOperationImpl.Dummy,
     );
@@ -349,5 +357,108 @@ describe("Multi Workspace Tests", () => {
     expect(
       workspaceOutside!.config.hasProgramConfig(outsideProgram),
     ).toBeTruthy();
+  });
+
+  test("Fallback folder does not flag relative libs from user settings", async () => {
+    const fs = new VirtualFileSystemProvider();
+    resetDocumentProviders(fs);
+    const settingsUri = UriUtils.toUri("file:///settings.json");
+    const ch = new CompilationUnitHandler(
+      fs,
+      new TestGlobalConfigLoader({
+        procGrps: [
+          {
+            configKey: "pli.proc_grps",
+            uri: settingsUri.toString(),
+            containerPath: [],
+            scope: "user",
+          },
+        ],
+      }),
+      LongRunningOperationImpl.Dummy,
+    );
+
+    await fs.writeFile(
+      settingsUri,
+      JSON.stringify({
+        "pli.proc_grps": {
+          pgroups: [
+            { name: "default", libs: ["cpy"], "include-extensions": [".inc"] },
+          ],
+        },
+      }),
+    );
+    // The real folder DOES contain the relative lib directory.
+    await fs.writeFile(UriUtils.toUri("file:///ws/cpy/x.inc"), "");
+
+    const realFolder = await ch.initializeWorkspaceFolder("file:///ws");
+    const fallback = await ch.initializeFallbackFolder();
+
+    // Real folder resolves `cpy` against its own root -> no diagnostic.
+    expect(
+      realFolder.config
+        .getConfigInternalDiagnostics()
+        .some(
+          (d) => d.code === LspCodes.PluginConfiguration.UnresolvedEntry.code,
+        ),
+    ).toBe(false);
+
+    // Fallback (rooted at file://) can't resolve the RELATIVE lib, but must
+    // not surface a diagnostic for it on the shared user settings.json.
+    expect(
+      fallback.config
+        .getConfigInternalDiagnostics()
+        .some(
+          (d) => d.code === LspCodes.PluginConfiguration.UnresolvedEntry.code,
+        ),
+    ).toBe(false);
+  });
+
+  test("Fallback folder still flags missing ABSOLUTE libs from user settings", async () => {
+    const fs = new VirtualFileSystemProvider();
+    resetDocumentProviders(fs);
+    const settingsUri = UriUtils.toUri("file:///settings.json");
+    const ch = new CompilationUnitHandler(
+      fs,
+      new TestGlobalConfigLoader({
+        procGrps: [
+          {
+            configKey: "pli.proc_grps",
+            uri: settingsUri.toString(),
+            containerPath: [],
+            scope: "user",
+          },
+        ],
+      }),
+      LongRunningOperationImpl.Dummy,
+    );
+
+    await fs.writeFile(
+      settingsUri,
+      JSON.stringify({
+        "pli.proc_grps": {
+          pgroups: [
+            {
+              name: "default",
+              libs: ["/definitely/missing"],
+              "include-extensions": [".inc"],
+            },
+          ],
+        },
+      }),
+    );
+
+    const fallback = await ch.initializeFallbackFolder();
+
+    // An absolute path that doesn't exist is still a genuine error, even in the
+    // fallback workspace.
+    expect(
+      fallback.config
+        .getConfigInternalDiagnostics()
+        .some(
+          (d) =>
+            d.code === fullCode(LspCodes.PluginConfiguration.UnresolvedEntry),
+        ),
+    ).toBe(true);
   });
 });

--- a/packages/language/test/workspace/plugin-configuration.test.ts
+++ b/packages/language/test/workspace/plugin-configuration.test.ts
@@ -20,7 +20,7 @@ import { WorkspaceContext } from "../../src/workspace/workspace-context";
 import { makeProcessGroup } from "../config-fixtures";
 import { Severity } from "../../src/language-server/types";
 import { resetDocumentProviders } from "../../src/language-server/text-documents";
-import { Messages, TestGlobalConfigLoader } from "../../src";
+import { TestGlobalConfigLoader } from "../../src";
 
 describe("Plugin Configuration Tests", () => {
   let vfs: VirtualFileSystemProvider;
@@ -165,125 +165,5 @@ describe("Plugin Configuration Tests", () => {
     const dirLibs = processGroup!.computedLibs.filter(isLibsDir);
     expect(dirLibs.length).toBe(1);
     expect(dirLibs[0].path).toBe("lib1/dir1");
-  });
-
-  describe("Merge of .pliplugin/ and VS Code settings", () => {
-    const WORKSPACE = "file:///ws/";
-    const SETTINGS_URI = "file:///ws/.vscode/settings.json";
-
-    async function writePluginFiles(
-      pgmConfText?: string,
-      procGrpsText?: string,
-    ): Promise<void> {
-      if (pgmConfText !== undefined) {
-        await vfs.writeFile(
-          UriUtils.toUri("file:///ws/.pliplugin/pgm_conf.json"),
-          pgmConfText,
-        );
-      }
-      if (procGrpsText !== undefined) {
-        await vfs.writeFile(
-          UriUtils.toUri("file:///ws/.pliplugin/proc_grps.json"),
-          procGrpsText,
-        );
-      }
-    }
-
-    async function writeSettingsFile(text: string): Promise<void> {
-      await vfs.writeFile(UriUtils.toUri(SETTINGS_URI), text);
-    }
-
-    function settingsConfig(args: {
-      pgmConf?: boolean;
-      procGrps?: boolean;
-    }): Messages.GlobalConfig {
-      const result: Messages.GlobalConfig = {};
-      if (args.pgmConf) {
-        result.pgmConf = {
-          uri: SETTINGS_URI,
-          containerPath: [],
-          configKey: "pli.pgm_conf",
-        };
-      }
-      if (args.procGrps) {
-        result.procGrps = {
-          uri: SETTINGS_URI,
-          containerPath: [],
-          configKey: "pli.proc_grps",
-        };
-      }
-      return result;
-    }
-
-    test("Non-overlapping entries from both sources are unioned", async () => {
-      await writePluginFiles(
-        `{ "pgms": [{ "program": "a.pli", "pgroup": "plugin-grp" }] }`,
-        `{ "pgroups": [{ "name": "plugin-grp", "libs": [] }] }`,
-      );
-      await writeSettingsFile(
-        `{
-          "pli.pgm_conf": { "pgms": [{ "program": "b.pli", "pgroup": "settings-grp" }] },
-          "pli.proc_grps": { "pgroups": [{ "name": "settings-grp", "libs": [] }] }
-        }`,
-      );
-      workspace = new WorkspaceContext(
-        vfs,
-        new TestGlobalConfigLoader(
-          settingsConfig({ pgmConf: true, procGrps: true }),
-        ),
-      );
-
-      await workspace.config.init(UriUtils.toUri(WORKSPACE));
-
-      expect(
-        workspace.config.getProcessGroupConfig("plugin-grp"),
-      ).toBeDefined();
-      expect(
-        workspace.config.getProcessGroupConfig("settings-grp"),
-      ).toBeDefined();
-      expect(
-        workspace.config.hasProgramConfig(UriUtils.toUri("file:///ws/a.pli")),
-      ).toBe(true);
-      expect(
-        workspace.config.hasProgramConfig(UriUtils.toUri("file:///ws/b.pli")),
-      ).toBe(true);
-    });
-
-    test(".pliplugin/ wins on duplicate pgroup name", async () => {
-      await vfs.writeFile(UriUtils.toUri("file:///ws/plugin-libs/x.inc"), "");
-      await vfs.writeFile(UriUtils.toUri("file:///ws/settings-libs/x.inc"), "");
-      await writePluginFiles(
-        `{ "pgms": [] }`,
-        `{ "pgroups": [{ "name": "default", "libs": ["plugin-libs"] }] }`,
-      );
-      await writeSettingsFile(
-        `{
-          "pli.proc_grps": { "pgroups": [{ "name": "default", "libs": ["settings-libs"] }] }
-        }`,
-      );
-      workspace = new WorkspaceContext(
-        vfs,
-        new TestGlobalConfigLoader(settingsConfig({ procGrps: true })),
-      );
-
-      await workspace.config.init(UriUtils.toUri(WORKSPACE));
-
-      const def = workspace.config.getProcessGroupConfig("default");
-      const dirPaths = (def?.computedLibs ?? [])
-        .filter(isLibsDir)
-        .map((lib) => lib.path);
-      expect(dirPaths).toContain("plugin-libs");
-      expect(dirPaths).not.toContain("settings-libs");
-    });
-
-    test(".pliplugin/-only mode (no connection) still works", async () => {
-      await writePluginFiles(
-        `{ "pgms": [] }`,
-        `{ "pgroups": [{ "name": "default", "libs": [] }] }`,
-      );
-      // workspace is created with no connection in beforeEach
-      await workspace.config.init(UriUtils.toUri(WORKSPACE));
-      expect(workspace.config.getProcessGroupConfig("default")).toBeDefined();
-    });
   });
 });

--- a/packages/vscode-extension/src/extension/config-loader.ts
+++ b/packages/vscode-extension/src/extension/config-loader.ts
@@ -16,6 +16,17 @@ import { sendNotification } from "./messages";
 
 type ConfigKey = "pgm_conf" | "proc_grps";
 
+/**
+ * Registers the LS-side handler for {@link Messages.GetGlobalConfig}.
+ * Called once per language client (desktop + browser) so the LS can
+ * fall back to VS Code settings when no `.pliplugin/` directory exists.
+ *
+ * The user-scope `settings.json` URI is derived from
+ * {@link vscode.ExtensionContext.globalStorageUri} (via
+ * {@link deriveUserSettingsUri}), which is the only documented way to reach
+ * the user data directory without platform-specific path math.
+ * (`vscode-userdata:/` is unreliable on desktop and is NOT used here.)
+ */
 export function registerConfigLoader(
   client: BaseLanguageClient,
   context: vscode.ExtensionContext,
@@ -35,8 +46,9 @@ export function registerConfigLoader(
  * Locates each PL/I plugin config value in VS Code settings and reports
  * back the actual JSON document URI plus the path inside that document.
  *
- * Scope precedence mirrors VS Code's normal resolution:
- *   workspaceFolder > workspace > user (global).
+ * Unlike VS Code's collapsed resolution, each key may yield an independent
+ * `user` and/or `workspace` entry; the LS decides precedence (workspace over
+ * user, both below `.pliplugin/`).
  *
  * The LS uses the result to read the source file via its `FileSystemProvider`
  * and parse the subtree directly - so diagnostics on a bad `pgroup`
@@ -51,39 +63,54 @@ async function getGlobalConfig(
   const result: Messages.GlobalConfig = {};
   if (workspaceFolder) {
     const pgmConf = locate("pgm_conf", workspaceFolder, userSettingsUri);
-    if (pgmConf) result.pgmConf = pgmConf;
+    if (pgmConf.length > 0) result.pgmConf = pgmConf;
     const procGrps = locate("proc_grps", workspaceFolder, userSettingsUri);
-    if (procGrps) result.procGrps = procGrps;
+    if (procGrps.length > 0) result.procGrps = procGrps;
   } else {
-    result.pgmConf = {
-      uri: userSettingsUri.toString(),
-      containerPath: [],
-      configKey: "pli.pgm_conf",
-    };
-    result.procGrps = {
-      uri: userSettingsUri.toString(),
-      containerPath: [],
-      configKey: "pli.proc_grps",
-    };
+    // No workspace folder contains the file: only user-scope settings can
+    // apply, so report them directly.
+    result.pgmConf = [
+      {
+        uri: userSettingsUri.toString(),
+        containerPath: [],
+        configKey: "pli.pgm_conf",
+        scope: "user",
+      },
+    ];
+    result.procGrps = [
+      {
+        uri: userSettingsUri.toString(),
+        containerPath: [],
+        configKey: "pli.proc_grps",
+        scope: "user",
+      },
+    ];
   }
   return result;
 }
 
+/**
+ * Returns one entry per settings scope that defines a value (user and/or
+ * workspace). Unlike VS Code's `get()`, scopes are not collapsed — the LS
+ * treats each as its own source. `*LanguageValue` variants are ignored.
+ */
 function locate(
   key: ConfigKey,
   folder: vscode.Uri,
   userSettingsUri: vscode.Uri,
-): Messages.GlobalConfigEntry | undefined {
+): Messages.GlobalConfigEntry[] {
   const inspect = vscode.workspace.getConfiguration("pli", folder).inspect(key);
-  if (!inspect) return undefined;
+  if (!inspect) return [];
 
   const entry = (
     uri: vscode.Uri,
+    scope: Messages.GlobalConfigScope,
     containerPath: string[] = [],
   ): Messages.GlobalConfigEntry => ({
     uri: uri.toString(),
     containerPath,
     configKey: `pli.${key}`,
+    scope,
   });
   const vscodeSettingsUri = vscode.Uri.joinPath(
     folder,
@@ -91,26 +118,31 @@ function locate(
     "settings.json",
   );
 
-  // Most-specific scope wins. The `*LanguageValue` variants are
-  // ignored - `pli.pgm_conf` isn't language-scoped.
-  if (inspect.workspaceFolderValue !== undefined) {
-    return entry(vscodeSettingsUri);
+  const entries: Messages.GlobalConfigEntry[] = [];
+
+  // User (global) scope.
+  if (inspect.globalValue !== undefined) {
+    entries.push(entry(userSettingsUri, "user"));
   }
-  if (inspect.workspaceValue !== undefined) {
+
+  // Workspace scope. Within this bucket, workspace-folder settings win over
+  // the workspace file, mirroring VS Code; the whole bucket outranks user.
+  if (inspect.workspaceFolderValue !== undefined) {
+    entries.push(entry(vscodeSettingsUri, "workspace"));
+  } else if (inspect.workspaceValue !== undefined) {
     const workspaceFile = vscode.workspace.workspaceFile;
     if (workspaceFile && workspaceFile.scheme !== "untitled") {
       // Multi-root or saved workspace: value lives inside the
       // `.code-workspace` file under the `settings` object.
-      return entry(workspaceFile, ["settings"]);
+      entries.push(entry(workspaceFile, "workspace", ["settings"]));
+    } else {
+      // Single-folder workspace: VS Code treats `.vscode/settings.json`
+      // as the workspace scope.
+      entries.push(entry(vscodeSettingsUri, "workspace"));
     }
-    // Single-folder workspace: VS Code treats `.vscode/settings.json`
-    // as the workspace scope.
-    return entry(vscodeSettingsUri);
   }
-  if (inspect.globalValue !== undefined) {
-    return entry(userSettingsUri);
-  }
-  return undefined;
+
+  return entries;
 }
 
 /**
@@ -147,6 +179,11 @@ export function watchPluginSettings(
   });
 }
 
+/**
+ * Finds the workspace folder that contains the given file URI. When folders
+ * are nested, the most specific (longest matching) folder wins. Returns
+ * `undefined` when no workspace folder contains the file.
+ */
 export function locateWorkspaceFolder(
   textEditorUri: vscode.Uri,
 ): vscode.Uri | undefined {


### PR DESCRIPTION
Related to #804 

## Per-file config source selection + workspace-settings scope

Plugin config (`pli.pgm_conf` / `pli.proc_grps`) now resolves per file from a
single source by precedence — **project `.pliplugin/` > workspace settings >
user settings** — instead of merging sources. Adds a `workspace` settings
scope alongside `user` (mirroring VS Code), so `.vscode/settings.json` /
`.code-workspace` values are honored and outrank user settings.

### Behavior
- Each config file (`pgm_conf`, `proc_grps`) is selected independently and
  taken **whole** — never merged property-by-property.
- A `.pliplugin/` file that *exists* (even empty/invalid) is used as-is and
  blocks fallback; fallback only kicks in when it's missing.
- Fallback workspace (files outside any folder) no longer flags
  workspace-relative libs from user settings as unresolved, since it has no
  root to resolve them against; absolute libs are still validated.

### Tests
- Config precedence/fallback pinned end-to-end via new Fourslash tests under
  `fourslash/preprocessor/include/program-config-*`.
- Regression tests for the fallback-workspace relative-vs-absolute lib handling.