### PR TITLE
Support case insensitive linking in SQL

### DIFF
--- a/packages/language/test/fourslash/preprocessor/pp-phases/exec-sql-case-insensitive-linking.ts
+++ b/packages/language/test/fourslash/preprocessor/pp-phases/exec-sql-case-insensitive-linking.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/// <reference path="../../framework.ts" />
+
+//// TEST: PROC;
+////   DCL <|X|> CHAR(1);
+////   EXEC SQL SELECT ';' INTO :<|X>x FROM T;
+//// END;
+
+verify.noParserDiagnostics();
+linker.expectLinks();

--- a/packages/preprocessor-db2/src/engine/parsing.ts
+++ b/packages/preprocessor-db2/src/engine/parsing.ts
@@ -86,8 +86,9 @@ export class CollectingIdentifierVisitor extends Db2SqlExecParserVisitor<void> {
   ): void => {
     if (ctx.start && ctx.stop) {
       this.identifiers.push({
-        //remove leading colon
-        image: ctx.getText().slice(1),
+        // Remove leading colon
+        // Also: convert to upper case because linking is case-insensitive
+        image: ctx.getText().slice(1).toUpperCase(),
         startOffset: ctx.start.start + 1,
         endOffset: ctx.stop.stop,
         semanticsKind: SemanticsKind.Identifier,


### PR DESCRIPTION
Closes https://github.com/zowe/zowe-pli-language-support/issues/822

The fix should be self-explanatory. We didn't upper case the variable value before sending it back to the language server.