### PR TITLE
Add cross-compiler options mutual exclusivity

### DIFF
--- a/packages/language/src/preprocessor/compiler-options/codes.ts
+++ b/packages/language/src/preprocessor/compiler-options/codes.ts
@@ -124,6 +124,13 @@ export const CompilerOptionsCodes = {
       `The compiler option '${option}' is recognized but not supported by this preprocessor.`,
   },
 
+  CrossMutexOptionIssue: {
+    code: "COOP14",
+    severity: Severity.E,
+    message: (a: string, b: string) =>
+      `Options ${a} and ${b} are mutually exclusive and must not be specified together.`,
+  },
+
   Assert: {
     InvalidParameter: {
       code: "COAS01",
@@ -203,6 +210,12 @@ export const CompilerOptionsCodes = {
       message: (value: string) =>
         `Expected two different characters for brackets, but received '${value}'.`,
     },
+    ConflictWithOption: {
+      code: "COBR04",
+      severity: Severity.E,
+      message: (char: string, option: string) =>
+        `The bracket character '${char}' must not be used by the ${option} option.`,
+    },
   },
 
   Case: {
@@ -244,6 +257,20 @@ export const CompilerOptionsCodes = {
       severity: Severity.E,
       message: (value: string) =>
         `Expected "LE", "V1", "V2" or "V3", but received '${value}'.`,
+    },
+  },
+
+  Common: {
+    ConflictWithRent: {
+      code: "COMM01",
+      severity: Severity.E,
+      message: () => `The COMMON option must not be used with the RENT option.`,
+    },
+    ConflictWithExtName: {
+      code: "COMM02",
+      severity: Severity.E,
+      message: (n: number) =>
+        `The COMMON option must not be used with LIMITS(EXTNAME(${n})) when the value exceeds 7.`,
     },
   },
 
@@ -293,6 +320,15 @@ export const CompilerOptionsCodes = {
     // TODO ssm: Mainframe actually reports a warning IBM1105I, and truncates to the first character.
   },
 
+  Dbcs: {
+    ConflictWithGraphic: {
+      code: "CODB01",
+      severity: Severity.W,
+      message: () =>
+        `The NODBCS option should not be specified if the GRAPHIC option is also specified.`,
+    },
+  },
+
   DBRMLib: {
     InvalidEmptyParameter: {
       code: PLICodes.Warning.IBM1172I.code,
@@ -339,6 +375,7 @@ export const CompilerOptionsCodes = {
       message: (value: string) =>
         `INITFILL expects a hex value, but received '${value}'.`,
     },
+    DescListConflictsWithCmpat: PLICodes.Severe.IBM2135I,
   },
 
   Deprecate: {
@@ -605,6 +642,12 @@ export const CompilerOptionsCodes = {
       message: (value: string) =>
         `Expected "SOURCE", "AFTERALL", "AFTERCICS", "AFTERMACRO" or "AFTERSQL", but received '${value}'.`,
     },
+    IgnoredWithNoSource: {
+      code: "COLV02",
+      severity: Severity.W,
+      message: () =>
+        `The LISTVIEW option is ignored if the NOSOURCE option is in effect.`,
+    },
   },
 
   Lp: {
@@ -684,6 +727,15 @@ export const CompilerOptionsCodes = {
     },
   },
 
+  Name: {
+    TooLongForExtName: {
+      code: "CONA01",
+      severity: Severity.W,
+      message: (value: string, n: number) =>
+        `The length of the NAME option value '${value}' must not be greater than 8 characters when LIMITS(EXTNAME(${n})) is used with n <= 8.`,
+    },
+  },
+
   NatLang: {
     InvalidParameter: {
       code: "COLN01",
@@ -713,6 +765,15 @@ export const CompilerOptionsCodes = {
     },
   },
 
+  Object: {
+    IgnoredOption: {
+      code: "COOB01",
+      severity: Severity.W,
+      message: (value: string) =>
+        `The ${value} option is ignored under the NOOBJECT option.`,
+    },
+  },
+
   OffsetSize: {
     // [Warning] IBM1161I: The suboption 3 is not valid for the OFFSETSIZE compiler option.
     InvalidParameter: {
@@ -720,6 +781,12 @@ export const CompilerOptionsCodes = {
       severity: Severity.E,
       message: (value: string) =>
         `Expected "4" or "8", but received '${value}'.`,
+    },
+    IgnoredWithLp32: {
+      code: "COOS03",
+      severity: Severity.W,
+      message: () =>
+        `The OFFSETSIZE option is ignored if the LP(32) option is in effect.`,
     },
   },
 
@@ -878,6 +945,21 @@ export const CompilerOptionsCodes = {
       severity: Severity.E,
       message: (value: string) =>
         `Expected a valid quote character, but received '${value}'.`,
+    },
+    IgnoredWithGraphic: {
+      code: "COQT03",
+      severity: Severity.W,
+      message: () =>
+        `The QUOTE option is ignored if the GRAPHIC option is also specified.`,
+    },
+  },
+
+  Rent: {
+    IgnoredWithLp64: {
+      code: "CORN01",
+      severity: Severity.W,
+      message: () =>
+        `Under the LP(64) option, the RENT option is ignored; effectively NORENT is in effect.`,
     },
   },
 
@@ -1038,6 +1120,18 @@ export const CompilerOptionsCodes = {
       message: (value: string) =>
         `Expected "ALL", "BLOCK", "NONE", "PATH", "STMT", "HOOK", "NOHOOK", "SEPARATE", "NOSEPARATE", "SEPNAME", "NOSEPNAME", "SOURCE", "NOSOURCE", "SYM" or "NOSYM", but received '${value}'.`,
     },
+    ConflictWithLineDir: {
+      code: "COTS02",
+      severity: Severity.W,
+      message: () =>
+        `The LINEDIR option rejects the use of the SEPARATE suboption of the TEST option.`,
+    },
+    SepNameIgnoredWithoutSeparate: {
+      code: "COTS03",
+      severity: Severity.W,
+      message: () =>
+        `The SEPNAME suboption of the TEST option is ignored if the SEPARATE suboption is not in effect.`,
+    },
   },
 
   Unroll: {
@@ -1046,6 +1140,12 @@ export const CompilerOptionsCodes = {
       severity: Severity.E,
       message: (value: string) =>
         `Expected "AUTO" or "NO", but received '${value}'.`,
+    },
+    IgnoredWithNoOptimize: {
+      code: "COUN02",
+      severity: Severity.W,
+      message: () =>
+        `The UNROLL option is ignored when the NOOPTIMIZE option is in effect.`,
     },
   },
 
@@ -1115,6 +1215,11 @@ export const CompilerOptionsCodes = {
       severity: Severity.E,
       message: (value: string) =>
         `Expected "FWS" or "PRV", but received '${value}'.`,
+    },
+    IgnoredWithLp64: {
+      code: "COWR02",
+      severity: Severity.W,
+      message: () => `The WRITABLE option is ignored under the LP(64) option.`,
     },
   },
 
@@ -1275,6 +1380,14 @@ export const CompilerOptionsCodes = {
         severity: Severity.E,
         message: (value: string) =>
           `Expected "EXPLAIN", "GRANT", "REVOKE", or "SET_CURRENT_SQLID" suboption, but received '${value}'.`,
+      },
+    },
+
+    HostCopy: {
+      IgnoredWithLp32: {
+        code: "COPPSQL03",
+        severity: Severity.W,
+        message: () => `The HOSTCOPY option is ignored under LP(32).`,
       },
     },
   },

--- a/packages/language/src/preprocessor/compiler-options/translate.ts
+++ b/packages/language/src/preprocessor/compiler-options/translate.ts
@@ -172,17 +172,20 @@ export class CompilerOptionTranslator {
     this.translator.postProcess();
     this.translatorMacro.postProcess();
     this.translatorSQL.postProcess();
+    this.translatorCICS.postProcess();
 
     this.result.issues.push(
       ...this.applyDiagnosticAnchor([
         ...this.translator.diagnostics,
         ...this.translatorMacro.diagnostics,
         ...this.translatorSQL.diagnostics,
+        ...this.translatorCICS.diagnostics,
       ]),
     );
     this.translator.clearIssues();
     this.translatorMacro.clearIssues();
     this.translatorSQL.clearIssues();
+    this.translatorCICS.clearIssues();
   }
 
   protected parseNestedOptions<T extends CompilerOptionsPP>(

--- a/packages/language/src/preprocessor/compiler-options/translator-cics.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator-cics.ts
@@ -223,6 +223,9 @@ translator.rule(["SYSEIB"], (option, options) => {
 
 translator.flag("vbref", ["VBREF", "XREF"], ["NOVBREF", "NOXREF"]);
 
+translator.crossMutex("EXCI", "CICS");
+translator.crossMutex("EXCI", "DLI");
+
 export function getTranslator(): Translator<CompilerOptions> {
   return translator;
 }

--- a/packages/language/src/preprocessor/compiler-options/translator-pli.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator-pli.ts
@@ -182,45 +182,94 @@ translator.rule(
 translator.flag("blkoff", ["BLKOFF"], ["NOBLKOFF"]);
 
 /** {@link CompilerOptions.brackets} */
-translator.rule(
-  ["BRACKETS"],
-  stringTranslate((options, value) => {
-    const length = value.value.length;
-    if (length !== 2) {
-      throw diagnosticFromCode(
-        CompilerOptionsCodes.Brackets.InvalidParameterLength,
-        value.token,
-        value.value,
-      );
-    }
-    const start = value.value.charAt(0);
-    const end = value.value.charAt(1);
+translator
+  .rule(
+    ["BRACKETS"],
+    stringTranslate((options, value) => {
+      const length = value.value.length;
+      if (length !== 2) {
+        throw diagnosticFromCode(
+          CompilerOptionsCodes.Brackets.InvalidParameterLength,
+          value.token,
+          value.value,
+        );
+      }
+      const start = value.value.charAt(0);
+      const end = value.value.charAt(1);
 
-    if (
-      Options.PLI_CHARACTER_REGEX.test(start) ||
-      Options.PLI_CHARACTER_REGEX.test(end)
-    ) {
-      throw diagnosticFromCode(
-        CompilerOptionsCodes.Brackets.InvalidParameter,
-        value.token,
-        value.value,
-      );
-    }
+      if (
+        Options.PLI_CHARACTER_REGEX.test(start) ||
+        Options.PLI_CHARACTER_REGEX.test(end)
+      ) {
+        throw diagnosticFromCode(
+          CompilerOptionsCodes.Brackets.InvalidParameter,
+          value.token,
+          value.value,
+        );
+      }
 
-    if (start === end) {
-      throw diagnosticFromCode(
-        CompilerOptionsCodes.Brackets.InvalidEqualCharacters,
-        value.token,
-        value.value,
-      );
-    }
+      if (start === end) {
+        throw diagnosticFromCode(
+          CompilerOptionsCodes.Brackets.InvalidEqualCharacters,
+          value.token,
+          value.value,
+        );
+      }
 
-    options.brackets = [start, end];
-  }),
-  undefined,
-  undefined,
-  { recompile: true },
-);
+      options.brackets = [start, end];
+    }),
+    undefined,
+    undefined,
+    { recompile: true },
+  )
+  .postProcess({
+    // The two BRACKETS characters must not be characters used by other PL/I
+    // options such as NAMES, NOT, or OR.
+    id: "brackets.conflictsWithOtherOptions",
+    run: (options, acceptor, getOwnToken) => {
+      if (!options.brackets) {
+        return;
+      }
+
+      const conflictsWith: { chars: string; option: string }[] = [];
+      if (options.names?.extralingChar) {
+        conflictsWith.push({
+          chars: options.names.extralingChar,
+          option: "NAMES",
+        });
+      }
+      if (
+        options.names?.uppExtralingChar &&
+        options.names.uppExtralingChar !== options.names.extralingChar
+      ) {
+        conflictsWith.push({
+          chars: options.names.uppExtralingChar,
+          option: "NAMES",
+        });
+      }
+      if (options.not) {
+        conflictsWith.push({ chars: options.not, option: "NOT" });
+      }
+      if (options.or) {
+        conflictsWith.push({ chars: options.or, option: "OR" });
+      }
+
+      for (const bracketChar of options.brackets) {
+        for (const { chars, option } of conflictsWith) {
+          if (chars.includes(bracketChar)) {
+            acceptor(
+              diagnosticFromCode(
+                CompilerOptionsCodes.Brackets.ConflictWithOption,
+                getOwnToken(),
+                bracketChar,
+                option,
+              ),
+            );
+          }
+        }
+      }
+    },
+  });
 
 /** {@link CompilerOptions.case} */
 translator.rule(
@@ -351,7 +400,42 @@ translator.rule(
 );
 
 /** {@link CompilerOptions.common} */
-translator.flag("common", ["COMMON"], ["NOCOMMON"]);
+translator
+  .flag("common", ["COMMON"], ["NOCOMMON"])
+  .postProcess({
+    id: "common.conflictsWithRent",
+    run: (options, acceptor, getOwnToken) => {
+      if (!options.common) {
+        return;
+      }
+      if (options.rent) {
+        acceptor(
+          diagnosticFromCode(
+            CompilerOptionsCodes.Common.ConflictWithRent,
+            getOwnToken(),
+          ),
+        );
+      }
+    },
+  })
+  .postProcess({
+    id: "common.conflictsWithExtName",
+    run: (options, acceptor, getOwnToken) => {
+      if (!options.common) {
+        return;
+      }
+      const extname = options.limits?.extname;
+      if (extname !== undefined && extname > 7) {
+        acceptor(
+          diagnosticFromCode(
+            CompilerOptionsCodes.Common.ConflictWithExtName,
+            getOwnToken(),
+            extname,
+          ),
+        );
+      }
+    },
+  });
 
 /** {@link CompilerOptions.compile} */
 translator.rule(
@@ -433,7 +517,18 @@ translator.rule(["CURRENCY", "CURR"], (option, options) => {
 });
 
 /** {@link CompilerOptions.dbcs} */
-translator.flag("dbcs", ["DBCS"], ["NODBCS"]);
+translator.flag("dbcs", ["DBCS"], ["NODBCS"]).postProcess({
+  id: "dbcs.conflictsWithGraphic",
+  run: (options, acceptor, getOwnToken) => {
+    const token = getOwnToken();
+    if (token === undefined || options.dbcs !== false || !options.graphic) {
+      return;
+    }
+    acceptor(
+      diagnosticFromCode(CompilerOptionsCodes.Dbcs.ConflictWithGraphic, token),
+    );
+  },
+});
 
 /** {@link CompilerOptions.dbrmlib} */
 translator.rule(
@@ -589,361 +684,385 @@ translator.rule(["DECIMAL", "DEC"], (option, options, acceptor) => {
 translator.flag("decomp", ["DECOMP"], ["NODECOMP"]);
 
 /** {@link CompilerOptions.default} */
-translator.rule(
-  ["DEFAULT", "DFT"],
-  (option, options, acceptor) => {
-    ensureArguments(option, 1);
-    ensureToBeDefined(options.default);
-    const def = options.default;
-    for (const opt of option.values) {
-      if (opt.kind === SyntaxKind.CompilerOptionText) {
-        const val = opt.value;
-        switch (val) {
-          case "ALIGNED":
-          case "UNALIGNED":
-            def.aligned = val === "ALIGNED";
-            break;
-          case "IBM":
-          case "ANS":
-            def.architecture = ensureEnum(
-              opt,
-              CompilerOptionsCodes.Default.InvalidParameter,
-              CompilerOptions.DefaultArchitecture,
-            );
-            break;
-          case "EBCDIC":
-          case "ASCII":
-            def.encoding = ensureEnum(
-              opt,
-              CompilerOptionsCodes.Default.InvalidParameter,
-              CompilerOptions.DefaultEncoding,
-            );
-            break;
-          case "ASGN":
-          case "ASSIGNABLE":
-          case "NONASGN":
-          case "NONASSIGNABLE":
-            def.assignable = val === "ASSIGNABLE" || val === "ASGN";
-            break;
-          case "BIN1ARG":
-          case "NOBIN1ARG":
-            def.bin1arg = val === "BIN1ARG";
-            break;
-          case "BYADDR":
-          case "BYVALUE":
-            def.allocator = ensureEnum(
-              opt,
-              CompilerOptionsCodes.Default.InvalidParameter,
-              CompilerOptions.DefaultAllocator,
-            );
-            break;
-          case "CONN":
-          case "CONNECTED":
-          case "NONCONN":
-          case "NONCONNECTED":
-            def.connected = val === "CONNECTED" || val === "CONN";
-            break;
-          case "DESCLIST":
-          case "DESCLOCATOR":
-            def.desc = ensureEnum(
-              opt,
-              CompilerOptionsCodes.Default.InvalidParameter,
-              CompilerOptions.DefaultDesc,
-              [
-                ["LIST", "DESCLIST"],
-                ["LOCATOR", "DESCLOCATOR"],
-              ],
-            );
-            break;
-          case "DESCRIPTOR":
-          case "NODESCRIPTOR":
-            def.descriptor = val === "DESCRIPTOR";
-            break;
-          case "EVENDEC":
-          case "NOEVENDEC":
-            def.evendec = val === "EVENDEC";
-            break;
-          case "HEXADEC":
-          case "IEEE":
-            def.format = ensureEnum(
-              opt,
-              CompilerOptionsCodes.Default.InvalidParameter,
-              CompilerOptions.DefaultFormat,
-            );
-            break;
-          case "INITFILL":
-          case "NOINITFILL":
-            // Initfill is actually valid without a parameter and falls back to 00 in that case.
-            def.initfill = val === "INITFILL" ? "00" : false;
-            break;
-          case "INL":
-          case "INLINE":
-          case "NOINL":
-          case "NOINLINE":
-            def.inline = val === "INLINE" || val === "INL";
-            break;
-          case "LAXQUAL":
-          case "NOLAXQUAL":
-            def.laxqual = val === "LAXQUAL";
-            break;
-          case "LOWERINC":
-          case "UPPERINC":
-            def.inc = ensureEnum(
-              opt,
-              CompilerOptionsCodes.Default.InvalidParameter,
-              CompilerOptions.DefaultInc,
-            );
-            break;
-          case "NATIVE":
-          case "NONNATIVE":
-            def.native = val === "NATIVE";
-            break;
-          case "NATIVEADDR":
-          case "NONNATIVEADDR":
-            def.nativeAddr = val === "NATIVEADDR";
-            break;
-          case "NULLSYS":
-          case "NULL370":
-            def.nullsys = ensureEnum(
-              opt,
-              CompilerOptionsCodes.Default.InvalidParameter,
-              CompilerOptions.DefaultNullSys,
-            );
-            break;
-          case "NULLSTRADDR":
-          case "NONULLSTRADDR":
-            def.nullStrAddr = val === "NULLSTRADDR";
-            break;
-          case "ORDER":
-          case "REORDER":
-            def.order = ensureEnum(
-              opt,
-              CompilerOptionsCodes.Default.InvalidParameter,
-              CompilerOptions.DefaultOrder,
-            );
-            break;
-          case "OVERLAP":
-          case "NOOVERLAP":
-            def.overlap = val === "OVERLAP";
-            break;
-          case "PADDING":
-          case "NOPADDING":
-            def.padding = val === "PADDING";
-            break;
-          case "PSEUDODUMMY":
-          case "NOPSEUDODUMMY":
-            def.pseudodummy = val === "PSEUDODUMMY";
-            break;
-          case "RECURSIVE":
-          case "NONRECURSIVE":
-            def.recursive = val === "RECURSIVE";
-            break;
-          case "RETCODE":
-          case "NORETCODE":
-            def.retcode = val === "RETCODE";
-            break;
-          case "":
-            // Empty is valid.
-            break;
-          case "DUMMY":
-          case "E":
-          case "LINKAGE":
-          case "NULLINIT":
-          case "NULLSTRPTR":
-          case "ORDINAL":
-          case "RETURNS":
-          case "SHORT":
-            // All option values should report an expected option error.
-            throw diagnosticFromCode(
-              CompilerOptionsCodes.ExpectedOption,
-              opt.token,
-            );
-          default:
-            throw diagnosticFromCode(
-              CompilerOptionsCodes.Default.InvalidParameter,
-              opt.token,
-              val,
-            );
-        }
-      } else if (opt.kind === SyntaxKind.CompilerOption) {
-        ensureArguments(opt, 1, 1);
-        ensureType(opt.values[0], "plainNotEmpty");
-        const value = opt.values[0].value;
+translator
+  .rule(
+    ["DEFAULT", "DFT"],
+    (option, options, acceptor) => {
+      ensureArguments(option, 1);
+      ensureToBeDefined(options.default);
+      const def = options.default;
+      for (const opt of option.values) {
+        if (opt.kind === SyntaxKind.CompilerOptionText) {
+          const val = opt.value;
+          switch (val) {
+            case "ALIGNED":
+            case "UNALIGNED":
+              def.aligned = val === "ALIGNED";
+              break;
+            case "IBM":
+            case "ANS":
+              def.architecture = ensureEnum(
+                opt,
+                CompilerOptionsCodes.Default.InvalidParameter,
+                CompilerOptions.DefaultArchitecture,
+              );
+              break;
+            case "EBCDIC":
+            case "ASCII":
+              def.encoding = ensureEnum(
+                opt,
+                CompilerOptionsCodes.Default.InvalidParameter,
+                CompilerOptions.DefaultEncoding,
+              );
+              break;
+            case "ASGN":
+            case "ASSIGNABLE":
+            case "NONASGN":
+            case "NONASSIGNABLE":
+              def.assignable = val === "ASSIGNABLE" || val === "ASGN";
+              break;
+            case "BIN1ARG":
+            case "NOBIN1ARG":
+              def.bin1arg = val === "BIN1ARG";
+              break;
+            case "BYADDR":
+            case "BYVALUE":
+              def.allocator = ensureEnum(
+                opt,
+                CompilerOptionsCodes.Default.InvalidParameter,
+                CompilerOptions.DefaultAllocator,
+              );
+              break;
+            case "CONN":
+            case "CONNECTED":
+            case "NONCONN":
+            case "NONCONNECTED":
+              def.connected = val === "CONNECTED" || val === "CONN";
+              break;
+            case "DESCLIST":
+            case "DESCLOCATOR":
+              def.desc = ensureEnum(
+                opt,
+                CompilerOptionsCodes.Default.InvalidParameter,
+                CompilerOptions.DefaultDesc,
+                [
+                  ["LIST", "DESCLIST"],
+                  ["LOCATOR", "DESCLOCATOR"],
+                ],
+              );
+              break;
+            case "DESCRIPTOR":
+            case "NODESCRIPTOR":
+              def.descriptor = val === "DESCRIPTOR";
+              break;
+            case "EVENDEC":
+            case "NOEVENDEC":
+              def.evendec = val === "EVENDEC";
+              break;
+            case "HEXADEC":
+            case "IEEE":
+              def.format = ensureEnum(
+                opt,
+                CompilerOptionsCodes.Default.InvalidParameter,
+                CompilerOptions.DefaultFormat,
+              );
+              break;
+            case "INITFILL":
+            case "NOINITFILL":
+              // Initfill is actually valid without a parameter and falls back to 00 in that case.
+              def.initfill = val === "INITFILL" ? "00" : false;
+              break;
+            case "INL":
+            case "INLINE":
+            case "NOINL":
+            case "NOINLINE":
+              def.inline = val === "INLINE" || val === "INL";
+              break;
+            case "LAXQUAL":
+            case "NOLAXQUAL":
+              def.laxqual = val === "LAXQUAL";
+              break;
+            case "LOWERINC":
+            case "UPPERINC":
+              def.inc = ensureEnum(
+                opt,
+                CompilerOptionsCodes.Default.InvalidParameter,
+                CompilerOptions.DefaultInc,
+              );
+              break;
+            case "NATIVE":
+            case "NONNATIVE":
+              def.native = val === "NATIVE";
+              break;
+            case "NATIVEADDR":
+            case "NONNATIVEADDR":
+              def.nativeAddr = val === "NATIVEADDR";
+              break;
+            case "NULLSYS":
+            case "NULL370":
+              def.nullsys = ensureEnum(
+                opt,
+                CompilerOptionsCodes.Default.InvalidParameter,
+                CompilerOptions.DefaultNullSys,
+              );
+              break;
+            case "NULLSTRADDR":
+            case "NONULLSTRADDR":
+              def.nullStrAddr = val === "NULLSTRADDR";
+              break;
+            case "ORDER":
+            case "REORDER":
+              def.order = ensureEnum(
+                opt,
+                CompilerOptionsCodes.Default.InvalidParameter,
+                CompilerOptions.DefaultOrder,
+              );
+              break;
+            case "OVERLAP":
+            case "NOOVERLAP":
+              def.overlap = val === "OVERLAP";
+              break;
+            case "PADDING":
+            case "NOPADDING":
+              def.padding = val === "PADDING";
+              break;
+            case "PSEUDODUMMY":
+            case "NOPSEUDODUMMY":
+              def.pseudodummy = val === "PSEUDODUMMY";
+              break;
+            case "RECURSIVE":
+            case "NONRECURSIVE":
+              def.recursive = val === "RECURSIVE";
+              break;
+            case "RETCODE":
+            case "NORETCODE":
+              def.retcode = val === "RETCODE";
+              break;
+            case "":
+              // Empty is valid.
+              break;
+            case "DUMMY":
+            case "E":
+            case "LINKAGE":
+            case "NULLINIT":
+            case "NULLSTRPTR":
+            case "ORDINAL":
+            case "RETURNS":
+            case "SHORT":
+              // All option values should report an expected option error.
+              throw diagnosticFromCode(
+                CompilerOptionsCodes.ExpectedOption,
+                opt.token,
+              );
+            default:
+              throw diagnosticFromCode(
+                CompilerOptionsCodes.Default.InvalidParameter,
+                opt.token,
+                val,
+              );
+          }
+        } else if (opt.kind === SyntaxKind.CompilerOption) {
+          ensureArguments(opt, 1, 1);
+          ensureType(opt.values[0], "plainNotEmpty");
+          const value = opt.values[0].value;
 
-        const invalidOption = () => {
+          const invalidOption = () => {
+            throw diagnosticFromCode(
+              CompilerOptionsCodes.Default.InvalidParameter,
+              opt.values[0].token,
+              value,
+            );
+          };
+
+          switch (opt.name) {
+            case "DUMMY":
+              def.dummy = {};
+              if (value === "ALIGNED" || value === "") {
+                def.dummy.aligned = true;
+              } else if (value === "UNALIGNED") {
+                def.dummy.aligned = false;
+              } else {
+                invalidOption();
+              }
+              break;
+
+            case "E":
+              def.e = {};
+              if (value === "HEXADEC" || value === "") {
+                def.e.format = CompilerOptions.DefaultFormat.HEXADEC;
+              } else if (value === "IEEE") {
+                def.e.format = CompilerOptions.DefaultFormat.IEEE;
+              } else {
+                invalidOption();
+              }
+              break;
+
+            case "INITFILL":
+              // TODO ssmifi: INITFILL can also accept a string value in which case the hex value should not have an X suffix.
+              if (/[0-9a-fA-F]{2}x/i.test(value)) {
+                def.initfill = value;
+              } else {
+                throw diagnosticFromCode(
+                  CompilerOptionsCodes.Default.InvalidInitFillParameter,
+                  opt.values[0].token,
+                  value,
+                );
+              }
+              break;
+
+            case "LINKAGE":
+              def.linkage = {};
+              if (value === "OPTLINK" || value === "") {
+                def.linkage.type = CompilerOptions.DefaultLinkageType.OPTLINK;
+              } else if (value === "SYSTEM") {
+                def.linkage.type = CompilerOptions.DefaultLinkageType.SYSTEM;
+              } else {
+                invalidOption();
+              }
+              break;
+
+            case "NULLINIT":
+              def.nullinit = {};
+              if (value === "NULL" || value === "") {
+                def.nullinit.type = CompilerOptions.DefaultNullInitType.NULL;
+              } else if (value === "SYSNULL") {
+                def.nullinit.type = CompilerOptions.DefaultNullInitType.SYSNULL;
+              } else {
+                invalidOption();
+              }
+              break;
+
+            case "NULLSTRPTR":
+              def.nullStrPtr = {};
+              if (value === "NULL") {
+                def.nullStrPtr.type =
+                  CompilerOptions.DefaultNullStrPtrType.NULL;
+              } else if (value === "STRICT") {
+                def.nullStrPtr.type =
+                  CompilerOptions.DefaultNullStrPtrType.STRICT;
+              } else if (value === "SYSNULL") {
+                def.nullStrPtr.type =
+                  CompilerOptions.DefaultNullStrPtrType.SYSNULL;
+              } else {
+                invalidOption();
+              }
+              break;
+
+            case "ORDINAL":
+              if (value === "MIN") {
+                def.ordinal = { type: CompilerOptions.DefaultOrdinalType.MIN };
+              } else if (value === "MAX") {
+                def.ordinal = { type: CompilerOptions.DefaultOrdinalType.MAX };
+              } else {
+                invalidOption();
+              }
+              break;
+
+            case "RETURNS":
+              // Diagram specifies that no option inside the parenthesesis valid. Default is BYADDR.
+              if (value === "" || value === "BYADDR") {
+                def.returns = {
+                  type: CompilerOptions.DefaultReturnsType.BYADDR,
+                };
+              } else if (value === "BYVALUE") {
+                def.returns = {
+                  type: CompilerOptions.DefaultReturnsType.BYVALUE,
+                };
+              } else {
+                invalidOption();
+              }
+              break;
+
+            case "SHORT":
+              // Diagram specifies that no option inside the parentheses is valid. Default is HEXADEC.
+              if (value === "" || value === "HEXADEC") {
+                def.short = { format: CompilerOptions.DefaultFormat.HEXADEC };
+              } else if (value === "IEEE") {
+                def.short = { format: CompilerOptions.DefaultFormat.IEEE };
+              } else {
+                invalidOption();
+              }
+              break;
+
+            default:
+              invalidOption();
+          }
+        } else {
           throw diagnosticFromCode(
             CompilerOptionsCodes.Default.InvalidParameter,
-            opt.values[0].token,
-            value,
+            opt.token,
+            opt.value,
           );
-        };
-
-        switch (opt.name) {
-          case "DUMMY":
-            def.dummy = {};
-            if (value === "ALIGNED" || value === "") {
-              def.dummy.aligned = true;
-            } else if (value === "UNALIGNED") {
-              def.dummy.aligned = false;
-            } else {
-              invalidOption();
-            }
-            break;
-
-          case "E":
-            def.e = {};
-            if (value === "HEXADEC" || value === "") {
-              def.e.format = CompilerOptions.DefaultFormat.HEXADEC;
-            } else if (value === "IEEE") {
-              def.e.format = CompilerOptions.DefaultFormat.IEEE;
-            } else {
-              invalidOption();
-            }
-            break;
-
-          case "INITFILL":
-            // TODO ssmifi: INITFILL can also accept a string value in which case the hex value should not have an X suffix.
-            if (/[0-9a-fA-F]{2}x/i.test(value)) {
-              def.initfill = value;
-            } else {
-              throw diagnosticFromCode(
-                CompilerOptionsCodes.Default.InvalidInitFillParameter,
-                opt.values[0].token,
-                value,
-              );
-            }
-            break;
-
-          case "LINKAGE":
-            def.linkage = {};
-            if (value === "OPTLINK" || value === "") {
-              def.linkage.type = CompilerOptions.DefaultLinkageType.OPTLINK;
-            } else if (value === "SYSTEM") {
-              def.linkage.type = CompilerOptions.DefaultLinkageType.SYSTEM;
-            } else {
-              invalidOption();
-            }
-            break;
-
-          case "NULLINIT":
-            def.nullinit = {};
-            if (value === "NULL" || value === "") {
-              def.nullinit.type = CompilerOptions.DefaultNullInitType.NULL;
-            } else if (value === "SYSNULL") {
-              def.nullinit.type = CompilerOptions.DefaultNullInitType.SYSNULL;
-            } else {
-              invalidOption();
-            }
-            break;
-
-          case "NULLSTRPTR":
-            def.nullStrPtr = {};
-            if (value === "NULL") {
-              def.nullStrPtr.type = CompilerOptions.DefaultNullStrPtrType.NULL;
-            } else if (value === "STRICT") {
-              def.nullStrPtr.type =
-                CompilerOptions.DefaultNullStrPtrType.STRICT;
-            } else if (value === "SYSNULL") {
-              def.nullStrPtr.type =
-                CompilerOptions.DefaultNullStrPtrType.SYSNULL;
-            } else {
-              invalidOption();
-            }
-            break;
-
-          case "ORDINAL":
-            if (value === "MIN") {
-              def.ordinal = { type: CompilerOptions.DefaultOrdinalType.MIN };
-            } else if (value === "MAX") {
-              def.ordinal = { type: CompilerOptions.DefaultOrdinalType.MAX };
-            } else {
-              invalidOption();
-            }
-            break;
-
-          case "RETURNS":
-            // Diagram specifies that no option inside the parenthesesis valid. Default is BYADDR.
-            if (value === "" || value === "BYADDR") {
-              def.returns = { type: CompilerOptions.DefaultReturnsType.BYADDR };
-            } else if (value === "BYVALUE") {
-              def.returns = {
-                type: CompilerOptions.DefaultReturnsType.BYVALUE,
-              };
-            } else {
-              invalidOption();
-            }
-            break;
-
-          case "SHORT":
-            // Diagram specifies that no option inside the parentheses is valid. Default is HEXADEC.
-            if (value === "" || value === "HEXADEC") {
-              def.short = { format: CompilerOptions.DefaultFormat.HEXADEC };
-            } else if (value === "IEEE") {
-              def.short = { format: CompilerOptions.DefaultFormat.IEEE };
-            } else {
-              invalidOption();
-            }
-            break;
-
-          default:
-            invalidOption();
         }
-      } else {
-        throw diagnosticFromCode(
-          CompilerOptionsCodes.Default.InvalidParameter,
-          opt.token,
-          opt.value,
-        );
       }
-    }
-    reportDuplicateSubOptions(option, acceptor, {
-      ASGN: "ASSIGNABLE",
-      NONASGN: "NONASSIGNABLE",
-      CONN: "CONNECTED",
-      NONCONN: "NONCONNECTED",
-      INL: "INLINE",
-      NOINL: "NOINLINE",
-    });
-    reportMutexSubOptions(option, acceptor, [
-      ["ALIGNED", "UNALIGNED"],
-      ["IBM", "ANS"],
-      ["EBCDIC", "ASCII"],
-      ["ASSIGNABLE", "NONASSIGNABLE"],
-      ["ASSIGNABLE", "NONASGN"],
-      ["ASGN", "NONASSIGNABLE"],
-      ["ASGN", "NONASGN"],
-      ["BIN1ARG", "NOBIN1ARG"],
-      ["BYADDR", "BYVALUE"],
-      ["CONNECTED", "NONCONNECTED"],
-      ["CONNECTED", "NONCONN"],
-      ["CONN", "NONCONNECTED"],
-      ["CONN", "NONCONN"],
-      ["DESCLIST", "DESCLOCATOR"],
-      ["DESCRIPTOR", "NODESCRIPTOR"],
-      ["EVENDEC", "NOEVENDEC"],
-      ["HEXADEC", "IEEE"],
-      ["INLINE", "NOINLINE"],
-      ["INLINE", "NOINL"],
-      ["INL", "NOINLINE"],
-      ["INL", "NOINL"],
-      ["LAXQUAL", "NOLAXQUAL"],
-      ["LOWERINC", "UPPERINC"],
-      ["NATIVE", "NONNATIVE"],
-      ["NATIVEADDR", "NONNATIVEADDR"],
-      ["NULLSYS", "NULL370"],
-      ["NULLSTRADDR", "NONULLSTRADDR"],
-      ["ORDER", "REORDER"],
-      ["OVERLAP", "NOOVERLAP"],
-      ["PADDING", "NOPADDING"],
-      ["PSEUDODUMMY", "NOPSEUDODUMMY"],
-      ["RECURSIVE", "NORECURSIVE"],
-      ["RETCODE", "NORETCODE"],
-    ]);
-  },
-  undefined,
-  undefined,
-  { recompile: true },
-);
+      reportDuplicateSubOptions(option, acceptor, {
+        ASGN: "ASSIGNABLE",
+        NONASGN: "NONASSIGNABLE",
+        CONN: "CONNECTED",
+        NONCONN: "NONCONNECTED",
+        INL: "INLINE",
+        NOINL: "NOINLINE",
+      });
+      reportMutexSubOptions(option, acceptor, [
+        ["ALIGNED", "UNALIGNED"],
+        ["IBM", "ANS"],
+        ["EBCDIC", "ASCII"],
+        ["ASSIGNABLE", "NONASSIGNABLE"],
+        ["ASSIGNABLE", "NONASGN"],
+        ["ASGN", "NONASSIGNABLE"],
+        ["ASGN", "NONASGN"],
+        ["BIN1ARG", "NOBIN1ARG"],
+        ["BYADDR", "BYVALUE"],
+        ["CONNECTED", "NONCONNECTED"],
+        ["CONNECTED", "NONCONN"],
+        ["CONN", "NONCONNECTED"],
+        ["CONN", "NONCONN"],
+        ["DESCLIST", "DESCLOCATOR"],
+        ["DESCRIPTOR", "NODESCRIPTOR"],
+        ["EVENDEC", "NOEVENDEC"],
+        ["HEXADEC", "IEEE"],
+        ["INLINE", "NOINLINE"],
+        ["INLINE", "NOINL"],
+        ["INL", "NOINLINE"],
+        ["INL", "NOINL"],
+        ["LAXQUAL", "NOLAXQUAL"],
+        ["LOWERINC", "UPPERINC"],
+        ["NATIVE", "NONNATIVE"],
+        ["NATIVEADDR", "NONNATIVEADDR"],
+        ["NULLSYS", "NULL370"],
+        ["NULLSTRADDR", "NONULLSTRADDR"],
+        ["ORDER", "REORDER"],
+        ["OVERLAP", "NOOVERLAP"],
+        ["PADDING", "NOPADDING"],
+        ["PSEUDODUMMY", "NOPSEUDODUMMY"],
+        ["RECURSIVE", "NORECURSIVE"],
+        ["RETCODE", "NORETCODE"],
+      ]);
+    },
+    undefined,
+    undefined,
+    { recompile: true },
+  )
+  .postProcess({
+    id: "default.desclistConflictsWithCmpat",
+    run: (options, acceptor, getOwnToken) => {
+      if (
+        options.default?.desc !== CompilerOptions.DefaultDesc.LIST ||
+        options.cmpat === undefined ||
+        options.cmpat === CompilerOptions.CMPat.LE
+      ) {
+        return;
+      }
+      acceptor(
+        diagnosticFromCode(
+          CompilerOptionsCodes.Default.DescListConflictsWithCmpat,
+          getOwnToken(),
+          CompilerOptions.CMPat[options.cmpat],
+        ),
+      );
+      options.default.desc = CompilerOptions.DefaultDesc.LOCATOR;
+    },
+  });
 
 /** {@link CompilerOptions.deprecate} */
 /** {@link CompilerOptions.deprecateNext} */
@@ -1662,23 +1781,52 @@ translator.rule(["LINECOUNT", "LC"], (option, options) => {
 translator.flag("lineDir", ["LINEDIR"], ["NOLINEDIR"]);
 
 /** {@link CompilerOptions.list} */
-translator.flag("list", ["LIST"], ["NOLIST"]);
+translator.flag("list", ["LIST"], ["NOLIST"]).postProcess({
+  id: "list.ignoredWithNoObject",
+  run: (options, acceptor, getOwnToken) => {
+    if (!options.list || options.object !== false) {
+      return;
+    }
+    acceptor(
+      diagnosticFromCode(
+        CompilerOptionsCodes.Object.IgnoredOption,
+        getOwnToken(),
+        "LIST",
+      ),
+    );
+  },
+});
 
 /** {@link CompilerOptions.listView} */
-translator.rule(["LISTVIEW"], (option, options, acceptor) => {
-  ensureArguments(option, 1);
-  for (const value of option.values) {
-    ensureType(value, "plain");
-    options.listView = ensureEnum(
-      value,
-      CompilerOptionsCodes.ListView.InvalidParameter,
-      CompilerOptions.ListView,
-    );
-  }
-  reportMutexSubOptions(option, acceptor, [
-    ["SOURCE", "AFTERALL", "AFTERCICS", "AFTERMACRO", "AFTERSQL"],
-  ]);
-});
+translator
+  .rule(["LISTVIEW"], (option, options, acceptor) => {
+    ensureArguments(option, 1);
+    for (const value of option.values) {
+      ensureType(value, "plain");
+      options.listView = ensureEnum(
+        value,
+        CompilerOptionsCodes.ListView.InvalidParameter,
+        CompilerOptions.ListView,
+      );
+    }
+    reportMutexSubOptions(option, acceptor, [
+      ["SOURCE", "AFTERALL", "AFTERCICS", "AFTERMACRO", "AFTERSQL"],
+    ]);
+  })
+  .postProcess({
+    id: "listView.ignoredWithNoSource",
+    run: (options, acceptor, getOwnToken) => {
+      if (options.listView === undefined || options.source) {
+        return;
+      }
+      acceptor(
+        diagnosticFromCode(
+          CompilerOptionsCodes.ListView.IgnoredWithNoSource,
+          getOwnToken(),
+        ),
+      );
+    },
+  });
 
 /** {@link CompilerOptions.LP} */
 translator.rule(["LP"], (option, options) => {
@@ -1699,7 +1847,21 @@ translator.rule(["LP"], (option, options) => {
 translator.flag("macro", ["MACRO", "M"], ["NOMACRO", "NM"]);
 
 /** {@link CompilerOptions.map} */
-translator.flag("map", ["MAP"], ["NOMAP"]);
+translator.flag("map", ["MAP"], ["NOMAP"]).postProcess({
+  id: "map.ignoredWithNoObject",
+  run: (options, acceptor, getOwnToken) => {
+    if (!options.map || options.object !== false) {
+      return;
+    }
+    acceptor(
+      diagnosticFromCode(
+        CompilerOptionsCodes.Object.IgnoredOption,
+        getOwnToken(),
+        "MAP",
+      ),
+    );
+  },
+});
 
 /** {@link CompilerOptions.margini} */
 translator.rule(
@@ -1961,34 +2123,57 @@ translator.rule(
 );
 
 /** {@link CompilerOptions.name} */
-translator.rule(
-  ["NAME", "N"],
-  (option, options) => {
-    ensureArguments(option, 0, 1);
-    if (option.values.length === 1) {
-      const value = option.values[0];
-      ensureType(value, "plainOrString");
-      if (
-        value.kind === SyntaxKind.CompilerOptionText &&
-        value.value.length === 0
-      ) {
-        // If it is just plain text, no text is not recognized.
-        throw diagnosticFromCode(
-          CompilerOptionsCodes.ExpectedPlainNotEmpty,
-          value.token,
-        );
+translator
+  .rule(
+    ["NAME", "N"],
+    (option, options) => {
+      ensureArguments(option, 0, 1);
+      if (option.values.length === 1) {
+        const value = option.values[0];
+        ensureType(value, "plainOrString");
+        if (
+          value.kind === SyntaxKind.CompilerOptionText &&
+          value.value.length === 0
+        ) {
+          // If it is just plain text, no text is not recognized.
+          throw diagnosticFromCode(
+            CompilerOptionsCodes.ExpectedPlainNotEmpty,
+            value.token,
+          );
+        }
+        options.name = value.value;
+      } else {
+        options.name = true;
       }
-      options.name = value.value;
-    } else {
-      options.name = true;
-    }
-  },
-  ["NONAME"],
-  (option, options) => {
-    ensureArguments(option, 0, 0);
-    options.name = false;
-  },
-);
+    },
+    ["NONAME"],
+    (option, options) => {
+      ensureArguments(option, 0, 0);
+      options.name = false;
+    },
+  )
+  .postProcess({
+    id: "name.tooLongForExtName",
+    run: (options, acceptor, getOwnToken) => {
+      const extname = options.limits?.extname;
+      if (
+        typeof options.name !== "string" ||
+        options.name.length <= 8 ||
+        extname === undefined ||
+        extname > 8
+      ) {
+        return;
+      }
+      acceptor(
+        diagnosticFromCode(
+          CompilerOptionsCodes.Name.TooLongForExtName,
+          getOwnToken(),
+          options.name,
+          extname,
+        ),
+      );
+    },
+  });
 
 /** {@link CompilerOptions.names} */
 translator.rule(
@@ -2102,23 +2287,53 @@ translator.flag("nullDate", ["NULLDATE"], ["NONULLDATE"]);
 translator.flag("object", ["OBJECT", "OBJ"], ["NOOBJECT", "NOBJ"]);
 
 /** {@link CompilerOptions.offset} */
-translator.flag("offset", ["OFFSET", "OF"], ["NOOFFSET", "NOF"]);
+translator.flag("offset", ["OFFSET", "OF"], ["NOOFFSET", "NOF"]).postProcess({
+  id: "offset.ignoredWithNoObject",
+  run: (options, acceptor, getOwnToken) => {
+    if (!options.offset || options.object !== false) {
+      return;
+    }
+    acceptor(
+      diagnosticFromCode(
+        CompilerOptionsCodes.Object.IgnoredOption,
+        getOwnToken(),
+        "OFFSET",
+      ),
+    );
+  },
+});
 
 /** {@link CompilerOptions.offsetSize} */
-translator.rule(["OFFSETSIZE"], (option, options) => {
-  ensureArguments(option, 1, 1);
-  const value = option.values[0];
-  ensureType(value, "plainNotEmpty");
-  const offsetSize = ensureNumberValue(value);
-  if (offsetSize !== 4 && offsetSize !== 8) {
-    throw diagnosticFromCode(
-      CompilerOptionsCodes.OffsetSize.InvalidParameter,
-      value.token,
-      value.value,
-    );
-  }
-  options.offsetSize = offsetSize;
-});
+translator
+  .rule(["OFFSETSIZE"], (option, options) => {
+    ensureArguments(option, 1, 1);
+    const value = option.values[0];
+    ensureType(value, "plainNotEmpty");
+    const offsetSize = ensureNumberValue(value);
+    if (offsetSize !== 4 && offsetSize !== 8) {
+      throw diagnosticFromCode(
+        CompilerOptionsCodes.OffsetSize.InvalidParameter,
+        value.token,
+        value.value,
+      );
+    }
+    options.offsetSize = offsetSize;
+  })
+  .postProcess({
+    id: "offsetSize.ignoredWithLp32",
+    run: (options, acceptor, getOwnToken) => {
+      const token = getOwnToken();
+      if (token === undefined || options.LP !== CompilerOptions.LP.LP32) {
+        return;
+      }
+      acceptor(
+        diagnosticFromCode(
+          CompilerOptionsCodes.OffsetSize.IgnoredWithLp32,
+          token,
+        ),
+      );
+    },
+  });
 
 /** {@link CompilerOptions.onSnap} */
 translator.rule(
@@ -2656,33 +2871,64 @@ translator.rule(
 );
 
 /** {@link CompilerOptions.quote} */
-translator.rule(["QUOTE"], (option, options) => {
-  ensureArguments(option, 1, 1);
-  const value = option.values[0];
-  // TODO ssmifi: The directive does not allow to use " as string delimiter. It must be set via '.
-  ensureType(value, "string");
-  if (value.value.length !== 1) {
-    throw diagnosticFromCode(
-      CompilerOptionsCodes.Quote.InvalidParameterLength,
-      value.token,
-      value.value,
-    );
-  }
-  if (value.value !== '"' && Options.PLI_CHARACTER_REGEX.test(value.value)) {
-    throw diagnosticFromCode(
-      CompilerOptionsCodes.Quote.InvalidParameterCharacter,
-      value.token,
-      value.value,
-    );
-  }
-  options.quote = value.value;
-});
+translator
+  .rule(["QUOTE"], (option, options) => {
+    ensureArguments(option, 1, 1);
+    const value = option.values[0];
+    // TODO ssmifi: The directive does not allow to use " as string delimiter. It must be set via '.
+    ensureType(value, "string");
+    if (value.value.length !== 1) {
+      throw diagnosticFromCode(
+        CompilerOptionsCodes.Quote.InvalidParameterLength,
+        value.token,
+        value.value,
+      );
+    }
+    if (value.value !== '"' && Options.PLI_CHARACTER_REGEX.test(value.value)) {
+      throw diagnosticFromCode(
+        CompilerOptionsCodes.Quote.InvalidParameterCharacter,
+        value.token,
+        value.value,
+      );
+    }
+    options.quote = value.value;
+  })
+  .postProcess({
+    id: "quote.ignoredWithGraphic",
+    run: (options, acceptor, getOwnToken) => {
+      const token = getOwnToken();
+      if (token === undefined || !options.graphic) {
+        return;
+      }
+      acceptor(
+        diagnosticFromCode(
+          CompilerOptionsCodes.Quote.IgnoredWithGraphic,
+          token,
+        ),
+      );
+    },
+  });
 
 /** {@link CompilerOptions.reduce} */
 translator.flag("reduce", ["REDUCE"], ["NOREDUCE"]);
 
 /** {@link CompilerOptions.rent} */
-translator.flag("rent", ["RENT"], ["NORENT"]);
+translator.flag("rent", ["RENT"], ["NORENT"]).postProcess({
+  id: "rent.ignoredWithLp64",
+  run: (options, acceptor, getOwnToken) => {
+    const token = getOwnToken();
+    if (
+      token === undefined ||
+      !options.rent ||
+      options.LP !== CompilerOptions.LP.LP64
+    ) {
+      return;
+    }
+    acceptor(
+      diagnosticFromCode(CompilerOptionsCodes.Rent.IgnoredWithLp64, token),
+    );
+  },
+});
 
 /** {@link CompilerOptions.resExp} */
 translator.flag("resExp", ["RESEXP"], ["NORESEXP"]);
@@ -3562,7 +3808,23 @@ translator.flag("stdsys", ["STDSYS"], ["NOSTDSYS"]);
 translator.flag("stmt", ["STMT"], ["NOSTMT"]);
 
 /** {@link CompilerOptions.storage} */
-translator.flag("storage", ["STORAGE", "STG"], ["NOSTORAGE", "NSTG"]);
+translator
+  .flag("storage", ["STORAGE", "STG"], ["NOSTORAGE", "NSTG"])
+  .postProcess({
+    id: "storage.ignoredWithNoObject",
+    run: (options, acceptor, getOwnToken) => {
+      if (!options.storage || options.object !== false) {
+        return;
+      }
+      acceptor(
+        diagnosticFromCode(
+          CompilerOptionsCodes.Object.IgnoredOption,
+          getOwnToken(),
+          "STORAGE",
+        ),
+      );
+    },
+  });
 
 /** {@link CompilerOptions.stringOfGraphic} */
 translator.rule(["STRINGOFGRAPHIC", "CHAR", "G"], (option, options) => {
@@ -3660,110 +3922,152 @@ translator.rule(
 translator.flag("terminal", ["TERMINAL", "TERM"], ["NOTERMINAL", "NTERM"]);
 
 /** {@link CompilerOptions.test} */
-translator.rule(
-  ["TEST"],
-  (option, options, acceptor) => {
-    // If there are multiple *PROCESS TEST directives,
-    // the last one takes precedence and all suboptions that are not specified
-    // are set to default.
-    options.test = {
-      level: CompilerOptions.TestLevel.ALL,
-      hook: true,
-      separate: false,
-      sepName: true,
-      source: false,
-      sym: true,
-    };
-    for (const value of option.values) {
-      ensureType(value, "plain");
-      const name = value.value.toUpperCase();
-      switch (name) {
-        case "ALL":
-        case "BLOCK":
-        case "NONE":
-        case "PATH":
-        case "STMT":
-          options.test.level = ensureEnum(
-            value,
-            CompilerOptionsCodes.Test.InvalidParameter,
-            CompilerOptions.TestLevel,
-          );
-          break;
-        case "HOOK":
-          options.test.hook = true;
-          break;
-        case "NOHOOK":
-          options.test.hook = false;
-          break;
-        case "SEPARATE":
-          options.test.separate = true;
-          break;
-        case "NOSEPARATE":
-          options.test.separate = false;
-          break;
-        case "SEPNAME":
-          options.test.sepName = true;
-          break;
-        case "NOSEPNAME":
-          options.test.sepName = false;
-          break;
-        case "SOURCE":
-          options.test.source = true;
-          break;
-        case "NOSOURCE":
-          options.test.source = false;
-          break;
-        case "SYM":
-          options.test.sym = true;
-          break;
-        case "NOSYM":
-          options.test.sym = false;
-          break;
-        default:
-          throw diagnosticFromCode(
-            CompilerOptionsCodes.Test.InvalidParameter,
-            value.token,
-            name,
-          );
+translator
+  .rule(
+    ["TEST"],
+    (option, options, acceptor) => {
+      // If there are multiple *PROCESS TEST directives,
+      // the last one takes precedence and all suboptions that are not specified
+      // are set to default.
+      options.test = {
+        level: CompilerOptions.TestLevel.ALL,
+        hook: true,
+        separate: false,
+        sepName: true,
+        source: false,
+        sym: true,
+      };
+      let sepNameToken: CompilerOption["token"] | undefined;
+      for (const value of option.values) {
+        ensureType(value, "plain");
+        const name = value.value.toUpperCase();
+        switch (name) {
+          case "ALL":
+          case "BLOCK":
+          case "NONE":
+          case "PATH":
+          case "STMT":
+            options.test.level = ensureEnum(
+              value,
+              CompilerOptionsCodes.Test.InvalidParameter,
+              CompilerOptions.TestLevel,
+            );
+            break;
+          case "HOOK":
+            options.test.hook = true;
+            break;
+          case "NOHOOK":
+            options.test.hook = false;
+            break;
+          case "SEPARATE":
+            options.test.separate = true;
+            break;
+          case "NOSEPARATE":
+            options.test.separate = false;
+            break;
+          case "SEPNAME":
+            options.test.sepName = true;
+            sepNameToken = value.token;
+            break;
+          case "NOSEPNAME":
+            options.test.sepName = false;
+            break;
+          case "SOURCE":
+            options.test.source = true;
+            break;
+          case "NOSOURCE":
+            options.test.source = false;
+            break;
+          case "SYM":
+            options.test.sym = true;
+            break;
+          case "NOSYM":
+            options.test.sym = false;
+            break;
+          default:
+            throw diagnosticFromCode(
+              CompilerOptionsCodes.Test.InvalidParameter,
+              value.token,
+              name,
+            );
+        }
       }
-    }
-    reportDuplicateSubOptions(option, acceptor);
-    reportMutexSubOptions(option, acceptor, [
-      ["ALL", "BLOCK", "NONE", "PATH", "STMT"],
-      ["HOOK", "NOHOOK"],
-      ["SEPARATE", "NOSEPARATE"],
-      ["SEPNAME", "NOSEPNAME"],
-      ["SOURCE", "NOSOURCE"],
-      ["SYM", "NOSYM"],
-    ]);
-  },
-  ["NOTEST"],
-  (option, options) => {
-    ensureArguments(option, 0, 0);
-    options.test = false;
-  },
-);
+      reportDuplicateSubOptions(option, acceptor);
+      reportMutexSubOptions(option, acceptor, [
+        ["ALL", "BLOCK", "NONE", "PATH", "STMT"],
+        ["HOOK", "NOHOOK"],
+        ["SEPARATE", "NOSEPARATE"],
+        ["SEPNAME", "NOSEPNAME"],
+        ["SOURCE", "NOSOURCE"],
+        ["SYM", "NOSYM"],
+      ]);
+      // SEPNAME is ignored if SEPARATE is not in effect.
+      if (sepNameToken && !options.test.separate) {
+        acceptor(
+          diagnosticFromCode(
+            CompilerOptionsCodes.Test.SepNameIgnoredWithoutSeparate,
+            sepNameToken,
+          ),
+        );
+      }
+    },
+    ["NOTEST"],
+    (option, options) => {
+      ensureArguments(option, 0, 0);
+      options.test = false;
+    },
+  )
+  .postProcess({
+    id: "test.conflictsWithLineDir",
+    run: (options, acceptor, getOwnToken) => {
+      if (!options.lineDir || !options.test || !options.test.separate) {
+        return;
+      }
+      acceptor(
+        diagnosticFromCode(
+          CompilerOptionsCodes.Test.ConflictWithLineDir,
+          getOwnToken(),
+        ),
+      );
+    },
+  });
 
 /** {@link CompilerOptions.unroll} */
-translator.rule(["UNROLL"], (option, options) => {
-  ensureArguments(option, 1, 1);
-  const value = option.values[0];
-  ensureType(value, "plainNotEmpty");
-  const name = value.value.toUpperCase();
-  if (["AUTO", "NO"].includes(name)) {
-    options.unroll = ensureEnum(
-      value,
-      CompilerOptionsCodes.Unroll.InvalidParameter,
-      CompilerOptions.Unroll,
-    );
-  } else {
-    throw diagnosticFromCode(
-      CompilerOptionsCodes.Unroll.InvalidParameter,
-      value.token,
-      name,
-    );
-  }
-});
+translator
+  .rule(["UNROLL"], (option, options) => {
+    ensureArguments(option, 1, 1);
+    const value = option.values[0];
+    ensureType(value, "plainNotEmpty");
+    const name = value.value.toUpperCase();
+    if (["AUTO", "NO"].includes(name)) {
+      options.unroll = ensureEnum(
+        value,
+        CompilerOptionsCodes.Unroll.InvalidParameter,
+        CompilerOptions.Unroll,
+      );
+    } else {
+      throw diagnosticFromCode(
+        CompilerOptionsCodes.Unroll.InvalidParameter,
+        value.token,
+        name,
+      );
+    }
+  })
+  .postProcess({
+    id: "unroll.ignoredWithNoOptimize",
+    run: (options, acceptor, getOwnToken) => {
+      const token = getOwnToken();
+      if (token === undefined || options.optimize !== 0) {
+        return;
+      }
+      acceptor(
+        diagnosticFromCode(
+          CompilerOptionsCodes.Unroll.IgnoredWithNoOptimize,
+          token,
+        ),
+      );
+    },
+  });
 
 /** {@link CompilerOptions.usage} */
 translator.rule(["USAGE"], (option, options, acceptor) => {
@@ -3859,30 +4163,52 @@ translator.rule(["WINDOW"], (option, options) => {
 });
 
 /** {@link CompilerOptions.writable} */
-translator.rule(
-  ["WRITABLE"],
-  (option, options) => {
-    ensureArguments(option, 0, 0);
-    options.writable = true;
-  },
-  ["NOWRITABLE"],
-  (option, options) => {
-    ensureArguments(option, 0, 1);
-    if (option.values.length === 0) {
-      options.writable = { noWritable: CompilerOptions.WritableNoWritable.FWS };
-      return;
-    }
-    const value = option.values[0];
-    ensureType(value, "plainNotEmpty");
-    options.writable = {
-      noWritable: ensureEnum(
-        value,
-        CompilerOptionsCodes.Writable.InvalidParameter,
-        CompilerOptions.WritableNoWritable,
-      ),
-    };
-  },
-);
+translator
+  .rule(
+    ["WRITABLE"],
+    (option, options) => {
+      ensureArguments(option, 0, 0);
+      options.writable = true;
+    },
+    ["NOWRITABLE"],
+    (option, options) => {
+      ensureArguments(option, 0, 1);
+      if (option.values.length === 0) {
+        options.writable = {
+          noWritable: CompilerOptions.WritableNoWritable.FWS,
+        };
+        return;
+      }
+      const value = option.values[0];
+      ensureType(value, "plainNotEmpty");
+      options.writable = {
+        noWritable: ensureEnum(
+          value,
+          CompilerOptionsCodes.Writable.InvalidParameter,
+          CompilerOptions.WritableNoWritable,
+        ),
+      };
+    },
+  )
+  .postProcess({
+    id: "writable.ignoredWithLp64",
+    run: (options, acceptor, getOwnToken) => {
+      const token = getOwnToken();
+      if (
+        token === undefined ||
+        options.writable !== true ||
+        options.LP !== CompilerOptions.LP.LP64
+      ) {
+        return;
+      }
+      acceptor(
+        diagnosticFromCode(
+          CompilerOptionsCodes.Writable.IgnoredWithLp64,
+          token,
+        ),
+      );
+    },
+  });
 
 /** {@link CompilerOptions.xInfo} */
 translator.rule(["XINFO"], (option, options, acceptor) => {

--- a/packages/language/src/preprocessor/compiler-options/translator-sql.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator-sql.ts
@@ -11,8 +11,10 @@
 
 import { diagnosticFromCode } from "../../language-server/types";
 import { CompilerOptionsCodes } from "./codes";
+import { CompilerOptions as CompilerOptionsPLI } from "./options-pli";
 import { CompilerOptions, getDefaultCompilerOptions } from "./options-sql";
 import { ensureArguments, ensureType, Translator } from "./translator";
+import { getTranslator as getTranslatorPLI } from "./translator-pli";
 
 const translator = new Translator<CompilerOptions>(() =>
   getDefaultCompilerOptions(),
@@ -57,7 +59,25 @@ translator.rule(["DEPRECATE"], (option, options) => {
 
 translator.flag("emptyDbrm", ["EMPTYDBRM"], ["NOEMPTYDBRM"]);
 
-translator.flag("hostCopy", ["HOSTCOPY"], ["NOHOSTCOPY"]);
+translator.flag("hostCopy", ["HOSTCOPY"], ["NOHOSTCOPY"]).postProcess({
+  id: "hostCopy.ignoredWithLp32",
+  run: (options, acceptor, getOwnToken) => {
+    const token = getOwnToken();
+    if (
+      token === undefined ||
+      !options.hostCopy ||
+      getTranslatorPLI().options.LP !== CompilerOptionsPLI.LP.LP32
+    ) {
+      return;
+    }
+    acceptor(
+      diagnosticFromCode(
+        CompilerOptionsCodes.PPSQL.HostCopy.IgnoredWithLp32,
+        token,
+      ),
+    );
+  },
+});
 
 translator.flag("incOnly", ["INCONLY"], ["NOINCONLY"]);
 

--- a/packages/language/src/preprocessor/compiler-options/translator.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator.ts
@@ -71,6 +71,22 @@ export interface PostProcessHook<
   run: (options: T, acceptor: TranslationDiagnosticAcceptor) => void;
 }
 
+/**
+ * A {@link PostProcessHook} registered via {@link RuleBuilder.postProcess},
+ * colocated with the specific rule it belongs to. Its `run` function
+ * receives an additional `getOwnToken` accessor that returns
+ * the token of the option's most recent occurrence.
+ */
+export interface RuleAwarePostProcessHook<
+  T extends CompilerOptionsPP = CompilerOptionsPP,
+> extends Omit<PostProcessHook<T>, "run"> {
+  run: (
+    options: T,
+    acceptor: TranslationDiagnosticAcceptor,
+    getOwnToken: () => CompilerOption["token"] | undefined,
+  ) => void;
+}
+
 type TranslationDiagnosticAcceptor = (diagnostic: Diagnostic) => void;
 
 type Translate<T extends CompilerOptionsPP> = (
@@ -95,6 +111,8 @@ type AppliedRuleRecord = {
   alignment: RuleAlignment;
   /** Serialized argument values, used for the recompile fingerprint. */
   args?: string;
+  /** The token of the option occurrence that (most recently) applied this rule. */
+  token?: CompilerOption["token"];
 };
 
 /**
@@ -134,8 +152,15 @@ export class RuleBuilder<T extends CompilerOptionsPP = CompilerOptionsPP> {
    * Registers one or more {@link PostProcessHook}s colocated with this rule.
    * Hooks run once per compilation via {@link Translator.postProcess}.
    */
-  postProcess(hook: PostProcessHook<T>): this {
-    this.translator.registerPostProcessHooks(hook);
+  postProcess(hook: RuleAwarePostProcessHook<T>): this {
+    const ruleObj = this.ruleObj;
+    const translator = this.translator;
+    this.translator.registerPostProcessHooks({
+      id: hook.id,
+      dependsOn: hook.dependsOn,
+      run: (options, acceptor) =>
+        hook.run(options, acceptor, () => translator.getRuleToken(ruleObj)),
+    });
     return this;
   }
 }
@@ -195,14 +220,80 @@ export class Translator<T extends CompilerOptionsPP = CompilerOptionsPP> {
     this.postProcessHooks.push(hook);
   }
 
+  private findRule(name: string): TranslatorRule<T> | undefined {
+    return this.rules.find(
+      (r) => r.positive?.includes(name) || r.negative?.includes(name),
+    );
+  }
+
+  /**
+   * Returns the token of the option occurrence that most recently,
+   * explicitly applied the given rule, or `undefined` if it was never
+   * explicitly applied.
+   */
+  getRuleToken(rule: TranslatorRule<T>): CompilerOption["token"] | undefined {
+    if (this.isRuleApplied(rule)) {
+      return this.appliedRules.get(rule)?.token;
+    }
+    return undefined;
+  }
+
+  /**
+   * Declares that two option names, registered as separate rules, are
+   * mutually exclusive.
+   */
+  crossMutex(a: string, b: string): void {
+    if (this.crossMutexPairs.length === 0) {
+      this.registerPostProcessHooks({
+        id: "_crossMutex",
+        run: (_options, acceptor) => this.checkCrossMutex(acceptor),
+      });
+    }
+    this.crossMutexPairs.push([a, b]);
+  }
+
+  private crossMutexPairs: [string, string][] = [];
+
+  private checkCrossMutex(acceptor: TranslationDiagnosticAcceptor): void {
+    for (const [a, b] of this.crossMutexPairs) {
+      const ruleA = this.findRule(a);
+      const ruleB = this.findRule(b);
+      if (
+        ruleA &&
+        ruleB &&
+        this.isRuleApplied(ruleA) &&
+        this.isRuleApplied(ruleB)
+      ) {
+        const tokenA = this.appliedRules.get(ruleA)?.token;
+        const tokenB = this.appliedRules.get(ruleB)?.token;
+        // Anchor the diagnostic at whichever of the two options was written
+        // later in the source.
+        const token =
+          tokenA && tokenB
+            ? tokenA.startOffset >= tokenB.startOffset
+              ? tokenA
+              : tokenB
+            : (tokenA ?? tokenB);
+        acceptor(
+          diagnosticFromCode(
+            CompilerOptionsCodes.CrossMutexOptionIssue,
+            token,
+            a,
+            b,
+          ),
+        );
+      }
+    }
+  }
+
   flag(
     key: keyof T,
     positive: string[],
     negative: string[],
     callback?: (option: CompilerOption, options: T) => void,
     settings?: RuleSettings,
-  ) {
-    this.rules.push({
+  ): RuleBuilder<T> {
+    const ruleObj: TranslatorRule<T> = {
       positive,
       positiveTranslate: (option, options) => {
         ensureArguments(option, 0, 0);
@@ -216,7 +307,9 @@ export class Translator<T extends CompilerOptionsPP = CompilerOptionsPP> {
         callback?.(option, options);
       },
       settings,
-    });
+    };
+    this.rules.push(ruleObj);
+    return new RuleBuilder(this, ruleObj);
   }
 
   clear() {
@@ -361,7 +454,7 @@ export class Translator<T extends CompilerOptionsPP = CompilerOptionsPP> {
 
       if (!this.isRuleApplied(rule)) {
         const args = this.serializeOptionValues(option);
-        this.appliedRules.set(rule, { alignment, args });
+        this.appliedRules.set(rule, { alignment, args, token: option.token });
       } else if (this.isRuleAlignedWith(rule, alignment)) {
         if (!rule.settings?.allowDuplicates) {
           this.reportDupeOptIssue(option, name);

--- a/packages/language/test/fourslash/preprocessor/compiler-options/default-pli/default.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/default-pli/default.ts
@@ -12,6 +12,7 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
+////*PROCESS CMPAT(LE); // CMPAT(LE) does not conflict with DFT(DESCLIST).
 ////*PROCESS <|0:DEFAULT|>;
 ////*PROCESS <|d1:DEFAULT|>(<|1:)|>;
 ////*PROCESS <|d2:DEFAULT|>(<|2:INVALID|>);

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-cics/cross-mutex-dli.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-cics/cross-mutex-dli.ts
@@ -12,13 +12,8 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
-verify.noDiagnostics();
+////*PROCESS PP(CICS("EXCI <|1:DLI|>"));
 
-verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
-  },
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.CrossMutexOptionIssue.message("EXCI", "DLI"),
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/brackets-conflict-names.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/brackets-conflict-names.ts
@@ -12,13 +12,15 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
-verify.noDiagnostics();
+////*PROCESS NAMES('@?');
+////*PROCESS <|1:BRACKETS|>('@}');
 
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.Brackets.ConflictWithOption.message(
+    "@",
+    "NAMES",
+  ),
+});
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
-  },
+  brackets: ["@", "}"],
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/brackets-conflict-not.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/brackets-conflict-not.ts
@@ -12,13 +12,12 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
-verify.noDiagnostics();
+////*PROCESS NOT('!');
+////*PROCESS <|1:BRACKETS|>('!}');
 
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.Brackets.ConflictWithOption.message("!", "NOT"),
+});
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
-  },
+  brackets: ["!", "}"],
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/brackets-conflict-or.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/brackets-conflict-or.ts
@@ -12,13 +12,12 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
-verify.noDiagnostics();
+////*PROCESS OR('~');
+////*PROCESS <|1:BRACKETS|>('~}');
 
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.Brackets.ConflictWithOption.message("~", "OR"),
+});
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
-  },
+  brackets: ["~", "}"],
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/brackets-no-conflict.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/brackets-no-conflict.ts
@@ -12,13 +12,17 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
+////*PROCESS NAMES('@?'), NOT('!'), OR('~');
+////*PROCESS BRACKETS('{}');
+
 verify.noDiagnostics();
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
+  brackets: ["{", "}"],
+  names: {
+    extralingChar: "@?",
+    uppExtralingChar: "@?",
   },
+  not: "!",
+  or: "~",
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/common-conflict-extname.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/common-conflict-extname.ts
@@ -12,13 +12,16 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
-verify.noDiagnostics();
+////*PROCESS LIMITS(EXTNAME(80));
+////*PROCESS <|1:COMMON|>;
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.Common.ConflictWithExtName.message(80),
+});
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
+  common: true,
+  limits: {
+    extname: 80,
   },
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/common-conflict-rent.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/common-conflict-rent.ts
@@ -12,13 +12,14 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
-verify.noDiagnostics();
+////*PROCESS RENT;
+////*PROCESS <|1:COMMON|>;
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.Common.ConflictWithRent.message(),
+});
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
-  },
+  common: true,
+  rent: true,
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/common-no-conflict.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/common-no-conflict.ts
@@ -12,13 +12,15 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
+////*PROCESS NORENT, LIMITS(EXTNAME(7));
+////*PROCESS COMMON;
+
 verify.noDiagnostics();
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
+  common: true,
+  rent: false,
+  limits: {
+    extname: 7,
   },
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/dbcs-conflict-graphic.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/dbcs-conflict-graphic.ts
@@ -12,13 +12,14 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
-verify.noDiagnostics();
+////*PROCESS GRAPHIC;
+////*PROCESS <|1:NODBCS|>;
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.Dbcs.ConflictWithGraphic.message(),
+});
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
-  },
+  graphic: true,
+  dbcs: false,
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/dbcs-no-conflict-graphic.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/dbcs-no-conflict-graphic.ts
@@ -12,13 +12,12 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
+////*PROCESS GRAPHIC;
+////*PROCESS DBCS;
+
 verify.noDiagnostics();
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
-  },
+  graphic: true,
+  dbcs: true,
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/default-desclist-cmpat-conflict.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/default-desclist-cmpat-conflict.ts
@@ -12,13 +12,18 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
-verify.noDiagnostics();
+////*PROCESS CMPAT(V2);
+////*PROCESS <|1:DEFAULT|>(DESCLIST);
 
+verify.expectDiagnosticsAt(1, {
+  message:
+    code.CompilerOptions.Default.DescListConflictsWithCmpat.message("V2"),
+});
+
+// DFT(DESCLOCATOR) is assumed instead of DFT(DESCLIST) as specified in the spec.
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
+  cmpat: constants.CompilerOptions.CMPat.V2,
+  default: {
+    desc: constants.CompilerOptions.DefaultDesc.LOCATOR,
   },
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/default-desclist-cmpat-no-conflict.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/default-desclist-cmpat-no-conflict.ts
@@ -12,13 +12,14 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
+////*PROCESS CMPAT(LE);
+////*PROCESS DEFAULT(DESCLIST);
+
 verify.noDiagnostics();
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
+  cmpat: constants.CompilerOptions.CMPat.LE,
+  default: {
+    desc: constants.CompilerOptions.DefaultDesc.LIST,
   },
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/listview-ignored-nosource.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/listview-ignored-nosource.ts
@@ -12,13 +12,14 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
-verify.noDiagnostics();
+////*PROCESS NOSOURCE;
+////*PROCESS <|1:LISTVIEW|>(AFTERALL);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ListView.IgnoredWithNoSource.message(),
+});
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
-  },
+  source: false,
+  listView: constants.CompilerOptions.ListView.AFTERALL,
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/listview-no-conflict-source.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/listview-no-conflict-source.ts
@@ -12,13 +12,12 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
+////*PROCESS SOURCE;
+////*PROCESS LISTVIEW(AFTERALL);
+
 verify.noDiagnostics();
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
-  },
+  source: true,
+  listView: constants.CompilerOptions.ListView.AFTERALL,
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/name-conflict-default-extname.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/name-conflict-default-extname.ts
@@ -12,13 +12,17 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
-verify.noDiagnostics();
+////*PROCESS <|1:NAME|>('123456789');
+
+// LIMITS(EXTNAME(n)) is never specified here, so its default value of 7
+// applies, which is <= 8, so the NAME length restriction still applies.
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.Name.TooLongForExtName.message("123456789", 7),
+});
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
+  name: "123456789",
+  limits: {
+    extname: 7,
   },
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/name-no-conflict-extname.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/name-no-conflict-extname.ts
@@ -12,13 +12,15 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
+////*PROCESS LIMITS(EXTNAME(9));
+////*PROCESS NAME('123456789');
+
+// EXTNAME(9) is greater than 8, so the NAME length restriction does not apply.
 verify.noDiagnostics();
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
+  name: "123456789",
+  limits: {
+    extname: 9,
   },
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/name-too-long-for-extname.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/name-too-long-for-extname.ts
@@ -12,13 +12,16 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
-verify.noDiagnostics();
+////*PROCESS LIMITS(EXTNAME(8));
+////*PROCESS <|1:NAME|>('123456789');
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.Name.TooLongForExtName.message("123456789", 8),
+});
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
+  name: "123456789",
+  limits: {
+    extname: 8,
   },
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/object-ignores-list-map-offset-storage.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/object-ignores-list-map-offset-storage.ts
@@ -1,0 +1,40 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS NOOBJECT;
+////*PROCESS <|1:LIST|>;
+////*PROCESS <|2:MAP|>;
+////*PROCESS <|3:OFFSET|>;
+////*PROCESS <|4:STORAGE|>;
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.Object.IgnoredOption.message("LIST"),
+});
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.Object.IgnoredOption.message("MAP"),
+});
+verify.expectDiagnosticsAt(3, {
+  message: code.CompilerOptions.Object.IgnoredOption.message("OFFSET"),
+});
+verify.expectDiagnosticsAt(4, {
+  message: code.CompilerOptions.Object.IgnoredOption.message("STORAGE"),
+});
+
+verify.expectCompilerOptions({
+  object: false,
+  list: true,
+  map: true,
+  offset: true,
+  storage: true,
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/object-no-conflict.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/object-no-conflict.ts
@@ -12,13 +12,19 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
+////*PROCESS LIST;
+////*PROCESS MAP;
+////*PROCESS OFFSET;
+////*PROCESS STORAGE;
+////*PROCESS OBJECT;
+
+// OBJECT is in effect, so LIST/MAP/OFFSET/STORAGE are not ignored.
 verify.noDiagnostics();
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
-  },
+  object: true,
+  list: true,
+  map: true,
+  offset: true,
+  storage: true,
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/offsetsize-ignored-default-lp.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/offsetsize-ignored-default-lp.ts
@@ -12,13 +12,15 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
-verify.noDiagnostics();
+////*PROCESS <|1:OFFSETSIZE|>(8);
+
+// LP is never specified here, so its default value of LP(32) applies, which
+// still causes OFFSETSIZE to be ignored.
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.OffsetSize.IgnoredWithLp32.message(),
+});
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
-  },
+  LP: constants.CompilerOptions.LP.LP32,
+  offsetSize: 8,
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/offsetsize-ignored-lp32.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/offsetsize-ignored-lp32.ts
@@ -12,13 +12,14 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
-verify.noDiagnostics();
+////*PROCESS LP(32);
+////*PROCESS <|1:OFFSETSIZE|>(8);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.OffsetSize.IgnoredWithLp32.message(),
+});
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
-  },
+  LP: constants.CompilerOptions.LP.LP32,
+  offsetSize: 8,
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/offsetsize-no-conflict-lp64.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/offsetsize-no-conflict-lp64.ts
@@ -12,13 +12,12 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
+////*PROCESS LP(64);
+////*PROCESS OFFSETSIZE(8);
+
 verify.noDiagnostics();
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
-  },
+  LP: constants.CompilerOptions.LP.LP64,
+  offsetSize: 8,
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/quote-ignored-graphic.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/quote-ignored-graphic.ts
@@ -12,13 +12,14 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
-verify.noDiagnostics();
+////*PROCESS GRAPHIC;
+////*PROCESS <|1:QUOTE|>('$');
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.Quote.IgnoredWithGraphic.message(),
+});
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
-  },
+  graphic: true,
+  quote: "$",
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/quote-no-conflict-nographic.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/quote-no-conflict-nographic.ts
@@ -12,13 +12,12 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
+////*PROCESS NOGRAPHIC;
+////*PROCESS QUOTE('$');
+
 verify.noDiagnostics();
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
-  },
+  graphic: false,
+  quote: "$",
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/rent-ignored-lp64.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/rent-ignored-lp64.ts
@@ -12,13 +12,14 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
-verify.noDiagnostics();
+////*PROCESS LP(64);
+////*PROCESS <|1:RENT|>;
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.Rent.IgnoredWithLp64.message(),
+});
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
-  },
+  LP: constants.CompilerOptions.LP.LP64,
+  rent: true,
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/rent-no-conflict-lp32.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/rent-no-conflict-lp32.ts
@@ -12,13 +12,12 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
+////*PROCESS LP(32);
+////*PROCESS RENT;
+
 verify.noDiagnostics();
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
-  },
+  LP: constants.CompilerOptions.LP.LP32,
+  rent: true,
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/test-conflict-linedir.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/test-conflict-linedir.ts
@@ -12,13 +12,16 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
-verify.noDiagnostics();
+////*PROCESS LINEDIR;
+////*PROCESS <|1:TEST|>(SEPARATE);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.Test.ConflictWithLineDir.message(),
+});
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
+  lineDir: true,
+  test: {
+    separate: true,
   },
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/test-no-conflict-linedir.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/test-no-conflict-linedir.ts
@@ -12,13 +12,14 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
+////*PROCESS LINEDIR;
+////*PROCESS TEST(NOSEPARATE);
+
 verify.noDiagnostics();
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
+  lineDir: true,
+  test: {
+    separate: false,
   },
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/test-sepname-ignored-without-separate.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/test-sepname-ignored-without-separate.ts
@@ -12,13 +12,15 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
-verify.noDiagnostics();
+////*PROCESS TEST(<|1:SEPNAME|>);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.Test.SepNameIgnoredWithoutSeparate.message(),
+});
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
+  test: {
+    separate: false,
+    sepName: true,
   },
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/test-sepname-no-conflict-with-separate.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/test-sepname-no-conflict-with-separate.ts
@@ -12,13 +12,13 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
+////*PROCESS TEST(SEPARATE SEPNAME);
+
 verify.noDiagnostics();
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
+  test: {
+    separate: true,
+    sepName: true,
   },
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/unroll-ignored-default-optimize.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/unroll-ignored-default-optimize.ts
@@ -12,13 +12,15 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
-verify.noDiagnostics();
+////*PROCESS <|1:UNROLL|>(AUTO);
+
+// OPTIMIZE is never specified here, so its default value of NOOPTIMIZE (0)
+// applies, which still causes UNROLL to be ignored.
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.Unroll.IgnoredWithNoOptimize.message(),
+});
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
-  },
+  optimize: 0,
+  unroll: constants.CompilerOptions.Unroll.AUTO,
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/unroll-ignored-nooptimize.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/unroll-ignored-nooptimize.ts
@@ -12,13 +12,14 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
-verify.noDiagnostics();
+////*PROCESS NOOPTIMIZE;
+////*PROCESS <|1:UNROLL|>(AUTO);
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.Unroll.IgnoredWithNoOptimize.message(),
+});
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
-  },
+  optimize: 0,
+  unroll: constants.CompilerOptions.Unroll.AUTO,
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/unroll-no-conflict-optimize.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/unroll-no-conflict-optimize.ts
@@ -12,13 +12,12 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
+////*PROCESS OPTIMIZE;
+////*PROCESS UNROLL(AUTO);
+
 verify.noDiagnostics();
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
-  },
+  optimize: 3,
+  unroll: constants.CompilerOptions.Unroll.AUTO,
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/writable-ignored-lp64.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/writable-ignored-lp64.ts
@@ -12,13 +12,14 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
-verify.noDiagnostics();
+////*PROCESS LP(64);
+////*PROCESS <|1:WRITABLE|>;
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.Writable.IgnoredWithLp64.message(),
+});
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
-  },
+  LP: constants.CompilerOptions.LP.LP64,
+  writable: true,
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/writable-no-conflict-lp32.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/writable-no-conflict-lp32.ts
@@ -12,13 +12,12 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
+////*PROCESS LP(32);
+////*PROCESS WRITABLE;
+
 verify.noDiagnostics();
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
-  },
+  LP: constants.CompilerOptions.LP.LP32,
+  writable: true,
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/writable-no-conflict-nowritable.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/writable-no-conflict-nowritable.ts
@@ -12,13 +12,12 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
+////*PROCESS LP(64);
+////*PROCESS NOWRITABLE;
+
 verify.noDiagnostics();
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
-  },
+  LP: constants.CompilerOptions.LP.LP64,
+  writable: { noWritable: constants.CompilerOptions.WritableNoWritable.FWS },
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/hostcopy-ignored-default-lp.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/hostcopy-ignored-default-lp.ts
@@ -12,13 +12,17 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
-verify.noDiagnostics();
+////*PROCESS PP(SQL("<|1:HOSTCOPY|>"));
+
+// LP is never specified here, so its default value of LP(32) applies, which
+// still causes HOSTCOPY to be ignored.
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.PPSQL.HostCopy.IgnoredWithLp32.message(),
+});
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
+  LP: constants.CompilerOptions.LP.LP32,
+  sqlOptions: {
+    hostCopy: true,
   },
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/hostcopy-ignored-lp32.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/hostcopy-ignored-lp32.ts
@@ -12,13 +12,16 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
-verify.noDiagnostics();
+////*PROCESS LP(32);
+////*PROCESS PP(SQL("<|1:HOSTCOPY|>"));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.PPSQL.HostCopy.IgnoredWithLp32.message(),
+});
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
+  LP: constants.CompilerOptions.LP.LP32,
+  sqlOptions: {
+    hostCopy: true,
   },
 });

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/hostcopy-no-conflict-lp64.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/hostcopy-no-conflict-lp64.ts
@@ -12,13 +12,14 @@
 /// <reference path="../../../framework.ts" />
 
 // @wrap: process
-////*PROCESS PP(CICS("EXCI SP SYSEIB"));
+////*PROCESS LP(64);
+////*PROCESS PP(SQL("HOSTCOPY"));
+
 verify.noDiagnostics();
 
 verify.expectCompilerOptions({
-  cicsOptions: {
-    exci: true,
-    sp: true,
-    sysEib: true,
+  LP: constants.CompilerOptions.LP.LP64,
+  sqlOptions: {
+    hostCopy: true,
   },
 });


### PR DESCRIPTION
Closes #780

Uses the generic compiler options post process system to check for mutual exclusive compiler options. Added `crossMutex` as a convenient method at the translator, because adding a post-process task to one option might be confusing. 

- Cross dependencies for CICS:
  - EXCI is mutually exclusive to CICS and DLI
- Also added cross dependencies for the other PLI options:
  - BRACKETS  cannot use characters that are used by NAMES, NOT, or OR
  - CMPAT(V*) is not compatible with DFT(DESCLIST)
  - COMMON must not be used with LIMITS(EXTNAME(n)) if n > 7
  - NODBCS should not be used if GRAPHIC is specified
  - LINEDIR will reject TEST(SEPARATE())
  - LISTVIEW is ignored if NOSOURCE is in effect
  - NAME must not be greater than 8 characters if the LIMITS(EXTNAME(n)) option is used with n <= 8
  - NOOBJECT will cause LIST, MAP, OFFSET and STORAGE to be ignored
  - OFFSETSIZE is ignored if LP(32) is in effect
  - QUOTE is ignored if GRAPHIC is in effect
  - RENT is ignored under LP(64)
  - UNROLL is ignored when NOOPTIMIZE is in effect
  - WRITABLE is ignored under LP(64)
- Cross dependencies for SQL:
  - HOSTCOPY is ignored under LP(32)
  
  
Additional added checks:
- TEST checks for SEPNAME if SEPARATE is in effect
  
Dependencies that were identified in the spec, but are not (yet) implemented (potential todos for follow-ups):  
- If the NOSYNTAX option is in effect, any specification of the CICS preprocessor through the CICS, XOPT 
or XOPTS options will be ignored. This allows the MACRO preprocessor to be invoked before the compiler 
invokes the CICS translator.
- For MACRO: Under the GRAPHIC option, CASE(ASIS) is always in effect.