### PR TITLE
Recognize wildcard and extensionless program entries

### DIFF
--- a/packages/language/src/config/lib-expander.ts
+++ b/packages/language/src/config/lib-expander.ts
@@ -46,7 +46,7 @@ import {
  * diagnostics; the lib-expander itself emits no LSP types.
  */
 
-const DATASET_MEMBER_FILE_REGEX = /^(.+)\((.+)\)(\..+)?$/;
+export const DATASET_MEMBER_FILE_REGEX = /^(.+)\((.+)\)(\..+)?$/;
 
 async function safeStat(
   fs: FileSystemProvider,

--- a/packages/language/src/language-server/connection-handler.ts
+++ b/packages/language/src/language-server/connection-handler.ts
@@ -478,6 +478,19 @@ export function startLanguageServer(
     return compilationUnit !== undefined;
   });
 
+  onRequest(
+    connection,
+    Messages.MatchesProgramConfig,
+    (uriString: string): Messages.ProgramConfigMatchKind => {
+      const uri = UriUtils.toUri(uriString);
+      const context = compilationUnitHandler.getWorkspaceFolderOf(uri);
+      if (!context) {
+        return "none";
+      }
+      return context.config.classifyProgramMatch(uri);
+    },
+  );
+
   /**
    * Resolves a {@link JsonItemMeta} into a client-facing
    * {@link Messages.PluginConfigEntryLocation}.

--- a/packages/language/src/language-server/connection-handler.ts
+++ b/packages/language/src/language-server/connection-handler.ts
@@ -447,7 +447,6 @@ export function startLanguageServer(
       );
     });
   });
-
   onNotification(
     connection,
     Messages.OnDidChangePluginConfigSettingsNotification,
@@ -468,26 +467,19 @@ export function startLanguageServer(
   connection.onDidChangeWatchedFiles(async (params) => {
     await compilationUnitHandler.triggerOnFileChange(params, connection);
   });
-  onRequest(connection, Messages.ExistingFile, (uriString: string): boolean => {
-    const uri = UriUtils.toUri(uriString);
-    const context = compilationUnitHandler.getWorkspaceFolderOf(uri);
-    if (!context) {
-      return false;
-    }
-    const compilationUnit = context.getCompilationUnit(uri);
-    return compilationUnit !== undefined;
-  });
-
   onRequest(
     connection,
-    Messages.MatchesProgramConfig,
-    (uriString: string): Messages.ProgramConfigMatchKind => {
+    Messages.ExistingFile,
+    (uriString: string): Messages.FileIdentification => {
       const uri = UriUtils.toUri(uriString);
       const context = compilationUnitHandler.getWorkspaceFolderOf(uri);
       if (!context) {
-        return "none";
+        return { existing: false, programMatch: "none" };
       }
-      return context.config.classifyProgramMatch(uri);
+      return {
+        existing: context.getCompilationUnit(uri) !== undefined,
+        programMatch: context.config.classifyProgramMatch(uri),
+      };
     },
   );
 

--- a/packages/language/src/utils/messages.ts
+++ b/packages/language/src/utils/messages.ts
@@ -85,21 +85,21 @@ export namespace Messages {
   export const OnDidChangePluginConfigSettingsNotification =
     createNotificationType<void>("workspace/didChangePluginConfig");
 
-  /**
-   * Request sent to the LS to check if a file is already present in the workspace (i.e. included in a program)
-   */
-  export const ExistingFile = createRequestType<string, boolean>(
-    "pli/existingFile",
-  );
-
   /** How a file matches `pgm_conf.json` program entries. */
   export type ProgramConfigMatchKind = "exact" | "glob" | "none";
 
-  /** Backs client-side language identification of configured program entries. */
-  export const MatchesProgramConfig = createRequestType<
-    string,
-    ProgramConfigMatchKind
-  >("pli/matchesProgramConfig");
+  /** How a file relates to the PL/I workspace, for client-side language ID. */
+  export interface FileIdentification {
+    /** Whether the LS already tracks the file as a compilation unit. */
+    existing: boolean;
+    /** How the file matches configured program entries. */
+    programMatch: ProgramConfigMatchKind;
+  }
+
+  /** Identifies whether/how a file relates to the PL/I workspace. */
+  export const ExistingFile = createRequestType<string, FileIdentification>(
+    "pli/existingFile",
+  );
 
   /**
    * Notification sent to the language client to inform that an operation is in progress.

--- a/packages/language/src/utils/messages.ts
+++ b/packages/language/src/utils/messages.ts
@@ -92,6 +92,15 @@ export namespace Messages {
     "pli/existingFile",
   );
 
+  /** How a file matches `pgm_conf.json` program entries. */
+  export type ProgramConfigMatchKind = "exact" | "glob" | "none";
+
+  /** Backs client-side language identification of configured program entries. */
+  export const MatchesProgramConfig = createRequestType<
+    string,
+    ProgramConfigMatchKind
+  >("pli/matchesProgramConfig");
+
   /**
    * Notification sent to the language client to inform that an operation is in progress.
    * Client should show a progress indicator until the operation is complete.

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -18,7 +18,7 @@ import {
   offsetLengthToRange,
 } from "../language-server/types";
 import { mergeAbstractOptions } from "../config/compiler-options-merge";
-import { expandGroup } from "../config/lib-expander";
+import { DATASET_MEMBER_FILE_REGEX, expandGroup } from "../config/lib-expander";
 import { resolveLibUri } from "../config/path-resolver";
 import {
   ParseEntry,
@@ -179,6 +179,19 @@ const ProgramMatchRank = {
   Exact: 0,
   Glob: 1,
 } as const;
+
+// Fallback source extensions assumed when a program entry omits one.
+const DEFAULT_PROGRAM_EXTENSIONS = [".pli", ".pl1"] as const;
+
+// A dataset member ref or a dotted name already names a concrete target, so no
+// extension is fabricated for it (unlike a bare stem).
+function programBasenameIsConcrete(basename: string): boolean {
+  if (DATASET_MEMBER_FILE_REGEX.test(basename)) {
+    return true;
+  }
+  const dot = basename.lastIndexOf(".");
+  return dot > 0 && dot < basename.length - 1;
+}
 
 /**
  * Plugin configuration provider for loading '.pliplugin/pgm_conf.json' and '.pliplugin/proc_grps.json' (when they exist),
@@ -1127,7 +1140,7 @@ export class PluginConfigurationProvider {
 
     let globMatch: ProgramRecord | undefined;
     for (const [pattern, config] of this.programConfigs.entries()) {
-      const rank = this.programMatchRank(path, pattern);
+      const rank = this.programMatchRank(path, pattern, config);
       if (rank === ProgramMatchRank.Exact) {
         return config;
       }
@@ -1146,21 +1159,88 @@ export class PluginConfigurationProvider {
    * @param path Decoded program path being resolved.
    * @param pattern The program config's key (an exact path or a glob).
    */
-  private programMatchRank(path: string, pattern: string): number | undefined {
-    if (pattern === path) {
-      return ProgramMatchRank.Exact;
+  private programMatchRank(
+    path: string,
+    pattern: string,
+    record: ProgramRecord,
+  ): number | undefined {
+    const kind = this.programMatchKind(path, pattern, record);
+    if (kind === "none") {
+      return;
     }
+    return kind === "exact" ? ProgramMatchRank.Exact : ProgramMatchRank.Glob;
+  }
+
+  /**
+   * Classifies `pattern` against `path` as exact/glob/none, letting an
+   * extensionless entry also bind its on-disk file via an assumed extension.
+   */
+  private programMatchKind(
+    path: string,
+    pattern: string,
+    record: ProgramRecord,
+  ): "exact" | "glob" | "none" {
+    if (pattern === path) {
+      return "exact";
+    }
+    let decoded: string;
     try {
-      if (!minimatch(path, decodeURIComponent(pattern), { nocase: true })) {
-        return undefined;
+      decoded = decodeURIComponent(pattern);
+    } catch (e) {
+      console.error(
+        `Invalid program pattern "${pattern}" for program "${path}": ${e}`,
+      );
+      return "none";
+    }
+
+    const hasWildcard = decoded.includes("*");
+    const basename = decoded.substring(decoded.lastIndexOf("/") + 1);
+    const assumedExts = programBasenameIsConcrete(basename)
+      ? []
+      : this.assumedProgramExtensions(record);
+
+    // A stem that only matches once an extension is assumed is still a
+    // specifically-named entry, so treat it as exact rather than glob.
+    if (!hasWildcard && assumedExts.length > 0) {
+      const lowerPath = path.toLowerCase();
+      for (const ext of assumedExts) {
+        if (lowerPath === (decoded + ext).toLowerCase()) {
+          return "exact";
+        }
+      }
+    }
+
+    try {
+      if (minimatch(path, decoded, { nocase: true })) {
+        return "glob";
+      }
+      for (const ext of assumedExts) {
+        if (minimatch(path, decoded + ext, { nocase: true })) {
+          return "glob";
+        }
       }
     } catch (e) {
       console.error(
         `Invalid glob pattern "${pattern}" for program "${path}": ${e}`,
       );
-      return undefined;
+      return "none";
     }
-    return ProgramMatchRank.Glob;
+    return "none";
+  }
+
+  // Prefer the bound group's include-extensions, but always keep the .pli/.pl1
+  // fallback so an entry still binds when the group declares none.
+  private assumedProgramExtensions(record: ProgramRecord): string[] {
+    const exts = new Set<string>();
+    const pgroup = this.processGroupConfigs.get(record.pgroup.value);
+    for (const item of pgroup?.includeExtensions ?? []) {
+      const value = item.value.toLowerCase();
+      exts.add(value.startsWith(".") ? value : `.${value}`);
+    }
+    for (const ext of DEFAULT_PROGRAM_EXTENSIONS) {
+      exts.add(ext);
+    }
+    return Array.from(exts);
   }
 
   /**
@@ -1168,6 +1248,25 @@ export class PluginConfigurationProvider {
    */
   public hasProgramConfig(program: URI): boolean {
     return this.getProgramConfig(program) !== undefined;
+  }
+
+  /**
+   * Lets the client trust an exact entry outright while still content-checking
+   * a mere glob match before reclassifying a file.
+   */
+  public classifyProgramMatch(program: URI): "exact" | "glob" | "none" {
+    const path = program.path;
+    let sawGlob = false;
+    for (const [pattern, config] of this.programConfigs.entries()) {
+      const kind = this.programMatchKind(path, pattern, config);
+      if (kind === "exact") {
+        return "exact";
+      }
+      if (kind === "glob") {
+        sawGlob = true;
+      }
+    }
+    return sawGlob ? "glob" : "none";
   }
 
   /**

--- a/packages/language/test/fourslash/preprocessor/include/program-match-assumed-include-extension.ts
+++ b/packages/language/test/fourslash/preprocessor/include/program-match-assumed-include-extension.ts
@@ -1,0 +1,50 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+// An extensionless entry assumes the bound process group's own
+// include-extensions (not just the .pli/.pl1 fallback). The "iba" group
+// declares ".cpy", so "KO/prog1" binds "KO/prog1.cpy" and its include resolves.
+/// <reference path="../../framework.ts" />
+
+// @filename: .pliplugin/pgm_conf.json
+//// {
+////   "pgms": [
+////     {
+////       "program": "KO/prog1",
+////       "pgroup": "iba"
+////     }
+////   ]
+//// }
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////             "name": "iba",
+////             "libs": [
+////                 "cpy"
+////             ],
+////             "include-extensions": [
+////                 ".cpy"
+////             ]
+////         }
+////     ]
+//// }
+
+// @filename: cpy/lib.cpy
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: KO/prog1.cpy
+//// %INCLUDE "lib";
+
+preprocessor.expectTokens(`
+  DECLARE LIB_VAR FIXED;
+`);

--- a/packages/language/test/fourslash/preprocessor/include/program-match-dataset-member-no-fabrication.ts
+++ b/packages/language/test/fourslash/preprocessor/include/program-match-dataset-member-no-fabrication.ts
@@ -1,0 +1,53 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+// A data-set member reference is concrete: no extension is ever fabricated for
+// it. "KO/ABC.AMD.PLLIB(MAIN)" therefore does NOT bind
+// "KO/ABC.AMD.PLLIB(MAIN).pli", so that file is unbound and its include cannot
+// resolve.
+/// <reference path="../../framework.ts" />
+
+// @filename: .pliplugin/pgm_conf.json
+//// {
+////   "pgms": [
+////     {
+////       "program": "KO/ABC.AMD.PLLIB(MAIN)",
+////       "pgroup": "iba"
+////     }
+////   ]
+//// }
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////             "name": "iba",
+////             "libs": [
+////                 "cpy"
+////             ],
+////             "include-extensions": [
+////                 ".pli"
+////             ]
+////         }
+////     ]
+//// }
+
+// @filename: cpy/lib.pli
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: KO/ABC.AMD.PLLIB(MAIN).pli
+//// %INCLUDE <|inc:"lib.pli"|>;
+
+preprocessor.expectTokens("");
+verify.expectDiagnosticsAt(
+  "inc",
+  code.LSP.IncludeResolution.MissingConfiguration,
+);

--- a/packages/language/test/fourslash/preprocessor/include/program-match-dataset-stem.ts
+++ b/packages/language/test/fourslash/preprocessor/include/program-match-dataset-stem.ts
@@ -1,0 +1,49 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+// A dotted, data-set-style stem ("KO/ABC.AMD.PLLIB") names a concrete target,
+// so it binds the file of that exact name and its include resolves.
+/// <reference path="../../framework.ts" />
+
+// @filename: .pliplugin/pgm_conf.json
+//// {
+////   "pgms": [
+////     {
+////       "program": "KO/ABC.AMD.PLLIB",
+////       "pgroup": "iba"
+////     }
+////   ]
+//// }
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////             "name": "iba",
+////             "libs": [
+////                 "cpy"
+////             ],
+////             "include-extensions": [
+////                 ".pli"
+////             ]
+////         }
+////     ]
+//// }
+
+// @filename: cpy/lib.pli
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: KO/ABC.AMD.PLLIB
+//// %INCLUDE "lib.pli";
+
+preprocessor.expectTokens(`
+  DECLARE LIB_VAR FIXED;
+`);

--- a/packages/language/test/fourslash/preprocessor/include/program-match-extensionless-stem-pl1.ts
+++ b/packages/language/test/fourslash/preprocessor/include/program-match-extensionless-stem-pl1.ts
@@ -1,0 +1,49 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+// The ".pl1" fallback extension is assumed for an extensionless entry too:
+// "KO/prog1" binds "KO/prog1.pl1", so its include resolves.
+/// <reference path="../../framework.ts" />
+
+// @filename: .pliplugin/pgm_conf.json
+//// {
+////   "pgms": [
+////     {
+////       "program": "KO/prog1",
+////       "pgroup": "iba"
+////     }
+////   ]
+//// }
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////             "name": "iba",
+////             "libs": [
+////                 "cpy"
+////             ],
+////             "include-extensions": [
+////                 ".pli"
+////             ]
+////         }
+////     ]
+//// }
+
+// @filename: cpy/lib.pli
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: KO/prog1.pl1
+//// %INCLUDE "lib.pli";
+
+preprocessor.expectTokens(`
+  DECLARE LIB_VAR FIXED;
+`);

--- a/packages/language/test/fourslash/preprocessor/include/program-match-extensionless-stem.ts
+++ b/packages/language/test/fourslash/preprocessor/include/program-match-extensionless-stem.ts
@@ -1,0 +1,50 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+// An extensionless program entry ("KO/prog1") binds the on-disk source file
+// via an assumed PL/I extension: "KO/prog1.pli" therefore picks up the "iba"
+// group's libs, so its include resolves.
+/// <reference path="../../framework.ts" />
+
+// @filename: .pliplugin/pgm_conf.json
+//// {
+////   "pgms": [
+////     {
+////       "program": "KO/prog1",
+////       "pgroup": "iba"
+////     }
+////   ]
+//// }
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////             "name": "iba",
+////             "libs": [
+////                 "cpy"
+////             ],
+////             "include-extensions": [
+////                 ".pli"
+////             ]
+////         }
+////     ]
+//// }
+
+// @filename: cpy/lib.pli
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: KO/prog1.pli
+//// %INCLUDE "lib.pli";
+
+preprocessor.expectTokens(`
+  DECLARE LIB_VAR FIXED;
+`);

--- a/packages/language/test/fourslash/preprocessor/include/program-match-extensionless-wrong-ext.ts
+++ b/packages/language/test/fourslash/preprocessor/include/program-match-extensionless-wrong-ext.ts
@@ -1,0 +1,54 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+// An extensionless entry ("KO/prog1") only assumes PL/I source extensions, so
+// an unrelated ".cbl" file is NOT bound: with no program config, its include
+// cannot resolve and reports the missing-configuration diagnostic.
+/// <reference path="../../framework.ts" />
+
+// @filename: .pliplugin/pgm_conf.json
+//// {
+////   "pgms": [
+////     {
+////       "program": "KO/prog1",
+////       "pgroup": "iba"
+////     }
+////   ]
+//// }
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////             "name": "iba",
+////             "libs": [
+////                 "cpy"
+////             ],
+////             "include-extensions": [
+////                 ".pli"
+////             ]
+////         }
+////     ]
+//// }
+
+// @filename: cpy/lib.pli
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: KO/prog1.cbl
+//// %INCLUDE <|inc:"lib.pli"|>;
+
+// The ".cbl" file matches no program entry, so the unit is unbound and the
+// include cannot be resolved.
+preprocessor.expectTokens("");
+verify.expectDiagnosticsAt(
+  "inc",
+  code.LSP.IncludeResolution.MissingConfiguration,
+);

--- a/packages/language/test/fourslash/preprocessor/include/program-match-recursive-extensionless-direct.ts
+++ b/packages/language/test/fourslash/preprocessor/include/program-match-recursive-extensionless-direct.ts
@@ -1,0 +1,50 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+// A recursive "KO/**/*" glob also covers an extensionless file directly under
+// KO ("**" matches zero path segments). "KO/FOO" therefore binds to the "iba"
+// group, so its include resolves.
+/// <reference path="../../framework.ts" />
+
+// @filename: .pliplugin/pgm_conf.json
+//// {
+////   "pgms": [
+////     {
+////       "program": "KO/**/*",
+////       "pgroup": "iba"
+////     }
+////   ]
+//// }
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////             "name": "iba",
+////             "libs": [
+////                 "cpy"
+////             ],
+////             "include-extensions": [
+////                 ".pli"
+////             ]
+////         }
+////     ]
+//// }
+
+// @filename: cpy/lib.pli
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: KO/FOO
+//// %INCLUDE "lib.pli";
+
+preprocessor.expectTokens(`
+  DECLARE LIB_VAR FIXED;
+`);

--- a/packages/language/test/fourslash/preprocessor/include/program-match-recursive-extensionless.ts
+++ b/packages/language/test/fourslash/preprocessor/include/program-match-recursive-extensionless.ts
@@ -1,0 +1,50 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+// A recursive "KO/**/*" glob binds files regardless of extension, including
+// mainframe-style members with no extension. A nested "KO/sub/MEMBER"
+// therefore picks up the "iba" group's libs, so its include resolves.
+/// <reference path="../../framework.ts" />
+
+// @filename: .pliplugin/pgm_conf.json
+//// {
+////   "pgms": [
+////     {
+////       "program": "KO/**/*",
+////       "pgroup": "iba"
+////     }
+////   ]
+//// }
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////             "name": "iba",
+////             "libs": [
+////                 "cpy"
+////             ],
+////             "include-extensions": [
+////                 ".pli"
+////             ]
+////         }
+////     ]
+//// }
+
+// @filename: cpy/lib.pli
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: KO/sub/MEMBER
+//// %INCLUDE "lib.pli";
+
+preprocessor.expectTokens(`
+  DECLARE LIB_VAR FIXED;
+`);

--- a/packages/language/test/fourslash/preprocessor/include/program-match-recursive-outside.ts
+++ b/packages/language/test/fourslash/preprocessor/include/program-match-recursive-outside.ts
@@ -1,0 +1,52 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+// A recursive "KO/**/*" glob is scoped to the KO directory: a file elsewhere
+// ("other/x.pli") is NOT bound, so the unit has no configuration and its
+// include cannot resolve.
+/// <reference path="../../framework.ts" />
+
+// @filename: .pliplugin/pgm_conf.json
+//// {
+////   "pgms": [
+////     {
+////       "program": "KO/**/*",
+////       "pgroup": "iba"
+////     }
+////   ]
+//// }
+
+// @filename: .pliplugin/proc_grps.json
+//// {
+////     "pgroups": [
+////         {
+////             "name": "iba",
+////             "libs": [
+////                 "cpy"
+////             ],
+////             "include-extensions": [
+////                 ".pli"
+////             ]
+////         }
+////     ]
+//// }
+
+// @filename: cpy/lib.pli
+//// DECLARE LIB_VAR FIXED;
+
+// @filename: other/x.pli
+//// %INCLUDE <|inc:"lib.pli"|>;
+
+preprocessor.expectTokens("");
+verify.expectDiagnosticsAt(
+  "inc",
+  code.LSP.IncludeResolution.MissingConfiguration,
+);

--- a/packages/language/test/lsp/get-prog-config.test.ts
+++ b/packages/language/test/lsp/get-prog-config.test.ts
@@ -80,3 +80,54 @@ describe("Check if `getProgramConfig` inside `PluginConfigurationProvider` retri
       expect(config).toBeDefined();
     }));
 });
+
+describe("classifyProgramMatch distinguishes exact from glob matches", () => {
+  test("returns 'exact' for a specifically-named program entry", () => {
+    const cfg = setupConfig([{ program: "KO/main.pli", pgroup: "iba" }]);
+    expect(
+      cfg.classifyProgramMatch(UriUtils.toUri("/workspace/KO/main.pli")),
+    ).toBe("exact");
+  });
+
+  test("returns 'exact' for a specifically-named extensionless entry", () => {
+    const cfg = setupConfig([{ program: "KO/MAINPGM", pgroup: "iba" }]);
+    expect(
+      cfg.classifyProgramMatch(UriUtils.toUri("/workspace/KO/MAINPGM")),
+    ).toBe("exact");
+  });
+
+  test("returns 'exact' for an extensionless stem resolved via an assumed extension", () => {
+    const cfg = setupConfig([{ program: "KO/prog1", pgroup: "iba" }]);
+    expect(
+      cfg.classifyProgramMatch(UriUtils.toUri("/workspace/KO/prog1.pli")),
+    ).toBe("exact");
+  });
+
+  test("returns 'glob' when only a wildcard entry matches", () => {
+    const cfg = setupConfig([
+      { program: ["KO", "**", "*"].join("/"), pgroup: "iba" },
+    ]);
+    expect(
+      cfg.classifyProgramMatch(UriUtils.toUri("/workspace/KO/sub/README")),
+    ).toBe("glob");
+  });
+
+  test("prefers 'exact' when both an exact and a glob entry match", () => {
+    const cfg = setupConfig([
+      { program: ["KO", "**", "*"].join("/"), pgroup: "iba" },
+      { program: "KO/sub/main.pli", pgroup: "iba" },
+    ]);
+    expect(
+      cfg.classifyProgramMatch(UriUtils.toUri("/workspace/KO/sub/main.pli")),
+    ).toBe("exact");
+  });
+
+  test("returns 'none' when nothing matches", () => {
+    const cfg = setupConfig([
+      { program: ["KO", "**", "*"].join("/"), pgroup: "iba" },
+    ]);
+    expect(
+      cfg.classifyProgramMatch(UriUtils.toUri("/workspace/other/x.pli")),
+    ).toBe("none");
+  });
+});

--- a/packages/vscode-extension/src/extension/document-identification.ts
+++ b/packages/vscode-extension/src/extension/document-identification.ts
@@ -44,13 +44,16 @@ async function checkFileType(
     // Only attempt to identify PL/I documents that are currently marked as plaintext
     return;
   }
-  if (
-    // Assert that this can even be a PL/I document
-    // (and isn't something else, like a .git file or a listing file)
-    !isNotPliDocument(document) &&
-    // Check that it likely is a PL/I document
-    (await isPossiblePliDocument(document, lc))
-  ) {
+  if (isNotPliDocument(document)) {
+    // Never reclassify obvious non-PL/I files, even if a broad glob matches.
+    return;
+  }
+  const programMatch = await classifyProgramConfig(document, lc);
+  if (programMatch === "exact") {
+    vscode.languages.setTextDocumentLanguage(document, "pli");
+    return;
+  }
+  if (await isPossiblePliDocument(document, lc)) {
     proposePliLanguage(proposedFiles, document);
   }
 }
@@ -85,6 +88,22 @@ function isNotPliDocument(document: vscode.TextDocument): boolean {
     return true;
   }
   return false;
+}
+
+/** Fails safe to "none" so the caller falls back to heuristic detection. */
+async function classifyProgramConfig(
+  document: vscode.TextDocument,
+  lc: BaseLanguageClient,
+): Promise<Messages.ProgramConfigMatchKind> {
+  try {
+    return await sendRequest(
+      lc,
+      Messages.MatchesProgramConfig,
+      document.uri.toString(),
+    );
+  } catch {
+    return "none";
+  }
 }
 
 async function isPossiblePliDocument(

--- a/packages/vscode-extension/src/extension/document-identification.ts
+++ b/packages/vscode-extension/src/extension/document-identification.ts
@@ -48,12 +48,12 @@ async function checkFileType(
     // Never reclassify obvious non-PL/I files, even if a broad glob matches.
     return;
   }
-  const programMatch = await classifyProgramConfig(document, lc);
-  if (programMatch === "exact") {
+  const identity = await identifyFile(document, lc);
+  if (identity.programMatch === "exact") {
     vscode.languages.setTextDocumentLanguage(document, "pli");
     return;
   }
-  if (await isPossiblePliDocument(document, lc)) {
+  if (isPossiblePliDocument(document, identity.existing)) {
     proposePliLanguage(proposedFiles, document);
   }
 }
@@ -90,44 +90,34 @@ function isNotPliDocument(document: vscode.TextDocument): boolean {
   return false;
 }
 
-/** Fails safe to "none" so the caller falls back to heuristic detection. */
-async function classifyProgramConfig(
+async function identifyFile(
   document: vscode.TextDocument,
   lc: BaseLanguageClient,
-): Promise<Messages.ProgramConfigMatchKind> {
+): Promise<Messages.FileIdentification> {
   try {
     return await sendRequest(
       lc,
-      Messages.MatchesProgramConfig,
+      Messages.ExistingFile,
       document.uri.toString(),
     );
   } catch {
-    return "none";
+    return { existing: false, programMatch: "none" };
   }
 }
 
-async function isPossiblePliDocument(
+function isPossiblePliDocument(
   document: vscode.TextDocument,
-  lc: BaseLanguageClient,
-): Promise<boolean> {
+  existing: boolean,
+): boolean {
   // Try to do a simple check based on file extension first.
   const ext = UriUtils.extname(document.uri).toLowerCase();
   const possibleExt = ["pli", "pl1", "pl", "p1"];
   if (ext && possibleExt.includes(ext)) {
     return true;
   }
-  // If the file extension doesn't give it away, ask the language server if it recognizes the file.
-  try {
-    const exists = await sendRequest(
-      lc,
-      Messages.ExistingFile,
-      document.uri.toString(),
-    );
-    if (exists) {
-      return true;
-    }
-  } catch {
-    // Ignore errors, we'll just do a heuristic check below.
+  // Already a known compilation unit.
+  if (existing) {
+    return true;
   }
   // Then, look for PL/I specific constellations in the first 200 lines of the document.
   const text = document.getText(


### PR DESCRIPTION
Solves #799

`pgm_conf.json` entries that use a wildcard or omit a file extension now
correctly bind their on-disk files as PL/I program entry points.

## What changed

- **Extensionless entries bind the real file.** An entry like `KO/PROG1` now
  matches `KO/PROG1.pli` / `.pl1` (and any extension the bound process group
  declares via `include-extensions`), so a program listed without an extension
  still resolves.
- **Wildcards cover extensionless members.** A recursive glob such as
  `KO/lib/**/*` picks up mainframe-style members that have no extension.
- **Client language identification.** The extension can now identify a
  configured file as PL/I even when VS Code opens it as `plaintext`. An
  **exact** program entry is trusted and the language is set silently; anything
  else — including broad **glob** matches — defers to the existing content
  heuristic and the one-time *"set language to PL/I?"* prompt (gated by
  `pli.autoDetect`), so a broad glob can never silently mislabel a non-PL/I file.
- **Unified identification request.** Following review feedback, the separate
  `pli/matchesProgramConfig` request was merged into `pli/existingFile`, which now
  returns `{ existing, programMatch }` in a single round-trip. The matcher
  classifies each candidate as `exact` / `glob` / `none`, and an exact match always
  wins over a glob (extensionless stems that resolve via an assumed extension still
  count as exact).