### PR TITLE
Refactor fallback workspace to undefined URI

### DIFF
--- a/packages/language/src/config/lib-expander.ts
+++ b/packages/language/src/config/lib-expander.ts
@@ -87,6 +87,8 @@ export enum ExpandedLibKind {
  */
 export interface ExpandedLib {
   kind: ExpandedLibKind;
+  /** The reason why a lib might be unresolved. */
+  reason?: string;
   libItem: JsonItem<string>;
   /**
    * Computed entries. Empty for unresolved. May be multiple {@link LibsDirEntry}s
@@ -103,8 +105,11 @@ export interface ExpandedLib {
  */
 export interface ExpandedGroup {
   libs: LibsEntry[];
-  /** Lib items that didn't resolve to anything on disk. */
-  unresolved: JsonItem<string>[];
+  /**
+   * Lib items that didn't resolve to anything on disk.
+   * The second tuple element is the reason why it was unresolved, if any.
+   */
+  unresolved: [JsonItem<string>, string | undefined][];
 }
 
 /**
@@ -134,7 +139,7 @@ function baseDepthOf(base: string): number {
 async function planLibs(
   libItems: readonly JsonItem<string>[],
   fs: FileSystemProvider,
-  workspace: URI,
+  workspace: URI | undefined,
 ): Promise<PlannedLib[]> {
   const planned: PlannedLib[] = [];
   for (let configIndex = 0; configIndex < libItems.length; configIndex++) {
@@ -167,7 +172,7 @@ async function planLibs(
 export async function expandGroup(
   libItems: readonly JsonItem<string>[],
   fs: FileSystemProvider,
-  workspace: URI,
+  workspace: URI | undefined,
 ): Promise<ExpandedGroup> {
   const planned = await planLibs(libItems, fs, workspace);
   const expansions = await Promise.all(
@@ -176,11 +181,11 @@ export async function expandGroup(
 
   const seen = new Set<string>();
   const sortable: SortableLib[] = [];
-  const unresolved: JsonItem<string>[] = [];
+  const unresolved: [JsonItem<string>, string | undefined][] = [];
   for (let i = 0; i < expansions.length; i++) {
     const expansion = expansions[i];
     if (expansion.kind === ExpandedLibKind.Unresolved) {
-      unresolved.push(expansion.libItem);
+      unresolved.push([expansion.libItem, expansion.reason]);
       continue;
     }
     const { configIndex, baseDepth } = planned[i];
@@ -213,9 +218,19 @@ export async function expandGroup(
 export async function expandLib(
   libItem: JsonItem<string>,
   fs: FileSystemProvider,
-  workspace: URI,
+  workspace: URI | undefined,
 ): Promise<ExpandedLib> {
   const libUri = resolveLibUri(libItem.value, workspace);
+  if (!libUri) {
+    // Workspace-relative lib with no workspace to resolve against
+    // (the fallback workspace).
+    return {
+      kind: ExpandedLibKind.Unresolved,
+      reason: "Cannot resolve relative lib without a workspace.",
+      libItem,
+      entries: [],
+    };
+  }
   let statIsDirectory = false;
   let statIsFile = false;
   const stats = await safeStat(fs, libUri);
@@ -231,7 +246,12 @@ export async function expandLib(
   if (statIsFile) {
     // Lib paths must point at a directory or a (notional) data set, not a
     // single file. Treat as unresolved so the user sees a diagnostic.
-    return { kind: ExpandedLibKind.Unresolved, libItem, entries: [] };
+    return {
+      kind: ExpandedLibKind.Unresolved,
+      reason: "Lib path points to a file.",
+      libItem,
+      entries: [],
+    };
   }
 
   // The path itself doesn't exist on disk. Try the data-set convention:
@@ -252,7 +272,19 @@ export async function expandLib(
     const dirEntries = [await expandDirectoryTree(libItem.value, libUri, fs)];
     return { kind: ExpandedLibKind.Directory, libItem, entries: dirEntries };
   }
-  return { kind: ExpandedLibKind.Unresolved, libItem, entries: [] };
+  // At this point, we cannot resolve the lib to anything in the file system
+  // Create a special error message for libs in the Zowe Explorer extension
+  let reason = "Path does not exist.";
+  if (libUri.scheme === "zowe-ds") {
+    reason =
+      "Please make sure that the Zowe Explorer extension is installed and configured correctly.";
+  }
+  return {
+    kind: ExpandedLibKind.Unresolved,
+    reason,
+    libItem,
+    entries: [],
+  };
 }
 
 /**
@@ -325,13 +357,16 @@ function joinBaseRel(base: string, rel: string): string {
 async function expandWildcardLib(
   pattern: string,
   fs: FileSystemProvider,
-  workspace: URI,
+  workspace: URI | undefined,
 ): Promise<string[]> {
   const { base, tail } = splitGlobPattern(pattern);
   if (!tail) {
     return [];
   }
   const root = resolveLibUri(base, workspace);
+  if (!root) {
+    return [];
+  }
   const tailHasGlobstar = tail.includes("**");
   // A bare-globstar tail (i.e. a `.../**` pattern) also matches the base
   // directory itself, which the walk below never reaches as a child.

--- a/packages/language/src/config/path-resolver.ts
+++ b/packages/language/src/config/path-resolver.ts
@@ -21,21 +21,27 @@ import { URI, UriUtils } from "../utils/uri";
  * `scheme` parameter overrides the absolute-path scheme so include
  * resolution can match the entry file's scheme; lib expansion passes the
  * workspace scheme.
+ *
+ * A workspace-relative path cannot be resolved without a workspace
+ * (`workspace === undefined`, i.e. the fallback workspace) and yields
+ * `undefined`.
  */
 export function resolveLibUri(
   lib: string,
-  workspace: URI,
+  workspace: URI | undefined,
   scheme?: string,
-): URI {
+): URI | undefined {
   lib = UriUtils.normalizePath(lib);
   const pathType = UriUtils.computePathType(lib);
   if (pathType === UriUtils.PathType.URI) {
     return UriUtils.parse(lib);
   }
   if (pathType === UriUtils.PathType.Absolute) {
-    return UriUtils.file(lib).with({ scheme: scheme ?? workspace.scheme });
+    const fileUri = UriUtils.file(lib);
+    const targetScheme = scheme ?? workspace?.scheme;
+    return targetScheme ? fileUri.with({ scheme: targetScheme }) : fileUri;
   }
-  return UriUtils.joinPath(workspace, lib);
+  return workspace ? UriUtils.joinPath(workspace, lib) : undefined;
 }
 
 /**
@@ -46,10 +52,13 @@ export function resolveLibUri(
 export function resolveLibFileUri(
   lib: string,
   fileName: string | undefined,
-  workspace: URI,
+  workspace: URI | undefined,
   scheme?: string,
 ): URI | undefined {
   const base = resolveLibUri(lib, workspace, scheme);
+  if (!base) {
+    return undefined;
+  }
   if (fileName) {
     const joined = UriUtils.joinPath(base, fileName);
     if (!UriUtils.contains(base, joined)) {

--- a/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
+++ b/packages/language/src/language-server/code-actions/apply-quick-fixes.ts
@@ -69,7 +69,11 @@ export async function quickFixResolveInclude(
   );
   if (!unresolvedFilePath) return undefined;
 
-  const workspaceFolderUri = workspace.config.getWorkspacePath();
+  const workspaceFolderUri = workspace.config.getWorkspaceUri();
+  if (!workspaceFolderUri) {
+    // Fallback workspace: there is no root to express the lib relative to.
+    return undefined;
+  }
 
   const parentFolder = UriUtils.computeWorkspaceRelativeParentFolder(
     unresolvedFilePath,
@@ -132,7 +136,7 @@ export async function quickFixCreateConfig(
   diagnostic: Diagnostic,
   workspace: WorkspaceContext,
 ): Promise<CodeAction | undefined> {
-  const workspaceUri = workspace.config.getWorkspacePath();
+  const workspaceUri = workspace.config.getWorkspaceUri();
   const entryUri = diagnostic.data.entryUri as string;
   if (!workspaceUri || !entryUri) {
     return;
@@ -401,12 +405,14 @@ export function quickFixReplaceUnknownProcGroup(
   workspace: WorkspaceContext,
   documentUri?: string,
 ): CodeAction[] {
+  const workspaceUri = workspace.config.getWorkspaceUri();
   const uri =
     documentUri ??
-    UriUtils.joinPath(
-      workspace.config.getWorkspacePath(),
-      PluginConfiguration.PROGRAM_FILE_PATH,
-    ).toString();
+    (workspaceUri &&
+      UriUtils.joinPath(
+        workspaceUri,
+        PluginConfiguration.PROGRAM_FILE_PATH,
+      ).toString());
   const unknownEntryRange = diagnostic.range;
   if (!unknownEntryRange || !uri) {
     return [];

--- a/packages/language/src/preprocessor/exec-phase.ts
+++ b/packages/language/src/preprocessor/exec-phase.ts
@@ -687,11 +687,10 @@ function buildIncludeDirective(
   }
   if (attempt.uri) {
     item.filePath = attempt.uri.toString();
-    const workspace = context.unit.services.workspace.config.getWorkspacePath();
-    item.relativeFilePath = UriUtils.composeRelativePath(
-      workspace.path,
-      attempt.uri.toString(),
-    );
+    const workspace = context.unit.services.workspace.config.getWorkspaceUri();
+    item.relativeFilePath = workspace
+      ? UriUtils.composeRelativePath(workspace.path, attempt.uri.toString())
+      : attempt.uri.toString();
   }
   const directive = ast.createIncludeDirective();
   directive.items.push(item);

--- a/packages/language/src/preprocessor/include-resolver.ts
+++ b/packages/language/src/preprocessor/include-resolver.ts
@@ -238,7 +238,7 @@ async function tryLiveFile(
 function buildDatasetMemberUri(
   libPath: string,
   memberFileName: string,
-  workspace: URI,
+  workspace: URI | undefined,
   scheme: string,
 ): URI | undefined {
   const datasetUri = resolveLibFileUri(libPath, undefined, workspace, scheme);
@@ -258,7 +258,7 @@ function buildDatasetMemberUri(
 function tryResolveDatasetMemberInDir(
   lib: LibsDirEntry,
   query: string,
-  workspace: URI,
+  workspace: URI | undefined,
   scheme: string,
 ): URI | undefined {
   if (!MEMBER_NAME_REGEX.test(query)) {
@@ -282,7 +282,7 @@ async function tryResolveFileInDir(
   query: string,
   extensions: readonly string[],
   unit: CompilationUnit,
-  workspace: URI,
+  workspace: URI | undefined,
   scheme: string,
 ): Promise<URI | undefined> {
   const matchedFileName = findIndexedFile(lib.files, query, extensions);
@@ -304,7 +304,7 @@ async function tryResolveFileInDir(
 function tryResolveStandaloneMemberInDDLib(
   lib: LibsDDEntry,
   memberName: string,
-  workspace: URI,
+  workspace: URI | undefined,
   scheme: string,
 ): URI | undefined {
   const memberFileName = lib.members.get(memberName.toLowerCase());
@@ -323,7 +323,7 @@ function tryResolveDDNameMember(
   lib: LibsDDEntry,
   ddname: string,
   memberName: string,
-  workspace: URI,
+  workspace: URI | undefined,
   scheme: string,
 ): URI | undefined {
   // Ensure that we match the whole ddname, not just a suffix of it
@@ -381,7 +381,7 @@ export async function resolveIncludeFileUri(
     return undefined;
   }
 
-  const workspaceUri = workspaceCtx.config.getWorkspacePath();
+  const workspaceUri = workspaceCtx.config.getWorkspaceUri();
   const scheme = context.entryUri.scheme;
   const includeExtensions = pgroup.includeExtensions.map((e) => e.value);
 

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -2164,11 +2164,10 @@ function setFilePath(
   if (!filePath) return;
   item.filePath = filePath;
   if (!context.currentUri) return;
-  const workspace = context.unit.services.workspace.config.getWorkspacePath();
-  item.relativeFilePath = UriUtils.composeRelativePath(
-    workspace.path,
-    filePath,
-  );
+  const workspace = context.unit.services.workspace.config.getWorkspaceUri();
+  item.relativeFilePath = workspace
+    ? UriUtils.composeRelativePath(workspace.path, filePath)
+    : filePath;
 }
 
 async function runInclude(

--- a/packages/language/src/utils/config.ts
+++ b/packages/language/src/utils/config.ts
@@ -29,6 +29,11 @@ export async function updateOrCreateConfig(
   workspace: WorkspaceContext,
 ): Promise<void> {
   const config = workspace.config;
+  const workspaceFolderUri = config.getWorkspaceUri();
+  if (!workspaceFolderUri) {
+    // Fallback workspace: there is no workspace to write config files into.
+    return;
+  }
   const hasExistingConfigs = config.hasRegisteredProgramConfigs();
 
   if (!hasExistingConfigs) {
@@ -44,7 +49,6 @@ export async function updateOrCreateConfig(
     return;
   }
 
-  const workspaceFolderUri = config.getWorkspacePath();
   const configFilePath = UriUtils.joinPath(
     workspaceFolderUri,
     PluginConfiguration.PROGRAM_FILE_PATH,

--- a/packages/language/src/utils/messages.ts
+++ b/packages/language/src/utils/messages.ts
@@ -74,8 +74,13 @@ export function sendNotification<P>(
 }
 
 export namespace Messages {
+  /**
+   * Request sent to the client to load the VS Code settings backing for the
+   * plugin config. The param is the workspace folder URI, or `null` for the
+   * fallback workspace (no folder; only user-scope settings can apply).
+   */
   export const GetGlobalConfig = createRequestType<
-    string,
+    string | null,
     Messages.GlobalConfig
   >("pli/getGlobalConfig");
 
@@ -189,12 +194,17 @@ export namespace Messages {
 }
 
 export interface GlobalConfigLoader {
-  loadGlobalConfig(workspaceUri: URI): Promise<Messages.GlobalConfig>;
+  /** `workspaceUri` is `undefined` for the fallback workspace. */
+  loadGlobalConfig(
+    workspaceUri: URI | undefined,
+  ): Promise<Messages.GlobalConfig>;
 }
 
 export class TestGlobalConfigLoader implements GlobalConfigLoader {
   constructor(private readonly config: Messages.GlobalConfig) {}
-  loadGlobalConfig(_workspaceUri: URI): Promise<Messages.GlobalConfig> {
+  loadGlobalConfig(
+    _workspaceUri: URI | undefined,
+  ): Promise<Messages.GlobalConfig> {
     return Promise.resolve(this.config);
   }
 }

--- a/packages/language/src/validation/lsp-codes.ts
+++ b/packages/language/src/validation/lsp-codes.ts
@@ -76,8 +76,9 @@ export const LspCodes = {
     UnresolvedEntry: {
       code: "COPC01",
       severity: Severity.E,
-      message: (lib: string) =>
-        `Plugin Configuration failed to resolve library entry '${lib}'`,
+      message: (lib: string, reason?: string) =>
+        `Plugin Configuration failed to resolve library entry '${lib}'.` +
+        (reason ? ` ${reason}` : ""),
     },
 
     ParseError: {

--- a/packages/language/src/workspace/compilation-unit.ts
+++ b/packages/language/src/workspace/compilation-unit.ts
@@ -414,17 +414,15 @@ export class CompilationUnitHandler {
 
   /** must be initialized at least once */
   async initializeFallbackFolder() {
-    const uri = UriUtils.toUri(`file://`);
     const workspace = new WorkspaceContext(
       this.fs,
       this.configLoader,
       this.longRunningOperation,
     );
-    // The fallback workspace has no real root; relative library paths from
-    // user-scope settings can't be resolved here and must not be flagged.
-    workspace.config.markAsFallbackWorkspace();
     this.fallbackWorkspace = workspace;
-    const diagnosticsByUri = await workspace.config.init(uri);
+    // The fallback workspace has no root; relative library paths from
+    // user-scope settings can't be resolved here and must not be flagged.
+    const diagnosticsByUri = await workspace.config.init(undefined);
     if (this.connection) {
       publishPluginConfigDiagnostics(this.connection, diagnosticsByUri);
     }

--- a/packages/language/src/workspace/plugin-configuration-provider.ts
+++ b/packages/language/src/workspace/plugin-configuration-provider.ts
@@ -208,9 +208,13 @@ export class PluginConfigurationProvider {
   private processGroupConfigs: Map<string, GroupRecord>;
 
   /**
-   * The workspace path that we're initialized with.
+   * The workspace path that we're initialized with. `undefined` when this
+   * provider backs the fallback workspace that serves files outside any real
+   * workspace folder (or hasn't been initialized yet). Without a workspace
+   * there is no base to resolve workspace-relative paths against, so such
+   * libs are unresolvable and must not be reported as unresolved.
    */
-  private workspacePath: URI;
+  private workspaceUri: URI | undefined;
 
   /**
    * Per-source snapshots from the most recent postProcessProcessGroups run,
@@ -246,15 +250,6 @@ export class PluginConfigurationProvider {
   private readonly longRunningOperation: LongRunningOperation;
   private readonly globalConfigLoader: GlobalConfigLoader;
 
-  /**
-   * True when this provider backs the fallback workspace (rooted at the
-   * filesystem root) that serves files outside any real workspace folder.
-   * A fallback workspace has no base to resolve workspace-relative library
-   * paths against, so it must not report such libs as unresolved. Set once
-   * via {@link markAsFallbackWorkspace} right after construction.
-   */
-  private isFallbackWorkspace = false;
-
   constructor(
     fs: FileSystemProvider,
     globalConfigLoader: GlobalConfigLoader,
@@ -265,15 +260,6 @@ export class PluginConfigurationProvider {
     this.globalConfigLoader = globalConfigLoader;
     this.programConfigs = new Map<string, ProgramRecord>();
     this.processGroupConfigs = new Map<string, GroupRecord>();
-    this.workspacePath = UriUtils.parse(""); // empty workspace to start with
-  }
-
-  /**
-   * Marks this provider as backing the fallback workspace. See
-   * {@link isFallbackWorkspace}. Must be called before {@link init}.
-   */
-  public markAsFallbackWorkspace(): void {
-    this.isFallbackWorkspace = true;
   }
 
   /**
@@ -323,11 +309,15 @@ export class PluginConfigurationProvider {
   /**
    * Initializes the plugin configuration provider with a workspace path, using any plugin configs present in the workspace.
    *
-   * @param workspacePath The full path to the workspace to load plugin configurations from
+   * @param workspacePath The full path to the workspace to load plugin
+   *   configurations from, or `undefined` for the fallback workspace (config
+   *   then comes from settings sources only).
    * @returns Diagnostics keyed by config URI
    */
-  public async init(workspacePath: URI): Promise<PluginConfigLspDiagnostics> {
-    this.workspacePath = workspacePath;
+  public async init(
+    workspacePath: URI | undefined,
+  ): Promise<PluginConfigLspDiagnostics> {
+    this.workspaceUri = workspacePath;
     return this.loadConfigurations();
   }
 
@@ -337,10 +327,6 @@ export class PluginConfigurationProvider {
    * dirs are not "lib directories" in the file-membership sense).
    */
   private buildLibFileMatchers(): void {
-    let wsPrefix = this.workspacePath.toString(true).toLowerCase();
-    if (wsPrefix && !wsPrefix.endsWith("/")) {
-      wsPrefix += "/";
-    }
     const matchers = new Map<string, Set<string>>();
     for (const processGroup of this.processGroupConfigs.values()) {
       const exts = processGroup.includeExtensions.map((item) =>
@@ -356,8 +342,12 @@ export class PluginConfigurationProvider {
         if (!isLibsDir(lib)) {
           continue;
         }
-        const dir = lib.path.replace(/[\\/]+$/, "").toLowerCase();
-        const prefix = `${wsPrefix}${dir}/`;
+        const dirUri = resolveLibUri(lib.path, this.workspaceUri);
+        if (!dirUri) {
+          continue;
+        }
+        const dir = UriUtils.normalizePath(dirUri.toString(true)).toLowerCase();
+        const prefix = `${dir}/`;
         let set = matchers.get(prefix);
         if (!set) {
           set = new Set<string>();
@@ -431,7 +421,7 @@ export class PluginConfigurationProvider {
    *   LSP clears prior diagnostics on files that are no longer a source.
    */
   private async loadConfigurations(): Promise<PluginConfigLspDiagnostics> {
-    const workspaceUri = UriUtils.toUri(this.workspacePath);
+    const workspaceUri = this.workspaceUri;
     const cancel = this.longRunningOperation.start(
       "Processing plugin configuration...",
     );
@@ -446,17 +436,14 @@ export class PluginConfigurationProvider {
 
     const diagnostics: PluginConfigDiagnostics = [];
 
-    const plipluginDir = UriUtils.joinPath(workspaceUri, ".pliplugin");
-    const plipluginPgmConfUri = UriUtils.joinPath(
-      plipluginDir,
-      "pgm_conf.json",
-    );
-    const plipluginProcGrpsUri = UriUtils.joinPath(
-      plipluginDir,
-      "proc_grps.json",
-    );
+    const plipluginDir =
+      workspaceUri && UriUtils.joinPath(workspaceUri, ".pliplugin");
+    const plipluginPgmConfUri =
+      plipluginDir && UriUtils.joinPath(plipluginDir, "pgm_conf.json");
+    const plipluginProcGrpsUri =
+      plipluginDir && UriUtils.joinPath(plipluginDir, "proc_grps.json");
 
-    const global = await this.fetchGlobalSettings(this.workspacePath);
+    const global = await this.fetchGlobalSettings(this.workspaceUri);
 
     const [pgmSource, procGrpsSource] = await Promise.all([
       this.resolveConfigSource(plipluginPgmConfUri, global?.pgmConf),
@@ -476,11 +463,10 @@ export class PluginConfigurationProvider {
       diagnostics.push(...result.diagnostics);
       if (result.config) {
         for (const config of result.config) {
-          const resolvedUri = this.resolveProgramPath(
+          const key = this.resolveProgramKey(
             config.program.value,
-            this.workspacePath,
+            this.workspaceUri,
           );
-          const key = resolvedUri.toString();
           if (!selectedPrograms.has(key)) {
             selectedPrograms.set(key, config);
           }
@@ -488,7 +474,7 @@ export class PluginConfigurationProvider {
       }
     }
     this.applyProgramConfigs(
-      this.workspacePath,
+      this.workspaceUri,
       Array.from(selectedPrograms.values()),
     );
 
@@ -530,10 +516,13 @@ export class PluginConfigurationProvider {
     this.configDiagnostics = diagnostics;
     const lspDiagnostics = await this.convertDiagnosticsToLsp();
     // Now override which URIs we published diagnostics for this time
-    this.previouslyPublishedUris = new Set([
-      plipluginPgmConfUri.toString(),
-      plipluginProcGrpsUri.toString(),
-    ]);
+    this.previouslyPublishedUris = new Set<string>();
+    if (plipluginPgmConfUri) {
+      this.previouslyPublishedUris.add(plipluginPgmConfUri.toString());
+    }
+    if (plipluginProcGrpsUri) {
+      this.previouslyPublishedUris.add(plipluginProcGrpsUri.toString());
+    }
     for (const diagnostic of diagnostics) {
       const uri = diagnostic.uri?.toString();
       if (uri) {
@@ -580,7 +569,7 @@ export class PluginConfigurationProvider {
    * this round-trips to the client; in tests it's a fixture-backed loader.
    */
   private async fetchGlobalSettings(
-    workspaceUri: URI,
+    workspaceUri: URI | undefined,
   ): Promise<Messages.GlobalConfig | undefined> {
     return this.globalConfigLoader.loadGlobalConfig(workspaceUri);
   }
@@ -645,7 +634,7 @@ export class PluginConfigurationProvider {
    * lazily). Returns `undefined` if no tier provides the file.
    */
   private async resolveConfigSource(
-    pluginUri: URI,
+    pluginUri: URI | undefined,
     entries: Messages.GlobalConfigEntry[] | undefined,
   ): Promise<ConfigSource | undefined> {
     return (
@@ -666,7 +655,7 @@ export class PluginConfigurationProvider {
   public async writeProcessGroupsFile(
     content = PluginConfiguration.DEFAULT_PROCESS_GROUP_FILE_CONTENT,
   ): Promise<void> {
-    const workspaceUri = this.getWorkspacePath();
+    const workspaceUri = this.requireWorkspaceUri();
     try {
       await this.fs.writeFile(
         UriUtils.joinPath(
@@ -704,7 +693,7 @@ export class PluginConfigurationProvider {
   public async writeProgramConfigFile(
     content: PgmsConfig = PluginConfiguration.DEFAULT_PROGRAM_FILE_CONTENT,
   ): Promise<void> {
-    const workspaceUri = this.getWorkspacePath();
+    const workspaceUri = this.requireWorkspaceUri();
     try {
       await this.fs.writeFile(
         UriUtils.joinPath(workspaceUri, PluginConfiguration.PROGRAM_FILE_PATH),
@@ -717,16 +706,33 @@ export class PluginConfigurationProvider {
   }
 
   /**
-   * Return the workspace URI that this provider was initialized with
+   * Return the workspace URI that this provider was initialized with, or
+   * `undefined` for the fallback workspace.
    */
-  public getWorkspacePath(): URI {
-    return this.workspacePath;
+  public getWorkspaceUri(): URI | undefined {
+    return this.workspaceUri;
+  }
+
+  /**
+   * The workspace URI for operations that make no sense without one
+   * (config file authoring). Throws on the fallback workspace.
+   */
+  public requireWorkspaceUri(): URI {
+    if (!this.workspaceUri) {
+      throw new Error(
+        "Operation requires a workspace, but this provider has none (fallback workspace).",
+      );
+    }
+    return this.workspaceUri;
   }
 
   public isPgmConfigDocumentUri(uri: URI | string): boolean {
+    if (!this.workspaceUri) {
+      return false;
+    }
     const inputUri = typeof uri === "string" ? UriUtils.toUri(uri) : uri;
     const pgmConfigUri = UriUtils.joinPath(
-      this.getWorkspacePath(),
+      this.workspaceUri,
       ".pliplugin",
       "pgm_conf.json",
     );
@@ -734,9 +740,12 @@ export class PluginConfigurationProvider {
   }
 
   public isProcGrpsDocumentUri(uri: URI | string): boolean {
+    if (!this.workspaceUri) {
+      return false;
+    }
     const inputUri = typeof uri === "string" ? UriUtils.toUri(uri) : uri;
     const procGrpsUri = UriUtils.joinPath(
-      this.getWorkspacePath(),
+      this.workspaceUri,
       ".pliplugin",
       "proc_grps.json",
     );
@@ -780,13 +789,13 @@ export class PluginConfigurationProvider {
 
     // The fallback workspace has no base for workspace-relative paths, so skip
     // "unresolved" diagnostics for them (absolute-path libs are still checked).
-    const isFallback = this.isFallbackWorkspace;
+    const isFallback = this.workspaceUri === undefined;
 
     for (const record of this.processGroupConfigs.values()) {
       const expanded = await expandGroup(
         record.libs,
         this.fs,
-        this.workspacePath,
+        this.workspaceUri,
       );
       record.computedLibs = expanded.libs;
 
@@ -796,11 +805,13 @@ export class PluginConfigurationProvider {
       // is exact and duplicate-safe. Computed once per pgroup and shared by all
       // of its unresolved diagnostics so the "remove all" quick fix can rewrite
       // the array without re-parsing.
-      const unresolvedItems = new Set(expanded.unresolved);
+      const unresolvedItems = new Set(
+        expanded.unresolved.map((item) => item[0]),
+      );
       const survivingLibs = record.libs
         .filter((item) => !unresolvedItems.has(item))
         .map((item) => item.value);
-      for (const libItem of expanded.unresolved) {
+      for (const [libItem, reason] of expanded.unresolved) {
         // Skip relative libs in the fallback workspace (see above).
         if (isFallback && !this.isAbsolutePath(libItem.value)) {
           continue;
@@ -822,6 +833,7 @@ export class PluginConfigurationProvider {
             sourceUri,
             range,
             lib,
+            reason,
           ),
           data,
         };
@@ -886,7 +898,10 @@ export class PluginConfigurationProvider {
         if (!isLibsDir(lib)) {
           continue;
         }
-        const libUri = resolveLibUri(lib.path, this.workspacePath);
+        const libUri = resolveLibUri(lib.path, this.workspaceUri);
+        if (!libUri) {
+          continue;
+        }
         // Dedupe: one warning per program entry overlapping this lib dir,
         // even if many files in the dir match that entry.
         const seenProgramKeys = new Set<string>();
@@ -985,20 +1000,17 @@ export class PluginConfigurationProvider {
    * post-processed so abstract options are built.
    */
   private applyProgramConfigs(
-    workspaceUri: URI,
+    workspaceUri: URI | undefined,
     programConfigs: ProgramConfig[],
   ): void {
     this.programConfigs.clear();
 
     for (const config of programConfigs) {
-      const resolvedUri = this.resolveProgramPath(
-        config.program.value,
-        workspaceUri,
-      );
+      const key = this.resolveProgramKey(config.program.value, workspaceUri);
       // Wrap the loaded config into a ProgramRecord. `abstractOptions` and
       // `issues` are filled in by `postProcessProgramConfigs` once the
       // bound process group is also available.
-      this.programConfigs.set(resolvedUri.path, {
+      this.programConfigs.set(key, {
         ...config,
         abstractOptions: { options: [], tokens: [], issues: [], comments: [] },
         issues: [],
@@ -1008,11 +1020,16 @@ export class PluginConfigurationProvider {
   }
 
   /**
-   * Resolves a program path to an absolute URI.
-   * Normalizes backslashes to forward slashes, then returns the path as-is if absolute,
-   * or joins it with the workspace URI if relative.
+   * Resolves a program path to the key it's matched under (see
+   * {@link getProgramConfig}). Normalizes backslashes to forward slashes,
+   * then uses the path as-is if absolute, or joins it with the workspace URI
+   * if relative. Without a workspace (the fallback workspace), a relative
+   * path stays as-is and matches unanchored against full file paths.
    */
-  private resolveProgramPath(programPath: string, workspaceUri: URI): URI {
+  private resolveProgramKey(
+    programPath: string,
+    workspaceUri: URI | undefined,
+  ): string {
     let normalizedProgramPath = UriUtils.normalizePath(programPath);
     // A bare "." or "./" means the workspace folder itself, matching its direct
     // (non-recursive) children. Expressed as the "*" glob, since joining "."
@@ -1021,9 +1038,12 @@ export class PluginConfigurationProvider {
       normalizedProgramPath = "*";
     }
     if (this.isAbsolutePath(normalizedProgramPath)) {
-      return UriUtils.toUri(normalizedProgramPath);
+      return UriUtils.toUri(normalizedProgramPath).path;
     }
-    return UriUtils.joinPath(workspaceUri, normalizedProgramPath);
+    if (!workspaceUri) {
+      return normalizedProgramPath;
+    }
+    return UriUtils.joinPath(workspaceUri, normalizedProgramPath).path;
   }
 
   /**
@@ -1063,7 +1083,7 @@ export class PluginConfigurationProvider {
 
   private getConfigUri(fileName: string): string {
     return UriUtils.joinPath(
-      UriUtils.toUri(this.workspacePath),
+      this.requireWorkspaceUri(),
       ".pliplugin",
       fileName,
     ).toString();
@@ -1221,7 +1241,10 @@ export class PluginConfigurationProvider {
     const uris: URI[] = [];
     for (const config of this.processGroupConfigs.values()) {
       for (const lib of config.computedLibs) {
-        const libUri = resolveLibUri(lib.path, this.workspacePath);
+        const libUri = resolveLibUri(lib.path, this.workspaceUri);
+        if (!libUri) {
+          continue;
+        }
         uris.push(isLibsDir(lib) ? libUri : UriUtils.dirname(libUri));
       }
     }

--- a/packages/language/test/fourslash/preprocessor/include/program-config-precedence-exact-settings.ts
+++ b/packages/language/test/fourslash/preprocessor/include/program-config-precedence-exact-settings.ts
@@ -58,5 +58,8 @@ preprocessor.expectTokens(`
 // The project `default` group is the active source: its missing `cpy` lib is
 // flagged on proc_grps.json, while `cpyla` resolves.
 verify.expectDiagnosticsAt("missing", {
-  message: code.LSP.PluginConfiguration.UnresolvedEntry.message("cpy"),
+  message: code.LSP.PluginConfiguration.UnresolvedEntry.message(
+    "cpy",
+    "Path does not exist.",
+  ),
 });

--- a/packages/language/test/fourslash/preprocessor/include/program-config-precedence-over-settings.ts
+++ b/packages/language/test/fourslash/preprocessor/include/program-config-precedence-over-settings.ts
@@ -56,5 +56,8 @@ preprocessor.expectTokens(`
 // The project `default` group is the active source: its missing `cpy` lib is
 // flagged on proc_grps.json, while `cpyla` resolves.
 verify.expectDiagnosticsAt("missing", {
-  message: code.LSP.PluginConfiguration.UnresolvedEntry.message("cpy"),
+  message: code.LSP.PluginConfiguration.UnresolvedEntry.message(
+    "cpy",
+    "Path does not exist.",
+  ),
 });

--- a/packages/language/test/fourslash/preprocessor/include/wildcard-libs-partial-match-diagnostic.ts
+++ b/packages/language/test/fourslash/preprocessor/include/wildcard-libs-partial-match-diagnostic.ts
@@ -46,5 +46,8 @@ preprocessor.expectTokens(`
 
 // ...and only the unresolvable wildcard is flagged.
 verify.expectDiagnosticsAt("bad", {
-  message: code.LSP.PluginConfiguration.UnresolvedEntry.message("**/missing"),
+  message: code.LSP.PluginConfiguration.UnresolvedEntry.message(
+    "**/missing",
+    "Path does not exist.",
+  ),
 });

--- a/packages/language/test/fourslash/preprocessor/include/wildcard-libs-unresolved-diagnostic.ts
+++ b/packages/language/test/fourslash/preprocessor/include/wildcard-libs-unresolved-diagnostic.ts
@@ -40,5 +40,8 @@
 //// DECLARE Y FIXED;
 
 verify.expectDiagnosticsAt("bad", {
-  message: code.LSP.PluginConfiguration.UnresolvedEntry.message("**/missing"),
+  message: code.LSP.PluginConfiguration.UnresolvedEntry.message(
+    "**/missing",
+    "Path does not exist.",
+  ),
 });

--- a/packages/language/test/lsp/apply-quick-fixes.test.ts
+++ b/packages/language/test/lsp/apply-quick-fixes.test.ts
@@ -51,7 +51,7 @@ const CODE_UNRESOLVED_LIB = fullCode(
 
 function procGrpsDocumentUri(): string {
   return UriUtils.joinPath(
-    pluginConfig.getWorkspacePath(),
+    pluginConfig.requireWorkspaceUri(),
     ".pliplugin",
     "proc_grps.json",
   ).toString();

--- a/packages/language/test/lsp/completion-plugin-configuration.test.ts
+++ b/packages/language/test/lsp/completion-plugin-configuration.test.ts
@@ -31,14 +31,14 @@ let workspace: WorkspaceContext;
 
 function pgmConfigUri(): URI {
   return UriUtils.joinPath(
-    workspace.config.getWorkspacePath(),
+    workspace.config.requireWorkspaceUri(),
     PluginConfiguration.PROGRAM_FILE_PATH,
   );
 }
 
 function processGroupUri(): URI {
   return UriUtils.joinPath(
-    workspace.config.getWorkspacePath(),
+    workspace.config.requireWorkspaceUri(),
     PluginConfiguration.PROCESS_GROUP_FILE_PATH,
   );
 }

--- a/packages/language/test/lsp/get-proc-group-config-from-lib.test.ts
+++ b/packages/language/test/lsp/get-proc-group-config-from-lib.test.ts
@@ -27,6 +27,7 @@ async function setupConfig(
     new TestGlobalConfigLoader({}),
     LongRunningOperationImpl.Dummy,
   );
+  await pluginConfig.init(UriUtils.toUri("file:///"));
   const processGroup = deserializeProcessGroup({
     name: "default",
     "include-extensions": [".pli"],

--- a/packages/language/test/test-builder.ts
+++ b/packages/language/test/test-builder.ts
@@ -315,16 +315,19 @@ export class TestBuilder extends AbstractTestBuilder {
       }
     }
     this.areProcGrpsSupplied = hasProcGrpsUri;
-    const config = defaultTestWorkspace().config;
     const workspaceUri = pgmConfUri
       ? UriUtils.dirname(UriUtils.dirname(UriUtils.toUri(pgmConfUri)))
-      : config.getWorkspacePath();
+      : UriUtils.toUri("file:///");
 
     // Skip default config creation if noDefaultConfig is set
     if (this.options.noDefaultConfig) {
       await defaultTestWorkspace().config.init(workspaceUri);
       return;
     }
+
+    // Writing the default config files requires an initialized workspace;
+    // the final init below reloads them.
+    await defaultTestWorkspace().config.init(workspaceUri);
 
     if (!pgmConfUri) {
       await defaultTestWorkspace().config.writeProgramConfigFile(

--- a/packages/language/test/workspace/multi-workspace.test.ts
+++ b/packages/language/test/workspace/multi-workspace.test.ts
@@ -461,4 +461,53 @@ describe("Multi Workspace Tests", () => {
         ),
     ).toBe(true);
   });
+
+  test("Fallback folder ignores a plugin config dir at the filesystem root", async () => {
+    const fs = new VirtualFileSystemProvider();
+    resetDocumentProviders(fs);
+    const settingsUri = UriUtils.toUri("file:///settings.json");
+    const ch = new CompilationUnitHandler(
+      fs,
+      new TestGlobalConfigLoader({
+        procGrps: [
+          {
+            configKey: "pli.proc_grps",
+            uri: settingsUri.toString(),
+            containerPath: [],
+            scope: "user",
+          },
+        ],
+      }),
+      LongRunningOperationImpl.Dummy,
+    );
+
+    // A `.pliplugin/` directory sitting at the filesystem root.
+    await fs.writeFile(
+      UriUtils.toUri("file:///.pliplugin/proc_grps.json"),
+      JSON.stringify({
+        pgroups: [{ name: "from-root-pliplugin", libs: [] }],
+      }),
+    );
+    await fs.writeFile(
+      settingsUri,
+      JSON.stringify({
+        "pli.proc_grps": {
+          pgroups: [{ name: "from-settings", libs: [] }],
+        },
+      }),
+    );
+
+    // The fallback workspace has no root, so it must not probe
+    // `file:///.pliplugin/` and falls through to the settings source.
+    const fallback = await ch.initializeFallbackFolder();
+    expect(fallback.config.getProcessGroupNames()).toEqual(["from-settings"]);
+
+    // A real workspace folder rooted at `file:///` DOES pick up that config
+    // dir — only the fallback ignores it. (The two were indistinguishable
+    // before workspacePath became optional.)
+    const rootWorkspace = await ch.initializeWorkspaceFolder("file:///");
+    expect(rootWorkspace.config.getProcessGroupNames()).toEqual([
+      "from-root-pliplugin",
+    ]);
+  });
 });

--- a/packages/language/test/workspace/plugin-configuration.test.ts
+++ b/packages/language/test/workspace/plugin-configuration.test.ts
@@ -132,6 +132,8 @@ describe("Plugin Configuration Tests", () => {
   });
 
   test("Duplicate Lib Entries are filtered from $computed props", async () => {
+    await workspace.config.init(UriUtils.toUri("file:///"));
+
     // ensure that duplicate lib & ddname entries are filtered out from computed props
     const libs = ["lib1/dir1", "lib1/dir1", "lib2/DDNAME", "lib2/DDNAME"];
     const uniqueLibs = Array.from(new Set(libs));

--- a/packages/vscode-extension/src/extension/config-loader.ts
+++ b/packages/vscode-extension/src/extension/config-loader.ts
@@ -33,9 +33,9 @@ export function registerConfigLoader(
 ): vscode.Disposable {
   return client.onRequest(
     Messages.GetGlobalConfig.method,
-    async (workspaceUri) => {
+    async (workspaceUri: string | null) => {
       return getGlobalConfig(
-        UriUtils.toUri(workspaceUri),
+        workspaceUri === null ? undefined : UriUtils.toUri(workspaceUri),
         deriveUserSettingsUri(context.globalStorageUri),
       );
     },
@@ -56,10 +56,10 @@ export function registerConfigLoader(
  * `.code-workspace` file.
  */
 async function getGlobalConfig(
-  workspaceUri: vscode.Uri,
+  workspaceUri: vscode.Uri | undefined,
   userSettingsUri: vscode.Uri,
 ): Promise<Messages.GlobalConfig> {
-  const workspaceFolder = locateWorkspaceFolder(workspaceUri);
+  const workspaceFolder = workspaceUri && locateWorkspaceFolder(workspaceUri);
   const result: Messages.GlobalConfig = {};
   if (workspaceFolder) {
     const pgmConf = locate("pgm_conf", workspaceFolder, userSettingsUri);

--- a/packages/vscode-extension/src/language/config-loader.ts
+++ b/packages/vscode-extension/src/language/config-loader.ts
@@ -13,11 +13,13 @@ import { Connection } from "vscode-languageserver";
 
 export class VscodeGlobalConfigLoader implements GlobalConfigLoader {
   constructor(private readonly connection: Connection) {}
-  async loadGlobalConfig(workspaceUri: URI): Promise<Messages.GlobalConfig> {
+  async loadGlobalConfig(
+    workspaceUri: URI | undefined,
+  ): Promise<Messages.GlobalConfig> {
     return await sendRequest(
       this.connection,
       Messages.GetGlobalConfig,
-      workspaceUri.toString(),
+      workspaceUri?.toString() ?? null,
     );
   }
 }


### PR DESCRIPTION
Closes https://github.com/zowe/zowe-pli-language-support/issues/819

Removes the crutch `isFallbackWorkspace` flag and replaces it with an `undefined` `workspaceUri` instead. Adjusts the rest of the codebase to deal with this case correctly.

Also closes (6) of https://github.com/zowe/zowe-pli-language-support/issues/668, by providing a `reason` field if a plugin config lib cannot be resolved. Returns a special error message if the lib in question has the `zowe-ds` URI scheme.