### PR TITLE
Display diagnostics on large macro arrays

### DIFF
--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -258,7 +258,7 @@ function generateVariableValue(
         ) {
           context.diagnostics.push(
             diagnosticFromCode(
-              LspCodes.TooLarge,
+              LspCodes.DimensionsTooLarge,
               instruction.node.nameToken,
               MAX_ARRAY_COUNT,
             ),

--- a/packages/language/src/preprocessor/instruction-interpreter.ts
+++ b/packages/language/src/preprocessor/instruction-interpreter.ts
@@ -252,6 +252,18 @@ function generateVariableValue(
         fullLength *= length;
       }
       if (fullLength > MAX_ARRAY_COUNT) {
+        if (
+          instruction.node?.kind === ast.SyntaxKind.DeclaredVariable &&
+          instruction.node.nameToken
+        ) {
+          context.diagnostics.push(
+            diagnosticFromCode(
+              LspCodes.TooLarge,
+              instruction.node.nameToken,
+              MAX_ARRAY_COUNT,
+            ),
+          );
+        }
         // Too many elements, return empty array
         return {
           array: [],

--- a/packages/language/src/validation/lsp-codes.ts
+++ b/packages/language/src/validation/lsp-codes.ts
@@ -69,6 +69,13 @@ export const LspCodes = {
     message: () => `Missing END statement for procedure.`,
   },
 
+  TooLarge: {
+    code: "LSPTL001",
+    severity: Severity.W,
+    message: (max: number) =>
+      `Dimensions exceed the maximum allowed size of ${max}.`,
+  },
+
   BuiltinAttributes: {
     IsForbiddenUsage: {
       code: "LSPTS001",

--- a/packages/language/src/validation/lsp-codes.ts
+++ b/packages/language/src/validation/lsp-codes.ts
@@ -69,7 +69,7 @@ export const LspCodes = {
     message: () => `Missing END statement for procedure.`,
   },
 
-  TooLarge: {
+  DimensionsTooLarge: {
     code: "LSPTL001",
     severity: Severity.W,
     message: (max: number) =>

--- a/packages/language/test/fourslash/preprocessor/initial/array-dimension-large-bound.ts
+++ b/packages/language/test/fourslash/preprocessor/initial/array-dimension-large-bound.ts
@@ -11,10 +11,11 @@
 
 /// <reference path="../../framework.ts" />
 
-//// %DCL X(999999999) CHAR;
+//// %DCL <|X|>(999999999) CHAR;
 //// %X1 = X(1);
 //// %ACT X1;
 //// X1
 
 // Array too large, interpreter should still be able to handle it
 preprocessor.expectTokens("");
+verify.expectDiagnosticsAt("X", code.LspCodes.TooLarge);

--- a/packages/language/test/fourslash/preprocessor/initial/array-dimension-large-bound.ts
+++ b/packages/language/test/fourslash/preprocessor/initial/array-dimension-large-bound.ts
@@ -18,4 +18,4 @@
 
 // Array too large, interpreter should still be able to handle it
 preprocessor.expectTokens("");
-verify.expectDiagnosticsAt("X", code.LspCodes.TooLarge);
+verify.expectDiagnosticsAt("X", code.LspCodes.DimensionsTooLarge);


### PR DESCRIPTION
Closes https://github.com/zowe/zowe-pli-language-support/issues/791

Right now, if we detect that a variable is too large, we just silently ignore the actual value and set it too an empty array. This change adds a diagnostic warning for this case.