### PR TITLE
Remove plugin loader error

### DIFF
--- a/packages/language/src/config/loader.ts
+++ b/packages/language/src/config/loader.ts
@@ -95,13 +95,6 @@ export function parseProgramConfigs(
     !pgmsNode ||
     pgmsNode.type !== "array"
   ) {
-    diagnostics.push(
-      createStructureDiagnostic(
-        document,
-        PGM_FILE,
-        formatExpectation(entry, "pgms array"),
-      ),
-    );
     return { config: undefined, diagnostics };
   }
 
@@ -143,13 +136,6 @@ export function parseProcessGroupConfigs(
     !pgroupsNode ||
     pgroupsNode.type !== "array"
   ) {
-    diagnostics.push(
-      createStructureDiagnostic(
-        document,
-        PROC_GRPS_FILE,
-        formatExpectation(entry, "pgroups array"),
-      ),
-    );
     return { config: undefined, diagnostics };
   }
 
@@ -201,11 +187,6 @@ function entryFullPath(entry: ParseEntry): JSONPath {
     base.push(entry.configKey);
   }
   return base;
-}
-
-function formatExpectation(entry: ParseEntry, suffix: string): string {
-  const prefix = entryFullPath(entry).join(".");
-  return prefix ? `${prefix}.${suffix}` : suffix;
 }
 
 function readProgramConfig(
@@ -412,20 +393,6 @@ function createParseErrorDiagnostics(
       jsoncPrintParseErrorCode(error.error),
     );
   });
-}
-
-function createStructureDiagnostic(
-  document: TextDocument,
-  fileName: string,
-  expected: string,
-): Diagnostic {
-  return diagnosticFromCodeAtRange(
-    LspCodes.PluginConfiguration.InvalidStructure,
-    document.uri,
-    offsetLengthToRange(0, 1),
-    fileName,
-    expected,
-  );
 }
 
 /**

--- a/packages/language/src/validation/lsp-codes.ts
+++ b/packages/language/src/validation/lsp-codes.ts
@@ -94,13 +94,6 @@ export const LspCodes = {
         `Plugin Configuration parse error in ${fileName}: ${parseErrorCode}`,
     },
 
-    InvalidStructure: {
-      code: "COPC03",
-      severity: Severity.E,
-      message: (fileName: string, expected: string) =>
-        `Plugin Configuration expected '${expected}' in ${fileName}.`,
-    },
-
     UnknownProcessGroup: {
       code: "COPC04",
       severity: Severity.E,

--- a/packages/language/test/config/loader.test.ts
+++ b/packages/language/test/config/loader.test.ts
@@ -76,17 +76,6 @@ describe("Loader entry-path navigation", () => {
     expect(text.substring(meta.range.start, meta.range.end)).toBe('"a.pli"');
   });
 
-  test("missing entry yields a structure diagnostic", () => {
-    const text = `{ "unrelated": {} }`;
-    const result = parseProgramConfigs(text, URI, {
-      containerPath: [],
-      configKey: "pli.pgm_conf",
-    });
-    expect(result.config).toBeUndefined();
-    expect(result.diagnostics).toHaveLength(1);
-    expect(result.diagnostics[0].message).toContain("pli.pgm_conf.pgms");
-  });
-
   test("proc_grps parses from flat settings-shaped wrapper", () => {
     const text = `{
       "pli.proc_grps": {


### PR DESCRIPTION
Removes an error message that we generate in case the pliplugin files are malformed. Quietly rejects them now. We do not lose any user facing diagnostics, because the json schema already validates that the corresponding settings/files are correctly formed JSON.