### PR TITLE
Support GONUMBER without parameters

### DIFF
--- a/packages/language/src/preprocessor/compiler-options/translator-pli.ts
+++ b/packages/language/src/preprocessor/compiler-options/translator-pli.ts
@@ -1325,7 +1325,14 @@ translator.flag("goff", ["GOFF"], ["NOGOFF"]);
 translator.rule(
   ["GONUMBER", "GN"],
   (option, options) => {
-    ensureArguments(option, 1, 1);
+    ensureArguments(option, 0, 1);
+    if (option.values.length === 0) {
+      // If no argument provided, the compiler defaults to GONUMBER(NOSEPARATE)
+      options.goNumber = {
+        separate: false,
+      };
+      return;
+    }
     const value = option.values[0];
     ensureType(value, "plain");
     if (!options.goNumber) {

--- a/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/gonumber.ts
+++ b/packages/language/test/fourslash/preprocessor/compiler-options/options-pli/gonumber.ts
@@ -19,6 +19,7 @@
 ////*PROCESS <|4:NOGONUMBER|>;
 ////*PROCESS <|5:GN|>(NOSEPARATE);
 ////*PROCESS <|6:NGN|>;
+////*PROCESS <|9:GONUMBER|>;
 ////*PROCESS <|7:GN|>(<|8:separate|>);
 
 verify.expectDiagnosticsAt(1, {
@@ -43,6 +44,8 @@ verify.expectDiagnosticsAt(7, {
   message: code.CompilerOptions.DupeOptionIssue.message("GN"),
 });
 verify.noDiagnostics(8);
+// The compiler defaults to GONUMBER(NOSEPARATE) if no argument is provided, so 0 parameters are fine
+verify.noDiagnostics(9, code.CompilerOptions.InvalidParameterCount);
 verify.expectCompilerOptions({
   goNumber: {
     separate: true,


### PR DESCRIPTION
The compiler seems to accept it. We should as well.