### PR TITLE
Fix low-hanging performance issues

### DIFF
--- a/packages/language/src/language-server/document-symbol-request.ts
+++ b/packages/language/src/language-server/document-symbol-request.ts
@@ -32,22 +32,38 @@ export function documentSymbolRequest(
     return [];
   }
 
-  const tokens = fileTokens
-    .filter((token) => token.element && isValidToken(token))
-    .map((token) => {
-      const element = token.element!;
-      if (!tokensByElement.has(element)) {
-        tokensByElement.set(element, []);
-      }
-      tokensByElement.get(element)?.push(token);
-      return token;
-    });
+  // First pass: find the tokens a builder can actually turn into a symbol,
+  // and remember their elements. Only those elements need a token index -
+  // indexing everything beyond that is quite expensive and unnecessary.
+  type Builder = (typeof DOCUMENT_SYMBOL_BUILDERS)[number];
+  const handledTokens: { token: Token; builder: Builder }[] = [];
+  const usedElements = new Set<SyntaxNode>();
+  for (const token of fileTokens) {
+    if (!token.element || !isValidToken(token)) {
+      continue;
+    }
+    const builder = DOCUMENT_SYMBOL_BUILDERS.find((b) => b.canHandle(token));
+    if (builder) {
+      handledTokens.push({ token, builder });
+      usedElements.add(token.element);
+    }
+  }
+
+  // Second pass: collect the tokens of just those elements.
+  for (const token of fileTokens) {
+    const element = token.element;
+    if (!element || !usedElements.has(element) || !isValidToken(token)) {
+      continue;
+    }
+    let elementTokens = tokensByElement.get(element);
+    if (!elementTokens) {
+      tokensByElement.set(element, (elementTokens = []));
+    }
+    elementTokens.push(token);
+  }
 
   let hierarchy: DocumentSymbol[] = [];
-  for (const token of tokens) {
-    const builder = DOCUMENT_SYMBOL_BUILDERS.find((b) => b.canHandle(token));
-    if (!builder) continue;
-
+  for (const { token, builder } of handledTokens) {
     const symbols = builder.buildSymbols(
       token,
       tokensByElement.get(token.element!)!,

--- a/packages/language/src/linking/qualified-syntax-node.ts
+++ b/packages/language/src/linking/qualified-syntax-node.ts
@@ -35,8 +35,6 @@ export class QualifiedSyntaxNode {
    */
   public isRedeclared: boolean | undefined = undefined;
 
-  private _id: string | null = null;
-
   private constructor(
     public readonly token: Token,
     public readonly node: SyntaxNode,
@@ -94,26 +92,21 @@ export class QualifiedSyntaxNode {
   }
 
   getId(): string {
-    // Computing the ID is somewhat expensive, cache the result
-    if (this._id !== null) {
-      return this._id;
-    }
-    const parts: string[] = [];
-    // Ensure that implicit and explicit declarations get different IDs
-    // Some declarations (mainly parameters) are first implicitly declared
-    // and then augmented to be explicit declarations
-    if (this.isImplicit) {
-      parts.push("implicit");
-    }
+    // FYI: We used to cache this ID - but it's actually only used once per node, so caching is not necessary.
+    let id = this.isImplicit
+      ? // Ensure that implicit and explicit declarations get different IDs
+        // Some declarations (mainly parameters) are first implicitly declared
+        // and then augmented to be explicit declarations
+        "implicit"
+      : "";
     let current: QualifiedSyntaxNode | null = this;
     while (current) {
       // The ID of the token uniquely identifies the node in the source code
       // It can sometimes be undefined, still push something to avoid collisions
-      parts.push(current.token.id?.toString() || "NaN");
+      id += "_" + (current.token.id ?? "NaN");
       current = current.parent;
     }
-    this._id = parts.join("_");
-    return this._id;
+    return id;
   }
 
   /**

--- a/packages/language/src/linking/resolver.ts
+++ b/packages/language/src/linking/resolver.ts
@@ -22,6 +22,7 @@ import {
   Reference,
   ReferenceItem,
   ReferenceType,
+  Statement,
   SyntaxKind,
   SyntaxNode,
 } from "../syntax-tree/ast";
@@ -43,9 +44,9 @@ import {
   reiterateSymbols,
 } from "./symbol-table";
 import { DiagnosticCategory } from "../validation/diagnostics-store";
-import { MultiMap } from "../utils/collections";
+import { largePush, MultiMap } from "../utils/collections";
 
-function getParentStatement(node: SyntaxNode): SyntaxNode {
+function getParentStatement(node: SyntaxNode): Statement {
   if (node.container?.kind === SyntaxKind.Statement) {
     return node.container;
   }
@@ -69,19 +70,18 @@ function getParentStatement(node: SyntaxNode): SyntaxNode {
  */
 export class StatementOrderCache {
   private id: number = 0;
-  private map = new Map<SyntaxNode, number>();
 
-  add(node: SyntaxNode) {
-    this.map.set(node, this.id++);
+  add(node: Statement) {
+    node.statementOrder = this.id++;
   }
 
-  get(node: SyntaxNode) {
-    return this.map.get(node);
+  get(node: Statement) {
+    const order = node.statementOrder;
+    return order < 0 ? undefined : order;
   }
 
   clear(): void {
     this.id = 0;
-    this.map.clear();
   }
 
   /**
@@ -130,7 +130,7 @@ export class ReferencesCache {
   }
 
   addAll(references: Reference[]): void {
-    this.list.push(...references);
+    largePush(this.list, references);
   }
 
   addInverse(reference: Reference): void {
@@ -210,7 +210,9 @@ function assignQualifiedReference(
   }
 
   reference.node = resolved.node;
-  if (matchingSymbols) {
+  if (matchingSymbols && matchingSymbols.length > 1) {
+    // Only allocate the array if there is actually more than one matching symbol.
+    // Otherwise, "node" will be used for all purposes.
     reference.nodes = matchingSymbols.map((symbol) => symbol.node);
   }
 
@@ -239,7 +241,7 @@ function assignReference(
     );
   } else {
     reference.node = resolved.node;
-    if (matchingSymbols) {
+    if (matchingSymbols && matchingSymbols.length > 1) {
       reference.nodes = matchingSymbols.map((symbol) => symbol.node);
     }
   }

--- a/packages/language/src/linking/symbol-table.ts
+++ b/packages/language/src/linking/symbol-table.ts
@@ -24,7 +24,6 @@ import {
   TypeExtendingAttribute,
 } from "../syntax-tree/ast";
 import { forEachNode } from "../syntax-tree/ast-iterator";
-import { groupBy } from "../utils/common";
 import { CompilationUnit } from "../workspace/compilation-unit";
 import { ReferencesCache, StatementOrderCache } from "./resolver";
 import { getReference } from "./tokens";
@@ -49,9 +48,17 @@ import { getFirstStructureVariable } from "../syntax-tree/ast-utils";
 
 export class SymbolTable {
   symbols: MultiMap<string, QualifiedSyntaxNode> = new MultiMap();
-  typeSymbols: MultiMap<string, QualifiedSyntaxNode> = new MultiMap();
-  nodeLookup: Map<SyntaxNode, QualifiedSyntaxNode> = new Map();
+  /**
+   * Lazily allocated: type symbols (`DEFINE ALIAS`/`STRUCTURE`/`ORDINAL`) are
+   * rare, and one scope exists per procedure - eagerly allocating an always
+   * empty map per scope wastes memory on large files.
+   */
+  private _typeSymbols?: MultiMap<string, QualifiedSyntaxNode>;
   existingNodes = new Set<string>();
+
+  get typeSymbols(): MultiMap<string, QualifiedSyntaxNode> {
+    return (this._typeSymbols ??= new MultiMap());
+  }
 
   addImplicitDeclaration(
     text: string,
@@ -167,7 +174,6 @@ export class SymbolTable {
 
   addTypeDeclaration(name: string, node: QualifiedSyntaxNode): void {
     this.typeSymbols.add(name, node);
-    this.nodeLookup.set(node.node, node);
   }
 
   addSymbolDeclaration(name: string, node: QualifiedSyntaxNode): void {
@@ -181,7 +187,6 @@ export class SymbolTable {
     }
     this.existingNodes.add(id);
     this.symbols.add(name, node);
-    this.nodeLookup.set(node.node, node);
   }
 
   allDistinctSymbols(qualifiedName: string[]): QualifiedSyntaxNode[] {
@@ -189,7 +194,10 @@ export class SymbolTable {
   }
 
   allDistinctTypeSymbols(qualifiedName: string[]): QualifiedSyntaxNode[] {
-    return this.distinctMapSymbols(this.typeSymbols, qualifiedName);
+    if (!this._typeSymbols) {
+      return [];
+    }
+    return this.distinctMapSymbols(this._typeSymbols, qualifiedName);
   }
 
   private distinctMapSymbols(
@@ -238,64 +246,79 @@ export class SymbolTable {
     qualifiedName: readonly string[],
   ): readonly QualifiedSyntaxNode[] | undefined {
     const [name] = qualifiedName;
-    if (!name) {
+    if (!name || !this._typeSymbols) {
       return undefined;
     }
-    const symbols = this.typeSymbols.get(name);
+    const symbols = this._typeSymbols.get(name);
+    if (symbols.length === 0) {
+      return undefined;
+    }
     return getQualifiedSymbols(qualifiedName, symbols);
   }
 
   getExplicitSymbols(
     qualifiedName: readonly string[],
   ): readonly QualifiedSyntaxNode[] | undefined {
-    const [name] = qualifiedName;
-    if (!name) {
-      return undefined;
-    }
-    const symbols = this.symbols
-      .get(name)
-      .filter((symbol) => !symbol.isImplicit);
-
-    return getQualifiedSymbols(qualifiedName, symbols);
+    return this.getSymbolsByKind(qualifiedName, false);
   }
 
   getImplicitSymbols(
     qualifiedName: readonly string[],
   ): readonly QualifiedSyntaxNode[] | undefined {
+    return this.getSymbolsByKind(qualifiedName, true);
+  }
+
+  /**
+   * This sits on the reference-resolution hot path and misses are the common
+   * case (every lookup walks the scope chain to the root) - so the miss path
+   * and the "nothing filtered out" path are kept allocation-free.
+   */
+  private getSymbolsByKind(
+    qualifiedName: readonly string[],
+    implicit: boolean,
+  ): readonly QualifiedSyntaxNode[] | undefined {
     const [name] = qualifiedName;
     if (!name) {
       return undefined;
     }
-
-    const symbols = this.symbols
-      .get(name)
-      .filter((symbol) => symbol.isImplicit);
-
+    const all = this.symbols.get(name);
+    let matching = 0;
+    for (const symbol of all) {
+      if (symbol.isImplicit === implicit) {
+        matching++;
+      }
+    }
+    if (matching === 0) {
+      return undefined;
+    }
+    const symbols =
+      matching === all.length
+        ? all
+        : all.filter((symbol) => symbol.isImplicit === implicit);
     return getQualifiedSymbols(qualifiedName, symbols);
   }
 }
 
-// Return all qualified symbols
+// Return all qualified symbols, preferring full over partial qualification.
+// Single pass without intermediate group objects - this runs once per scope
+// level for every reference in the file.
 function getQualifiedSymbols(
   qualifiedName: readonly string[],
   symbols: readonly QualifiedSyntaxNode[],
 ): readonly QualifiedSyntaxNode[] | undefined {
-  const qualifiedSymbols = groupBy(symbols, (symbol) =>
-    symbol.getQualificationStatus(qualifiedName),
-  );
-
-  const fullQualification =
-    qualifiedSymbols[QualificationStatus.FullQualification];
-  const partialQualification =
-    qualifiedSymbols[QualificationStatus.PartialQualification];
-
-  if (fullQualification) {
-    return fullQualification;
-  } else if (partialQualification) {
-    return partialQualification;
-  } else {
-    return undefined;
+  let fullQualification: QualifiedSyntaxNode[] | undefined;
+  let partialQualification: QualifiedSyntaxNode[] | undefined;
+  for (const symbol of symbols) {
+    switch (symbol.getQualificationStatus(qualifiedName)) {
+      case QualificationStatus.FullQualification:
+        (fullQualification ??= []).push(symbol);
+        break;
+      case QualificationStatus.PartialQualification:
+        (partialQualification ??= []).push(symbol);
+        break;
+    }
   }
+  return fullQualification ?? partialQualification;
 }
 
 function redeclarationPriority(kind: SyntaxKind): number {
@@ -498,16 +521,15 @@ function handleProcedureStatement(
   context: IterateSymbolTableContext,
 ) {
   const scope = Scope.createChild(parentScope);
-  const newNode: ProcedureStatement | Package = {
-    ...node,
-    end: null,
-  };
 
   context.scopeCache.add(node, scope);
 
-  forEachNode(newNode, (child) =>
-    iterateSymbolTable(child, scope, context, false),
-  );
+  // Iterate all children except the end node (handled below with the parent scope)
+  forEachNode(node, (child) => {
+    if (child !== node.end) {
+      iterateSymbolTable(child, scope, context, false);
+    }
+  });
   if (node.end) {
     // Iterate the end node with a separate scope
     iterateSymbolTable(node.end, parentScope, context, false);

--- a/packages/language/src/parser/parser-state.ts
+++ b/packages/language/src/parser/parser-state.ts
@@ -48,6 +48,12 @@ export enum RecoveryResult {
 
 export type RecoveryFunction = () => RecoveryResult;
 
+const NOOP_LOOP_CONTEXT = {
+  inc: () => {
+    /* nothing to do */
+  },
+};
+
 export class ParserState {
   readonly tokens: t.Token[];
   readonly diagnostics: Diagnostic[];
@@ -78,11 +84,10 @@ export class ParserState {
         },
       };
     }
-    return {
-      inc: () => {
-        /* nothing to do */
-      },
-    };
+    // Outside of debugging this is a no-op, and createLoopContext is called
+    // several times per parsed statement - return a shared instance instead of
+    // allocating a fresh closure each time.
+    return NOOP_LOOP_CONTEXT;
   }
 
   enterProcedure(): void {

--- a/packages/language/src/parser/parser.ts
+++ b/packages/language/src/parser/parser.ts
@@ -657,7 +657,7 @@ const statement = rule(
     while (performLabelPrefixLookahead(state)) {
       inc();
       const label = labelPrefix.rule(state);
-      label && element.labels.push(label);
+      label && (element.labels = ast.appendList(element.labels, label));
     }
 
     // Store labels in state so compound statements can access them
@@ -998,7 +998,7 @@ const assignmentStatement = rule(
 
     // Parse left-hand side references (comma-separated)
     const lhs = locatorCall.rule(state);
-    lhs && element.refs.push(lhs);
+    lhs && (element.refs = ast.appendList(element.refs, lhs));
     const { inc } = state.createLoopContext("AssignmentStatement");
     while (
       state.tryConsume(
@@ -1009,7 +1009,7 @@ const assignmentStatement = rule(
     ) {
       inc();
       const rhs = locatorCall.rule(state);
-      rhs && element.refs.push(rhs);
+      rhs && (element.refs = ast.appendList(element.refs, rhs));
     }
 
     // Parse assignment operator
@@ -5598,7 +5598,8 @@ const dimensions = rule(
     // Optional dimension bounds
     if (state.canConsumeFirst(dimensionBound.first())) {
       let current = dimensionBound.rule(state, ast.ReferenceType.Variable);
-      current && element.dimensions.push(current);
+      current &&
+        (element.dimensions = ast.appendList(element.dimensions, current));
       const { inc } = state.createLoopContext("Dimensions");
       while (
         (endToken = state.tryConsume(
@@ -5611,7 +5612,8 @@ const dimensions = rule(
         applyBoundsTokens(current);
         startToken = endToken;
         current = dimensionBound.rule(state, ast.ReferenceType.Variable);
-        current && element.dimensions.push(current);
+        current &&
+          (element.dimensions = ast.appendList(element.dimensions, current));
       }
     }
 
@@ -5656,7 +5658,8 @@ const dimensionsWithTypes = rule(
         state,
         ast.ReferenceType.TypeOrVariable,
       );
-      current && element.dimensions.push(current);
+      current &&
+        (element.dimensions = ast.appendList(element.dimensions, current));
       const { inc } = state.createLoopContext("DimensionsWithTypes");
       while (
         (endToken = state.tryConsume(
@@ -5669,7 +5672,8 @@ const dimensionsWithTypes = rule(
         applyBoundsTokens(current);
         startToken = endToken;
         current = dimensionBound.rule(state, ast.ReferenceType.TypeOrVariable);
-        current && element.dimensions.push(current);
+        current &&
+          (element.dimensions = ast.appendList(element.dimensions, current));
       }
     }
 
@@ -6243,11 +6247,11 @@ const referenceItem = rule(
       if (withoutType) {
         // "Normal" dimensions, that simply target variables in their references
         const dim = dimensions.rule(state);
-        dim && element.dimensions.push(dim);
+        dim && (element.dimensions = ast.appendList(element.dimensions, dim));
       } else if (withType) {
         // Dimensions that can also target types in their references
         const dim = dimensionsWithTypes.rule(state);
-        dim && element.dimensions.push(dim);
+        dim && (element.dimensions = ast.appendList(element.dimensions, dim));
       }
     }
     return element;
@@ -6258,15 +6262,23 @@ const expression = rule(
   () => primaryExpression.first(),
   (state: ParserState, params?: ExpressionParameter): ast.Expression | null => {
     params ??= {};
+
+    // Parse first primary expression
+    const lhs = primaryExpression.rule(state, params);
+    if (!state.canConsume(tokens.BinaryOperator)) {
+      // Fast path for the overwhelmingly common single-primary expression:
+      // no operator follows, so skip the IntermediateBinaryExpression
+      // scaffolding entirely (matches constructBinaryExpression's unwrapping
+      // of empty/one-item inputs).
+      return lhs;
+    }
+
     const element: IntermediateBinaryExpression = {
       infix: true,
       items: [],
       operators: [],
       operatorTokens: [],
     };
-
-    // Parse first primary expression
-    const lhs = primaryExpression.rule(state, params);
     lhs && element.items.push(lhs);
 
     // Parse zero or more operator-expression pairs

--- a/packages/language/src/parser/preprocessor-parser.ts
+++ b/packages/language/src/parser/preprocessor-parser.ts
@@ -1271,7 +1271,10 @@ function parseReferenceItem(
   );
   if (withDimensions) {
     while (state.canConsume(t.OpenParen)) {
-      reference.dimensions.push(dimensions(state));
+      reference.dimensions = ast.appendList(
+        reference.dimensions,
+        dimensions(state),
+      );
     }
   }
   return reference;
@@ -1373,7 +1376,7 @@ function noprintDirective(state: ParserState): ast.NoPrintDirective {
 
 function assignmentStatement(state: ParserState): ast.AssignmentStatement {
   const assignment = ast.createAssignmentStatement();
-  assignment.refs.push(locatorCall(state, true));
+  assignment.refs = [locatorCall(state, true)];
   const operatorToken = state.consume(
     assignment,
     CstNodeKind.AssignmentStatement_Operator,
@@ -1524,7 +1527,7 @@ function dimensions(state: ParserState): ast.Dimensions {
   }
   let startToken = dimensions.token;
   let endtoken: t.Token | null = null;
-  dimensions.dimensions.push(parseBound(state));
+  dimensions.dimensions = [parseBound(state)];
   while (
     (endtoken = state.tryConsume(
       dimensions,

--- a/packages/language/src/parser/tokens/shared.ts
+++ b/packages/language/src/parser/tokens/shared.ts
@@ -61,6 +61,21 @@ export interface Token {
    */
   ppSemanticType?: SemanticTokenTypes;
 }
+// Token instances exist by the millions on large files, so every in-object
+// field is ~8 bytes per token times the token count. The four booleans and the
+// small `ppSemanticType` enum are therefore packed into a single `flags` number
+// behind prototype accessors. This also keeps the hidden class stable when
+// `synthetic`/`ppSemanticType` are assigned after construction - as own fields
+// added late they would force every such token into an out-of-object property
+// store.
+const FLAG_INSERTED_IN_RECOVERY = 1 << 0;
+const FLAG_IMMEDIATE_FOLLOW = 1 << 1;
+const FLAG_STARTS_NEW_LINE = 1 << 2;
+const FLAG_SYNTHETIC = 1 << 3;
+/** Bits above the boolean flags hold `ppSemanticType + 1` (0 = unset). */
+const PP_SEMANTIC_TYPE_SHIFT = 4;
+const PP_SEMANTIC_TYPE_MASK = (1 << PP_SEMANTIC_TYPE_SHIFT) - 1;
+
 class TokenImpl implements Token {
   image: string;
   originalImage: string;
@@ -68,13 +83,11 @@ class TokenImpl implements Token {
   startOffset: number;
   endOffset: number;
   tokenTypeIdx: number;
-  isInsertedInRecovery: boolean;
   tokenType: TokenType;
   uri: URI | undefined;
   kind: CstNodeKind | undefined;
   element: ast.SyntaxNode | undefined;
-  immediateFollow: boolean;
-  startsNewLine: boolean;
+  private flags: number;
   constructor(
     image: string,
     originalImage: string,
@@ -95,10 +108,78 @@ class TokenImpl implements Token {
     this.uri = uri;
     this.kind = undefined;
     this.element = undefined;
-    this.isInsertedInRecovery = false;
-    this.immediateFollow = false;
-    this.startsNewLine = startsNewLine;
+    this.flags = startsNewLine ? FLAG_STARTS_NEW_LINE : 0;
   }
+
+  private setFlag(flag: number, value: boolean): void {
+    this.flags = value ? this.flags | flag : this.flags & ~flag;
+  }
+
+  get isInsertedInRecovery(): boolean {
+    return (this.flags & FLAG_INSERTED_IN_RECOVERY) !== 0;
+  }
+  set isInsertedInRecovery(value: boolean) {
+    this.setFlag(FLAG_INSERTED_IN_RECOVERY, value);
+  }
+
+  get immediateFollow(): boolean {
+    return (this.flags & FLAG_IMMEDIATE_FOLLOW) !== 0;
+  }
+  set immediateFollow(value: boolean) {
+    this.setFlag(FLAG_IMMEDIATE_FOLLOW, value);
+  }
+
+  get startsNewLine(): boolean {
+    return (this.flags & FLAG_STARTS_NEW_LINE) !== 0;
+  }
+  set startsNewLine(value: boolean) {
+    this.setFlag(FLAG_STARTS_NEW_LINE, value);
+  }
+
+  get synthetic(): boolean {
+    return (this.flags & FLAG_SYNTHETIC) !== 0;
+  }
+  set synthetic(value: boolean) {
+    this.setFlag(FLAG_SYNTHETIC, value);
+  }
+
+  get ppSemanticType(): SemanticTokenTypes | undefined {
+    const value = this.flags >>> PP_SEMANTIC_TYPE_SHIFT;
+    return value === 0 ? undefined : value - 1;
+  }
+  set ppSemanticType(value: SemanticTokenTypes | undefined) {
+    this.flags =
+      (this.flags & PP_SEMANTIC_TYPE_MASK) |
+      ((value === undefined ? 0 : value + 1) << PP_SEMANTIC_TYPE_SHIFT);
+  }
+}
+
+/**
+ * Clones a token, optionally overriding fields. Use this instead of an object
+ * spread: `TokenImpl` keeps its boolean flags behind prototype accessors, which
+ * a spread would silently drop.
+ */
+export function cloneToken(
+  token: Token,
+  overrides?: { image?: string; uri?: URI | undefined },
+): Token {
+  const clone = new TokenImpl(
+    overrides?.image ?? token.image,
+    token.originalImage,
+    token.id ?? 0,
+    token.tokenType,
+    token.startOffset,
+    token.endOffset,
+    overrides && "uri" in overrides ? overrides.uri : token.uri,
+    token.startsNewLine,
+  );
+  clone.kind = token.kind;
+  clone.element = token.element;
+  clone.isInsertedInRecovery = token.isInsertedInRecovery ?? false;
+  clone.immediateFollow = token.immediateFollow;
+  clone.synthetic = token.synthetic ?? false;
+  clone.ppSemanticType = token.ppSemanticType;
+  return clone;
 }
 /**
  * A simple incrementing ID generator for tokens.

--- a/packages/language/src/preprocessor/exec-phase.ts
+++ b/packages/language/src/preprocessor/exec-phase.ts
@@ -54,6 +54,7 @@ import {
 } from "./preprocessor-context";
 import { SourceMap } from "./source-map";
 import { extractDirectiveTokens } from "./token-annotator";
+import { largePush } from "../utils/collections";
 
 /** `SQL TYPE IS BINARY/VARBINARY` real numeric ranges - see `computeLobLength`. */
 const LOCATOR_TYPE = "FIXED BIN(31)";
@@ -778,7 +779,7 @@ abstract class ExecPreprocessorPhase implements PreprocessorPhase {
         state,
         handlers,
       );
-      allStatements.push(...statements);
+      largePush(allStatements, statements);
       for (const diagnostic of diagnostics) {
         context.pushDiagnostic(diagnostic);
       }
@@ -795,10 +796,11 @@ abstract class ExecPreprocessorPhase implements PreprocessorPhase {
         contextDocument,
         sourceMapForDirectives,
       );
-      allStatements.push(...execMetadata.statements);
-      allDirectiveTokens.push(...execMetadata.directiveTokens);
-      allDirectiveTokens.push(
-        ...extractDirectiveTokens(tokenization.tokens, sourceMapForDirectives),
+      largePush(allStatements, execMetadata.statements);
+      largePush(allDirectiveTokens, execMetadata.directiveTokens);
+      largePush(
+        allDirectiveTokens,
+        extractDirectiveTokens(tokenization.tokens, sourceMapForDirectives),
       );
     };
 
@@ -893,7 +895,10 @@ export class UnresolvedExecPhase implements PreprocessorPhase {
   ) {}
 
   async execute(input: PhaseInput): Promise<PhaseResult> {
-    if ((this.hasCics && this.hasSql) || !/EXEC/i.test(input.text)) {
+    if (
+      (this.hasCics && this.hasSql) ||
+      !/\bEXEC\s+(\w+)\b/i.test(input.text)
+    ) {
       // Both preprocessors are configured (no EXEC statement can be left unresolved), or
       // there is no EXEC-looking text at all - skip the tokenize pass entirely, like the
       // real phases' own `triggerPattern` pre-scan.

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -16,7 +16,13 @@ import { Diagnostic, diagnosticFromCode } from "../language-server/types";
 import { preprocessorParse, StatementParser } from "../parser/parser-entry";
 import { ParserState } from "../parser/parser-state";
 import { tokenize } from "../parser/tokenizer";
-import { createTokenInstance, ExecFragment, ID, Token } from "../parser/tokens";
+import {
+  cloneToken,
+  createTokenInstance,
+  ExecFragment,
+  ID,
+  Token,
+} from "../parser/tokens";
 import * as ast from "../syntax-tree/ast";
 import { CstNodeKind } from "../syntax-tree/cst";
 import { URI, UriUtils } from "../utils/uri";
@@ -41,6 +47,7 @@ import * as inst from "./instructions";
 import { MarginsProcessor } from "./pli-margins-processor";
 import { PreprocessorTokens } from "./pli-preprocessor-tokens";
 import { assertUnreachable } from "../utils/common";
+import { largePush } from "../utils/collections";
 
 interface Variable {
   name: string;
@@ -641,7 +648,7 @@ function runAnswerInstruction(
       if (previousLast) {
         previousLast.immediateFollow = false;
       }
-      context.tokens.push(...tokens);
+      largePush(context.tokens, tokens);
     } else {
       mergePush(context.tokens, tokens, true);
     }
@@ -1624,7 +1631,8 @@ function runTokenInstruction(
       mergePush(context.tokens, result.tokens, i === 0);
       i += result.advance;
     } else {
-      const token = tokens[i];
+      // If the scan found no active variable, push the original token.
+      let token = tokens[i];
       // For ExecFragment tokens, expand macro variables embedded in the image.
       if (token.tokenTypeIdx === ExecFragment.tokenTypeIdx) {
         const expandedImage = expandVariablesInText(token, context);
@@ -1632,18 +1640,17 @@ function runTokenInstruction(
           // The image no longer matches the source span, so the token must count as
           // *generated* (`uri: undefined`) - the serializer emits same-file tokens by
           // slicing the phase text, which would silently discard the expansion.
-          const newToken: Token = {
-            ...token,
-            image: expandedImage,
-            uri: undefined,
-          };
-          mergePush(context.tokens, [newToken], i === 0);
-        } else {
-          mergePush(context.tokens, [token], i === 0);
+          token = cloneToken(token, { image: expandedImage, uri: undefined });
         }
+      }
+      if (i === 0) {
+        // Only the very first token can need lex-merging with an
+        // `immediateFollow` prefix already in the target.
+        mergePush(context.tokens, [token], true);
       } else {
-        // If the scan found no active variable, push the original token
-        mergePush(context.tokens, [token], i === 0);
+        // Hot path: this runs once per passthrough token (millions on large
+        // files) - push directly instead of wrapping each token in an array.
+        context.tokens.push(token);
       }
       i++;
     }
@@ -1706,21 +1713,6 @@ function mergePush(target: Token[], source: Token[], firstSource: boolean) {
     }
   }
   largePush(target, source);
-}
-
-function largePush<T>(target: T[], source: T[]): void {
-  if (source.length < 100_100) {
-    // If the source array is small enough, we can use the spread operator
-    // to push the items into the target array
-    target.push(...source);
-  } else {
-    // This is a workaround for the V8 engine's limit on the number of arguments
-    // that can be passed to a function. We use this to push large arrays into
-    // the result array.
-    for (const item of source) {
-      target.push(item);
-    }
-  }
 }
 
 function replaceTokensInText(
@@ -2272,7 +2264,7 @@ async function runInclude(
           subState,
           context.options.createParseHandlers(document),
         );
-        subProgram.diagnostics.push(...tokenizeResult.diagnostics);
+        largePush(subProgram.diagnostics, tokenizeResult.diagnostics);
         const result = generateInstructions(subProgram.statements);
         return {
           tokens: tokenizeResult.tokens,
@@ -2283,14 +2275,14 @@ async function runInclude(
         };
       },
     );
-    context.statements.push(...cachedResult.statements);
+    largePush(context.statements, cachedResult.statements);
     context.unit.services.files.set({
       textDocument: document,
       tokens: cachedResult.tokens,
       comments: cachedResult.comments,
       uri,
     });
-    context.diagnostics.push(...cachedResult.diagnostics);
+    largePush(context.diagnostics, cachedResult.diagnostics);
     for (const [key, value] of cachedResult.result.procedures.entries()) {
       context.procedures.set(key, value);
     }

--- a/packages/language/src/preprocessor/macro-phase.ts
+++ b/packages/language/src/preprocessor/macro-phase.ts
@@ -158,6 +158,14 @@ export class MacroPreprocessorPhase implements PreprocessorPhase {
 
     const serialized = serializeTokens(output.all, uri, text);
 
+    // Token statements have served their purpose and are no longer useful.
+    // We blank them out (remove their array), so that the garbage collector can reclaim the memory
+    for (const stmt of statements) {
+      if (stmt.value?.kind === ast.SyntaxKind.TokenStatement) {
+        stmt.value.tokens = ast.emptyList();
+      }
+    }
+
     // Fragments inside %INCLUDEd files already carry file-local offsets; the entry
     // file's source map must only remap the entry file's own exec tokens.
     const ownExecTokens: t.Token[] = [];
@@ -183,10 +191,8 @@ export class MacroPreprocessorPhase implements PreprocessorPhase {
       references: output.references,
       evaluationResults: output.evaluationResults,
       directiveTokens: [
-        ...extractDirectiveTokens(
-          [...tokenization.tokens, ...ownExecTokens],
-          input.sourceMap,
-        ),
+        ...extractDirectiveTokens(tokenization.tokens, input.sourceMap),
+        ...extractDirectiveTokens(ownExecTokens, input.sourceMap),
         ...foreignExecTokens,
       ],
     };

--- a/packages/language/src/preprocessor/pli-lexer.ts
+++ b/packages/language/src/preprocessor/pli-lexer.ts
@@ -11,6 +11,7 @@
 
 import { MarginsProcessor, PliMarginsProcessor } from "./pli-margins-processor";
 import { URI } from "../utils/uri";
+import { largePush } from "../utils/collections";
 import {
   CompilerOptionsProcessor,
   CompilerOptionsProcessorResult,
@@ -226,14 +227,21 @@ export class PliLexer {
     // numbering and would collide with this file's tokens at the same numeric offset
     // (they're merged into the foreign file's registration below). `synthetic` tokens
     // are excluded - see `Token.synthetic`.
-    const ownTokens = annotated.tokens.filter(
-      (t) => !t.synthetic && t.uri?.toString() === uriString,
-    );
     // Identity-dedupe: an `EXEC` host-variable sub-token shows up both as a directive
-    // token and as an annotate-emitted `sourceToken`.
-    const tokens = [
-      ...new Set([...optionTokens, ...ownTokens, ...ownDirectiveTokens]),
-    ];
+    // token and as an annotate-emitted `sourceToken`. Only the option/directive side is
+    // ever duplicated and it is tiny, so dedupe against that instead of pushing the
+    // full file's tokens (millions on large files) through a Set.
+    const smallSide = new Set([...optionTokens, ...ownDirectiveTokens]);
+    const tokens: Token[] = [...smallSide];
+    for (const token of annotated.tokens) {
+      if (
+        !token.synthetic &&
+        token.uri?.toString() === uriString &&
+        !smallSide.has(token)
+      ) {
+        tokens.push(token);
+      }
+    }
     tokens.sort((a, b) => a.startOffset - b.startOffset);
     unit.services.files.set({
       textDocument: document,
@@ -242,15 +250,21 @@ export class PliLexer {
       uri,
     });
     // Tokens attributed to a foreign file belong in that file's registration - see
-    // `mergeForeignTokens`. Same identity-dedupe as above.
-    const foreignTokens = annotated.tokens.filter(
-      (t) => !t.synthetic && t.uri && t.uri.toString() !== uriString,
-    );
-    this.mergeForeignTokens(
-      unit,
-      [...new Set([...directiveTokens, ...foreignTokens])],
-      uriString,
-    );
+    // `mergeForeignTokens`. Same identity-dedupe as above (against the small
+    // directive-token side only).
+    const directiveSet = new Set(directiveTokens);
+    const incomingTokens: Token[] = [...directiveSet];
+    for (const token of annotated.tokens) {
+      if (
+        !token.synthetic &&
+        token.uri &&
+        token.uri.toString() !== uriString &&
+        !directiveSet.has(token)
+      ) {
+        incomingTokens.push(token);
+      }
+    }
+    this.mergeForeignTokens(unit, incomingTokens, uriString);
   }
 
   /**
@@ -298,7 +312,7 @@ export class PliLexer {
           foreignTokens[index].startOffset <= token.endOffset
         );
       });
-      merged.push(...foreignTokens);
+      largePush(merged, foreignTokens);
       merged.sort((a, b) => a.startOffset - b.startOffset);
       unit.services.files.set({ ...existing, tokens: merged });
     }

--- a/packages/language/src/preprocessor/pli-margins-processor.ts
+++ b/packages/language/src/preprocessor/pli-margins-processor.ts
@@ -82,14 +82,15 @@ export class PliMarginsProcessor implements MarginsProcessor {
       }
     }
 
-    const lines = this.splitLines(input.text, margins, uri);
-    const adjustedLines = lines.map((line) => this.adjustLine(line, margins));
-    return adjustedLines.join("");
+    // Adjust each line as it is scanned - materializing all raw lines first and
+    // mapping them afterwards would hold two arrays of one string per line alive
+    return this.splitLines(input.text, margins, uri).join("");
   }
 
   private splitLines(text: string, margins: Range, uri: URI): string[] {
     const lines: string[] = [];
     const prefixLength = margins.start - 1;
+    const prefix = " ".repeat(prefixLength);
 
     const reportViolation = (
       side: "left" | "right",
@@ -172,7 +173,7 @@ export class PliMarginsProcessor implements MarginsProcessor {
         }
       }
       const line = text.substring(start, i + 1);
-      lines.push(line);
+      lines.push(this.adjustLine(line, margins, prefix));
 
       // Check the left margin.
       // TODO ssmifi: While COL1 should be reserved for %|*PROCESS, there are examples (ADVNTOPT)
@@ -204,7 +205,7 @@ export class PliMarginsProcessor implements MarginsProcessor {
     return lines;
   }
 
-  private adjustLine(line: string, margins: Range): string {
+  private adjustLine(line: string, margins: Range, prefix: string): string {
     let eol = "";
     if (line.endsWith("\r\n")) {
       eol = "\r\n";
@@ -217,7 +218,6 @@ export class PliMarginsProcessor implements MarginsProcessor {
       return " ".repeat(lineLength) + eol;
     }
     const lineEnd = margins.end;
-    const prefix = " ".repeat(prefixLength);
     let postfix = "";
     if (lineLength > lineEnd) {
       postfix = " ".repeat(lineLength - lineEnd);

--- a/packages/language/src/preprocessor/pp-pipeline.ts
+++ b/packages/language/src/preprocessor/pp-pipeline.ts
@@ -16,6 +16,7 @@ import { URI } from "../utils/uri";
 import { EvaluationResults } from "./instruction-interpreter";
 import { PhaseInput, PhaseResult, PreprocessorPhase } from "./pp-phase";
 import { SourceMap } from "./source-map";
+import { largePush } from "../utils/collections";
 
 export interface PipelineResult {
   text: string;
@@ -60,13 +61,13 @@ export async function runPipeline(
     sourceMap = SourceMap.compose(sourceMap, result.sourceMap);
     // No argument spreads: they throw a RangeError beyond ~100k elements, and
     // several of these lists scale with file size.
-    pushAll(allStatements, result.statements);
-    pushAll(
+    largePush(allStatements, result.statements);
+    largePush(
       allDiagnostics,
       remapPhaseDiagnostics(result.diagnostics, inputMap, input.uri),
     );
-    pushAll(allReferences, result.references);
-    pushAll(allDirectiveTokens, result.directiveTokens);
+    largePush(allReferences, result.references);
+    largePush(allDirectiveTokens, result.directiveTokens);
     if (result.evaluationResults) {
       for (const [key, value] of result.evaluationResults.branchExecutions) {
         evaluationResults.branchExecutions.set(key, value);
@@ -83,12 +84,6 @@ export async function runPipeline(
     evaluationResults,
     directiveTokens: allDirectiveTokens,
   };
-}
-
-function pushAll<T>(target: T[], source: readonly T[]): void {
-  for (const item of source) {
-    target.push(item);
-  }
 }
 
 /**

--- a/packages/language/src/preprocessor/pp-pipeline.ts
+++ b/packages/language/src/preprocessor/pp-pipeline.ts
@@ -58,12 +58,15 @@ export async function runPipeline(
     });
     text = result.text;
     sourceMap = SourceMap.compose(sourceMap, result.sourceMap);
-    allStatements.push(...result.statements);
-    allDiagnostics.push(
-      ...remapPhaseDiagnostics(result.diagnostics, inputMap, input.uri),
+    // No argument spreads: they throw a RangeError beyond ~100k elements, and
+    // several of these lists scale with file size.
+    pushAll(allStatements, result.statements);
+    pushAll(
+      allDiagnostics,
+      remapPhaseDiagnostics(result.diagnostics, inputMap, input.uri),
     );
-    allReferences.push(...result.references);
-    allDirectiveTokens.push(...result.directiveTokens);
+    pushAll(allReferences, result.references);
+    pushAll(allDirectiveTokens, result.directiveTokens);
     if (result.evaluationResults) {
       for (const [key, value] of result.evaluationResults.branchExecutions) {
         evaluationResults.branchExecutions.set(key, value);
@@ -80,6 +83,12 @@ export async function runPipeline(
     evaluationResults,
     directiveTokens: allDirectiveTokens,
   };
+}
+
+function pushAll<T>(target: T[], source: readonly T[]): void {
+  for (const item of source) {
+    target.push(item);
+  }
 }
 
 /**

--- a/packages/language/src/preprocessor/preprocessor-context.ts
+++ b/packages/language/src/preprocessor/preprocessor-context.ts
@@ -25,6 +25,7 @@ import {
 } from "../language-server/types";
 import { CompilationUnit } from "../workspace/compilation-unit";
 import { URI } from "../utils/uri";
+import { largePush } from "../utils/collections";
 import { LspCodes } from "../validation/lsp-codes";
 import { PLICodes } from "../validation/pli-codes";
 import {
@@ -491,7 +492,7 @@ export class PreprocessorContext implements api.PreprocessorContext {
         }
         // Nested diagnostics keep their ranges: offsets into the included file's own
         // text, which is the space they should be reported in.
-        nestedDiagnostics.push(...edit.subResult.diagnostics);
+        largePush(nestedDiagnostics, edit.subResult.diagnostics);
         chunks.push(edit.subResult.text);
         genCursor += edit.subResult.text.length;
       } else {

--- a/packages/language/src/preprocessor/token-serializer.ts
+++ b/packages/language/src/preprocessor/token-serializer.ts
@@ -202,9 +202,31 @@ function sameUri(a: URI | undefined, b: URI | undefined): boolean {
   return a !== undefined && b !== undefined && a.toString() === b.toString();
 }
 
+const SPACE = 0x20;
+const TAB = 0x09; // `\t`, first of the \t \n \v \f \r control range
+const CARRIAGE_RETURN = 0x0d; // `\r`, last of the \t \n \v \f \r control range
+const NO_BREAK_SPACE = 0xa0;
+/** First Unicode whitespace code point above Latin-1 (`\s` matches a few beyond it). */
+const OGHAM_SPACE_MARK = 0x1680;
+
 /** Whether `text[start, end)` (a gap between two verbatim tokens) is empty or whitespace-only. */
 function isWhitespaceGap(text: string, start: number, end: number): boolean {
-  return WHITESPACE_ONLY.test(text.slice(start, end));
+  // Called once per adjacent token pair - scan char codes instead of allocating
+  // a substring per call.
+  for (let i = start; i < end; i++) {
+    const code = text.charCodeAt(i);
+    // Matches the characters `/^\s*$/` accepts: space, \t \n \v \f \r, NBSP,
+    // and the (rare in source) Unicode space classes.
+    if (
+      code !== SPACE &&
+      !(code >= TAB && code <= CARRIAGE_RETURN) &&
+      code !== NO_BREAK_SPACE &&
+      !(code >= OGHAM_SPACE_MARK && WHITESPACE_ONLY.test(text[i]))
+    ) {
+      return false;
+    }
+  }
+  return true;
 }
 
 /**

--- a/packages/language/src/syntax-tree/ast.ts
+++ b/packages/language/src/syntax-tree/ast.ts
@@ -628,6 +628,35 @@ export interface AstNode {
   kind: SyntaxKind;
 }
 
+/**
+ * Shared frozen empty array used as the initial value of high-volume AST list
+ * fields (statement labels, reference nodes, dimensions, ...). These fields
+ * stay empty on the vast majority of nodes, and a fresh `[]` per node costs
+ * 32+ bytes times millions of nodes on large files. Reading is transparent;
+ * writers must swap in a real array first - see {@link appendList}.
+ */
+const EMPTY_LIST: readonly unknown[] = Object.freeze([]);
+
+/** The shared frozen empty list, typed for use as a factory initial value. */
+export function emptyList<T>(): T[] {
+  return EMPTY_LIST as T[];
+}
+
+/**
+ * Appends `item` to a lazily-allocated list field and returns the list to
+ * store back: `node.field = appendList(node.field, item)`. The first append
+ * replaces the shared frozen {@link emptyList} with a capacity-1 array literal
+ * (a pushed-into empty array grows straight to capacity 16, wasting ~120 bytes
+ * on the overwhelmingly common single-element case).
+ */
+export function appendList<T>(list: T[], item: T): T[] {
+  if ((list as readonly unknown[]) === EMPTY_LIST) {
+    return [item];
+  }
+  list.push(item);
+  return list;
+}
+
 export function isSyntaxNode(node: unknown): node is SyntaxNode {
   return isObject<AstNode>(node) && typeof node.kind === "number";
 }
@@ -715,7 +744,7 @@ export function createReference<T extends SyntaxNode>(
     owner,
     text: token.image,
     token,
-    nodes: [],
+    nodes: emptyList(),
     node: undefined,
     type,
   };
@@ -1376,7 +1405,7 @@ export function createAssignmentStatement(): AssignmentStatement {
   return {
     kind: SyntaxKind.AssignmentStatement,
     container: null,
-    refs: [],
+    refs: emptyList(),
     operator: null,
     expression: null,
     dimacrossExpr: null,
@@ -2041,7 +2070,7 @@ export function createDimensions(): Dimensions {
   return {
     kind: SyntaxKind.Dimensions,
     container: null,
-    dimensions: [],
+    dimensions: emptyList(),
     token: null,
   };
 }
@@ -3726,7 +3755,7 @@ export function createReferenceItem(): ReferenceItem {
     kind: SyntaxKind.ReferenceItem,
     container: null,
     ref: null,
-    dimensions: [],
+    dimensions: emptyList(),
   };
 }
 export interface ReinitStatement extends AstNode {
@@ -3961,16 +3990,23 @@ export interface Statement extends AstNode {
   value: Unit | null;
   startToken: Token | null;
   endToken: Token | null;
+  /**
+   * Position of this statement in the compilation unit's statement order,
+   * assigned during symbol table generation (see `StatementOrderCache`).
+   * `-1` until assigned.
+   */
+  statementOrder: number;
 }
 export function createStatement(): Statement {
   return {
     kind: SyntaxKind.Statement,
     container: null,
     condition: null,
-    labels: [],
+    labels: emptyList(),
     value: null,
     startToken: null,
     endToken: null,
+    statementOrder: -1,
   };
 }
 export interface StopStatement extends AstNode {

--- a/packages/language/src/typesystem/descriptions.ts
+++ b/packages/language/src/typesystem/descriptions.ts
@@ -1021,6 +1021,28 @@ PARAMETER
 [CALL]]
 */
 
+// Shared frozen defaults: one type description exists per declaration node
+// (hundreds of thousands on large files), so a fresh default object per
+// description adds up to serious memory. These are read-only fallbacks - any
+// non-default value is passed in by the caller as its own object.
+const DEFAULT_UNALIGNED: Alignment = Object.freeze({
+  type: AlignmentType.Unaligned,
+});
+const DEFAULT_ALIGNED: Alignment = Object.freeze({
+  type: AlignmentType.Aligned,
+  alignment: 1,
+} as const); //TODO no documentation of default value for alignment
+const EMPTY_WITNESSES: AttributeWitnesses = Object.freeze({
+  order: Object.freeze([]) as unknown as AttributeKind[],
+  witnesses: Object.freeze({}),
+});
+
+// Mirrors the failure mode of the previous per-object wrapper, which called an
+// absent provider.
+function missingToString(): string {
+  throw new TypeError("toString is not a function");
+}
+
 function createBaseTypeDescription(
   type: TypeDescriptions.TypeDescriptionType,
   {
@@ -1048,9 +1070,9 @@ function createBaseTypeDescription(
 ): BaseTypeDescriptionProps {
   if (!alignment) {
     if (type === PictureType || type === StringType) {
-      alignment = { type: AlignmentType.Unaligned };
+      alignment = DEFAULT_UNALIGNED;
     } else {
-      alignment = { type: AlignmentType.Aligned, alignment: 1 }; //TODO no documentation of default value for alignment
+      alignment = DEFAULT_ALIGNED;
     }
   }
 
@@ -1100,10 +1122,9 @@ function createBaseTypeDescription(
     variable,
     volatility,
 
-    witnesses: witnesses ?? { order: [], witnesses: {} },
-    toString() {
-      return toString!();
-    },
+    witnesses: witnesses ?? EMPTY_WITNESSES,
+    // The provider function itself, not a per-object wrapper closure around it.
+    toString: toString ?? missingToString,
   };
 }
 

--- a/packages/language/src/typesystem/infer.ts
+++ b/packages/language/src/typesystem/infer.ts
@@ -30,24 +30,25 @@ export interface TypeInferer {
   ): boolean;
 }
 
+const expressionKinds = new Set<ast.SyntaxKind>([
+  ast.SyntaxKind.BinaryExpression,
+  ast.SyntaxKind.UnaryExpression,
+  ast.SyntaxKind.Parenthesis,
+  ast.SyntaxKind.WildcardItem,
+  ast.SyntaxKind.NumberLiteral,
+  ast.SyntaxKind.StringLiteral,
+  ast.SyntaxKind.RepeatedExpression,
+  ast.SyntaxKind.LocatorCall,
+  ast.SyntaxKind.MemberCall,
+]);
+
 export class DefaultTypeInferer implements TypeInferer {
   inferType(
     node: ast.SyntaxNode,
     compilationUnit: CompilationUnit,
   ): TypeDescriptions.Any {
     return compilationUnit.services.typeCache.get(node, () => {
-      const expressionKinds = [
-        ast.SyntaxKind.BinaryExpression,
-        ast.SyntaxKind.UnaryExpression,
-        ast.SyntaxKind.Parenthesis,
-        ast.SyntaxKind.WildcardItem,
-        ast.SyntaxKind.NumberLiteral,
-        ast.SyntaxKind.StringLiteral,
-        ast.SyntaxKind.RepeatedExpression,
-        ast.SyntaxKind.LocatorCall,
-        ast.SyntaxKind.MemberCall,
-      ];
-      if (expressionKinds.includes(node.kind)) {
+      if (expressionKinds.has(node.kind)) {
         return this.inferExpressionType(
           node as ast.Expression,
           compilationUnit,

--- a/packages/language/src/utils/collections.ts
+++ b/packages/language/src/utils/collections.ts
@@ -176,9 +176,7 @@ export class MultiMap<K, V> {
   valuesArray(): V[] {
     const result: V[] = [];
     for (const values of this.map.values()) {
-      for (const value of values) {
-        result.push(value);
-      }
+      largePush(result, values);
     }
     return result;
   }

--- a/packages/language/src/utils/collections.ts
+++ b/packages/language/src/utils/collections.ts
@@ -9,6 +9,22 @@
  *
  */
 
+const EMPTY_VALUES: readonly unknown[] = Object.freeze([]);
+
+/**
+ * Pushes all elements of `source` onto `target`. Safe for arbitrarily large
+ * source arrays.
+ */
+export function largePush<T>(target: T[], source: readonly T[]): void {
+  if (source.length < 10_000) {
+    target.push(...(source as T[]));
+  } else {
+    for (const item of source) {
+      target.push(item);
+    }
+  }
+}
+
 export class MultiMap<K, V> {
   private map = new Map<K, V[]>();
 
@@ -65,7 +81,9 @@ export class MultiMap<K, V> {
    * value and `delete` to remove a value from the multimap.
    */
   get(key: K): readonly V[] {
-    return this.map.get(key) ?? [];
+    // Shared frozen empty result: misses are the common case on lookup-heavy
+    // paths (scope chains), and a fresh array per miss is pure GC churn.
+    return this.map.get(key) ?? (EMPTY_VALUES as readonly V[]);
   }
 
   /**
@@ -101,8 +119,12 @@ export class MultiMap<K, V> {
    * Add the given set of key / value pairs to the multimap.
    */
   addAll(key: K, values: Iterable<V>): this {
-    if (this.map.has(key)) {
-      this.map.get(key)!.push(...values);
+    const existing = this.map.get(key);
+    if (existing) {
+      // No `push(...values)`: argument spreads throw a RangeError beyond ~100k elements.
+      for (const value of values) {
+        existing.push(value);
+      }
     } else {
       this.map.set(key, Array.from(values));
     }
@@ -154,7 +176,9 @@ export class MultiMap<K, V> {
   valuesArray(): V[] {
     const result: V[] = [];
     for (const values of this.map.values()) {
-      result.push(...values);
+      for (const value of values) {
+        result.push(value);
+      }
     }
     return result;
   }

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -231,6 +231,22 @@ export async function createCompilationUnit(
       unit.scopeCaches.clear();
       unit.includeError = false;
       unit.diagnostics.clear();
+      // Release the previous run's AST, tokens and preprocessed text. reset()
+      // runs at the start of every lifecycle - without this, the old and the
+      // new structures are both reachable while the new ones are built,
+      // doubling the peak heap on every edit of a large file.
+      unit.ast = {
+        kind: SyntaxKind.Program,
+        container: null,
+        statements: [],
+      };
+      unit.preprocessorAst = {
+        kind: SyntaxKind.Program,
+        container: null,
+        statements: [],
+      };
+      unit.tokens = [];
+      unit.preprocessedText = "";
       cachedProcessGroup = null;
       cachedProgramConfig = null;
     },


### PR DESCRIPTION
Should resolve https://github.com/zowe/zowe-pli-language-support/issues/821.

Fixes a few bigger & lesser performance bottlenecks, mostly related to the amount of objects we were storing. The reported issue (stack overflow in `mergeForeignTokens`) is also resolved as part of that. It wasn't a real "stackoverflow", we just pushed a huge array via `push(...array)`, which triggered the error.