### PR TITLE
Fix remaining CICS bug findings

### DIFF
--- a/packages/preprocessor-cics/src/checks/check-converse-options.ts
+++ b/packages/preprocessor-cics/src/checks/check-converse-options.ts
@@ -88,11 +88,9 @@ export class ConverseOptionsChecker extends CICSOptionsCheckerBase {
 
     if (ctx.CTLCHAR().length !== 0) {
       this.checkHasIllegalOptions(ctx.CONVID(), "CONVID");
-      this.checkHasIllegalOptions(ctx.STRFIELD(), "STRFIELD");
     }
 
     if (ctx.cics_converse_erase().length !== 0) {
-      this.checkHasIllegalOptions(ctx.STRFIELD(), "STRFIELD");
       ctx.cics_converse_erase().forEach((eraseCtx) => {
         this.checkMutuallyExclusiveOptions(
           "ALTERNATE or DEFAULT",
@@ -100,10 +98,18 @@ export class ConverseOptionsChecker extends CICSOptionsCheckerBase {
           eraseCtx.DEFAULT(),
         );
       });
+      this.checkMutuallyExclusiveOptions(
+        "ERASE or STRFIELD",
+        ctx.STRFIELD(),
+        ctx.cics_converse_erase()?.[0].ERASE(),
+      );
     }
-    if (ctx.STRFIELD().length !== 0) {
-      this.checkHasIllegalOptions(ctx.cics_converse_erase(), "ERASE");
-    }
+    this.checkMutuallyExclusiveOptions(
+      "CTLCHAR or STRFIELD",
+      ctx.STRFIELD(),
+      ctx.CTLCHAR(),
+    );
+
     if (this.noLengthOptionsEnabled()) {
       this.checkHasMandatoryOptions(
         ctx.cics_converse_fromlength(),

--- a/packages/preprocessor-cics/src/engine/collect-semantic-errors.ts
+++ b/packages/preprocessor-cics/src/engine/collect-semantic-errors.ts
@@ -56,11 +56,10 @@ export class CollectingSemanticErrorVisitor extends CICSParserVisitor<
     );
     for (const group of Object.values(groups)) {
       if (group && group.length > 0) {
+        const deduplicated = new Set(group.map((e) => e.enumerablePart));
         nonAggregatableErrors.push({
           code: group[0].code,
-          message:
-            group[0].commonMessage +
-            orify(group.map((e) => e.enumerablePart).sort()),
+          message: group[0].commonMessage + orify([...deduplicated].sort()),
           severity: group[0].severity,
           startOffset: group[0].startOffset,
           endOffset: group[0].endOffset,

--- a/packages/preprocessor-cics/test/converse.test.ts
+++ b/packages/preprocessor-cics/test/converse.test.ts
@@ -23,6 +23,26 @@ describe("CICS CONVERSE", () => {
     expect(diagnostics).toHaveLength(0);
   });
 
+  test("Conflicting ERASE and STRFIELD", () => {
+    const { diagnostics } = cicsPreprocessor.parse("CONVERSE ERASE STRFIELD");
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].severity).toBe(Severity.Error);
+    expect(diagnostics[0].message).toMatch(
+      /Options \"ERASE or STRFIELD\" are mutually exclusive./,
+    );
+  });
+
+  test("Conflicting CTLCHAR and STRFIELD", () => {
+    const { diagnostics } = cicsPreprocessor.parse(
+      "CONVERSE CTLCHAR(1) STRFIELD",
+    );
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].severity).toBe(Severity.Error);
+    expect(diagnostics[0].message).toMatch(
+      /Options \"CTLCHAR or STRFIELD\" are mutually exclusive./,
+    );
+  });
+
   test("Conflicting ALTERNATE and DEFAULT", () => {
     const { diagnostics } = cicsPreprocessor.parse(
       "CONVERSE ALTERNATE DEFAULT",


### PR DESCRIPTION
STRFIELD is conflicting with ERASE and CTLCHAR.
This PR takes care of a better error message.

Also error aggregating was improved by removing duplicates.