### PR TITLE
Add additional sql options

### DIFF
--- a/packages/language/src/preprocessor/compiler-options/codes.ts
+++ b/packages/language/src/preprocessor/compiler-options/codes.ts
@@ -1390,6 +1390,170 @@ export const CompilerOptionsCodes = {
         message: () => `The HOSTCOPY option is ignored under LP(32).`,
       },
     },
+
+    Float: {
+      InvalidParameter: {
+        code: "COPPSQL08",
+        severity: Severity.E,
+        message: (value: string) =>
+          `Expected "S390" or "IEEE", but received '${value}'.`,
+      },
+    },
+
+    StdSql: {
+      InvalidParameter: {
+        code: "COPPSQL09",
+        severity: Severity.E,
+        message: (value: string) =>
+          `Expected "YES" or "NO", but received '${value}'.`,
+      },
+    },
+
+    Attach: {
+      InvalidParameter: {
+        code: "COPPSQL13",
+        severity: Severity.E,
+        message: (value: string) =>
+          `Expected "TSO", "CAF", "RRSAF", or "ULI", but received '${value}'.`,
+      },
+    },
+
+    Graphic: {
+      SupersededByCcsid: {
+        code: "COPPSQL14",
+        severity: Severity.W,
+        message: () =>
+          `The GRAPHIC/NOGRAPHIC SQL processing option is ignored because it is superseded by the CCSID option.`,
+      },
+    },
+
+    Date: {
+      InvalidParameter: {
+        code: "COPPSQL15",
+        severity: Severity.E,
+        message: (value: string) =>
+          `Expected "ISO", "USA", "EUR", "JIS", or "LOCAL", but received '${value}'.`,
+      },
+    },
+
+    Dec: {
+      InvalidParameter: {
+        code: "COPPSQL16",
+        severity: Severity.E,
+        message: (value: string) =>
+          `Expected "15" or "31", but received '${value}'.`,
+      },
+    },
+
+    Decp: {
+      InvalidParameterLength: {
+        code: "COPPSQL17",
+        severity: Severity.E,
+        message: (value: string) =>
+          `Expected a module name with 1 to 8 characters, but received '${value}'.`,
+      },
+    },
+
+    Flag: {
+      InvalidParameter: {
+        code: "COPPSQL18",
+        severity: Severity.E,
+        message: (value: string) =>
+          `Expected "I", "W", "E", or "S", but received '${value}'.`,
+      },
+    },
+
+    Host: {
+      InvalidParameter: {
+        code: "COPPSQL19",
+        severity: Severity.E,
+        message: (value: string) =>
+          `Expected "ASM", "C", "CPP", "IBMCOB", "PLI", "FORTRAN", "SQL", or "SQLPL", but received '${value}'.`,
+      },
+
+      ExpectedPLI: {
+        code: "COPPSQL20",
+        severity: Severity.E,
+        message: (value: string) =>
+          `Expected PLI host language, but received '${value}'.`,
+      },
+    },
+
+    Level: {
+      InvalidParameter: {
+        code: "COPPSQL22",
+        severity: Severity.E,
+        message: (value: string) =>
+          `Expected an alphanumeric value of up to 7 characters, but received '${value}'.`,
+      },
+    },
+
+    Margins: {
+      InvalidMarginPosition: {
+        code: "COPPSQL23",
+        severity: Severity.E,
+        message: () =>
+          `The beginning column (m) must be less than the ending column (n).`,
+      },
+
+      InvalidContinuationPosition: {
+        code: "COPPSQL24",
+        severity: Severity.E,
+        message: () =>
+          `The continuation column (c) must not be between the beginning column (m) and ending column (n).`,
+      },
+    },
+
+    NewFun: {
+      InvalidParameter: {
+        code: "COPPSQL25",
+        severity: Severity.E,
+        message: (value: string) =>
+          `Expected "V8", "V9", "V10", "V11", or "V12", but received '${value}'.`,
+      },
+
+      Deprecated: {
+        code: "COPPSQL26",
+        severity: Severity.W,
+        message: () =>
+          `The NEWFUN precompiler option is deprecated. Use the SQLLEVEL option instead.`,
+      },
+    },
+
+    SqlLevel: {
+      InvalidParameter: {
+        code: "COPPSQL31",
+        severity: Severity.E,
+        message: (value: string) =>
+          `Expected "V8R1", "V9R1", "V10R1", "V11R1", or a function level in the format VvvRrMmmm, but received '${value}'.`,
+      },
+    },
+
+    Time: {
+      InvalidParameter: {
+        code: "COPPSQL32",
+        severity: Severity.E,
+        message: (value: string) =>
+          `Expected "ISO", "USA", "EUR", "JIS", or "LOCAL", but received '${value}'.`,
+      },
+    },
+
+    Apost: {
+      QuoteOnlyValidForCobol: {
+        code: "COPPSQL27",
+        severity: Severity.E,
+        message: () => `The QUOTE option is only valid for COBOL applications.`,
+      },
+    },
+
+    ApostSql: {
+      QuoteSqlOnlyValidForCobol: {
+        code: "COPPSQL29",
+        severity: Severity.E,
+        message: () =>
+          `The QUOTESQL option is only valid for COBOL applications.`,
+      },
+    },
   },
 
   PPCICS: {

--- a/packages/language/src/preprocessor/compiler-options/options-sql.ts
+++ b/packages/language/src/preprocessor/compiler-options/options-sql.ts
@@ -10,14 +10,39 @@
  */
 
 export interface CompilerOptions {
+  apost?: CompilerOptions.QuoteChar;
+  apostSql?: CompilerOptions.QuoteChar;
+  attach?: CompilerOptions.Attach;
+  ccsid?: number;
   ccsid0?: boolean;
   codepage?: boolean;
+  comma?: CompilerOptions.DecimalPoint;
+  connect?: 1 | 2;
+  date?: CompilerOptions.Date;
+  dec?: 15 | 31;
+  decp?: string;
   deprecate?: Set<string>;
   emptyDbrm?: boolean;
+  flag?: CompilerOptions.Flag;
+  float?: CompilerOptions.Float;
+  graphic?: boolean;
+  host?: CompilerOptions.Host;
   hostCopy?: boolean;
   incOnly?: boolean;
+  level?: string;
   line?: CompilerOptions.Line;
+  lineCount?: number;
+  margins?: { m: number; n: number; c?: number };
+  newFun?: CompilerOptions.NewFun;
+  noFor?: boolean;
+  onePass?: boolean;
+  printOptions?: boolean;
+  source?: boolean;
+  sqlLevel?: string;
+  stdSql?: boolean;
+  time?: CompilerOptions.Time;
   warnDecp?: boolean;
+  xref?: boolean;
 }
 
 export namespace CompilerOptions {
@@ -25,17 +50,101 @@ export namespace CompilerOptions {
     LINEONLY,
     LINEFILE,
   }
+
+  export enum QuoteChar {
+    APOST,
+    QUOTE,
+  }
+
+  export enum Attach {
+    TSO,
+    CAF,
+    RRSAF,
+    ULI,
+  }
+
+  export enum DecimalPoint {
+    COMMA,
+    PERIOD,
+  }
+
+  export enum Date {
+    ISO,
+    USA,
+    EUR,
+    JIS,
+    LOCAL,
+  }
+
+  export enum Time {
+    ISO,
+    USA,
+    EUR,
+    JIS,
+    LOCAL,
+  }
+
+  export enum Float {
+    S390,
+    IEEE,
+  }
+
+  export enum Flag {
+    I,
+    W,
+    E,
+    S,
+  }
+
+  export enum NewFun {
+    V8,
+    V9,
+    V10,
+    V11,
+    V12,
+  }
+
+  export enum HostLanguage {
+    ASM,
+    C,
+    CPP,
+    IBMCOB,
+    PLI,
+    FORTRAN,
+    SQL,
+    SQLPL,
+  }
+
+  export interface Host {
+    language: HostLanguage;
+  }
 }
 
 export function getDefaultCompilerOptions(): CompilerOptions {
   return {
+    apost: CompilerOptions.QuoteChar.APOST,
+    apostSql: CompilerOptions.QuoteChar.APOST,
+    attach: CompilerOptions.Attach.TSO,
     ccsid0: true,
     codepage: false,
+    connect: 2,
+    decp: "DSNHDECP",
     deprecate: new Set(),
     emptyDbrm: false,
+    flag: CompilerOptions.Flag.I,
+    float: CompilerOptions.Float.S390,
+    graphic: undefined,
+    host: { language: CompilerOptions.HostLanguage.PLI },
     hostCopy: true,
     incOnly: false,
     line: CompilerOptions.Line.LINEONLY,
+    lineCount: 60,
+    noFor: false,
+    onePass: true,
+    printOptions: true,
+    source: false,
+    stdSql: undefined,
     warnDecp: false,
+    xref: false,
   };
 }

--- a/packages/language/src/preprocessor/compiler-options/translator-sql.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator-sql.ts
@@ -10,19 +10,147 @@
  */
 
 import { diagnosticFromCode } from "../../language-server/types";
+import { SyntaxKind } from "../../syntax-tree/ast";
 import { CompilerOptionsCodes } from "./codes";
 import { CompilerOptions as CompilerOptionsPLI } from "./options-pli";
 import { CompilerOptions, getDefaultCompilerOptions } from "./options-sql";
-import { ensureArguments, ensureType, Translator } from "./translator";
+import {
+  ensureArguments,
+  ensureEnum,
+  ensureNumberValue,
+  ensureType,
+  getCompilerOptionValueName,
+  plainTranslateEnum,
+  Translator,
+} from "./translator";
 import { getTranslator as getTranslatorPLI } from "./translator-pli";
 
 const translator = new Translator<CompilerOptions>(() =>
   getDefaultCompilerOptions(),
 );
 
+/**
+ * QUOTE is only valid for COBOL applications.
+ */
+translator.rule(
+  ["APOST"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.apost = CompilerOptions.QuoteChar.APOST;
+  },
+  ["QUOTE"],
+  (option, options, acceptor) => {
+    ensureArguments(option, 0, 0);
+    options.apost = CompilerOptions.QuoteChar.QUOTE;
+    acceptor(
+      diagnosticFromCode(
+        CompilerOptionsCodes.PPSQL.Apost.QuoteOnlyValidForCobol,
+        option.token,
+      ),
+    );
+  },
+);
+
+/**
+ * QUOTESQL is only valid for COBOL applications.
+ */
+translator.rule(
+  ["APOSTSQL"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.apostSql = CompilerOptions.QuoteChar.APOST;
+  },
+  ["QUOTESQL"],
+  (option, options, acceptor) => {
+    ensureArguments(option, 0, 0);
+    options.apostSql = CompilerOptions.QuoteChar.QUOTE;
+    acceptor(
+      diagnosticFromCode(
+        CompilerOptionsCodes.PPSQL.ApostSql.QuoteSqlOnlyValidForCobol,
+        option.token,
+      ),
+    );
+  },
+);
+
+translator.rule(
+  ["ATTACH"],
+  plainTranslateEnum<CompilerOptions>(
+    (options, value) => {
+      options.attach =
+        CompilerOptions.Attach[
+          value.value as keyof typeof CompilerOptions.Attach
+        ];
+    },
+    CompilerOptionsCodes.PPSQL.Attach.InvalidParameter,
+    CompilerOptions.Attach,
+  ),
+);
+
+translator.rule(["CCSID"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "plainNotEmpty");
+  options.ccsid = ensureNumberValue(value, 1, 65535);
+});
+
 translator.flag("ccsid0", ["CCSID0"], ["NOCCSID0"]);
 
 translator.flag("codepage", ["CODEPAGE"], ["NOCODEPAGE"]);
+
+translator.rule(
+  ["COMMA"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.comma = CompilerOptions.DecimalPoint.COMMA;
+  },
+  ["PERIOD"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.comma = CompilerOptions.DecimalPoint.PERIOD;
+  },
+);
+
+translator.rule(["CONNECT", "CT"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "plainNotEmpty");
+  const connect = ensureNumberValue(value, 1, 2);
+  options.connect = connect as 1 | 2;
+});
+
+translator.rule(
+  ["DATE"],
+  plainTranslateEnum<CompilerOptions>(
+    (options, value) => {
+      options.date =
+        CompilerOptions.Date[value.value as keyof typeof CompilerOptions.Date];
+    },
+    CompilerOptionsCodes.PPSQL.Date.InvalidParameter,
+    CompilerOptions.Date,
+  ),
+);
+
+// TODO ssmifi: The D15.s & D31.s syntax is currently not supported by the translator.
+translator.rule(["DEC", "DEC15", "DEC31"], (option, options) => {
+  if (option.name === "DEC15" || option.name === "DEC31") {
+    ensureArguments(option, 0, 0);
+    options.dec = option.name === "DEC15" ? 15 : 31;
+    return;
+  }
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "plainNotEmpty");
+  const dec = ensureNumberValue(value, 15, 31);
+  if (dec !== 15 && dec !== 31) {
+    throw diagnosticFromCode(
+      CompilerOptionsCodes.PPSQL.Dec.InvalidParameter,
+      value.token,
+      value.value,
+    );
+  }
+  options.dec = dec;
+});
 
 translator.rule(["DEPRECATE"], (option, options) => {
   ensureArguments(option, 1);
@@ -57,7 +185,90 @@ translator.rule(["DEPRECATE"], (option, options) => {
   }
 });
 
+translator.rule(["DECP"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "plainOrString");
+  if (value.value.length < 1 || value.value.length > 8) {
+    throw diagnosticFromCode(
+      CompilerOptionsCodes.PPSQL.Decp.InvalidParameterLength,
+      value.token,
+      value.value,
+    );
+  }
+  options.decp = value.value;
+});
+
 translator.flag("emptyDbrm", ["EMPTYDBRM"], ["NOEMPTYDBRM"]);
+
+translator.rule(
+  ["FLAG"],
+  plainTranslateEnum<CompilerOptions>(
+    (options, value) => {
+      options.flag =
+        CompilerOptions.Flag[value.value as keyof typeof CompilerOptions.Flag];
+    },
+    CompilerOptionsCodes.PPSQL.Flag.InvalidParameter,
+    CompilerOptions.Flag,
+  ),
+);
+
+translator.rule(
+  ["FLOAT"],
+  plainTranslateEnum<CompilerOptions>(
+    (options, value) => {
+      options.float =
+        CompilerOptions.Float[
+          value.value as keyof typeof CompilerOptions.Float
+        ];
+    },
+    CompilerOptionsCodes.PPSQL.Float.InvalidParameter,
+    CompilerOptions.Float,
+  ),
+);
+
+/**
+ * No longer used for SQL statement processing; superseded by CCSID. Kept for
+ * compatibility. GRAPHIC/NOGRAPHIC are mutually exclusive.
+ */
+translator.flag("graphic", ["GRAPHIC"], ["NOGRAPHIC"]).postProcess({
+  id: "graphic.supersededByCcsid",
+  run: (options, acceptor, getOwnToken) => {
+    const token = getOwnToken();
+    if (token === undefined || options.ccsid === undefined) {
+      return;
+    }
+    acceptor(
+      diagnosticFromCode(
+        CompilerOptionsCodes.PPSQL.Graphic.SupersededByCcsid,
+        token,
+      ),
+    );
+  },
+});
+
+translator.rule(["HOST"], (option, options, acceptor) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+
+  if (value.kind === SyntaxKind.CompilerOptionText) {
+    ensureType(value, "plainNotEmpty");
+    const language = ensureEnum(
+      value,
+      CompilerOptionsCodes.PPSQL.Host.InvalidParameter,
+      CompilerOptions.HostLanguage,
+    );
+    options.host = { language };
+  } else {
+    acceptor(
+      diagnosticFromCode(
+        CompilerOptionsCodes.PPSQL.Host.ExpectedPLI,
+        value.token,
+        getCompilerOptionValueName(value),
+      ),
+    );
+  }
+});
 
 translator.flag("hostCopy", ["HOSTCOPY"], ["NOHOSTCOPY"]).postProcess({
   id: "hostCopy.ignoredWithLp32",
@@ -81,6 +292,60 @@ translator.flag("hostCopy", ["HOSTCOPY"], ["NOHOSTCOPY"]).postProcess({
 
 translator.flag("incOnly", ["INCONLY"], ["NOINCONLY"]);
 
+translator.rule(["LEVEL", "L"], (option, options) => {
+  ensureArguments(option, 0, 1);
+  if (option.values.length === 0) {
+    options.level = "";
+    return;
+  }
+  const value = option.values[0];
+  ensureType(value, "plainOrString");
+  if (value.value.length > 0 && !/^[a-zA-Z0-9]{1,7}$/.test(value.value)) {
+    throw diagnosticFromCode(
+      CompilerOptionsCodes.PPSQL.Level.InvalidParameter,
+      value.token,
+      value.value,
+    );
+  }
+  options.level = value.value;
+});
+
+translator.rule(["LINECOUNT", "LC"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "plainNotEmpty");
+  options.lineCount = ensureNumberValue(value, 0);
+});
+
+translator.rule(["MARGINS", "MAR"], (option, options) => {
+  ensureArguments(option, 2, 3);
+  const m = option.values[0];
+  const n = option.values[1];
+  ensureType(m, "plainNotEmpty");
+  ensureType(n, "plainNotEmpty");
+  const mValue = ensureNumberValue(m, 1, 80);
+  const nValue = ensureNumberValue(n, 1, 80);
+  if (mValue >= nValue) {
+    throw diagnosticFromCode(
+      CompilerOptionsCodes.PPSQL.Margins.InvalidMarginPosition,
+      m.token,
+    );
+  }
+  let cValue: number | undefined;
+  if (option.values.length > 2) {
+    const c = option.values[2];
+    ensureType(c, "plainNotEmpty");
+    cValue = ensureNumberValue(c, 1, 80);
+    if (cValue >= mValue && cValue <= nValue) {
+      throw diagnosticFromCode(
+        CompilerOptionsCodes.PPSQL.Margins.InvalidContinuationPosition,
+        c.token,
+      );
+    }
+  }
+  options.margins = { m: mValue, n: nValue, c: cValue };
+});
+
 translator.rule(
   ["LINEFILE"],
   (option, options) => {
@@ -94,7 +359,99 @@ translator.rule(
   },
 );
 
+/**
+ * Deprecated: use SQLLEVEL instead. Kept for compatibility; always warns when used.
+ */
+translator.rule(["NEWFUN"], (option, options, acceptor) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "plainNotEmpty");
+  const newFun = ensureEnum(
+    value,
+    CompilerOptionsCodes.PPSQL.NewFun.InvalidParameter,
+    CompilerOptions.NewFun,
+  );
+  options.newFun = newFun;
+  acceptor(
+    diagnosticFromCode(
+      CompilerOptionsCodes.PPSQL.NewFun.Deprecated,
+      option.token,
+    ),
+  );
+});
+
+// TODO: The spec does not mention a FOR option. Should be checked.
+translator.rule(["NOFOR"], (option, options) => {
+  ensureArguments(option, 0, 0);
+  options.noFor = true;
+});
+
+translator.rule(
+  ["ONEPASS", "ON"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.onePass = true;
+  },
+  ["TWOPASS", "TW"],
+  (option, options) => {
+    ensureArguments(option, 0, 0);
+    options.onePass = false;
+  },
+);
+
+translator.flag("printOptions", ["OPTIONS", "OPTN"], ["NOOPTIONS", "NOOPTN"]);
+
+translator.flag("source", ["SOURCE", "S"], ["NOSOURCE", "NOS"]);
+
+translator.rule(["SQLLEVEL"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "plainNotEmpty");
+  const level = value.value.toUpperCase();
+  if (!/^V\d{2}R\d(M\d{3})?$/.test(level)) {
+    throw diagnosticFromCode(
+      CompilerOptionsCodes.PPSQL.SqlLevel.InvalidParameter,
+      value.token,
+      value.value,
+    );
+  }
+  options.sqlLevel = level;
+});
+
+translator.rule(["STDSQL"], (option, options) => {
+  ensureArguments(option, 1, 1);
+  const value = option.values[0];
+  ensureType(value, "plainNotEmpty");
+  const upper = value.value.toUpperCase();
+  if (upper !== "YES" && upper !== "NO") {
+    throw diagnosticFromCode(
+      CompilerOptionsCodes.PPSQL.StdSql.InvalidParameter,
+      value.token,
+      value.value,
+    );
+  }
+  options.stdSql = upper === "YES";
+  // STDSQL(YES) implies NOFOR.
+  if (options.stdSql) {
+    options.noFor = true;
+  }
+});
+
+translator.rule(
+  ["TIME"],
+  plainTranslateEnum<CompilerOptions>(
+    (options, value) => {
+      options.time =
+        CompilerOptions.Time[value.value as keyof typeof CompilerOptions.Time];
+    },
+    CompilerOptionsCodes.PPSQL.Time.InvalidParameter,
+    CompilerOptions.Time,
+  ),
+);
+
 translator.flag("warnDecp", ["WARNDECP"], ["NOWARNDECP"]);
+
+translator.flag("xref", ["XREF"], ["NOXREF"]);
 
 export function getTranslator(): Translator<CompilerOptions> {
   return translator;

--- a/packages/language/src/preprocessor/compiler-options/translator.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator.ts
@@ -87,7 +87,7 @@ export interface RuleAwarePostProcessHook<
   ) => void;
 }
 
-type TranslationDiagnosticAcceptor = (diagnostic: Diagnostic) => void;
+export type TranslationDiagnosticAcceptor = (diagnostic: Diagnostic) => void;
 
 type Translate<T extends CompilerOptionsPP> = (
   option: CompilerOption,
@@ -830,12 +830,18 @@ function stringToNumber(text: string): number {
 
 export function stringTranslate<
   T extends CompilerOptionsPP = CompilerOptionsPP,
->(callback: (options: T, value: CompilerOptionString) => void): Translate<T> {
-  return (option, options) => {
+>(
+  callback: (
+    options: T,
+    value: CompilerOptionString,
+    acceptor: TranslationDiagnosticAcceptor,
+  ) => void,
+): Translate<T> {
+  return (option, options, acceptor) => {
     ensureArguments(option, 1, 1);
     const value = option.values[0];
     ensureType(value, "string");
-    callback(options, value);
+    callback(options, value, acceptor);
   };
 }
 
@@ -855,12 +861,16 @@ export function isEmptyParameterList(option: CompilerOption): boolean {
 export function plainTranslateEnum<
   T extends CompilerOptionsPP = CompilerOptionsPP,
 >(
-  callback: (options: T, value: CompilerOptionText) => void,
+  callback: (
+    options: T,
+    value: CompilerOptionText,
+    acceptor: TranslationDiagnosticAcceptor,
+  ) => void,
   code: ParametricPLICode,
   enumObject: Record<string, string | number>,
   aliases?: readonly (readonly [string, ...string[]])[],
 ): Translate<T> {
-  return (option, options) => {
+  return (option, options, acceptor) => {
     ensureArguments(option, 1, 1);
     const value = option.values[0];
     ensureType(value, "plainNotEmpty");
@@ -894,7 +904,7 @@ export function plainTranslateEnum<
       }
     }
 
-    callback(options, value);
+    callback(options, value, acceptor);
   };
 }
 
@@ -903,11 +913,15 @@ export function plainTranslateEnum<
  * Supports both simple lists and aliases mode.
  */
 export function plainTranslate<T extends CompilerOptionsPP = CompilerOptionsPP>(
-  callback: (options: T, value: CompilerOptionText) => void,
+  callback: (
+    options: T,
+    value: CompilerOptionText,
+    acceptor: TranslationDiagnosticAcceptor,
+  ) => void,
   code: ParametricPLICode,
   values: readonly string[] | readonly (readonly [string, ...string[]])[],
 ): Translate<T> {
-  return (option, options) => {
+  return (option, options, acceptor) => {
     ensureArguments(option, 1, 1);
     const value = option.values[0];
     ensureType(value, "plainNotEmpty");
@@ -920,11 +934,11 @@ export function plainTranslate<T extends CompilerOptionsPP = CompilerOptionsPP>(
       const aliasGroups = values as readonly (readonly [string, ...string[]])[];
       const canonicalValue = ensureArgument(value, code, aliasGroups);
       value.value = canonicalValue;
-      callback(options, value);
+      callback(options, value, acceptor);
     } else {
       const stringValues = values as readonly string[];
       ensureArgument(value, code, stringValues);
-      callback(options, value);
+      callback(options, value, acceptor);
     }
   };
 }

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/apost.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/apost.ts
@@ -1,0 +1,25 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("<|1:QUOTE|>"));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.PPSQL.Apost.QuoteOnlyValidForCobol.message(),
+});
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    apost: constants.CompilerOptions.SQL.QuoteChar.QUOTE,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/apostsql.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/apostsql.ts
@@ -1,0 +1,26 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("<|1:QUOTESQL|>"));
+
+verify.expectDiagnosticsAt(1, {
+  message:
+    code.CompilerOptions.PPSQL.ApostSql.QuoteSqlOnlyValidForCobol.message(),
+});
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    apostSql: constants.CompilerOptions.SQL.QuoteChar.QUOTE,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/attach.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/attach.ts
@@ -1,0 +1,27 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("ATTACH(CAF)"));
+////*PROCESS PP(SQL("ATTACH(<|1:INVALID|>)"));
+
+verify.expectDiagnosticsAt(1, {
+  message:
+    code.CompilerOptions.PPSQL.Attach.InvalidParameter.message("INVALID"),
+});
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    attach: constants.CompilerOptions.SQL.Attach.CAF,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/ccsid.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/ccsid.ts
@@ -1,0 +1,26 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("CCSID(1208)"));
+////*PROCESS PP(SQL("CCSID(<|1:70000|>)"));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.ExpectedNumberRange.message(70000, 1, 65535),
+});
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    ccsid: 1208,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/comma.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/comma.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("COMMA"));
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    comma: constants.CompilerOptions.SQL.DecimalPoint.COMMA,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/connect.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/connect.ts
@@ -1,0 +1,29 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("CT(1)"));
+////*PROCESS PP(SQL("<|1:CONNECT|>(<|2:3|>)"));
+
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.ExpectedNumberRange.message(3, 1, 2),
+});
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.DupeOptionIssue.message("CONNECT"),
+});
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    connect: 1,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/date.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/date.ts
@@ -1,0 +1,26 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("DATE(EUR)"));
+////*PROCESS PP(SQL("DATE(<|1:INVALID|>)"));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.PPSQL.Date.InvalidParameter.message("INVALID"),
+});
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    date: constants.CompilerOptions.SQL.Date.EUR,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/dec-invalid.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/dec-invalid.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("DEC(<|1:20|>)"));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.PPSQL.Dec.InvalidParameter.message("20"),
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/dec.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/dec.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("DEC15"));
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    dec: 15,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/dec31.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/dec31.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("DEC31"));
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    dec: 31,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/decp.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/decp.ts
@@ -1,0 +1,32 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("DECP(MYDECP)"));
+////*PROCESS PP(SQL("<|1:DECP|>(<|2:TOOLONGNAME|>)"));
+
+verify.expectDiagnosticsAt(2, {
+  message:
+    code.CompilerOptions.PPSQL.Decp.InvalidParameterLength.message(
+      "TOOLONGNAME",
+    ),
+});
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.DupeOptionIssue.message("DECP"),
+});
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    decp: "MYDECP",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/flag.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/flag.ts
@@ -1,0 +1,26 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("FLAG(W)"));
+////*PROCESS PP(SQL("FLAG(<|1:INVALID|>)"));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.PPSQL.Flag.InvalidParameter.message("INVALID"),
+});
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    flag: constants.CompilerOptions.SQL.Flag.W,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/float.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/float.ts
@@ -1,0 +1,26 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("FLOAT(IEEE)"));
+////*PROCESS PP(SQL("FLOAT(<|1:INVALID|>)"));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.PPSQL.Float.InvalidParameter.message("INVALID"),
+});
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    float: constants.CompilerOptions.SQL.Float.IEEE,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/graphic.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/graphic.ts
@@ -1,0 +1,27 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("CCSID(1208)"));
+////*PROCESS PP(SQL("<|1:GRAPHIC|>"));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.PPSQL.Graphic.SupersededByCcsid.message(),
+});
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    graphic: true,
+    ccsid: 1208,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/host.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/host.ts
@@ -1,0 +1,26 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("HOST(PLI)"));
+////*PROCESS PP(SQL("HOST(<|1:C(FOLD)|>)"));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.PPSQL.Host.ExpectedPLI.message("C"),
+});
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    host: { language: constants.CompilerOptions.SQL.HostLanguage.PLI },
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/level.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/level.ts
@@ -1,0 +1,30 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("L(REL100)"));
+////*PROCESS PP(SQL("<|1:LEVEL|>(<|2:TOOLONGVALUE|>)"));
+
+verify.expectDiagnosticsAt(2, {
+  message:
+    code.CompilerOptions.PPSQL.Level.InvalidParameter.message("TOOLONGVALUE"),
+});
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.DupeOptionIssue.message("LEVEL"),
+});
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    level: "REL100",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/linecount.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/linecount.ts
@@ -1,0 +1,29 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("LC(40)"));
+////*PROCESS PP(SQL("<|1:LINECOUNT|>(<|2:-5|>)"));
+
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.ExpectedNumberRange.message(-5, 0, undefined),
+});
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.DupeOptionIssue.message("LINECOUNT"),
+});
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    lineCount: 40,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/margins.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/margins.ts
@@ -1,0 +1,35 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("MAR(<|1:72|>, 10)"));
+////*PROCESS PP(SQL("MARGINS(2, 72, <|2:20|>)"));
+////*PROCESS PP(SQL("MARGINS(10, 72, 80)"));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.PPSQL.Margins.InvalidMarginPosition.message(),
+});
+verify.expectDiagnosticsAt(2, {
+  message:
+    code.CompilerOptions.PPSQL.Margins.InvalidContinuationPosition.message(),
+});
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    margins: {
+      m: 10,
+      n: 72,
+      c: 80,
+    },
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/newfun.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/newfun.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("<|1:NEWFUN|>(V11)"));
+////*PROCESS PP(SQL("NEWFUN(<|2:V99|>)"));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.PPSQL.NewFun.Deprecated.message(),
+});
+verify.expectDiagnosticsAt(2, {
+  message: code.CompilerOptions.PPSQL.NewFun.InvalidParameter.message("V99"),
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/nofor.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/nofor.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("NOFOR"));
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    noFor: true,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/nosource.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/nosource.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("NOS"));
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    source: false,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/onepass.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/onepass.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("ON"));
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    onePass: true,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/options.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/options.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("NOOPTN"));
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    printOptions: false,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/period.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/period.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("PERIOD"));
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    comma: constants.CompilerOptions.SQL.DecimalPoint.PERIOD,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/source.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/source.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("S"));
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    source: true,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/sqllevel.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/sqllevel.ts
@@ -1,0 +1,30 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("SQLLEVEL(V12R1M100)"));
+////*PROCESS PP(SQL("<|1:SQLLEVEL|>(<|2:INVALID|>)"));
+
+verify.expectDiagnosticsAt(2, {
+  message:
+    code.CompilerOptions.PPSQL.SqlLevel.InvalidParameter.message("INVALID"),
+});
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.DupeOptionIssue.message("SQLLEVEL"),
+});
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    sqlLevel: "V12R1M100",
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/stdsql-invalid.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/stdsql-invalid.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("STDSQL(<|1:MAYBE|>)"));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.PPSQL.StdSql.InvalidParameter.message("MAYBE"),
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/stdsql.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/stdsql.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("STDSQL(YES)"));
+
+// STDSQL(YES) automatically implies NOFOR.
+verify.expectCompilerOptions({
+  sqlOptions: {
+    stdSql: true,
+    noFor: true,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/time.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/time.ts
@@ -1,0 +1,26 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("TIME(JIS)"));
+////*PROCESS PP(SQL("TIME(<|1:INVALID|>)"));
+
+verify.expectDiagnosticsAt(1, {
+  message: code.CompilerOptions.PPSQL.Time.InvalidParameter.message("INVALID"),
+});
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    time: constants.CompilerOptions.SQL.Time.JIS,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/twopass.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/twopass.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("TW"));
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    onePass: false,
+  },
+});

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/xref.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-sql/xref.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../../framework.ts" />
+
+// @wrap: process
+////*PROCESS PP(SQL("XREF"));
+
+verify.expectCompilerOptions({
+  sqlOptions: {
+    xref: true,
+  },
+});


### PR DESCRIPTION
Adds the missing SQL compiler options based on 
https://www.ibm.com/docs/en/db2-for-zos/12.0.0?topic=processing-descriptions-sql-options
https://www.ibm.com/docs/en/epfz/6.1.0?topic=preprocessor-sql-options

Based on https://github.com/zowe/zowe-pli-language-support/pull/815